### PR TITLE
Add missing CLAUDE.md files and refresh existing ones for monorepo context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# foundry-toolkit
+
+Monorepo consolidating five Foundry VTT companion tools. npm-workspaces, no Turborepo/Nx/pnpm. See [README.md](./README.md) for the layout tree and top-level scripts.
+
+## Tech stack
+
+- TypeScript 6, shared strict config in `tsconfig.base.json` (ES2022, Bundler moduleResolution, `noUnusedLocals` / `noUnusedParameters` on).
+- ESLint 10 flat config (`eslint.config.js`), `typescript-eslint`, `eslint-config-prettier`.
+- Prettier 3 (`.prettierrc`): 120-col, `trailingComma: all`, `singleQuote: true`, `semi: true`.
+- `@electron/rebuild` at root for `better-sqlite3` postinstall.
+
+## Workspaces
+
+- `apps/*` — five apps (dm-tool, foundry-mcp, foundry-api-bridge, character-creator, player-portal).
+- `packages/*` — three internal libs (ai, db, shared).
+
+Internal dependency graph:
+
+- `shared` → `ai` → `db` → `dm-tool`
+- `shared` → `player-portal`
+- `foundry-mcp`, `foundry-api-bridge`, `character-creator` are standalone (no workspace deps).
+
+Every workspace has its own `CLAUDE.md` covering app-specific details.
+
+## Commands (root)
+
+- `npm install` — installs all workspaces; `postinstall` rebuilds `better-sqlite3` for Electron's ABI.
+- `npm run rebuild-sqlite` — manual escape hatch if the native module ever gets out of sync.
+- `npm run dev:dm-tool` / `dev:mcp` / `dev:character-creator` / `dev:player-portal` / `dev:api-bridge` — each targets one workspace.
+- `npm run typecheck` / `test` / `build` / `format` / `format:check` — fan out via `--workspaces --if-present`.
+- `npm run lint` — runs the root ESLint pass **and** each workspace's own lint script.
+
+## Root ESLint scope
+
+`eslint.config.js` explicitly ignores `apps/player-portal`, `apps/foundry-mcp`, `apps/foundry-api-bridge`, `apps/character-creator`, plus all `dist/`, `out/`, `server-dist/`, `tagger/`, `resources/`, and `.claude/`. The root ESLint pass therefore only covers **`apps/dm-tool` + `packages/*`**. The four excluded apps lint via their own workspace scripts.
+
+If monorepo CI ever flags lint in ported/vendored code (pf2e SCSS, forked Foundry module), scope CI — don't edit the source files.
+
+## Git workflow
+
+- All work MUST happen in a git worktree rooted at `.claude/worktrees/<branch-name>/` (monorepo root, **not** per-app).
+- Never work directly on `main`; PR-only.
+- Push frequently — at minimum after every logical unit of work, and always before ending a session.
+- Run `npm run lint` + `npm run format:check` before committing; fix warnings before pushing.
+
+## Key gotchas
+
+- `tagger/` is a Python subtool with its own build system; `auto-wall-bin/` holds a prebuilt binary. Neither is an npm workspace. `apps/dm-tool`'s electron-builder config references `../../tagger/dist/map-tagger.exe` and `../../auto-wall-bin/Auto-Wall.exe` as `extraResources` — both must exist at packaging time.
+- `.env` at the monorepo root holds Foundry credentials, `OPENAI_API_KEY`, and `ALLOW_EVAL`. Never commit it.
+- Deployments (Fly.io for `foundry-mcp`, electron-builder for `dm-tool`, GHCR images for `foundry-api-bridge` and `character-creator`) and CI workflows were **deferred** during consolidation — per-app Dockerfile and fly.toml references still point at the pre-consolidation GHCR repos. Re-point when productionizing.
+- The SPA → MCP rebuild cascade is manual right now: merges to `character-creator` don't auto-rebuild the `foundry-mcp` Docker image that bundles it. Trigger `gh workflow run Docker` on `foundry-mcp` after SPA merges if you need the live app updated.

--- a/apps/character-creator/CLAUDE.md
+++ b/apps/character-creator/CLAUDE.md
@@ -2,6 +2,8 @@
 
 React 19 SPA that renders a Pathfinder 2e character creator/viewer, consuming the foundry-mcp REST API.
 
