### PR TITLE
Externalize better-sqlite3 from dm-tool main bundle

### DIFF
--- a/apps/dm-tool/electron.vite.config.ts
+++ b/apps/dm-tool/electron.vite.config.ts
@@ -13,9 +13,14 @@ import react from '@vitejs/plugin-react';
 // Vite transform them during build.
 const workspaceBundled = ['@foundry-toolkit/ai', '@foundry-toolkit/db', '@foundry-toolkit/shared'];
 
+// Native modules pulled in transitively by bundled workspace packages must be
+// re-externalized so their `.node` binaries resolve at runtime instead of
+// being inlined by Rollup (which breaks the `bindings` loader).
+const nativeDeps = ['better-sqlite3'];
+
 export default defineConfig({
   main: {
-    plugins: [externalizeDepsPlugin({ exclude: workspaceBundled })],
+    plugins: [externalizeDepsPlugin({ exclude: workspaceBundled, include: nativeDeps })],
     build: {
       rollupOptions: {
         input: {


### PR DESCRIPTION
## Summary
- `better-sqlite3` was being inlined into `apps/dm-tool/out/main/index.js` by Rollup, causing the `bindings` loader to fail at runtime with `the app could not dynamically require better_sqlite3`.
- Root cause: `externalizeDepsPlugin` only externalizes packages in dm-tool's own `dependencies`. `better-sqlite3` lives in `packages/db`'s deps, and `@foundry-toolkit/db` is in `workspaceBundled` — so the native-module require got bundled too.
- Fix: pass `include: ['better-sqlite3']` to the `externalizeDepsPlugin` for the main process so the require survives bundling and Electron can resolve the `.node` binary at runtime.

## Test plan
- [x] `npx electron-vite build` in `apps/dm-tool`
- [x] Verified `out/main/index.js` now has `import Database from "better-sqlite3"` instead of `requireBindings()("better_sqlite3.node")`
- [x] Prettier + lint clean on the changed file
- [ ] Manual: `npm run dev:dm-tool` from monorepo root launches without the runtime require error

🤖 Generated with [Claude Code](https://claude.com/claude-code)