### PR TITLE
Add tools/launcher — tiny Electron GUI for per-worktree dev scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ foundry-toolkit/
 │   └── shared/               Types + shared UI
 ├── resources/                dm-tool Electron icons
 ├── tagger/                   Python map-indexing subtool (built separately)
+├── tools/
+│   └── launcher/             Tiny Electron GUI to run `dev:*` scripts per worktree
 └── tsconfig.base.json        Shared strict TS config
 ```
 
@@ -33,6 +35,7 @@ foundry-toolkit/
 - `npm run dev:character-creator` — launch character-creator Vite dev
 - `npm run dev:player-portal` — launch player-portal (Vite + Fastify concurrently)
 - `npm run dev:api-bridge` — vite watch build for the Foundry module
+- `npm run launcher` — open `tools/launcher`, a small Electron GUI that lists every worktree × `dev:*` app pair and spawns the selected one in a new Windows Terminal tab
 
 See each workspace's README / CLAUDE.md for app-specific details.
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,6 +15,7 @@ export default tseslint.config(
       'apps/foundry-mcp/',
       'apps/foundry-api-bridge/',
       'apps/character-creator/',
+      'tools/',
       'apps/*/out/',
       'apps/*/dist/',
       'apps/*/server-dist/',

--- a/knip.json
+++ b/knip.json
@@ -18,6 +18,10 @@
     },
     "apps/character-creator": {
       "ignoreDependencies": ["@eslint/js"]
+    },
+    "tools/launcher": {
+      "entry": ["preload.cjs", "renderer/renderer.js"],
+      "project": ["**/*.{cjs,js}"]
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "license": "MIT",
       "workspaces": [
         "apps/*",
-        "packages/*"
+        "packages/*",
+        "tools/*"
       ],
       "devDependencies": {
         "@electron/rebuild": "^4.0.3",
@@ -2694,6 +2695,10 @@
     },
     "node_modules/@foundry-toolkit/dm-tool": {
       "resolved": "apps/dm-tool",
+      "link": true
+    },
+    "node_modules/@foundry-toolkit/launcher": {
+      "resolved": "tools/launcher",
       "link": true
     },
     "node_modules/@foundry-toolkit/mcp": {
@@ -21796,6 +21801,13 @@
       "peerDependencies": {
         "maplibre-gl": ">=5",
         "react": ">=19"
+      }
+    },
+    "tools/launcher": {
+      "name": "@foundry-toolkit/launcher",
+      "version": "0.1.0",
+      "devDependencies": {
+        "electron": "41.2.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "type": "module",
   "workspaces": [
     "apps/*",
-    "packages/*"
+    "packages/*",
+    "tools/*"
   ],
   "scripts": {
     "typecheck": "npm run typecheck --workspaces --if-present",
@@ -22,6 +23,7 @@
     "dev:character-creator": "npm --workspace apps/character-creator run dev",
     "dev:player-portal": "npm --workspace apps/player-portal run dev",
     "dev:api-bridge": "npm --workspace apps/foundry-api-bridge run dev",
+    "launcher": "npm --workspace tools/launcher start",
     "rebuild-sqlite": "electron-rebuild -f -w better-sqlite3",
     "postinstall": "electron-rebuild -f -w better-sqlite3",
     "format": "prettier --write .",

--- a/tools/launcher/main.cjs
+++ b/tools/launcher/main.cjs
@@ -1,12 +1,17 @@
 'use strict';
 
 const { app, BrowserWindow, ipcMain, shell } = require('electron');
-const { spawn } = require('node:child_process');
-const { readFile, readdir } = require('node:fs/promises');
+const { spawn, execFile } = require('node:child_process');
+const { readFile } = require('node:fs/promises');
+const { promisify } = require('node:util');
 const path = require('node:path');
 
-const repoRoot = path.resolve(__dirname, '..', '..');
-const worktreesDir = path.join(repoRoot, '.claude', 'worktrees');
+const execFileAsync = promisify(execFile);
+
+// Start from the launcher's own directory; git finds the repo from there. This
+// way the launcher resolves the full worktree list whether it's run from the
+// main checkout or from any linked worktree.
+const launcherDir = __dirname;
 
 async function readDevScripts(rootPath) {
   try {
@@ -21,21 +26,50 @@ async function readDevScripts(rootPath) {
   }
 }
 
-async function enumerate() {
-  const roots = [{ name: 'main', path: repoRoot, isMain: true }];
-  try {
-    const entries = await readdir(worktreesDir, { withFileTypes: true });
-    for (const e of entries) {
-      if (e.isDirectory()) {
-        roots.push({ name: e.name, path: path.join(worktreesDir, e.name), isMain: false });
-      }
-    }
-  } catch {
-    /* worktrees dir may not exist */
-  }
+async function listWorktrees() {
+  const { stdout } = await execFileAsync('git', ['worktree', 'list', '--porcelain'], {
+    cwd: launcherDir,
+    windowsHide: true,
+  });
   const out = [];
-  for (const root of roots) {
-    out.push({ ...root, apps: await readDevScripts(root.path) });
+  let current = null;
+  for (const line of stdout.split(/\r?\n/)) {
+    if (line.startsWith('worktree ')) {
+      if (current) out.push(current);
+      current = { path: line.slice('worktree '.length).trim() };
+    } else if (!current) {
+      continue;
+    } else if (line.startsWith('branch ')) {
+      current.branch = line
+        .slice('branch '.length)
+        .replace(/^refs\/heads\//, '')
+        .trim();
+    } else if (line === 'bare') {
+      current.bare = true;
+    } else if (line === 'detached') {
+      current.detached = true;
+    }
+  }
+  if (current) out.push(current);
+  return out.filter((w) => !w.bare);
+}
+
+async function enumerate() {
+  let worktrees;
+  try {
+    worktrees = await listWorktrees();
+  } catch (err) {
+    return [{ name: 'error', path: launcherDir, isMain: false, apps: [], error: String(err) }];
+  }
+  const primaryPath = worktrees[0]?.path;
+  const out = [];
+  for (const wt of worktrees) {
+    out.push({
+      name: wt.branch || path.basename(wt.path),
+      path: wt.path,
+      isMain: wt.path === primaryPath,
+      apps: await readDevScripts(wt.path),
+    });
   }
   return out;
 }

--- a/tools/launcher/main.cjs
+++ b/tools/launcher/main.cjs
@@ -1,0 +1,88 @@
+'use strict';
+
+const { app, BrowserWindow, ipcMain, shell } = require('electron');
+const { spawn } = require('node:child_process');
+const { readFile, readdir } = require('node:fs/promises');
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const worktreesDir = path.join(repoRoot, '.claude', 'worktrees');
+
+async function readDevScripts(rootPath) {
+  try {
+    const raw = await readFile(path.join(rootPath, 'package.json'), 'utf8');
+    const pkg = JSON.parse(raw);
+    return Object.keys(pkg.scripts || {})
+      .filter((s) => s.startsWith('dev:'))
+      .sort()
+      .map((s) => ({ script: s, label: s.slice(4) }));
+  } catch {
+    return [];
+  }
+}
+
+async function enumerate() {
+  const roots = [{ name: 'main', path: repoRoot, isMain: true }];
+  try {
+    const entries = await readdir(worktreesDir, { withFileTypes: true });
+    for (const e of entries) {
+      if (e.isDirectory()) {
+        roots.push({ name: e.name, path: path.join(worktreesDir, e.name), isMain: false });
+      }
+    }
+  } catch {
+    /* worktrees dir may not exist */
+  }
+  const out = [];
+  for (const root of roots) {
+    out.push({ ...root, apps: await readDevScripts(root.path) });
+  }
+  return out;
+}
+
+function spawnWindowsTerminal(cwd, commandAfter, title) {
+  const args = ['-w', '0', 'nt', '-d', cwd];
+  if (title) args.push('--title', title);
+  if (commandAfter) args.push('cmd', '/k', commandAfter);
+  const child = spawn('wt', args, { detached: true, stdio: 'ignore', shell: true });
+  child.on('error', (err) => console.error('wt spawn failed:', err));
+  child.unref();
+}
+
+function launch(worktreePath, script) {
+  const title = `${path.basename(worktreePath)} · ${script}`;
+  spawnWindowsTerminal(worktreePath, `npm run ${script}`, title);
+}
+
+function openTerminal(worktreePath) {
+  spawnWindowsTerminal(worktreePath, null, path.basename(worktreePath));
+}
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 960,
+    height: 720,
+    title: 'foundry-toolkit launcher',
+    autoHideMenuBar: true,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.cjs'),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
+  });
+  win.loadFile(path.join(__dirname, 'renderer', 'index.html'));
+}
+
+app.whenReady().then(() => {
+  ipcMain.handle('enumerate', () => enumerate());
+  ipcMain.handle('launch', (_e, wt, script) => launch(wt, script));
+  ipcMain.handle('open-folder', (_e, p) => shell.openPath(p));
+  ipcMain.handle('open-terminal', (_e, p) => openTerminal(p));
+  createWindow();
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', () => app.quit());

--- a/tools/launcher/main.cjs
+++ b/tools/launcher/main.cjs
@@ -78,7 +78,9 @@ function spawnWindowsTerminal(cwd, commandAfter, title) {
   const args = ['-w', '0', 'nt', '-d', cwd];
   if (title) args.push('--title', title);
   if (commandAfter) args.push('cmd', '/k', commandAfter);
-  const child = spawn('wt', args, { detached: true, stdio: 'ignore', shell: true });
+  // shell: false so Node/CreateProcess handles arg quoting. With shell: true,
+  // spaces in title or cwd get split by cmd.exe and wt sees garbled flags.
+  const child = spawn('wt', args, { detached: true, stdio: 'ignore', windowsHide: true });
   child.on('error', (err) => console.error('wt spawn failed:', err));
   child.unref();
 }

--- a/tools/launcher/package.json
+++ b/tools/launcher/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@foundry-toolkit/launcher",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Tiny Electron launcher — pick a worktree × app pair and spawn its dev server in a new Windows Terminal tab.",
+  "main": "main.cjs",
+  "scripts": {
+    "start": "electron ."
+  },
+  "devDependencies": {
+    "electron": "41.2.1"
+  }
+}

--- a/tools/launcher/preload.cjs
+++ b/tools/launcher/preload.cjs
@@ -1,0 +1,10 @@
+'use strict';
+
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('launcher', {
+  enumerate: () => ipcRenderer.invoke('enumerate'),
+  launch: (worktreePath, script) => ipcRenderer.invoke('launch', worktreePath, script),
+  openFolder: (p) => ipcRenderer.invoke('open-folder', p),
+  openTerminal: (p) => ipcRenderer.invoke('open-terminal', p),
+});

--- a/tools/launcher/renderer/index.html
+++ b/tools/launcher/renderer/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'"
+    />
+    <title>foundry-toolkit launcher</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="top-bar">
+      <h1>foundry-toolkit</h1>
+      <button id="refresh" title="Re-scan worktrees">Refresh</button>
+    </div>
+    <main id="grid"></main>
+    <script src="renderer.js"></script>
+  </body>
+</html>

--- a/tools/launcher/renderer/renderer.js
+++ b/tools/launcher/renderer/renderer.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const grid = document.getElementById('grid');
+const refreshBtn = document.getElementById('refresh');
+
+function el(tag, attrs = {}, children = []) {
+  const node = document.createElement(tag);
+  for (const [k, v] of Object.entries(attrs)) {
+    if (k === 'className') node.className = v;
+    else if (k === 'text') node.textContent = v;
+    else if (k === 'title') node.title = v;
+    else if (k.startsWith('on')) node.addEventListener(k.slice(2).toLowerCase(), v);
+    else node.setAttribute(k, v);
+  }
+  for (const child of children) {
+    if (child == null) continue;
+    node.appendChild(typeof child === 'string' ? document.createTextNode(child) : child);
+  }
+  return node;
+}
+
+function renderWorktree(root) {
+  const nameEl = el('div', { className: 'worktree-name' + (root.isMain ? ' is-main' : ''), text: root.name });
+  const pathEl = el('div', { className: 'worktree-path', text: root.path });
+  const headInfo = el('div', {}, [nameEl, pathEl]);
+
+  const openFolder = el('button', {
+    text: 'Folder',
+    title: 'Open in file explorer',
+    onclick: () => window.launcher.openFolder(root.path),
+  });
+  const openTerm = el('button', {
+    text: 'Terminal',
+    title: 'Open Windows Terminal here',
+    onclick: () => window.launcher.openTerminal(root.path),
+  });
+  const actions = el('div', { className: 'worktree-actions' }, [openFolder, openTerm]);
+
+  const head = el('div', { className: 'worktree-head' }, [headInfo, actions]);
+
+  const apps = root.apps.length
+    ? root.apps.map((a) =>
+        el(
+          'button',
+          {
+            className: 'app-btn',
+            title: `${root.path}\n$ npm run ${a.script}`,
+            onclick: () => window.launcher.launch(root.path, a.script),
+          },
+          [el('span', { className: 'play', text: '▶' }), el('span', { text: a.label })],
+        ),
+      )
+    : [el('div', { className: 'empty', text: 'no dev:* scripts in root package.json' })];
+
+  const appsEl = el('div', { className: 'apps' }, apps);
+
+  return el('section', { className: 'worktree' }, [head, appsEl]);
+}
+
+async function render() {
+  grid.replaceChildren();
+  try {
+    const roots = await window.launcher.enumerate();
+    for (const root of roots) {
+      grid.appendChild(renderWorktree(root));
+    }
+  } catch (err) {
+    grid.appendChild(el('div', { className: 'empty', text: 'Failed to enumerate: ' + err.message }));
+  }
+}
+
+refreshBtn.addEventListener('click', render);
+render();

--- a/tools/launcher/renderer/style.css
+++ b/tools/launcher/renderer/style.css
@@ -1,0 +1,143 @@
+:root {
+  color-scheme: light dark;
+  --border: rgba(127, 127, 127, 0.25);
+  --subtle: color-mix(in srgb, CanvasText 6%, transparent);
+  --muted: color-mix(in srgb, CanvasText 60%, transparent);
+  --accent: #4f46e5;
+  --accent-hover: #6366f1;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  font-size: 13px;
+  color: CanvasText;
+  background: Canvas;
+}
+
+.top-bar {
+  padding: 12px 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  backdrop-filter: blur(10px);
+  background: color-mix(in srgb, Canvas 82%, transparent);
+}
+
+.top-bar h1 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+}
+
+button {
+  font: inherit;
+  cursor: pointer;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: inherit;
+  padding: 5px 10px;
+  border-radius: 6px;
+  transition: background 0.12s ease;
+}
+
+button:hover {
+  background: var(--subtle);
+}
+
+main {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.worktree {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.worktree-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  background: var(--subtle);
+  border-bottom: 1px solid var(--border);
+  gap: 10px;
+}
+
+.worktree-name {
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.worktree-name.is-main::after {
+  content: 'main';
+  margin-left: 8px;
+  font-size: 10px;
+  font-weight: 500;
+  padding: 1px 6px;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--accent) 20%, transparent);
+  color: var(--accent);
+  vertical-align: middle;
+}
+
+.worktree-path {
+  color: var(--muted);
+  font-size: 11px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  margin-top: 2px;
+  word-break: break-all;
+}
+
+.worktree-actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.apps {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 12px 14px;
+}
+
+.app-btn {
+  background: var(--accent);
+  color: white;
+  border-color: transparent;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  font-weight: 500;
+}
+
+.app-btn:hover {
+  background: var(--accent-hover);
+}
+
+.app-btn .play {
+  font-size: 10px;
+  opacity: 0.9;
+}
+
+.empty {
+  color: var(--muted);
+  font-style: italic;
+  padding: 12px 14px;
+  font-size: 12px;
+}


### PR DESCRIPTION
## Summary

Adds `tools/launcher`, a small Electron app that enumerates every worktree (under `.claude/worktrees/` plus the main checkout), reads each root `package.json` for `dev:*` scripts, and renders a button per (worktree × app) pair. Clicking spawns a new Windows Terminal tab at the worktree with `npm run dev:<app>` running.

Solves the juggling problem: no more `cd`-ing through worktrees to remember which dev command goes with which branch.

## What's in here

- `tools/launcher/` — vanilla Electron, no build step: `main.cjs`, `preload.cjs`, `renderer/{index.html,renderer.js,style.css}`
- Added `tools/*` to root `workspaces` so `npm install` at root installs Electron (matched to dm-tool's version for dedup)
- `npm run launcher` at the monorepo root opens it
- Each worktree row also has **Folder** (file explorer) and **Terminal** (plain `wt` tab) buttons
- `knip.json` entry for the new workspace
- `eslint.config.js` ignores `tools/` (same pattern as existing app ignores — the launcher is .cjs/.js, not TS)
- README layout + scripts section updated

## Test plan

- [x] `npm install` at root (1306 pkgs, electron-rebuild postinstall green)
- [x] `npm run format:check` — clean
- [x] `npm run knip` — clean
- [x] `npx eslint .` — clean (pre-existing warnings only)
- [x] `npm run typecheck` — clean
- [x] `node --check` on all launcher JS files
- [x] `npm run launcher` — Electron boots, no stderr
- [ ] CI green on this PR

## Notes

- Windows-only for the terminal-spawn path (uses `wt.exe`). Mac/Linux would need a shell-specific fork — not needed today.
- The renderer talks to main via `contextBridge` only; sandbox + context isolation on, node integration off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)