+Part of the foundry-toolkit monorepo at `apps/character-creator` — see the root [CLAUDE.md](../../CLAUDE.md) for cross-workspace context.
+
 ## Tech Stack
 - React 19 + Vite 8
 - TypeScript
@@ -36,7 +38,7 @@ Env overrides for dev server targets:
 
 ## Git Workflow
 - All work MUST be done in git worktrees. Never work directly on main.
-- Worktree directory: `.claude/worktrees/<branch-name>`
+- Worktree directory: `.claude/worktrees/<branch-name>/` at the monorepo root (not per-app)
 - Push work to the remote frequently — at minimum after every logical unit of work, and always before ending a session.
 - All changes go through PRs to main. Never commit directly to main.
 - Run linting before committing. Fix lint errors before pushing.

--- a/apps/dm-tool/CLAUDE.md
+++ b/apps/dm-tool/CLAUDE.md
@@ -1,0 +1,51 @@
+# dm-tool
+
+Electron desktop app for the GM: browses the dnd-map-tagger image library, reads PF2e books, drives Foundry VTT via MCP, runs the chat/loot/hooks AI agents, and pushes live state to the player-portal.
+
+Part of the foundry-toolkit monorepo at `apps/dm-tool` — see the root [CLAUDE.md](../../CLAUDE.md) for cross-workspace context.
+
+## Tech stack
+
+- TypeScript, React 19, Electron 41
+- electron-vite (three build targets: main, preload, renderer)
+- Tailwind CSS 4 (via `@tailwindcss/postcss`)
+- Radix UI primitives, `lucide-react`, `@tanstack/react-virtual`
+- maplibre-gl + pmtiles, pdfjs-dist
+- Vitest + happy-dom + Testing Library
+
+Workspace deps (raw TS, transpiled by electron-vite): `@foundry-toolkit/ai`, `@foundry-toolkit/db` (subpath imports `./pf2e`, `./books`, `./maps`), `@foundry-toolkit/shared`.
+
+## Build & run
+
+- `npm run dev` — electron-vite dev (renderer HMR + main restart).
+- `npm run build` — electron-vite build → `out/`.
+- `npm run typecheck` — two projects: `tsconfig.node.json` (main + preload) and `tsconfig.web.json` (renderer).
+- `npm run test` / `test:watch` / `test:coverage` — vitest.
+- `npm run package` — `electron-vite build && electron-builder --win` → NSIS one-click per-user installer at `../../dist/` (monorepo root, not the app dir).
+- `npm run package:ci` — same but `--publish never`.
+
+## Project structure
+
+- `electron/main.ts` — entry; bootstrap config, SQLite open, custom-protocol registration, session hooks, IPC wiring, BrowserWindow.
+- `electron/ipc/` — full IPC surface; `setup-ipc.ts` handles first-run before the main DB is configured.
+- `electron/config.ts` — bootstrap config loader + DB-backed config.
+- `electron/book-scanner.ts` — phase-1 filesystem walk for the book catalog; phase-2 cover extraction is lazy.
+- `electron/sidecar-client.ts` — HTTP client to player-portal's Fastify `/api/*` (ex-sidecar).
+- `src/` — React renderer (`src/main.tsx` entry).
+
+## Key decisions / gotchas
+
+- **Three custom privileged protocols**, all registered **before** `app.ready` (CSP requires pre-ready registration):
+  - `map-file://maps/<filename>` — flat library filenames only; path-traversal hard-rejected (no `..`, `/`, `\`); host pinned to `maps` because Chromium lowercases custom-scheme hostnames and would otherwise swallow the filename.
+  - `book-file://files/<id>` / `book-file://covers/<id>` — PDFs and cover PNGs by integer id; id is validated against BookDb so a renderer bug can't read arbitrary filesystem paths. Range-request support via `net.fetch` lets large PDFs stream page-by-page.
+  - `monster-file://img/<relative-path>` — monster art; progressively strips leading path segments to find the file under the pf2e.db directory.
+- **Session hook** on `defaultSession.webRequest.onHeadersReceived`: strips `X-Frame-Options` and `frame-ancestors` (so external sites embed in iframes), and injects `Access-Control-Allow-Origin: *` for `https://map.pathfinderwiki.com/` so MapLibre can fetch PMTiles, sprites, and font glyphs from the renderer.
+- `sandbox: false` on the BrowserWindow — preload needs `fs` access via `ipcRenderer`.
+- **Packaging pulls external binaries** that aren't npm modules: `../../tagger/dist/map-tagger.exe` and `../../auto-wall-bin/Auto-Wall.exe`. Both must exist at `package` time.
+- **`better-sqlite3` rebuild** is covered by root `postinstall` + electron-builder's `npmRebuild: true`. If the renderer shows ABI-mismatch errors, run `npm run rebuild-sqlite` from the monorepo root.
+- `MapDb` is a read-only consumer of the map-tagger index (the `tagger/` Python subtool is the writer). `BookDb` shares the `pf2e.db` connection opened at startup.
+- **Tailwind 4 JIT + HMR quirk**: newly-introduced utility classes occasionally fail to materialize during hot reload. For layout-critical sizing, prefer inline styles until a full reload.
+
+## Git workflow
+
+Worktrees at the monorepo root `.claude/worktrees/<branch-name>/`, PR-only, push frequently, lint + format before committing.

--- a/apps/foundry-api-bridge/CLAUDE.md
+++ b/apps/foundry-api-bridge/CLAUDE.md
@@ -2,6 +2,8 @@
 
 Foundry VTT module that exposes a WebSocket command interface to a self-hosted MCP server. Fork of `foundry-api-bridge` (MIT) with phone-home behaviour removed.
 
+Part of the foundry-toolkit monorepo at `apps/foundry-api-bridge` — see the root [CLAUDE.md](../../CLAUDE.md) for cross-workspace context.
+
 ## Tech Stack
 - TypeScript
 - Vite bundler (watch + build)
@@ -77,7 +79,7 @@ No module-side tests for `EventChannelController` yet — follow-up. Would need 
 
 ## Git Workflow
 - All work MUST be done in git worktrees. Never work directly on main.
-- Worktree directory: `.claude/worktrees/<branch-name>`
+- Worktree directory: `.claude/worktrees/<branch-name>/` at the monorepo root (not per-app)
 - Push work to the remote frequently — at minimum after every logical unit of work, and always before ending a session.
 - All changes go through PRs to main. Never commit directly to main.
 - Run linting before committing. Fix lint errors before pushing.

--- a/apps/foundry-mcp/CLAUDE.md
+++ b/apps/foundry-mcp/CLAUDE.md
@@ -1,6 +1,8 @@
 # foundry-mcp
 
-Self-hosted MCP server that bridges Claude Code (or any MCP client) to a live Foundry VTT instance. Pairs with the [foundry-api-bridge](https://github.com/AlexDickerson/foundry-api-bridge) module running in the GM's browser tab, plus the [foundry-character-creator](https://github.com/AlexDickerson/foundry-character-creator) SPA for the REST-driven character creator UI.
+Self-hosted MCP server that bridges Claude Code (or any MCP client) to a live Foundry VTT instance. Pairs with the [foundry-api-bridge](../foundry-api-bridge/) module running in the GM's browser tab, plus the [character-creator](../character-creator/) SPA for the REST-driven character creator UI.
+
+Part of the foundry-toolkit monorepo at `apps/foundry-mcp` — see the root [CLAUDE.md](../../CLAUDE.md) for cross-workspace context.
 
 ## Tech Stack
 
@@ -78,7 +80,7 @@ Currently implemented: `rolls`, `chat`, `combat`.
 ## Git Workflow
 
 - All work MUST be done in git worktrees. Never work directly on main.
-- Worktree directory: `.claude/worktrees/<branch-name>`
+- Worktree directory: `.claude/worktrees/<branch-name>/` at the monorepo root (not per-app)
 - Push work to the remote frequently — at minimum after every logical unit of work, and always before ending a session.
 - All changes go through PRs to main. Never commit directly to main.
 - Run linting before committing. Fix lint errors before pushing.
@@ -116,6 +118,6 @@ The Docker image for Foundry+module itself lives in [foundry-api-bridge](https:/
 - WebSocket bridge to Foundry lives at `/foundry`; the module opens the WS outbound from the GM browser.
 - REST `/api/*` exposes the same data the MCP tools see (actors, items, compendia, scenes, etc.) for the character-creator SPA.
 - OpenAI SDK used specifically for GPT-image-1 map editing (not for chat).
-- Module and frontend live in separate repos now; contract between them is WS (module) + REST (frontend). No shared code.
+- Module and frontend live in sibling workspaces (`apps/foundry-api-bridge`, `apps/character-creator`); contract between them is WS (module) + REST (frontend). No shared code.
 - Server ships three ways: as a source zip (GitHub Releases, for systemd-on-Foundry-host), as a bare Node process, and as a Docker image on GHCR that bundles the character-creator SPA for single-container Fly.io deploys. The Foundry + module Docker image still lives in foundry-api-bridge; this repo's image is MCP server + SPA only.
 - The SPA bundle is pulled into the Dockerfile via `COPY --from=ghcr.io/alexdickerson/foundry-character-creator:latest` rather than bundled here — keeps the frontend on its own release cadence and avoids duplicate checkouts in CI.

--- a/apps/player-portal/CLAUDE.md
+++ b/apps/player-portal/CLAUDE.md
@@ -1,0 +1,60 @@
+# player-portal
+
+Player-facing React SPA plus its Fastify live-sync server. In prod, one `node server-dist/index.js` process serves the SPA, the `/api/*` live-sync routes (absorbed from the old standalone sidecar), and a `/map/*` reverse-proxy to `map.pathfinderwiki.com`.
+
+Part of the foundry-toolkit monorepo at `apps/player-portal` — see the root [CLAUDE.md](../../CLAUDE.md) for cross-workspace context.
+
+## Tech stack
+
+- React 19 + Vite, `react-router-dom` 7
+- Fastify 5 + `@fastify/static` + `@fastify/http-proxy` + `@fastify/websocket`
+- TypeScript; `tsx` for dev-watch; `concurrently` for dual-process dev
+- maplibre-gl + pmtiles on the client
+
+## Build & run
+
+Two processes in dev, one in prod:
+
+- `npm run dev` — `concurrently` runs Vite on `:5173` + `tsx watch server/index.ts` on `:3000`; Vite proxies `/api` and `/map` → `:3000`.
+- `npm run dev:client` / `dev:server` — each half independently.
+- `npm run build` = `build:client` (Vite → `dist/`) + `build:server` (`tsc -p tsconfig.server.json` → `server-dist/`).
+- `npm run start` — `node server-dist/index.js`; Fastify serves built `dist/` if present and falls back to `index.html` for SPA deep links.
+- `npm run typecheck` — runs both tsconfigs.
+- `npm run preview` — Vite preview of the built SPA only (no server).
+
+Env:
+
+- `PORT` (default `3000`), `HOST` (default `0.0.0.0`).
+- `SHARED_SECRET` — **required**; bearer-auth for `/api/*` POST endpoints (`Authorization: Bearer <secret>`). Reads/WS streams are unauthed.
+- `STATIC_DIR` — override the SPA directory (defaults to `<server-dist>/../dist`).
+
+## Project structure
+
+- `src/` — React client (routes under `react-router-dom`).
+- `server/index.ts` — Fastify entry + route registration.
+- `server/store.ts` — in-memory snapshot stores with subscribe/publish.
+- `server/types.ts` — `InventorySnapshot`, `AurusSnapshot`, `GlobeSnapshot`.
+- `tsconfig.json` — client (Vite). `tsconfig.server.json` — server (`tsc` → `server-dist/`).
+
+## Live-sync API shape
+
+Three datasets (`inventory`, `aurus`, `globe`), each with:
+
+- `GET /api/<name>` — current snapshot, unauthed.
+- `POST /api/<name>` — overwrite snapshot; bearer-auth required.
+- `GET /api/<name>/stream` (WebSocket) — snapshot on connect + pushed updates, unauthed.
+
+Also: `GET /health`, and a reverse-proxy at `/map/*` → `https://map.pathfinderwiki.com/` (replaces the old nginx block so PMTiles fetches are same-origin).
+
+## Key decisions / gotchas
+
+- `/api/*` routes are ex-sidecar — they were absorbed into the player-portal process. dm-tool's `electron/sidecar-client.ts` is the write-side consumer.
+- State is in-memory only; a restart loses the cache, and the DM auto-pushes on every edit so it refills in seconds.
+- Auth is a single shared bearer secret for writes. Reads + WS streams are intentionally public — players need them and nothing private lives in these feeds (DM notes stay in dm-tool's SQLite / Obsidian vault).
+- `/map/*` proxy keeps tile fetches same-origin so the browser's CORS check passes.
+- **`@foundry-toolkit/shared` is a devDependency**, not a dependency — the server uses it for types only, and Vite bundles it into the client. Easy to get wrong on a refactor.
+- This workspace is ignored by root ESLint; lint runs via its own workspace script.
+
+## Git workflow
+
+Worktrees at the monorepo root `.claude/worktrees/<branch-name>/`, PR-only, push frequently, lint + format before committing.

--- a/packages/ai/CLAUDE.md
+++ b/packages/ai/CLAUDE.md
@@ -1,0 +1,36 @@
+# @foundry-toolkit/ai
+
+PF2e GM assistant agents — chat, book classifier, encounter-hook generator, loot generator. Pure TS library. No Electron, no SQLite, deliberately portable.
+
+Part of the foundry-toolkit monorepo at `packages/ai` — see the root [CLAUDE.md](../../CLAUDE.md).
+
+## Tech stack
+
+- TypeScript (raw — consumers transpile)
+- Vercel AI SDK **v6** + `@ai-sdk/anthropic` v3
+- Zod v4 for tool/arg schemas
+
+## Build & run
+
+- `npm run typecheck` — no build step; consumers (dm-tool's electron-vite) handle transpilation.
+- `npm run harness` — `tsx harness/run.ts`; local eval harness for iterating on agents offline.
+
+## Project structure
+
+Subpath exports map to `src/<name>/index.ts`:
+
+- `.` — aggregate (`src/index.ts`)
+- `./chat` — two-pass chat agent (drafter + adversarial reviewer) with AoN + community tool calls
+- `./classifier` — book classifier
+- `./hooks` — encounter-hook generator
+- `./loot` — loot generator
+
+## Key decisions / gotchas
+
+- **AI SDK v6** is a major bump from v4/v5 — message shapes and tool-call return types differ. If you port code from an older AI-SDK project, expect to rewrite the stream/tool-result plumbing.
+- Consumed by `@foundry-toolkit/db` (type imports only) and `apps/dm-tool` (runtime). No Electron coupling — keeps the door open for lifting this package into its own repo with an eval harness later.
+- Chat agent uses an adversarial-review pattern (second pass critiques the first) — see `src/chat/`.
+
+## Git workflow
+
+Worktrees at the monorepo root `.claude/worktrees/<branch-name>/`, PR-only.

--- a/packages/db/CLAUDE.md
+++ b/packages/db/CLAUDE.md
@@ -1,0 +1,39 @@
+# @foundry-toolkit/db
+
+Single data layer for dm-tool's Electron main process. Wraps:
+
+- `pf2e.db` — module functions over the shared SQLite file (settings, inventory, combat, globe pins, Aurus, compendium reads)
+- `BookDb` — class that shares the `pf2e.db` connection for the book catalog
+- `MapDb` — read-only wrapper around the map-tagger SQLite index
+
+Part of the foundry-toolkit monorepo at `packages/db` — see the root [CLAUDE.md](../../CLAUDE.md).
+
+## Tech stack
+
+- TypeScript (raw — consumers transpile)
+- `better-sqlite3` (native module; rebuild handled by the root `postinstall`)
+
+## Build & run
+
+- `npm run typecheck` — no build step; dm-tool's electron-vite consumes raw TS.
+
+## Project structure
+
+Subpath exports map to `src/<name>/index.ts`:
+
+- `.` — aggregate (`src/index.ts`)
+- `./pf2e` — state DB (open/close + functional accessors)
+- `./books` — `BookDb` class
+- `./maps` — `MapDb` (read-only)
+
+## Key decisions / gotchas
+
+- Consumed **only** by dm-tool's Electron main process — never the renderer. If you find yourself importing from the renderer (`src/`), stop and route through IPC instead.
+- Depends on `@foundry-toolkit/ai` for type imports (one-way: db imports ai types, not vice versa).
+- `better-sqlite3` native rebuild: root `postinstall` covers it; `npm run rebuild-sqlite` is the manual escape hatch.
+- `MapDb` is read-only — the `tagger/` Python subtool is the writer of its index.
+- `BookDb` shares the `pf2e.db` connection; its constructor runs a `CREATE TABLE` migration for the books table.
+
+## Git workflow
+
+Worktrees at the monorepo root `.claude/worktrees/<branch-name>/`, PR-only.

--- a/packages/shared/CLAUDE.md
+++ b/packages/shared/CLAUDE.md
@@ -1,0 +1,36 @@
+# @foundry-toolkit/shared
+
+Types and shared UI components used across dm-tool and player-portal.
+
+Part of the foundry-toolkit monorepo at `packages/shared` — see the root [CLAUDE.md](../../CLAUDE.md).
+
+## Tech stack
+
+- TypeScript (raw — consumers transpile)
+- `peerDependencies`: `react >=19`, `maplibre-gl >=5` — consumers provide them.
+- `@iconify-json/game-icons` for glyph sets.
+
+## Build & run
+
+- `npm run typecheck`
+- `npm run test` — vitest
+
+## Project structure
+
+Subpath exports:
+
+- `.` / `./types` — `src/types.ts`
+- `./foundry-markup` — `src/foundry-markup.ts`
+- `./map-stem` — `src/map-stem.ts`
+- `./MissionBriefing` — `src/MissionBriefing.tsx` (React component)
+- `./golarion-map` — `src/golarion-map/index.ts`
+
+## Key decisions / gotchas
+
+- Peer-deps, not direct deps: consumers (dm-tool via electron-vite, player-portal via Vite) bundle React + maplibre-gl themselves. This package just imports them.
+- `./MissionBriefing` is a `.tsx` export — consumers must bundle it. Works fine under Vite / electron-vite; would need a compiler step if anything else consumed it.
+- Lives in the root-ESLint scope — root `eslint.config.js` only excludes `packages/*/dist/`, not source.
+
+## Git workflow
+
+Worktrees at the monorepo root `.claude/worktrees/<branch-name>/`, PR-only.


### PR DESCRIPTION
## Summary

- Adds **6 new** `CLAUDE.md` files (monorepo root, dm-tool, player-portal, and all three packages) so every workspace has a quick-orient doc.
- Updates the **3 existing** `CLAUDE.md` files (foundry-mcp, character-creator, foundry-api-bridge) with surgical edits only: monorepo pointer in intro, clarify worktree path is at the monorepo root, and refresh the stale "separate repos" phrasing.

All new files follow the existing *Tech Stack / Build & Run / Project Structure / Git Workflow / Key Decisions* format already in use.

## Highlights of the non-obvious bits surfaced

- **dm-tool**: three custom privileged protocols (`map-file://`, `book-file://`, `monster-file://`), session hook stripping `X-Frame-Options` and injecting CORS for `map.pathfinderwiki.com`, `extraResources` build-time dependency on `../../tagger/dist/map-tagger.exe` and `../../auto-wall-bin/Auto-Wall.exe`, Tailwind 4 JIT+HMR quirk.
- **player-portal**: dual-process dev model (Vite :5173 + Fastify :3000), ex-sidecar `/api/*` routes, `/map/*` reverse-proxy, `SHARED_SECRET` env required, `@foundry-toolkit/shared` as devDependency (not dependency).
- **packages**: subpath exports, peer-dep model for `shared`, `better-sqlite3` native rebuild for `db`, Vercel AI SDK v6 jump for `ai`.
- **Root**: workspace dependency graph, root ESLint scope caveat (only `apps/dm-tool` + `packages/*`), deferred deployments/CI status.

## Test plan

- [x] `prettier --check` on all new/updated `CLAUDE.md` files: clean.
- [x] Root ESLint run: 0 errors, 2 pre-existing warnings (both in `apps/dm-tool` TS files, unrelated to this PR).
- [x] Cold-read each file: "what does this workspace do, how do I run it, what will bite me" answerable in under 30 seconds.
- [ ] CI green on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)