### PR TITLE
Load env from monorepo root .env across all apps

### DIFF
--- a/apps/character-creator/vite.config.ts
+++ b/apps/character-creator/vite.config.ts
@@ -2,7 +2,13 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { loadRootEnv } from '@foundry-toolkit/shared/env';
 import { mockApi } from './mock/api-middleware';
+
+// Populate process.env from the monorepo root .env before FOUNDRY_URL /
+// MCP_URL are read below. `envDir` on the returned config tells Vite to
+// read the same file for `import.meta.env.VITE_*` lookups in source.
+loadRootEnv();
 
 // Dev server at :5173.
 //   /api/*         → foundry-mcp bridge on :8765 (our REST surface)
@@ -33,6 +39,7 @@ const fixturesDir = path.resolve(here, 'src', 'fixtures');
 export default defineConfig(({ mode }) => {
   const useMock = mode === 'mock';
   return {
+    envDir: path.resolve(here, '../..'),
     plugins: [react(), ...(useMock ? [mockApi(fixturesDir)] : [])],
     build: {
       outDir: 'dist',

--- a/apps/dm-tool/electron.vite.config.ts
+++ b/apps/dm-tool/electron.vite.config.ts
@@ -18,8 +18,15 @@ const workspaceBundled = ['@foundry-toolkit/ai', '@foundry-toolkit/db', '@foundr
 // being inlined by Rollup (which breaks the `bindings` loader).
 const nativeDeps = ['better-sqlite3'];
 
+// Monorepo root holds the single .env. All three build targets point at it
+// so Vite's `import.meta.env.VITE_*` resolution reads the same file. The
+// main process also calls loadRootEnv() at startup (via
+// @foundry-toolkit/shared/env-auto) for non-VITE-prefixed vars.
+const rootEnvDir = resolve(__dirname, '../..');
+
 export default defineConfig({
   main: {
+    envDir: rootEnvDir,
     plugins: [externalizeDepsPlugin({ exclude: workspaceBundled, include: nativeDeps })],
     build: {
       rollupOptions: {
@@ -30,6 +37,7 @@ export default defineConfig({
     },
   },
   preload: {
+    envDir: rootEnvDir,
     plugins: [externalizeDepsPlugin({ exclude: workspaceBundled })],
     build: {
       rollupOptions: {
@@ -40,6 +48,7 @@ export default defineConfig({
     },
   },
   renderer: {
+    envDir: rootEnvDir,
     root: __dirname,
     plugins: [react()],
     server: {

--- a/apps/dm-tool/electron/main.ts
+++ b/apps/dm-tool/electron/main.ts
@@ -11,6 +11,7 @@
 // Failures during startup show an error dialog and quit rather than
 // leaving the user staring at a blank window.
 
+import '@foundry-toolkit/shared/env-auto';
 import { app, BrowserWindow, dialog, ipcMain, Menu, protocol, net, session } from 'electron';
 import { dirname, join, normalize, sep, resolve as resolvePath } from 'node:path';
 import { pathToFileURL } from 'node:url';

--- a/apps/foundry-mcp/src/index.ts
+++ b/apps/foundry-mcp/src/index.ts
@@ -1,3 +1,4 @@
+import '@foundry-toolkit/shared/env-auto';
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { randomUUID } from 'node:crypto';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';

--- a/apps/player-portal/package.json
+++ b/apps/player-portal/package.json
@@ -19,6 +19,7 @@
     "@fastify/http-proxy": "^11.0.0",
     "@fastify/static": "^9.1.1",
     "@fastify/websocket": "^11.0.2",
+    "dotenv": "^16.6.1",
     "fastify": "^5.3.2",
     "maplibre-gl": "^5.23.0",
     "pmtiles": "^4.4.1",

--- a/apps/player-portal/server/index.ts
+++ b/apps/player-portal/server/index.ts
@@ -14,6 +14,7 @@
 // Reads/WS are unauthed since players need them and nothing private lives
 // in these feeds (DM notes stay in dm-tool's SQLite / Obsidian vault).
 
+import './load-env.js';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { existsSync } from 'node:fs';

--- a/apps/player-portal/server/load-env.ts
+++ b/apps/player-portal/server/load-env.ts
@@ -1,0 +1,47 @@
+// Side-effect module: loads the monorepo root `.env` into `process.env`
+// before any sibling import reads it. Imported first in server/index.ts.
+//
+// Inlined rather than pulling from @foundry-toolkit/shared so the server's
+// runtime footprint stays at Fastify + node_modules deps — shared is a
+// devDependency here (client bundles it, server only uses its types).
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { config as dotenvConfig } from 'dotenv';
+
+// Walk up from two plausible starting points (this file's location and
+// cwd). At each toolkit-root package.json, check for a sibling `.env` —
+// worktree checkouts share their parent's `.env` so we can't stop at the
+// first matching package.json.
+const starts = [dirname(fileURLToPath(import.meta.url)), process.cwd()];
+for (const start of starts) {
+  const envPath = findRootEnv(start);
+  if (envPath) {
+    dotenvConfig({ path: envPath, override: false });
+    break;
+  }
+}
+
+function findRootEnv(start: string): string | null {
+  let dir = start;
+  while (true) {
+    if (isToolkitRoot(dir)) {
+      const envPath = join(dir, '.env');
+      if (existsSync(envPath)) return envPath;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+function isToolkitRoot(dir: string): boolean {
+  const pkgPath = join(dir, 'package.json');
+  if (!existsSync(pkgPath)) return false;
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as { name?: string; workspaces?: unknown };
+    return pkg.name === 'foundry-toolkit' && !!pkg.workspaces;
+  } catch {
+    return false;
+  }
+}

--- a/apps/player-portal/vite.config.ts
+++ b/apps/player-portal/vite.config.ts
@@ -1,10 +1,19 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
 
 // In dev, Vite serves the SPA on :5173 and proxies API + map-tile traffic
 // to the Fastify server on :3000. In prod, Fastify serves the built
 // dist/ itself — Vite isn't in the loop.
+//
+// `envDir` points at the monorepo root so `import.meta.env.VITE_*` reads
+// from the single root .env. The Fastify server loads the same file at
+// startup via server/load-env.ts.
 export default defineConfig({
+  envDir: path.resolve(here, '../..'),
   plugins: [react()],
   build: {
     outDir: 'dist',

--- a/package-lock.json
+++ b/package-lock.json
@@ -152,6 +152,7 @@
         "@fastify/http-proxy": "^11.0.0",
         "@fastify/static": "^9.1.1",
         "@fastify/websocket": "^11.0.2",
+        "dotenv": "^16.6.1",
         "fastify": "^5.3.2",
         "maplibre-gl": "^5.23.0",
         "pmtiles": "^4.4.1",
@@ -10357,7 +10358,6 @@
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -21731,6 +21731,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@iconify-json/game-icons": "^1.2.3",
+        "dotenv": "^16.6.1",
         "zod": "^4.3.6"
       },
       "devDependencies": {

--- a/packages/ai/harness/run.ts
+++ b/packages/ai/harness/run.ts
@@ -4,9 +4,11 @@
 //   tsx harness/run.ts --fixture fixtures/chat/rules-frightened.json
 //   tsx harness/run.ts --fixture fixtures/chat/general-flanking.json --transcript
 //
-// Reads ANTHROPIC_API_KEY from env. No pf2e-db deps — tool lookups fall through
-// to Archives of Nethys (realistic for prompt iteration).
+// Reads ANTHROPIC_API_KEY from the monorepo root .env (or existing env).
+// No pf2e-db deps — tool lookups fall through to Archives of Nethys
+// (realistic for prompt iteration).
 
+import '@foundry-toolkit/shared/env-auto';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { basename, dirname, resolve } from 'node:path';
 import { parseArgs } from 'node:util';

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -7,6 +7,8 @@
   "exports": {
     ".": "./src/types.ts",
     "./types": "./src/types.ts",
+    "./env": "./src/env.ts",
+    "./env-auto": "./src/env-auto.ts",
     "./foundry-api": "./src/foundry-api.ts",
     "./foundry-markup": "./src/foundry-markup.ts",
     "./map-stem": "./src/map-stem.ts",
@@ -20,6 +22,7 @@
   },
   "dependencies": {
     "@iconify-json/game-icons": "^1.2.3",
+    "dotenv": "^16.6.1",
     "zod": "^4.3.6"
   },
   "peerDependencies": {

--- a/packages/shared/src/env-auto.ts
+++ b/packages/shared/src/env-auto.ts
@@ -1,0 +1,8 @@
+// Side-effect import: `import '@foundry-toolkit/shared/env-auto'` at the top
+// of a Node entry point loads the monorepo root `.env` before any sibling
+// import's top-level code runs (ESM evaluates dependencies depth-first).
+// Use this instead of calling `loadRootEnv()` yourself when you need env
+// vars visible during module initialization of other imports.
+import { loadRootEnv } from './env.js';
+
+loadRootEnv();

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -1,0 +1,53 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { config as dotenvConfig } from 'dotenv';
+
+// Monorepo-wide convention: every app reads env vars from the single
+// `.env` at the toolkit root. Per-app `.env` files are not loaded by
+// code — they exist only for docker-compose (`--env-file`). This helper
+// walks up looking for a toolkit-root package.json with an adjacent
+// `.env`. In a git worktree the `.env` is untracked and lives only at
+// the main checkout, so we keep walking past the first matching
+// package.json until we find one that actually has an `.env` beside it.
+// Existing process env wins; the .env only fills in anything missing.
+let loaded: string | null | undefined;
+
+export function loadRootEnv(): string | null {
+  if (loaded !== undefined) return loaded;
+  const starts = [dirname(fileURLToPath(import.meta.url)), process.cwd()];
+  for (const start of starts) {
+    const envPath = findRootEnv(start);
+    if (envPath) {
+      dotenvConfig({ path: envPath, override: false });
+      loaded = envPath;
+      return envPath;
+    }
+  }
+  loaded = null;
+  return null;
+}
+
+function findRootEnv(start: string): string | null {
+  let dir = start;
+  while (true) {
+    if (isToolkitRoot(dir)) {
+      const envPath = join(dir, '.env');
+      if (existsSync(envPath)) return envPath;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+function isToolkitRoot(dir: string): boolean {
+  const pkgPath = join(dir, 'package.json');
+  if (!existsSync(pkgPath)) return false;
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as { name?: string; workspaces?: unknown };
+    return pkg.name === 'foundry-toolkit' && !!pkg.workspaces;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Every foundry-toolkit app that reads `process.env` at runtime now pulls values from the single `.env` at the toolkit root — matching what `apps/foundry-api-bridge/local.sh` already does on the docker side. Per-app `.env` files stay available for docker-compose (`--env-file`) but are no longer loaded by app code.

## What changed

- `packages/shared/src/env.ts` — `loadRootEnv()` walks up for a toolkit-root `package.json` (name `foundry-toolkit` + `workspaces` field) with an adjacent `.env`. Passes through the first match if `.env` is absent, so git worktrees (which don't carry untracked `.env`) still resolve to the parent checkout's file. Existing `process.env` wins; the `.env` only fills in missing values.
- `packages/shared/src/env-auto.ts` — side-effect variant. Importing it as the first statement of a Node entry loads env before ESM dep-graph evaluation hits any module that reads `process.env` at init (e.g. `foundry-mcp/src/config.ts`'s top-level `const PORT = parseInt(process.env.PORT ...)`).
- **Node entry points** — first import is now `@foundry-toolkit/shared/env-auto`:
  - `apps/foundry-mcp/src/index.ts`
  - `apps/dm-tool/electron/main.ts`
  - `packages/ai/harness/run.ts`
- **player-portal server** — inlined loader at `server/load-env.ts`, imported first in `server/index.ts`. Avoided the shared import to keep the server's "shared is types-only" invariant intact (CLAUDE.md note; the client bundles shared, the Fastify server doesn't need it at runtime). Added `dotenv` to `apps/player-portal/dependencies`.
- **Vite configs** — `envDir` pinned to the monorepo root so `import.meta.env.VITE_*` reads from the same file:
  - `apps/character-creator/vite.config.ts` (plus `loadRootEnv()` at top since the config itself reads `process.env.FOUNDRY_URL` / `MCP_URL` at config-eval time)
  - `apps/player-portal/vite.config.ts`
  - `apps/dm-tool/electron.vite.config.ts` (main, preload, renderer)

## Out of scope

- `apps/foundry-api-bridge` — no runtime `process.env` reads (it's a Foundry VTT module). Its `local.sh` already passes the root `.env` to docker-compose via `--env-file` (landed in #7).
- `tools/launcher` — reads no env vars.
- Existing prod-deploy breakage for foundry-mcp (`node dist/index.js` can't resolve workspace `.ts` re-exports) is unchanged — noted as deferred in the root CLAUDE.md. Dev flows (`tsx`, `vite`, `electron-vite`) all resolve the new shared/env imports correctly.

## Test plan

- [x] `npm run typecheck` — all workspaces clean
- [x] `npm run test` — 50 shared + 11 pf2e-rules + 34 foundry-mcp tests pass
- [x] `npm run build` — character-creator, dm-tool (main/preload/renderer), api-bridge, foundry-mcp, player-portal (client + server) all build
- [x] `npm run format:check` — clean
- [x] Smoke: `loadRootEnv()` called from inside the worktree resolves the parent checkout's `E:/TTRPG/Tools/foundry-toolkit/.env` and populates `OPENAI_API_KEY` + `ALLOW_EVAL`
- [x] Smoke: `node apps/player-portal/server-dist/index.js` boots with `SHARED_SECRET` from env (prod path, no tsx)
- [ ] Smoke after merge: `dev:mcp` / `dev:dm-tool` / `dev:character-creator` / `dev:player-portal` / `ai` harness all pick up root `.env` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)