### PR TITLE
Load foundry-api-bridge env from monorepo root .env

### DIFF
--- a/apps/foundry-api-bridge/README.md
+++ b/apps/foundry-api-bridge/README.md
@@ -29,7 +29,7 @@ npm run test         # Jest
 Layers the module onto `felddy/foundryvtt:14`, so the container serves Foundry with the bridge module pre-installed. The MCP server runs separately — point its `FOUNDRY_WS_URL` at this container's websocket once the module is enabled in your world.
 
 ```bash
-cp .env.example .env         # fill in FOUNDRY_USERNAME/PASSWORD
+cp .env.example ../../.env   # fill in FOUNDRY_USERNAME/PASSWORD at the toolkit root
 ./local.sh up                # build image, deps, dist, start container
 # open http://localhost:30000 and set up a world
 
@@ -40,7 +40,7 @@ cp .env.example .env         # fill in FOUNDRY_USERNAME/PASSWORD
 ./local.sh nuke              # destroy the data volume (asks first)
 ```
 
-Data lives in a named Docker volume (`foundry-data-local`) by default, so the workflow is OS-portable. Set `FOUNDRY_DATA=/some/host/path` in `.env` to bind to a host path instead. Port defaults to 30000 and can be overridden via `FOUNDRY_PORT` if you already have a production container running on the same machine.
+Data lives in a named Docker volume (`foundry-data-local`) by default, so the workflow is OS-portable. Set `FOUNDRY_DATA=/some/host/path` in the root `.env` to bind to a host path instead. Port defaults to 30000 and can be overridden via `FOUNDRY_PORT` if you already have a production container running on the same machine.
 
 ## Installation in Foundry
 

--- a/apps/foundry-api-bridge/local.sh
+++ b/apps/foundry-api-bridge/local.sh
@@ -12,7 +12,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-COMPOSE="docker compose -f docker-compose.local.yml"
+# Load env vars from the monorepo root .env so credentials are shared
+# across all foundry-toolkit apps instead of being duplicated per-app.
+ROOT_ENV="$SCRIPT_DIR/../../.env"
+COMPOSE="docker compose --env-file $ROOT_ENV -f docker-compose.local.yml"
 cd "$SCRIPT_DIR"
 
 usage() {
@@ -32,7 +35,8 @@ Commands:
   ps         Compose status
 
 First-time:
-  1. Copy .env.example to .env and fill in FOUNDRY_USERNAME/PASSWORD
+  1. Copy apps/foundry-api-bridge/.env.example to <repo-root>/.env
+     and fill in FOUNDRY_USERNAME/PASSWORD
   2. ./local.sh up
   3. Open http://localhost:30000 — log in, create a world, install the
      foundry-api-bridge module from /data/Data/modules
@@ -53,8 +57,8 @@ build_local() {
 }
 
 cmd_up() {
-  if [ ! -f .env ]; then
-    echo "ERROR: .env not found. Copy .env.example to .env and fill in credentials." >&2
+  if [ ! -f "$ROOT_ENV" ]; then
+    echo "ERROR: $ROOT_ENV not found. Copy apps/foundry-api-bridge/.env.example to the toolkit root as .env and fill in credentials." >&2
     exit 1
   fi
   build_local


### PR DESCRIPTION
## Summary

- `local.sh` now passes `--env-file ../../.env` to `docker compose`, so the bridge container reads credentials from the toolkit root instead of a per-app `.env`. A single shared `.env` at the repo root can now serve all foundry-toolkit apps.
- The missing-file guard in `cmd_up` and the README / help-text instructions point at the new root location.

No behavior change for `dev.sh` (remote-on-server flow) or the production `docker-compose.yml` — this only touches the local Docker Desktop workflow.

## Test plan

- [ ] `bash -n apps/foundry-api-bridge/local.sh` passes (syntax check).
- [ ] With `<repo-root>/.env` populated, `./local.sh up` starts the container and Foundry login succeeds at http://localhost:30000.
- [ ] With the root `.env` missing, `./local.sh up` aborts with the new error message pointing at the root path.
- [ ] `./local.sh rebuild` / `./local.sh logs` still work (no regression on other subcommands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)