### PR TITLE
Port compendium cache, bulk pack-dump, and shop mode

### DIFF
--- a/apps/character-creator/src/api/types.test.ts
+++ b/apps/character-creator/src/api/types.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import type { PreparedActorItem } from './types';
+import { isPhysicalItem } from './types';
+
+// `isPhysicalItem` gates what renders in the Inventory tab and what
+// participates in buy/sell flows. pf2e's canonical list
+// (src/module/item/physical/values.ts upstream) includes ammo, shield,
+// and book alongside the obvious ones. A prior version of this guard
+// only covered 6 of the 9, which silently dropped purchased ammo from
+// the player-visible inventory.
+describe('isPhysicalItem', () => {
+  const PHYSICAL: string[] = ['weapon', 'armor', 'shield', 'equipment', 'consumable', 'ammo', 'treasure', 'backpack', 'book'];
+  const NON_PHYSICAL: string[] = ['feat', 'action', 'ancestry', 'class', 'heritage', 'lore', 'background', 'spell'];
+
+  for (const type of PHYSICAL) {
+    it(`accepts ${type} as a physical item`, () => {
+      const item = { id: 'x', name: 'x', type, img: '', system: {} } as unknown as PreparedActorItem;
+      expect(isPhysicalItem(item)).toBe(true);
+    });
+  }
+
+  for (const type of NON_PHYSICAL) {
+    it(`rejects ${type} as a non-physical item`, () => {
+      const item = { id: 'x', name: 'x', type, img: '', system: {} } as unknown as PreparedActorItem;
+      expect(isPhysicalItem(item)).toBe(false);
+    });
+  }
+});

--- a/apps/character-creator/src/api/types.ts
+++ b/apps/character-creator/src/api/types.ts
@@ -355,6 +355,8 @@ export interface StrikeItemSource {
     damage?: { dice: number; die: string; damageType: string };
     range?: number | null;
     traits?: { value: string[]; rarity: string };
+    runes?: { potency: number; striking: number; property: string[] };
+    bonusDamage?: { value: number };
   };
 }
 
@@ -374,6 +376,7 @@ export interface Strike {
   weaponTraits: StrikeTrait[];
   variants: StrikeVariant[];
   canAttack: boolean;
+  domains?: string[];
 }
 
 // ─── Feats (Feats tab) ─────────────────────────────────────────────────
@@ -521,7 +524,22 @@ export interface PhysicalItemSystem {
   [key: string]: unknown;
 }
 
-export type PhysicalItemType = 'weapon' | 'armor' | 'equipment' | 'consumable' | 'treasure' | 'backpack';
+// Full set of physical item types in the pf2e system. Sourced from
+// pf2e's `src/module/item/physical/values.ts` (PHYSICAL_ITEM_TYPES).
+// `ammo`, `shield`, and `book` are distinct top-level types in pf2e
+// (not subtypes of consumable/armor/equipment), so they need to be
+// listed here or they're silently filtered out of the Inventory tab
+// and the Buy/Sell flows.
+export type PhysicalItemType =
+  | 'weapon'
+  | 'armor'
+  | 'shield'
+  | 'equipment'
+  | 'consumable'
+  | 'ammo'
+  | 'treasure'
+  | 'backpack'
+  | 'book';
 
 export interface PhysicalItem {
   id: string;
@@ -534,10 +552,13 @@ export interface PhysicalItem {
 const PHYSICAL_ITEM_TYPES: readonly PhysicalItemType[] = [
   'weapon',
   'armor',
+  'shield',
   'equipment',
   'consumable',
+  'ammo',
   'treasure',
   'backpack',
+  'book',
 ];
 
 export function isPhysicalItem(item: PreparedActorItem): item is PhysicalItem {

--- a/apps/character-creator/src/components/layout/SheetHeader.tsx
+++ b/apps/character-creator/src/components/layout/SheetHeader.tsx
@@ -2,6 +2,10 @@ import type { PreparedCharacter } from '../../api/types';
 
 interface Props {
   character: PreparedCharacter;
+  /** When provided, renders a "← Actors" link to the right of the
+   *  name row. Lets the character sheet reclaim the row the button
+   *  used to occupy above the header. */
+  onBack?: () => void;
 }
 
 // Rarity pill colours borrowed from pf2e's _colors.scss rarity palette
@@ -23,7 +27,7 @@ const ALLIANCE_CLASSES: Record<string, string> = {
 // Ported in spirit from pf2e's
 // static/templates/actors/character/partials/header.hbs but
 // render-only (no name/level inputs, no XP bar).
-export function SheetHeader({ character }: Props): React.ReactElement {
+export function SheetHeader({ character, onBack }: Props): React.ReactElement {
   const { name, system, items } = character;
   const level = system.details.level.value;
   const ancestry = system.details.ancestry?.name;
@@ -47,6 +51,16 @@ export function SheetHeader({ character }: Props): React.ReactElement {
         )}
         {alliance && (
           <Badge data-badge="alliance" label={capitalise(alliance)} className={ALLIANCE_CLASSES[alliance] ?? ''} />
+        )}
+        {onBack && (
+          <button
+            type="button"
+            onClick={onBack}
+            data-testid="back-to-actors"
+            className="ml-auto rounded border border-neutral-300 bg-white px-2 py-1 text-xs text-neutral-700 hover:bg-neutral-50"
+          >
+            ← Actors
+          </button>
         )}
       </div>
       {subtitle && (

--- a/apps/character-creator/src/components/shop/ItemShopPicker.test.tsx
+++ b/apps/character-creator/src/components/shop/ItemShopPicker.test.tsx
@@ -1,0 +1,375 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+import { api } from '../../api/client';
+import type { CompendiumDocument, CompendiumMatch } from '../../api/types';
+import { ItemShopPicker } from './ItemShopPicker';
+
+// Build a synthetic match stream large enough to trigger multiple
+// pages at the ItemShopPicker's PAGE_SIZE (60).
+function makeMatches(n: number): CompendiumMatch[] {
+  return Array.from({ length: n }, (_, i) => ({
+    packId: 'pf2e.equipment-srd',
+    packLabel: 'Equipment',
+    documentId: `item-${i.toString().padStart(4, '0')}`,
+    uuid: `Compendium.pf2e.equipment-srd.Item.item-${i.toString().padStart(4, '0')}`,
+    name: `Item ${i.toString().padStart(4, '0')}`,
+    type: 'equipment',
+    img: '/icons/placeholder.svg',
+    level: 0,
+    // Embedded price — exercises the cache-hit path (no doc prefetch).
+    price: { value: { gp: (i % 10) + 1 } },
+  }));
+}
+
+describe('ItemShopPicker — pagination', () => {
+  let searchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    searchSpy = vi.spyOn(api, 'searchCompendium').mockResolvedValue({ matches: makeMatches(150) });
+  });
+
+  afterEach(() => {
+    searchSpy.mockRestore();
+    cleanup();
+  });
+
+  // The actual page size is derived at runtime via ResizeObserver
+  // against the grid's measured height. jsdom doesn't back that with
+  // real layout, so the component stays on its FALLBACK_PAGE_SIZE
+  // (24) in tests. Tests below read the page indicator rather than
+  // hard-coding the size, so they survive tweaks to either constant.
+  const countTiles = (container: HTMLElement): number =>
+    container.querySelectorAll('[data-item-uuid]').length;
+  const readPageCount = (container: HTMLElement): number => {
+    const text = container.querySelector('[data-role="page-indicator"]')?.textContent ?? '';
+    const match = /\d+ \/ (\d+)/.exec(text);
+    return match?.[1] ? Number(match[1]) : 1;
+  };
+  const readCurrentPage = (container: HTMLElement): number => {
+    const text = container.querySelector('[data-role="page-indicator"]')?.textContent ?? '';
+    const match = /(\d+) \/ \d+/.exec(text);
+    return match?.[1] ? Number(match[1]) : 1;
+  };
+
+  it('caps the rendered tiles to one page', async () => {
+    const { container } = render(<ItemShopPicker items={[]} onBuy={vi.fn()} pending={new Set()} />);
+    await waitFor(() => {
+      expect(container.querySelector('[data-role="page-indicator"]')).toBeTruthy();
+    });
+    const pageSize = countTiles(container);
+    expect(pageSize).toBeGreaterThan(0);
+    expect(pageSize).toBeLessThan(150);
+    // A 150-match fixture should always produce at least 2 pages.
+    expect(readPageCount(container)).toBeGreaterThanOrEqual(2);
+    // First page lands on item-0000.
+    expect(container.querySelector('[data-item-uuid$=".item-0000"]')).toBeTruthy();
+  });
+
+  it('Next / Prev advance and rewind by exactly one page', async () => {
+    const { container } = render(<ItemShopPicker items={[]} onBuy={vi.fn()} pending={new Set()} />);
+    await waitFor(() => {
+      expect(container.querySelector('[data-role="page-indicator"]')).toBeTruthy();
+    });
+    const pageSize = countTiles(container);
+    expect(readCurrentPage(container)).toBe(1);
+
+    fireEvent.click(container.querySelector('[data-testid="pagination-next"]') as HTMLElement);
+    await waitFor(() => {
+      expect(readCurrentPage(container)).toBe(2);
+    });
+    // Page 2 starts at item index = pageSize.
+    const page2First = `.item-${pageSize.toString().padStart(4, '0')}`;
+    expect(container.querySelector(`[data-item-uuid$="${page2First}"]`)).toBeTruthy();
+    expect(container.querySelector('[data-item-uuid$=".item-0000"]')).toBeFalsy();
+
+    fireEvent.click(container.querySelector('[data-testid="pagination-prev"]') as HTMLElement);
+    await waitFor(() => {
+      expect(readCurrentPage(container)).toBe(1);
+    });
+    expect(container.querySelector('[data-item-uuid$=".item-0000"]')).toBeTruthy();
+  });
+
+  it('disables Prev on page 1 and Next on the last page', async () => {
+    const { container } = render(<ItemShopPicker items={[]} onBuy={vi.fn()} pending={new Set()} />);
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="pagination-prev"]')).toBeTruthy();
+    });
+    expect((container.querySelector('[data-testid="pagination-prev"]') as HTMLButtonElement).disabled).toBe(true);
+    const lastPage = readPageCount(container);
+    // Walk Next until we reach the last page. Each click advances by
+    // exactly one page (no stale-closure compounding because React
+    // flushes between fireEvent invocations under RTL).
+    for (let i = 1; i < lastPage; i++) {
+      fireEvent.click(container.querySelector('[data-testid="pagination-next"]') as HTMLElement);
+    }
+    await waitFor(() => {
+      expect(readCurrentPage(container)).toBe(lastPage);
+    });
+    expect(
+      (container.querySelector('[data-testid="pagination-next"]') as HTMLButtonElement).disabled,
+    ).toBe(true);
+    // Last page holds 150 % pageSize items (or pageSize if 150 divides evenly).
+    const pageSize = 150 / lastPage; // conservative — only exact when 150 divides
+    const expectedLastTiles = 150 % Math.floor(pageSize) === 0 ? Math.floor(pageSize) : 150 % Math.floor(pageSize);
+    // `expectedLastTiles` is a loose guess; just assert the page is non-empty and ≤ pageSize.
+    expect(countTiles(container)).toBeGreaterThan(0);
+    expect(countTiles(container)).toBeLessThanOrEqual(Math.ceil(pageSize));
+    void expectedLastTiles;
+  });
+
+  it('resets to page 0 when the search query changes', async () => {
+    const { container } = render(<ItemShopPicker items={[]} onBuy={vi.fn()} pending={new Set()} />);
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="pagination-next"]')).toBeTruthy();
+    });
+    fireEvent.click(container.querySelector('[data-testid="pagination-next"]') as HTMLElement);
+    await waitFor(() => {
+      expect(readCurrentPage(container)).toBe(2);
+    });
+
+    // Re-set the mock with a distinct id prefix so we can confirm the
+    // NEW search result has landed (vs. just rewinding within the
+    // old 150-item set, which also has an "item-0000"). Small enough
+    // to fit on one page regardless of the dynamic page size.
+    const filteredMatches: CompendiumMatch[] = Array.from({ length: 5 }, (_, i) => ({
+      packId: 'pf2e.equipment-srd',
+      packLabel: 'Equipment',
+      documentId: `sword-${i.toString()}`,
+      uuid: `Compendium.pf2e.equipment-srd.Item.sword-${i.toString()}`,
+      name: `Sword ${i.toString()}`,
+      type: 'weapon',
+      img: '',
+      level: 0,
+      price: { value: { gp: 4 } },
+    }));
+    searchSpy.mockResolvedValue({ matches: filteredMatches });
+    const input = container.querySelector('[data-testid="shop-search"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'sword' } });
+    await waitFor(() => {
+      expect(container.querySelector('[data-item-uuid$=".sword-0"]')).toBeTruthy();
+    });
+    // Few-enough matches → single page, pagination controls collapse.
+    expect(container.querySelector('[data-testid="pagination-next"]')).toBeFalsy();
+  });
+
+  it('omits pagination controls when there is only one page', async () => {
+    searchSpy.mockResolvedValue({ matches: makeMatches(12) });
+    const { container } = render(<ItemShopPicker items={[]} onBuy={vi.fn()} pending={new Set()} />);
+    await waitFor(() => {
+      expect(container.querySelectorAll('[data-item-uuid]').length).toBe(12);
+    });
+    expect(container.querySelector('[data-testid="pagination-prev"]')).toBeFalsy();
+    expect(container.querySelector('[data-testid="pagination-next"]')).toBeFalsy();
+  });
+});
+
+describe('ItemShopPicker — price filter', () => {
+  let searchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    const mixed: CompendiumMatch[] = [
+      {
+        packId: 'pf2e.equipment-srd',
+        packLabel: 'Equipment',
+        documentId: 'free',
+        uuid: 'Compendium.pf2e.equipment-srd.Item.free',
+        name: 'Free Thing',
+        type: 'equipment',
+        img: '',
+        level: 0,
+        price: { value: {} }, // 0 cp — should be filtered
+      },
+      {
+        packId: 'pf2e.equipment-srd',
+        packLabel: 'Equipment',
+        documentId: 'paid',
+        uuid: 'Compendium.pf2e.equipment-srd.Item.paid',
+        name: 'Paid Thing',
+        type: 'equipment',
+        img: '',
+        level: 0,
+        price: { value: { gp: 2 } }, // non-zero — should be visible
+      },
+      {
+        packId: 'pf2e.equipment-srd',
+        packLabel: 'Equipment',
+        documentId: 'unknown',
+        uuid: 'Compendium.pf2e.equipment-srd.Item.unknown',
+        name: 'Unknown Price Thing',
+        type: 'equipment',
+        img: '',
+        level: 0,
+        // price omitted entirely — should remain visible (uncached pack case)
+      },
+    ];
+    searchSpy = vi.spyOn(api, 'searchCompendium').mockResolvedValue({ matches: mixed });
+  });
+
+  afterEach(() => {
+    searchSpy.mockRestore();
+    cleanup();
+  });
+
+  it('hides items whose embedded price is 0 cp', async () => {
+    const { container } = render(<ItemShopPicker items={[]} onBuy={vi.fn()} pending={new Set()} />);
+    await waitFor(() => {
+      expect(container.querySelectorAll('[data-item-uuid]').length).toBe(2);
+    });
+    expect(container.querySelector('[data-item-uuid$=".free"]')).toBeFalsy();
+    expect(container.querySelector('[data-item-uuid$=".paid"]')).toBeTruthy();
+    expect(container.querySelector('[data-item-uuid$=".unknown"]')).toBeTruthy();
+  });
+});
+
+describe('ItemShopPicker — detail overlay', () => {
+  let searchSpy: ReturnType<typeof vi.spyOn>;
+  let docSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    const match: CompendiumMatch = {
+      packId: 'pf2e.equipment-srd',
+      packLabel: 'Equipment',
+      documentId: 'bastard-sword',
+      uuid: 'Compendium.pf2e.equipment-srd.Item.bastard-sword',
+      name: 'Bastard Sword',
+      type: 'weapon',
+      img: '',
+      level: 0,
+      traits: ['two-hand-d12'],
+      price: { value: { gp: 4 } },
+    };
+    const doc: CompendiumDocument = {
+      id: 'bastard-sword',
+      uuid: match.uuid,
+      name: match.name,
+      type: match.type,
+      img: match.img,
+      system: {
+        description: { value: '<p>A broad-bladed sword with a long grip.</p>' },
+        traits: { value: ['two-hand-d12'] },
+        price: { value: { gp: 4 } },
+      },
+    };
+    searchSpy = vi.spyOn(api, 'searchCompendium').mockResolvedValue({ matches: [match] });
+    docSpy = vi.spyOn(api, 'getCompendiumDocument').mockResolvedValue({ document: doc });
+  });
+
+  afterEach(() => {
+    searchSpy.mockRestore();
+    docSpy.mockRestore();
+    cleanup();
+  });
+
+  it('opens the detail overlay when a tile is clicked', async () => {
+    const { container } = render(<ItemShopPicker items={[]} onBuy={vi.fn()} pending={new Set()} />);
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="shop-tile"]')).toBeTruthy();
+    });
+    expect(container.querySelector('[data-testid="shop-item-detail"]')).toBeFalsy();
+
+    fireEvent.click(container.querySelector('[data-testid="shop-tile"]') as HTMLElement);
+    const detail = container.querySelector('[data-testid="shop-item-detail"]');
+    expect(detail).toBeTruthy();
+    await waitFor(() => {
+      expect(detail?.textContent).toContain('broad-bladed sword');
+    });
+  });
+
+  it('closes the detail overlay via the × button', async () => {
+    const { container } = render(<ItemShopPicker items={[]} onBuy={vi.fn()} pending={new Set()} />);
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="shop-tile"]')).toBeTruthy();
+    });
+    fireEvent.click(container.querySelector('[data-testid="shop-tile"]') as HTMLElement);
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="shop-detail-close"]')).toBeTruthy();
+    });
+    fireEvent.click(container.querySelector('[data-testid="shop-detail-close"]') as HTMLElement);
+    expect(container.querySelector('[data-testid="shop-item-detail"]')).toBeFalsy();
+  });
+
+  it('closes the detail overlay on Escape', async () => {
+    const { container } = render(<ItemShopPicker items={[]} onBuy={vi.fn()} pending={new Set()} />);
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="shop-tile"]')).toBeTruthy();
+    });
+    fireEvent.click(container.querySelector('[data-testid="shop-tile"]') as HTMLElement);
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="shop-item-detail"]')).toBeTruthy();
+    });
+    act(() => {
+      fireEvent.keyDown(window, { key: 'Escape' });
+    });
+    expect(container.querySelector('[data-testid="shop-item-detail"]')).toBeFalsy();
+  });
+
+  it('clicking the tile Buy button does NOT open the detail overlay', async () => {
+    const wealthyItems = [
+      {
+        id: 'gp',
+        name: 'Gold Pieces',
+        type: 'treasure',
+        img: '',
+        system: {
+          slug: 'gold-pieces',
+          level: { value: 0 },
+          quantity: 100,
+          bulk: { value: 0 },
+          equipped: { carryType: 'worn' as const },
+          containerId: null,
+          traits: { value: [], rarity: 'common' },
+          category: 'coin',
+          price: { value: { gp: 1 } },
+        },
+      },
+    ] as unknown as Parameters<typeof ItemShopPicker>[0]['items'];
+    const onBuy = vi.fn().mockResolvedValue(undefined);
+    const { container } = render(<ItemShopPicker items={wealthyItems} onBuy={onBuy} pending={new Set()} />);
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="shop-buy"]')).toBeTruthy();
+    });
+    fireEvent.click(container.querySelector('[data-testid="shop-buy"]') as HTMLElement);
+    expect(container.querySelector('[data-testid="shop-item-detail"]')).toBeFalsy();
+    expect(onBuy).toHaveBeenCalledTimes(1);
+  });
+
+  it('Buy from the detail overlay calls onBuy and dismisses the overlay', async () => {
+    const onBuy = vi.fn().mockResolvedValue(undefined);
+    // Give the actor a pile of coins so the Buy button in the detail
+    // isn't disabled (the sword costs 4 gp).
+    const wealthyItems = [
+      {
+        id: 'gp',
+        name: 'Gold Pieces',
+        type: 'treasure',
+        img: '',
+        system: {
+          slug: 'gold-pieces',
+          level: { value: 0 },
+          quantity: 100,
+          bulk: { value: 0 },
+          equipped: { carryType: 'worn' as const },
+          containerId: null,
+          traits: { value: [], rarity: 'common' },
+          category: 'coin',
+          price: { value: { gp: 1 } },
+        },
+      },
+    ] as unknown as Parameters<typeof ItemShopPicker>[0]['items'];
+    const { container } = render(<ItemShopPicker items={wealthyItems} onBuy={onBuy} pending={new Set()} />);
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="shop-tile"]')).toBeTruthy();
+    });
+    fireEvent.click(container.querySelector('[data-testid="shop-tile"]') as HTMLElement);
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="shop-detail-buy"]')).toBeTruthy();
+    });
+    await act(async () => {
+      fireEvent.click(container.querySelector('[data-testid="shop-detail-buy"]') as HTMLElement);
+    });
+    expect(onBuy).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="shop-item-detail"]')).toBeFalsy();
+    });
+  });
+});

--- a/apps/character-creator/src/components/shop/ItemShopPicker.tsx
+++ b/apps/character-creator/src/components/shop/ItemShopPicker.tsx
@@ -1,0 +1,791 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { api } from '../../api/client';
+import type {
+  CompendiumDocument,
+  CompendiumMatch,
+  CompendiumSearchOptions,
+  ItemPrice,
+  PreparedActorItem,
+} from '../../api/types';
+import { formatCp, priceToCp, sumActorCoinsCp } from '../../lib/coins';
+import { enrichDescription } from '../../lib/foundry-enrichers';
+
+export interface BuyRequest {
+  match: CompendiumMatch;
+  unitPriceCp: number;
+}
+
+interface Props {
+  items: readonly PreparedActorItem[];
+  onBuy: (req: BuyRequest) => Promise<void>;
+  pending: Set<string>;
+}
+
+// Equipment packs available for browsing. More packs can be appended
+// here — the server reads all of them via CompendiumSearchOptions.packIds.
+const EQUIPMENT_PACKS: readonly { id: string; label: string }[] = [
+  { id: 'pf2e.equipment-srd', label: 'Equipment' },
+];
+
+// Narrower item-type filter chips. Names follow pf2e's
+// `system.category` / `type` taxonomy loosely; the picker uses them
+// as a free-text filter that checks a match's displayed type + traits.
+type TypeFilter = 'all' | 'weapon' | 'armor' | 'consumable' | 'equipment' | 'backpack';
+
+const TYPE_FILTERS: Array<{ id: TypeFilter; label: string }> = [
+  { id: 'all', label: 'All' },
+  { id: 'weapon', label: 'Weapons' },
+  { id: 'armor', label: 'Armor' },
+  { id: 'consumable', label: 'Consumables' },
+  { id: 'equipment', label: 'Equipment' },
+  { id: 'backpack', label: 'Containers' },
+];
+
+const DEBOUNCE_MS = 220;
+// Server cap (foundry-mcp src/http/schemas.ts) is 10k; keep the
+// client request below that so a single round-trip fits every item
+// in the largest pf2e pack (equipment-srd ≈ 5.6k). Cached searches
+// filter/sort in-memory (microseconds); uncached searches iterate
+// the full index either way, so this ceiling just sizes the response.
+// The banner below the grid still kicks in on the rare search that
+// would exceed this — narrowing by type/name/level keeps it cheap.
+const SEARCH_LIMIT = 10_000;
+
+// Conservative fallback page size when the ResizeObserver hasn't
+// measured the grid yet (e.g. first render, or in unit tests that
+// render outside a real DOM). The visible page adapts to the grid's
+// actual dimensions on mount via `useFitPageSize` below.
+const FALLBACK_PAGE_SIZE = 24;
+
+// Approximate tile box (including gap). Used with ResizeObserver to
+// compute how many whole tiles fit in the available grid area without
+// introducing a scroll bar. The grid itself uses
+// `minmax(9rem, 1fr)` columns + `gap-2` (8px); 9rem = 144px.
+const TILE_WIDTH_PX = 144;
+const TILE_HEIGHT_PX = 146; // ≈ img h-12 + name line + level + price + buy btn + padding
+const GRID_GAP_PX = 8;
+// Floor for the computed page size so we never land on "0 tiles per
+// page" in extremely narrow viewports.
+const MIN_FIT_PAGE_SIZE = 6;
+
+// Breathing room between the grid's bottom edge and the viewport's
+// bottom. Sized to cover the sibling content below the grid that the
+// grid itself doesn't account for: the bottom pagination bar (~32px)
+// plus the main container's bottom padding (p-6 = 24px), with a
+// small safety margin so a horizontal scrollbar never kicks in.
+const VIEWPORT_BOTTOM_MARGIN_PX = 72;
+
+function useFitPageSize(): {
+  pageSize: number;
+  maxHeight: number | null;
+  gridRef: (el: HTMLUListElement | null) => void;
+} {
+  const [pageSize, setPageSize] = useState(FALLBACK_PAGE_SIZE);
+  const [maxHeight, setMaxHeight] = useState<number | null>(null);
+  // The grid is conditionally rendered (only after results arrive),
+  // so a plain RefObject whose effect runs once on mount would never
+  // see the populated element. A callback ref fires synchronously
+  // when the element attaches/detaches, so we wire the observer
+  // there instead of in a useEffect.
+  const [gridEl, setGridEl] = useState<HTMLUListElement | null>(null);
+  const gridRef = useCallback((el: HTMLUListElement | null) => {
+    setGridEl(el);
+  }, []);
+
+  useEffect(() => {
+    if (!gridEl || typeof ResizeObserver === 'undefined') return;
+    const recompute = (): void => {
+      // Derive the vertical budget from the grid's own offset in the
+      // viewport rather than hard-coding "minus some rem". That way
+      // the cap adapts when the header, filter bar, or chip row
+      // changes height — grid stays fully above the fold regardless.
+      const rect = gridEl.getBoundingClientRect();
+      const availableHeight = Math.max(200, window.innerHeight - rect.top - VIEWPORT_BOTTOM_MARGIN_PX);
+      setMaxHeight(availableHeight);
+
+      const widthForGrid = gridEl.clientWidth || rect.width;
+      if (widthForGrid === 0) return;
+      const cols = Math.max(1, Math.floor((widthForGrid + GRID_GAP_PX) / (TILE_WIDTH_PX + GRID_GAP_PX)));
+      const rows = Math.max(1, Math.floor((availableHeight + GRID_GAP_PX) / (TILE_HEIGHT_PX + GRID_GAP_PX)));
+      setPageSize(Math.max(MIN_FIT_PAGE_SIZE, cols * rows));
+    };
+    recompute();
+    const ro = new ResizeObserver(recompute);
+    ro.observe(gridEl);
+    // Grid's offset can change when the window height changes even
+    // if its own size doesn't (ResizeObserver wouldn't fire). Hook
+    // window resize too.
+    window.addEventListener('resize', recompute);
+    return (): void => {
+      ro.disconnect();
+      window.removeEventListener('resize', recompute);
+    };
+  }, [gridEl]);
+
+  return { pageSize, maxHeight, gridRef };
+}
+
+export function ItemShopPicker({ items, onBuy, pending }: Props): React.ReactElement {
+  const [query, setQuery] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+  const [maxLevel, setMaxLevel] = useState<number | ''>('');
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>('all');
+  const [packId, setPackId] = useState<string>(EQUIPMENT_PACKS[0]?.id ?? '');
+  const [matches, setMatches] = useState<CompendiumMatch[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Zero-indexed page within the current filtered result set.
+  // Re-zeroed whenever any filter input changes so the user never
+  // ends up on an out-of-range page after narrowing.
+  const [page, setPage] = useState(0);
+  // Prefetched prices keyed by uuid. `undefined` means "not yet
+  // fetched", `null` means "fetched but no price / error — treat as 0".
+  const [prices, setPrices] = useState<Map<string, ItemPrice | null>>(new Map());
+  // When non-null, the item detail overlay covers the grid. The
+  // match carries the identifying uuid + lean fields; the overlay
+  // lazily fetches the full document for description + traits.
+  const [selectedMatch, setSelectedMatch] = useState<CompendiumMatch | null>(null);
+
+  const purseCp = useMemo(() => sumActorCoinsCp(items), [items]);
+
+  // Debounce the search-as-you-type so the picker doesn't fire a
+  // compendium query on every keystroke.
+  useEffect(() => {
+    const t = window.setTimeout(() => {
+      setDebouncedQuery(query.trim());
+    }, DEBOUNCE_MS);
+    return (): void => {
+      window.clearTimeout(t);
+    };
+  }, [query]);
+
+  // Track the latest search invocation so stale responses don't
+  // overwrite fresh ones if the user changes filters mid-flight.
+  const searchTokenRef = useRef(0);
+  useEffect(() => {
+    if (packId === '') return;
+    const token = ++searchTokenRef.current;
+    const opts: CompendiumSearchOptions = {
+      packIds: [packId],
+      documentType: 'Item',
+      limit: SEARCH_LIMIT,
+      ...(debouncedQuery.length > 0 ? { q: debouncedQuery } : {}),
+      ...(maxLevel !== '' ? { maxLevel } : {}),
+    };
+    // Kick off loading state in a microtask so React doesn't treat
+    // the synchronous setState in this effect as a cascade.
+    queueMicrotask(() => {
+      if (token !== searchTokenRef.current) return;
+      setLoading(true);
+      setError(null);
+    });
+    api
+      .searchCompendium(opts)
+      .then((result) => {
+        if (token !== searchTokenRef.current) return;
+        setMatches(result.matches);
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (token !== searchTokenRef.current) return;
+        const msg = err instanceof Error ? err.message : String(err);
+        setError(msg);
+        setLoading(false);
+      });
+  }, [debouncedQuery, maxLevel, packId]);
+
+  const filtered = useMemo(() => {
+    const typed = filterMatchesByType(matches, typeFilter);
+    // Hide items with a known price of 0 cp — those are class/feat
+    // effect tokens or other "not actually for sale" artifacts that
+    // the compendium still carries as `Item` docs. Matches without a
+    // price field at all (e.g. uncached packs where price isn't
+    // embedded) remain visible; the tile price prefetch and the
+    // detail overlay pick up the real number later.
+    return typed.filter((m) => m.price === undefined || priceToCp(m.price) > 0);
+  }, [matches, typeFilter]);
+  // The grid's height is capped (see `gridRef` below) and the page
+  // size adapts to however many tiles fit at the current viewport via
+  // ResizeObserver + window-resize. Falling back to
+  // FALLBACK_PAGE_SIZE before the first measurement keeps SSR/tests
+  // deterministic.
+  const { pageSize, maxHeight, gridRef } = useFitPageSize();
+  const pageCount = Math.max(1, Math.ceil(filtered.length / pageSize));
+  // Clamp on every render so the page stays valid even if the result
+  // set shrinks (e.g. stricter filter) between renders. The effect
+  // below resets to page 0 on filter input changes; this clamp
+  // protects against any other shrink paths (e.g. async refetch).
+  const clampedPage = Math.min(page, pageCount - 1);
+  const pageStart = clampedPage * pageSize;
+  const pageSlice = useMemo(
+    () => filtered.slice(pageStart, pageStart + pageSize),
+    [filtered, pageStart, pageSize],
+  );
+
+  // Any filter input change → back to page 0. Keeps the user from
+  // landing on "page 27 of 2" after narrowing a 1000-result search
+  // down to 80. Done via a render-time comparison (React's
+  // recommended pattern for derived reset state) rather than an
+  // effect, which would trigger the set-state-in-effect lint and an
+  // extra render pass.
+  const filterKey = `${debouncedQuery}|${maxLevel.toString()}|${packId}|${typeFilter}`;
+  const [lastFilterKey, setLastFilterKey] = useState(filterKey);
+  if (filterKey !== lastFilterKey) {
+    setLastFilterKey(filterKey);
+    setPage(0);
+  }
+
+  // Prefetch prices for results that didn't come with `match.price`
+  // already attached. Cached packs (served from foundry-mcp's
+  // compendium-cache) embed the price on each match, so this loop
+  // short-circuits — no per-tile getCompendiumDocument calls in the
+  // common case. Scoped to the current page so uncached packs don't
+  // fire off thousands of fetches up-front.
+  useEffect(() => {
+    const needed = pageSlice.filter((m) => m.price === undefined && !prices.has(m.uuid));
+    if (needed.length === 0) return;
+    let cancelled = false;
+    const queue = [...needed];
+    const CONCURRENCY = 6;
+    const workers = Array.from({ length: Math.min(CONCURRENCY, queue.length) }, async () => {
+      while (queue.length > 0) {
+        if (cancelled) return;
+        const m = queue.shift();
+        if (!m) break;
+        try {
+          const { document } = await api.getCompendiumDocument(m.uuid);
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- cancelled toggles asynchronously in cleanup
+          if (cancelled) return;
+          setPrices((prev) => {
+            if (prev.has(m.uuid)) return prev;
+            const next = new Map(prev);
+            next.set(m.uuid, extractPriceFromDocument(document));
+            return next;
+          });
+        } catch {
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- cancelled toggles asynchronously in cleanup
+          if (cancelled) return;
+          setPrices((prev) => {
+            if (prev.has(m.uuid)) return prev;
+            const next = new Map(prev);
+            next.set(m.uuid, null);
+            return next;
+          });
+        }
+      }
+    });
+    void Promise.all(workers);
+    return (): void => {
+      cancelled = true;
+    };
+  }, [pageSlice, prices]);
+
+  const emptyResults = filtered.length === 0;
+
+  return (
+    <div className="space-y-2" data-section="shop-picker">
+      {/* Single-row control strip: search (flex-1), max-level, optional
+          pack selector, then pagination pinned to the right. Keeps the
+          shop's chrome to ~2 rows (this row + the type-chip row). */}
+      <div className="flex flex-wrap items-center gap-2">
+        <input
+          type="search"
+          value={query}
+          placeholder="Search equipment…"
+          onChange={(e): void => {
+            setQuery(e.target.value);
+          }}
+          className="min-w-[10rem] flex-1 rounded border border-pf-border bg-white px-2 py-1 text-sm"
+          data-testid="shop-search"
+        />
+        <label className="flex items-center gap-1 text-xs text-pf-alt-dark">
+          <span>Max level</span>
+          <input
+            type="number"
+            min={0}
+            max={30}
+            value={maxLevel}
+            onChange={(e): void => {
+              const v = e.target.value;
+              setMaxLevel(v === '' ? '' : Number(v));
+            }}
+            className="w-16 rounded border border-pf-border bg-white px-1 py-0.5 text-sm"
+          />
+        </label>
+        {EQUIPMENT_PACKS.length > 1 && (
+          <select
+            value={packId}
+            onChange={(e): void => {
+              setPackId(e.target.value);
+            }}
+            className="rounded border border-pf-border bg-white px-2 py-1 text-sm"
+          >
+            {EQUIPMENT_PACKS.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.label}
+              </option>
+            ))}
+          </select>
+        )}
+        {!emptyResults && (
+          <PaginationControls
+            page={clampedPage}
+            pageCount={pageCount}
+            onPageChange={setPage}
+            capHit={matches.length >= SEARCH_LIMIT}
+            capLimit={SEARCH_LIMIT}
+          />
+        )}
+      </div>
+
+      <ul className="flex flex-wrap gap-1" role="group" aria-label="Item type filter">
+        {TYPE_FILTERS.map((tf) => (
+          <li key={tf.id}>
+            <button
+              type="button"
+              aria-pressed={typeFilter === tf.id}
+              onClick={(): void => {
+                setTypeFilter(tf.id);
+              }}
+              className={[
+                'rounded-full border px-2 py-0.5 text-[11px] font-medium uppercase tracking-wider',
+                typeFilter === tf.id
+                  ? 'border-pf-primary bg-pf-primary text-white'
+                  : 'border-pf-border bg-white text-pf-alt-dark hover:bg-pf-bg-dark/40',
+              ].join(' ')}
+            >
+              {tf.label}
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      {error !== null && (
+        <p className="rounded border border-red-200 bg-red-50 px-2 py-1 text-xs text-red-800">
+          Search failed: {error}
+        </p>
+      )}
+
+      {loading && emptyResults ? (
+        <p className="text-sm italic text-pf-alt-dark">Loading…</p>
+      ) : emptyResults ? (
+        <p className="text-sm italic text-pf-alt-dark">No items match.</p>
+      ) : (
+        <>
+          {/* `relative` scopes the detail overlay's `absolute inset-0`
+              so it covers only the grid area, not the whole page. */}
+          <div className="relative">
+            <ul
+              ref={gridRef}
+              className="grid gap-2 overflow-hidden"
+              style={{
+                gridTemplateColumns: 'repeat(auto-fill, minmax(9rem, 1fr))',
+                // maxHeight is measured from the grid's live offset so
+                // the grid never extends past the viewport. Falls back
+                // to a conservative ceiling before the first measure.
+                maxHeight: maxHeight !== null ? `${maxHeight.toString()}px` : 'calc(100dvh - 20rem)',
+              }}
+              data-testid="shop-grid"
+            >
+              {pageSlice.map((m) => (
+                <ShopTile
+                  key={m.uuid}
+                  match={m}
+                  priceState={resolvePriceState(m, prices)}
+                  purseCp={purseCp}
+                  buying={pending.has(m.uuid)}
+                  onOpen={(): void => {
+                    setSelectedMatch(m);
+                  }}
+                  onBuy={(unitPriceCp): Promise<void> => onBuy({ match: m, unitPriceCp })}
+                />
+              ))}
+            </ul>
+            {selectedMatch && (
+              <ShopItemDetail
+                match={selectedMatch}
+                purseCp={purseCp}
+                buying={pending.has(selectedMatch.uuid)}
+                onBuy={async (unitPriceCp): Promise<void> => {
+                  await onBuy({ match: selectedMatch, unitPriceCp });
+                  setSelectedMatch(null);
+                }}
+                onClose={(): void => {
+                  setSelectedMatch(null);
+                }}
+              />
+            )}
+          </div>
+          {pageCount > 1 && (
+            <div className="flex justify-end" data-role="pagination" data-position="bottom">
+              <PaginationControls
+                page={clampedPage}
+                pageCount={pageCount}
+                onPageChange={setPage}
+                capHit={matches.length >= SEARCH_LIMIT}
+                capLimit={SEARCH_LIMIT}
+              />
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+// Compact Prev / N / M / Next strip. No result-count text — the grid
+// density already communicates scale, and omitting it lets the whole
+// control strip live inline with the filters.
+function PaginationControls({
+  page,
+  pageCount,
+  onPageChange,
+  capHit,
+  capLimit,
+}: {
+  page: number;
+  pageCount: number;
+  onPageChange: (p: number) => void;
+  capHit: boolean;
+  capLimit: number;
+}): React.ReactElement | null {
+  if (pageCount <= 1 && !capHit) return null;
+  return (
+    <div className="ml-auto flex items-center gap-1 text-xs text-pf-alt-dark">
+      {capHit && (
+        <span
+          className="mr-1 rounded border border-amber-200 bg-amber-50 px-1.5 py-0.5 text-[10px] text-amber-900"
+          data-role="result-cap-hint"
+          title={`Capped at ${capLimit.toString()} matches — narrow to see more`}
+        >
+          {capLimit.toString()}+
+        </span>
+      )}
+      {pageCount > 1 && (
+        <>
+          <button
+            type="button"
+            disabled={page === 0}
+            onClick={(): void => {
+              onPageChange(page - 1);
+            }}
+            data-testid="pagination-prev"
+            aria-label="Previous page"
+            className="rounded border border-pf-border bg-white px-1.5 py-0.5 font-medium text-pf-alt-dark hover:bg-pf-bg-dark/40 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            ←
+          </button>
+          <span className="px-1 font-mono tabular-nums" data-role="page-indicator">
+            {(page + 1).toString()} / {pageCount.toString()}
+          </span>
+          <button
+            type="button"
+            disabled={page >= pageCount - 1}
+            onClick={(): void => {
+              onPageChange(page + 1);
+            }}
+            data-testid="pagination-next"
+            aria-label="Next page"
+            className="rounded border border-pf-border bg-white px-1.5 py-0.5 font-medium text-pf-alt-dark hover:bg-pf-bg-dark/40 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            →
+          </button>
+        </>
+      )}
+    </div>
+  );
+}
+
+type PriceState = { kind: 'loading' } | { kind: 'ready'; price: ItemPrice | null };
+
+// Priority for the per-tile price:
+//   1. `match.price` when the server embedded it (cache hit) — instant
+//   2. The lazy-loaded prices Map (uncached packs)
+//   3. Loading state while the prefetch is in flight
+function resolvePriceState(match: CompendiumMatch, prefetched: Map<string, ItemPrice | null>): PriceState {
+  if (match.price !== undefined) return { kind: 'ready', price: match.price };
+  if (prefetched.has(match.uuid)) return { kind: 'ready', price: prefetched.get(match.uuid) ?? null };
+  return { kind: 'loading' };
+}
+
+function ShopTile({
+  match,
+  priceState,
+  purseCp,
+  buying,
+  onOpen,
+  onBuy,
+}: {
+  match: CompendiumMatch;
+  priceState: PriceState;
+  purseCp: number;
+  buying: boolean;
+  onOpen: () => void;
+  onBuy: (unitPriceCp: number) => Promise<void>;
+}): React.ReactElement {
+  const price = priceState.kind === 'ready' ? priceState.price : null;
+  const unitPriceCp = price ? priceToCp(price) : 0;
+  const priceText =
+    priceState.kind === 'loading' ? '…' : price ? formatCp(unitPriceCp) : '—';
+  const priceReady = priceState.kind === 'ready';
+  // Free items (0 cp) remain buyable. When price data hasn't loaded
+  // yet we optimistically allow hitting Buy — the real cost will be
+  // enforced when the buy handler re-checks the actor's purse.
+  const canAfford = !priceReady || unitPriceCp === 0 || purseCp >= unitPriceCp;
+
+  return (
+    <li
+      className="flex flex-col items-center gap-1 rounded border border-pf-border bg-white p-2 text-center transition-shadow hover:cursor-pointer hover:shadow-md"
+      data-item-uuid={match.uuid}
+      data-affordable={canAfford ? 'true' : 'false'}
+      onClick={(e): void => {
+        // The Buy button lives inside this tile, so clicks on the
+        // button would otherwise fall through to the tile click
+        // handler and pop the detail overlay. Skip when the click
+        // target is (or is inside) an interactive child.
+        if ((e.target as HTMLElement).closest('button, a, input')) return;
+        onOpen();
+      }}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e): void => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+      data-testid="shop-tile"
+    >
+      <img src={match.img} alt="" className="h-12 w-12 rounded border border-pf-border bg-pf-bg-dark" />
+      <span className="line-clamp-2 text-[11px] font-medium leading-tight text-pf-text" title={match.name}>
+        {match.name}
+      </span>
+      {typeof match.level === 'number' && (
+        <span className="text-[10px] uppercase tracking-widest text-pf-alt-dark">Level {match.level}</span>
+      )}
+      <span className="font-mono text-[10px] tabular-nums text-pf-alt-dark" data-role="tile-price">
+        {priceText}
+      </span>
+      <button
+        type="button"
+        onClick={(e): void => {
+          // Stop the tile's click handler from also firing and
+          // popping the detail overlay — the user's intent with a
+          // Buy click is purchase, not inspect.
+          e.stopPropagation();
+          void onBuy(unitPriceCp);
+        }}
+        disabled={!canAfford || buying}
+        data-testid="shop-buy"
+        className={[
+          'mt-auto w-full rounded border px-2 py-0.5 text-xs font-semibold uppercase tracking-wider',
+          !canAfford
+            ? 'cursor-not-allowed border-neutral-200 bg-neutral-50 text-neutral-400'
+            : buying
+              ? 'border-pf-primary bg-pf-primary/10 text-pf-primary'
+              : 'border-pf-primary bg-pf-primary text-white hover:bg-pf-primary-dark',
+        ].join(' ')}
+      >
+        {buying ? 'Buying…' : canAfford ? 'Buy' : 'Too rich'}
+      </button>
+    </li>
+  );
+}
+
+function extractPriceFromDocument(doc: CompendiumDocument): ItemPrice | null {
+  const sys = doc.system as { price?: unknown };
+  const price = sys.price;
+  if (!price || typeof price !== 'object') return null;
+  const v = (price as { value?: unknown }).value;
+  if (!v || typeof v !== 'object') return null;
+  return price as ItemPrice;
+}
+
+// Full-document overlay anchored over the grid. Lazily fetches the
+// compendium document for description + traits; when the pack is
+// cached on the mcp side, the fetch is a synchronous in-memory hit.
+// Dismissed via the × button, Esc, or clicking outside the panel.
+function ShopItemDetail({
+  match,
+  purseCp,
+  buying,
+  onBuy,
+  onClose,
+}: {
+  match: CompendiumMatch;
+  purseCp: number;
+  buying: boolean;
+  onBuy: (unitPriceCp: number) => Promise<void>;
+  onClose: () => void;
+}): React.ReactElement {
+  const [doc, setDoc] = useState<CompendiumDocument | null>(null);
+  const [docError, setDocError] = useState<string | null>(null);
+  const [docLoading, setDocLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    // Defer the "reset to loading" setStates to a microtask so React
+    // doesn't treat the synchronous trio as a cascading-render
+    // warning. The subsequent .then / .catch are already async.
+    queueMicrotask(() => {
+      if (cancelled) return;
+      setDoc(null);
+      setDocError(null);
+      setDocLoading(true);
+    });
+    api
+      .getCompendiumDocument(match.uuid)
+      .then((result) => {
+        if (cancelled) return;
+        setDoc(result.document);
+        setDocLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setDocError(err instanceof Error ? err.message : String(err));
+        setDocLoading(false);
+      });
+    return (): void => {
+      cancelled = true;
+    };
+  }, [match.uuid]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return (): void => {
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [onClose]);
+
+  // Prefer `match.price` when the server embedded it (cached pack).
+  // Falls back to reading from the freshly-fetched document for
+  // uncached packs.
+  const price = match.price ?? (doc ? extractPriceFromDocument(doc) : null);
+  const unitPriceCp = price ? priceToCp(price) : 0;
+  const priceText = price ? formatCp(unitPriceCp) : '—';
+  const canAfford = unitPriceCp === 0 || purseCp >= unitPriceCp;
+  const traits = match.traits ?? extractTraitsFromDocument(doc);
+  const description = doc ? extractDescriptionFromDocument(doc) : '';
+  const enriched = description.length > 0 ? enrichDescription(description) : '';
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={`${match.name} details`}
+      data-testid="shop-item-detail"
+      onClick={(e): void => {
+        // Click on the backdrop itself (not any child) closes.
+        if (e.target === e.currentTarget) onClose();
+      }}
+      className="absolute inset-0 z-20 flex items-start justify-center bg-black/10 p-2"
+    >
+      <div className="flex max-h-full w-full flex-col rounded border border-pf-border bg-pf-bg shadow-lg">
+        <header className="flex items-start gap-3 border-b border-pf-border p-3">
+          <img
+            src={match.img}
+            alt=""
+            className="h-12 w-12 flex-shrink-0 rounded border border-pf-border bg-pf-bg-dark"
+          />
+          <div className="min-w-0 flex-1">
+            <h3 className="font-serif text-base font-semibold text-pf-text">{match.name}</h3>
+            <p className="text-[10px] uppercase tracking-widest text-pf-alt-dark">
+              {match.type}
+              {typeof match.level === 'number' && ` · Level ${match.level.toString()}`}
+              {priceText !== '—' && ` · ${priceText}`}
+            </p>
+            {traits.length > 0 && (
+              <ul className="mt-1 flex flex-wrap gap-1">
+                {traits.slice(0, 8).map((t) => (
+                  <li
+                    key={t}
+                    className="rounded-full border border-pf-tertiary-dark bg-pf-tertiary/40 px-1.5 py-0.5 text-[10px] text-pf-alt-dark"
+                  >
+                    {t}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close details"
+            data-testid="shop-detail-close"
+            className="shrink-0 rounded border border-pf-border bg-white px-2 py-0.5 text-sm text-pf-alt-dark hover:bg-pf-bg-dark/40"
+          >
+            ×
+          </button>
+        </header>
+        <div className="flex-1 overflow-y-auto p-3 text-sm leading-relaxed text-pf-text [&_.pf-damage]:font-semibold [&_.pf-damage]:text-pf-primary [&_.pf-template]:italic [&_.pf-template]:text-pf-secondary [&_a]:cursor-pointer [&_a]:text-pf-primary [&_a]:underline [&_p]:my-2">
+          {docLoading && !doc ? (
+            <p className="italic text-pf-alt-dark">Loading…</p>
+          ) : docError !== null ? (
+            <p className="italic text-pf-primary">Couldn&apos;t load description: {docError}</p>
+          ) : enriched.length > 0 ? (
+            <div dangerouslySetInnerHTML={{ __html: enriched }} />
+          ) : (
+            <p className="italic text-pf-alt-dark">No description.</p>
+          )}
+        </div>
+        <footer className="flex items-center justify-end gap-2 border-t border-pf-border p-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded border border-pf-border bg-white px-3 py-1 text-xs text-pf-alt-dark hover:bg-pf-bg-dark/40"
+          >
+            Close
+          </button>
+          <button
+            type="button"
+            disabled={!canAfford || buying}
+            onClick={(): void => {
+              void onBuy(unitPriceCp);
+            }}
+            data-testid="shop-detail-buy"
+            className={[
+              'rounded border px-3 py-1 text-xs font-semibold uppercase tracking-wider',
+              !canAfford
+                ? 'cursor-not-allowed border-neutral-200 bg-neutral-50 text-neutral-400'
+                : buying
+                  ? 'border-pf-primary bg-pf-primary/10 text-pf-primary'
+                  : 'border-pf-primary bg-pf-primary text-white hover:bg-pf-primary-dark',
+            ].join(' ')}
+          >
+            {buying ? 'Buying…' : canAfford ? `Buy ${priceText}` : 'Too rich'}
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+function extractDescriptionFromDocument(doc: CompendiumDocument): string {
+  const sys = doc.system as { description?: { value?: unknown } };
+  const v = sys.description?.value;
+  return typeof v === 'string' ? v : '';
+}
+
+function extractTraitsFromDocument(doc: CompendiumDocument | null): string[] {
+  if (!doc) return [];
+  const raw = (doc.system as { traits?: { value?: unknown } }).traits?.value;
+  return Array.isArray(raw) ? raw.filter((v): v is string => typeof v === 'string') : [];
+}
+
+// Match types vary: `match.type` may be the Foundry document type
+// ('Item', 'weapon', 'armor'). When it's a generic 'Item' the server
+// didn't supply the subtype, so we fall back to traits and name.
+function filterMatchesByType(matches: readonly CompendiumMatch[], filter: TypeFilter): CompendiumMatch[] {
+  if (filter === 'all') return [...matches];
+  return matches.filter((m) => {
+    const t = m.type.toLowerCase();
+    if (t === filter) return true;
+    const traits = (m.traits ?? []).map((s) => s.toLowerCase());
+    if (traits.includes(filter)) return true;
+    if (filter === 'consumable' && (traits.includes('potion') || traits.includes('scroll') || traits.includes('elixir'))) return true;
+    return false;
+  });
+}

--- a/apps/character-creator/src/components/tabs/Actions.test.tsx
+++ b/apps/character-creator/src/components/tabs/Actions.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { render, cleanup, within } from '@testing-library/react';
+import { render, cleanup, fireEvent, within } from '@testing-library/react';
 import amiri from '../../fixtures/amiri-prepared.json';
-import type { PreparedActorItem, Strike } from '../../api/types';
+import type { Ability, AbilityKey, PreparedActorItem, Strike } from '../../api/types';
 import { Actions } from './Actions';
 
 // Amiri's three strikes with their expected attack modifiers (as per
@@ -15,6 +15,7 @@ const EXPECTED_STRIKES = {
 
 const actions = (amiri as unknown as { system: { actions: Strike[] } }).system.actions;
 const items = (amiri as unknown as { items: PreparedActorItem[] }).items;
+const abilities = (amiri as unknown as { system: { abilities: Record<AbilityKey, Ability> } }).system.abilities;
 
 describe('Actions tab — strikes', () => {
   afterEach(() => {
@@ -58,6 +59,49 @@ describe('Actions tab — strikes', () => {
     const card = container.querySelector('[data-strike-slug="javelin"]');
     expect(card?.textContent).toContain('×4');
   });
+
+  // Amiri: STR +4, trained weapons, no runes, no bonus damage.
+  //   Unarmed (melee):       1d4+4 bludgeoning
+  //   Bastard Sword (melee): 1d8+4 slashing
+  //   Javelin (ranged+thrown): 1d6+4 piercing
+  it('folds STR into melee strike damage when abilities are provided', () => {
+    const { container } = render(<Actions actions={actions} items={items} abilities={abilities} />);
+    const unarmed = container.querySelector('[data-strike-slug="basic-unarmed"] [data-role="strike-damage"]');
+    const bastard = container.querySelector('[data-strike-slug="bastard-sword"] [data-role="strike-damage"]');
+    expect(unarmed?.textContent).toBe('1d4+4 bludgeoning');
+    expect(bastard?.textContent).toBe('1d8+4 slashing');
+  });
+
+  it('adds STR to a thrown ranged weapon (javelin)', () => {
+    const { container } = render(<Actions actions={actions} items={items} abilities={abilities} />);
+    const javelin = container.querySelector('[data-strike-slug="javelin"] [data-role="strike-damage"]');
+    expect(javelin?.textContent).toBe('1d6+4 piercing');
+  });
+
+  it('falls back to base-die damage when abilities are not provided', () => {
+    const { container } = render(<Actions actions={actions} items={items} />);
+    const bastard = container.querySelector('[data-strike-slug="bastard-sword"] [data-role="strike-damage"]');
+    expect(bastard?.textContent).toBe('1d8 slashing');
+  });
+
+  it('applies the striking rune by adding dice', () => {
+    const buffed: Strike[] = actions.map((s) => {
+      if (s.slug !== 'bastard-sword') return s;
+      return {
+        ...s,
+        item: {
+          ...s.item,
+          system: {
+            ...s.item.system,
+            runes: { potency: 0, striking: 1, property: [] },
+          },
+        },
+      };
+    });
+    const { container } = render(<Actions actions={buffed} items={items} abilities={abilities} />);
+    const bastard = container.querySelector('[data-strike-slug="bastard-sword"] [data-role="strike-damage"]');
+    expect(bastard?.textContent).toBe('2d8+4 slashing');
+  });
 });
 
 describe('Actions tab — action items', () => {
@@ -95,5 +139,25 @@ describe('Actions tab — action items', () => {
   it('renders empty-state when no strikes and no action items', () => {
     const { container } = render(<Actions actions={[]} items={[]} />);
     expect(container.textContent).toContain('No actions available');
+  });
+
+  it('collapses action cards by default and expands on click', () => {
+    const { container } = render(<Actions actions={actions} items={items} />);
+    const section = container.querySelector('[data-action-section="action"]') as HTMLElement;
+    const rage = within(section)
+      .getAllByText(/Rage/i)[0]
+      ?.closest('[data-action-id]') as HTMLElement | null;
+    expect(rage, 'Rage card').toBeTruthy();
+    expect(rage?.getAttribute('data-expanded')).toBe('false');
+    expect(rage?.querySelector('[data-role="action-description"]')).toBeNull();
+
+    const toggle = rage?.querySelector('[data-testid="action-card-toggle"]') as HTMLElement;
+    fireEvent.click(toggle);
+
+    expect(rage?.getAttribute('data-expanded')).toBe('true');
+    const body = rage?.querySelector('[data-role="action-description"]');
+    expect(body, 'description body').toBeTruthy();
+    // Rage's description starts with "You tap into your inner fury".
+    expect(body?.textContent).toContain('inner fury');
   });
 });

--- a/apps/character-creator/src/components/tabs/Actions.tsx
+++ b/apps/character-creator/src/components/tabs/Actions.tsx
@@ -1,17 +1,20 @@
-import type { ActionItem, PreparedActorItem, Strike } from '../../api/types';
+import { useState } from 'react';
+import type { Ability, AbilityKey, ActionItem, PreparedActorItem, Strike } from '../../api/types';
 import { isActionItem } from '../../api/types';
+import { enrichDescription } from '../../lib/foundry-enrichers';
 import { SectionHeader } from '../common/SectionHeader';
 
 interface Props {
   actions: Strike[];
   items: PreparedActorItem[];
+  abilities?: Record<AbilityKey, Ability>;
 }
 
 // Actions tab — strikes (from system.actions[]) plus action-type items
 // split into Actions / Reactions / Free Actions. pf2e's full Actions tab
 // also has Encounter/Exploration/Downtime sub-tabs, which we skip since
 // the split mostly mirrors the same item data with a sub-trait filter.
-export function Actions({ actions, items }: Props): React.ReactElement {
+export function Actions({ actions, items, abilities }: Props): React.ReactElement {
   const strikes = actions.filter((a) => a.type === 'strike' && a.visible);
   const actionItems = items.filter(isActionItem);
   const regularActions = actionItems.filter((a) => a.system.actionType.value === 'action');
@@ -30,7 +33,7 @@ export function Actions({ actions, items }: Props): React.ReactElement {
           <SectionHeader>Strikes</SectionHeader>
           <ul className="space-y-2">
             {strikes.map((strike) => (
-              <StrikeCard key={strike.slug} strike={strike} />
+              <StrikeCard key={strike.slug} strike={strike} abilities={abilities} />
             ))}
           </ul>
         </div>
@@ -45,10 +48,15 @@ export function Actions({ actions, items }: Props): React.ReactElement {
 
 // ─── Strike card (existing) ────────────────────────────────────────────
 
-function StrikeCard({ strike }: { strike: Strike }): React.ReactElement {
+function StrikeCard({
+  strike,
+  abilities,
+}: {
+  strike: Strike;
+  abilities: Record<AbilityKey, Ability> | undefined;
+}): React.ReactElement {
   const allTraits = [...strike.traits, ...strike.weaponTraits];
-  const damage = strike.item.system.damage;
-  const damageText = damage ? `${damage.dice.toString()}${damage.die} ${damage.damageType}` : null;
+  const damageText = formatStrikeDamage(strike, abilities);
   const range = strike.item.system.range;
 
   return (
@@ -72,7 +80,12 @@ function StrikeCard({ strike }: { strike: Strike }): React.ReactElement {
               )}
             </span>
             {damageText !== null && (
-              <span className="flex-shrink-0 font-mono text-xs tabular-nums text-neutral-500">{damageText}</span>
+              <span
+                className="flex-shrink-0 font-mono text-xs tabular-nums text-neutral-500"
+                data-role="strike-damage"
+              >
+                {damageText}
+              </span>
             )}
           </div>
           <VariantStrip variants={strike.variants} />
@@ -84,6 +97,70 @@ function StrikeCard({ strike }: { strike: Strike }): React.ReactElement {
       </div>
     </li>
   );
+}
+
+// Compose the damage string from the weapon's static `system.damage`
+// plus striking runes, ability modifier, and any flat bonus damage.
+//
+// Rules we encode (pf2e Player Core "Damage Rolls"):
+//   - Base: `dice`d`die` (e.g. 1d8).
+//   - Striking runes add dice: +1 die for striking, +2 for greater,
+//     +3 for major. Applied to the base die size.
+//   - Ability mod to damage:
+//       • Melee strike           → STR
+//       • Ranged strike, thrown  → STR
+//       • Ranged strike, propulsive → floor(STR/2) if positive, full if negative
+//       • Otherwise               → none
+//   - Flat bonus: `bonusDamage.value` (typically from weapon specialization
+//     feats or runes). Weapon specialization is NOT recomputed here —
+//     we only show what pf2e already folded into `bonusDamage`.
+//
+// Property runes are intentionally left out of the main line — they're
+// typically conditional damage (on-crit, on-trigger) and their formulas
+// vary by rune, so listing them as always-on would mislead.
+function formatStrikeDamage(
+  strike: Strike,
+  abilities: Record<AbilityKey, Ability> | undefined,
+): string | null {
+  const dmg = strike.item.system.damage;
+  if (!dmg) return null;
+
+  const strikingExtra = strike.item.system.runes?.striking ?? 0;
+  const dice = dmg.dice + strikingExtra;
+  // Base die is shown as-is. The 'two-hand-dX' trait would swap it when
+  // the weapon is wielded two-handed, but the prepared payload doesn't
+  // expose the current grip reliably — we let the trait chip communicate
+  // the alternative instead of speculating.
+  let out = `${dice.toString()}${dmg.die}`;
+
+  const abilityMod = computeDamageAbilityMod(strike, abilities);
+  const bonus = strike.item.system.bonusDamage?.value ?? 0;
+  const flat = abilityMod + bonus;
+  if (flat > 0) out += `+${flat.toString()}`;
+  else if (flat < 0) out += flat.toString();
+
+  out += ` ${dmg.damageType}`;
+  return out;
+}
+
+function computeDamageAbilityMod(
+  strike: Strike,
+  abilities: Record<AbilityKey, Ability> | undefined,
+): number {
+  if (!abilities) return 0;
+  const domains = strike.domains ?? [];
+  const isMelee = domains.includes('melee-strike-attack-roll');
+  const isRanged = domains.includes('ranged-strike-attack-roll');
+  const traitNames = new Set(strike.weaponTraits.map((t) => t.name));
+  const strMod = abilities.str.mod;
+
+  if (isMelee) return strMod;
+  if (isRanged) {
+    if (traitNames.has('thrown')) return strMod;
+    if (traitNames.has('propulsive')) return strMod >= 0 ? Math.floor(strMod / 2) : strMod;
+    return 0;
+  }
+  return 0;
 }
 
 function VariantStrip({ variants }: { variants: { label: string }[] }): React.ReactElement {
@@ -134,36 +211,71 @@ function ActionCard({ item }: { item: ActionItem }): React.ReactElement {
   const kind = item.system.actionType.value;
   const count = item.system.actions.value;
   const traits = item.system.traits.value;
+  const [expanded, setExpanded] = useState(false);
+  const description = item.system.description?.value ?? '';
+  const hasDescription = description.trim() !== '';
+  const enriched = hasDescription ? enrichDescription(description) : '';
+
+  const toggle = (): void => {
+    setExpanded((v) => !v);
+  };
 
   return (
     <li
-      className="flex items-start gap-3 rounded border border-neutral-200 bg-white px-3 py-2"
+      className="rounded border border-neutral-200 bg-white"
       data-action-id={item.id}
       data-action-kind={kind}
+      data-expanded={expanded ? 'true' : 'false'}
     >
-      <img
-        src={item.img}
-        alt=""
-        className="mt-0.5 h-8 w-8 flex-shrink-0 rounded border border-neutral-200 bg-neutral-50"
-      />
-      <div className="min-w-0 flex-1">
-        <div className="flex items-baseline gap-2">
-          <span className="truncate text-sm font-medium text-neutral-900">{item.name}</span>
-          <ActionCostBadge kind={kind} count={count} />
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={expanded}
+        className="flex w-full items-start gap-3 px-3 py-2 text-left hover:bg-pf-bg-dark/40"
+        data-testid="action-card-toggle"
+      >
+        <img
+          src={item.img}
+          alt=""
+          className="mt-0.5 h-8 w-8 flex-shrink-0 rounded border border-neutral-200 bg-neutral-50"
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-baseline gap-2">
+            <span className="truncate text-sm font-medium text-neutral-900">{item.name}</span>
+            <ActionCostBadge kind={kind} count={count} />
+            <span className="ml-auto text-[10px] text-neutral-500" aria-hidden="true">
+              {expanded ? '▾' : '▸'}
+            </span>
+          </div>
+          {traits.length > 0 && (
+            <ul className="mt-1 flex flex-wrap gap-1">
+              {traits.map((slug) => (
+                <li
+                  key={slug}
+                  className="rounded-full border border-neutral-300 bg-neutral-50 px-1.5 py-0.5 text-[10px] text-neutral-600"
+                >
+                  {capitaliseSlug(slug)}
+                </li>
+              ))}
+            </ul>
+          )}
         </div>
-        {traits.length > 0 && (
-          <ul className="mt-1 flex flex-wrap gap-1">
-            {traits.map((slug) => (
-              <li
-                key={slug}
-                className="rounded-full border border-neutral-300 bg-neutral-50 px-1.5 py-0.5 text-[10px] text-neutral-600"
-              >
-                {capitaliseSlug(slug)}
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
+      </button>
+      {expanded && (
+        <div
+          className="border-t border-neutral-200 bg-pf-bg/60 px-3 py-2 text-sm text-pf-text"
+          data-role="action-description"
+        >
+          {hasDescription ? (
+            <div
+              className="leading-relaxed [&_.pf-damage]:font-semibold [&_.pf-damage]:text-pf-primary [&_.pf-template]:italic [&_.pf-template]:text-pf-secondary [&_a]:cursor-pointer [&_a]:text-pf-primary [&_a]:underline [&_p]:my-2"
+              dangerouslySetInnerHTML={{ __html: enriched }}
+            />
+          ) : (
+            <p className="italic text-neutral-400">No description.</p>
+          )}
+        </div>
+      )}
     </li>
   );
 }

--- a/apps/character-creator/src/components/tabs/Background.test.tsx
+++ b/apps/character-creator/src/components/tabs/Background.test.tsx
@@ -92,6 +92,41 @@ describe('Background tab', () => {
     const { container } = render(<Background details={details} />);
     expect(container.querySelector('[data-section="campaign-notes"]')).toBeNull();
   });
+
+  it('shows an empty-state message when every background field is blank', () => {
+    const bare: CharacterDetails = {
+      ...details,
+      gender: { value: '' },
+      ethnicity: { value: '' },
+      nationality: { value: '' },
+      age: { value: '' },
+      height: { value: '' },
+      weight: { value: '' },
+      biography: {
+        ...details.biography,
+        birthPlace: '',
+        appearance: '',
+        backstory: '',
+        campaignNotes: '',
+        attitude: '',
+        beliefs: '',
+        likes: '',
+        dislikes: '',
+        catchphrases: '',
+        allies: '',
+        enemies: '',
+        organizations: '',
+        edicts: [],
+        anathema: [],
+      },
+    };
+    const { container } = render(<Background details={bare} />);
+    expect(container.querySelector('[data-section="background-empty"]')).toBeTruthy();
+    expect(container.textContent).toContain('No background details');
+    // None of the populated-only sections should have rendered.
+    expect(container.querySelector('[data-section="demographics"]')).toBeNull();
+    expect(container.querySelector('[data-section="backstory"]')).toBeNull();
+  });
 });
 
 // Quick sanity test: biography type fields line up with what Background consumes.

--- a/apps/character-creator/src/components/tabs/Background.tsx
+++ b/apps/character-creator/src/components/tabs/Background.tsx
@@ -11,6 +11,15 @@ interface Props {
 // Foundry; there's no untrusted-user input path into these fields.
 export function Background({ details }: Props): React.ReactElement {
   const bio = details.biography;
+  if (!hasAnyBackgroundContent(details)) {
+    return (
+      <section className="space-y-6" data-section="background-empty">
+        <p className="text-sm italic text-neutral-500">
+          No background details recorded for this character yet.
+        </p>
+      </section>
+    );
+  }
   return (
     <section className="space-y-6">
       <DemographicsBlock details={details} />
@@ -22,6 +31,36 @@ export function Background({ details }: Props): React.ReactElement {
       <TextBlock title="Campaign Notes" html={bio.campaignNotes} dataSection="campaign-notes" />
     </section>
   );
+}
+
+function hasAnyBackgroundContent(details: CharacterDetails): boolean {
+  const bio = details.biography;
+  const demographicValues = [
+    details.gender.value,
+    details.ethnicity.value,
+    details.nationality.value,
+    details.age.value,
+    details.height.value,
+    details.weight.value,
+    bio.birthPlace,
+  ];
+  const textValues = [
+    bio.appearance,
+    bio.backstory,
+    bio.campaignNotes,
+    bio.attitude,
+    bio.beliefs,
+    bio.likes,
+    bio.dislikes,
+    bio.catchphrases,
+    bio.allies,
+    bio.enemies,
+    bio.organizations,
+  ];
+  if (demographicValues.some((v) => v.trim() !== '')) return true;
+  if (textValues.some((v) => v.trim() !== '')) return true;
+  if (bio.edicts.length > 0 || bio.anathema.length > 0) return true;
+  return false;
 }
 
 // ─── Sub-sections ──────────────────────────────────────────────────────

--- a/apps/character-creator/src/components/tabs/Inventory.test.tsx
+++ b/apps/character-creator/src/components/tabs/Inventory.test.tsx
@@ -98,10 +98,11 @@ describe('Inventory tab', () => {
   it('nests stowed items under their container, not at the top level', () => {
     const { container } = render(<Inventory items={items} />);
     selectListView(container);
-    // Top-level list items are direct children of the section's primary
-    // <ul>. Check via item-id so we don't confuse ourselves with nested
-    // textContent (Backpack's <li> contains its children's text too).
-    const topIds = Array.from(container.querySelectorAll('section > ul > [data-item-id]')).map((el) =>
+    // Top-level list items now live inside a per-category list:
+    // `[data-category] > ul > [data-item-id]`. The backpack appears
+    // in the `containers` category at the top level; stowed items
+    // show up as descendants of that <li>, not as siblings.
+    const topIds = Array.from(container.querySelectorAll('[data-category] > ul > [data-item-id]')).map((el) =>
       el.getAttribute('data-item-id'),
     );
     expect(topIds).toContain(BACKPACK_ID);
@@ -121,5 +122,25 @@ describe('Inventory tab', () => {
   it('renders empty-state when no physical items exist', () => {
     const { container } = render(<Inventory items={[]} />);
     expect(container.textContent).toContain('No items yet');
+  });
+
+  it('groups items under category headers (weapons / armor / consumables / equipment / containers)', () => {
+    const { container } = render(<Inventory items={items} />);
+    const cats = Array.from(container.querySelectorAll('[data-category]')).map((el) =>
+      el.getAttribute('data-category'),
+    );
+    // Amiri carries at least one of each of these types, so every
+    // bucket should render in the grid view (the default).
+    expect(cats).toEqual(expect.arrayContaining(['weapons', 'armor', 'consumables', 'equipment', 'containers']));
+  });
+
+  it('places the Bastard Sword under Weapons and Hide Armor under Armor & Shields', () => {
+    const { container } = render(<Inventory items={items} />);
+    const weapons = container.querySelector('[data-category="weapons"]');
+    const armor = container.querySelector('[data-category="armor"]');
+    expect(weapons?.textContent).toContain('Bastard Sword');
+    expect(weapons?.textContent).not.toContain('Hide Armor');
+    expect(armor?.textContent).toContain('Hide Armor');
+    expect(armor?.textContent).not.toContain('Bastard Sword');
   });
 });

--- a/apps/character-creator/src/components/tabs/Inventory.tsx
+++ b/apps/character-creator/src/components/tabs/Inventory.tsx
@@ -1,14 +1,89 @@
 import { useState } from 'react';
-import type { PhysicalItem, PreparedActorItem } from '../../api/types';
+import { api } from '../../api/client';
+import type { PhysicalItem, PhysicalItemType, PreparedActorItem } from '../../api/types';
 import { isCoin, isContainer, isPhysicalItem } from '../../api/types';
+import {
+  coinItemsByDenom,
+  coinSlugFor,
+  cpToDenominations,
+  coinItemValueCp,
+  priceToCp,
+  sumActorCoinsCp,
+  type Denom,
+} from '../../lib/coins';
 import { enrichDescription } from '../../lib/foundry-enrichers';
+import { useShopMode } from '../../lib/useShopMode';
 import { useUuidHover } from '../../lib/useUuidHover';
+import { SectionHeader } from '../common/SectionHeader';
+import { ItemShopPicker, type BuyRequest } from '../shop/ItemShopPicker';
 
 interface Props {
   items: PreparedActorItem[];
+  actorId?: string;
+  onActorChanged?: () => void;
 }
 
 type ViewMode = 'list' | 'grid';
+type ShopView = 'inventory' | 'shop';
+
+// Category buckets for the inventory separators. Related pf2e item
+// types share a bucket ("Armor & Shields", "Consumables" holds ammo)
+// so the player sees a familiar grouping rather than one header per
+// strict Foundry type. Order matches how players typically scan:
+// weapons and defenses first, then expendables, then everything else.
+type InventoryCategory = 'weapons' | 'armor' | 'consumables' | 'equipment' | 'containers' | 'books' | 'treasure';
+
+const CATEGORY_ORDER: readonly InventoryCategory[] = [
+  'weapons',
+  'armor',
+  'consumables',
+  'equipment',
+  'containers',
+  'books',
+  'treasure',
+];
+
+const CATEGORY_LABEL: Record<InventoryCategory, string> = {
+  weapons: 'Weapons',
+  armor: 'Armor & Shields',
+  consumables: 'Consumables',
+  equipment: 'Equipment',
+  containers: 'Containers',
+  books: 'Books',
+  treasure: 'Treasure',
+};
+
+function categoryOf(type: PhysicalItemType): InventoryCategory {
+  switch (type) {
+    case 'weapon':
+      return 'weapons';
+    case 'armor':
+    case 'shield':
+      return 'armor';
+    case 'consumable':
+    case 'ammo':
+      return 'consumables';
+    case 'equipment':
+      return 'equipment';
+    case 'backpack':
+      return 'containers';
+    case 'book':
+      return 'books';
+    case 'treasure':
+      return 'treasure';
+  }
+}
+
+function groupByCategory(items: readonly PhysicalItem[]): Map<InventoryCategory, PhysicalItem[]> {
+  const out = new Map<InventoryCategory, PhysicalItem[]>();
+  for (const item of items) {
+    const cat = categoryOf(item.type);
+    const arr = out.get(cat) ?? [];
+    arr.push(item);
+    out.set(cat, arr);
+  }
+  return out;
+}
 
 // Inventory tab — reads `items[]`, filters to physical item types
 // (weapon/armor/equipment/consumable/treasure/backpack), renders a
@@ -20,23 +95,77 @@ type ViewMode = 'list' | 'grid';
 // Ported in spirit from pf2e's static/templates/actors/character/tabs/
 // inventory.hbs, but flattened — our read-only viewer doesn't need
 // stow/carry/drop controls or quantity adjusters.
-export function Inventory({ items }: Props): React.ReactElement {
+export function Inventory({ items, actorId, onActorChanged }: Props): React.ReactElement {
   // One uuid-hover instance for every expanded item description —
   // event delegation on the section picks up anchors produced by
   // `enrichDescription` regardless of which item was expanded.
   const uuidHover = useUuidHover();
   const [view, setView] = useState<ViewMode>('grid');
+  const [shopView, setShopView] = useState<ShopView>('inventory');
+  const [pendingBuys, setPendingBuys] = useState<Set<string>>(new Set());
+  const [pendingSells, setPendingSells] = useState<Set<string>>(new Set());
+  const [txError, setTxError] = useState<string | null>(null);
+  const shopMode = useShopMode();
+
+  const canTransact = actorId !== undefined && onActorChanged !== undefined;
+
+  const handleBuy = async (req: BuyRequest): Promise<void> => {
+    if (!canTransact) return;
+    const { match, unitPriceCp } = req;
+    setTxError(null);
+    setPendingBuys((prev) => new Set(prev).add(match.uuid));
+    try {
+      if (unitPriceCp > 0) {
+        await spendCoins(actorId, items, unitPriceCp);
+      }
+      await api.addItemFromCompendium(actorId, { packId: match.packId, itemId: match.documentId });
+      onActorChanged();
+    } catch (err) {
+      setTxError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setPendingBuys((prev) => {
+        const next = new Set(prev);
+        next.delete(match.uuid);
+        return next;
+      });
+    }
+  };
+
+  const handleSell = async (item: PhysicalItem): Promise<void> => {
+    if (!canTransact) return;
+    setTxError(null);
+    setPendingSells((prev) => new Set(prev).add(item.id));
+    try {
+      const unitPriceCp = priceToCp(item.system.price);
+      const payoutCp = Math.floor(unitPriceCp * item.system.quantity * shopMode.sellRatio);
+      if (payoutCp > 0) {
+        await grantCoins(actorId, items, payoutCp);
+      }
+      await api.deleteActorItem(actorId, item.id);
+      onActorChanged();
+    } catch (err) {
+      setTxError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setPendingSells((prev) => {
+        const next = new Set(prev);
+        next.delete(item.id);
+        return next;
+      });
+    }
+  };
+
   const physical = items.filter(isPhysicalItem);
-  if (physical.length === 0) {
-    return <p className="text-sm text-neutral-500">No items yet.</p>;
-  }
 
   const coins = physical.filter(isCoin);
+  // Treasure coins get their own dedicated strip at the top; strip
+  // them out so the "Treasure" category header shows only non-coin
+  // treasure items (gems, artwork, trade goods).
   const nonCoin = physical.filter((i) => !isCoin(i));
 
-  // Items nested inside containers are rendered under the container
-  // in list view. Grid view flattens everything into one tile pool
-  // since container grouping doesn't survive the compact layout.
+  // Items nested inside containers are rendered under their parent
+  // container in list view (preserves the backpack/sack grouping).
+  // Grid view flattens everything into per-category grids since the
+  // nested tree doesn't survive a tile layout.
   const topLevel = nonCoin.filter((i) => !i.system.containerId);
   const byContainer = new Map<string, PhysicalItem[]>();
   for (const item of nonCoin) {
@@ -46,6 +175,13 @@ export function Inventory({ items }: Props): React.ReactElement {
     arr.push(item);
     byContainer.set(cid, arr);
   }
+  const topLevelByCategory = groupByCategory(topLevel);
+  const allByCategory = groupByCategory(nonCoin);
+
+  // When shop mode is off or we can't transact, force back to the
+  // inventory pane so the toggle doesn't strand the user on an empty
+  // shop tab.
+  const effectiveShopView: ShopView = shopMode.enabled && canTransact ? shopView : 'inventory';
 
   return (
     <section
@@ -53,29 +189,305 @@ export function Inventory({ items }: Props): React.ReactElement {
       onMouseOver={uuidHover.delegationHandlers.onMouseOver}
       onMouseOut={uuidHover.delegationHandlers.onMouseOut}
     >
-      <div className="flex items-center justify-between gap-4">
-        {coins.length > 0 ? <CoinStrip coins={coins} /> : <div />}
-        <ViewToggle view={view} onChange={setView} />
-      </div>
-      {view === 'list' ? (
-        <ul className="space-y-1.5">
-          {topLevel.map((item) => (
-            <ItemRow key={item.id} item={item} contents={isContainer(item) ? (byContainer.get(item.id) ?? []) : []} />
-          ))}
-        </ul>
+      {txError !== null && (
+        <p className="rounded border border-red-200 bg-red-50 px-2 py-1 text-xs text-red-800" data-role="tx-error">
+          {txError}
+        </p>
+      )}
+      {physical.length === 0 && effectiveShopView === 'inventory' ? (
+        <p className="text-sm text-neutral-500">No items yet.</p>
       ) : (
-        <ul
-          className="grid gap-2"
-          style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(8rem, 1fr))' }}
-          data-view="grid"
-        >
-          {nonCoin.map((item) => (
-            <GridTile key={item.id} item={item} />
-          ))}
-        </ul>
+        <>
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+              {coins.length > 0 && <CoinStrip coins={coins} />}
+              {shopMode.enabled && canTransact && (
+                <ShopViewToggle view={effectiveShopView} onChange={setShopView} />
+              )}
+              <ShopGearMenu shopMode={shopMode} />
+            </div>
+            {effectiveShopView === 'inventory' && <ViewToggle view={view} onChange={setView} />}
+          </div>
+          {effectiveShopView === 'shop' && canTransact ? (
+            <ItemShopPicker items={items} onBuy={handleBuy} pending={pendingBuys} />
+          ) : (
+            <CategorizedInventory
+              view={view}
+              topLevelByCategory={topLevelByCategory}
+              allByCategory={allByCategory}
+              byContainer={byContainer}
+              sellContext={
+                shopMode.enabled && canTransact
+                  ? { sellRatio: shopMode.sellRatio, pending: pendingSells, onSell: handleSell }
+                  : undefined
+              }
+            />
+          )}
+        </>
       )}
       {uuidHover.popover}
     </section>
+  );
+}
+
+interface SellContext {
+  sellRatio: number;
+  pending: Set<string>;
+  onSell: (item: PhysicalItem) => Promise<void>;
+}
+
+// ─── Shop transactions ─────────────────────────────────────────────────
+
+// Deduct `totalCp` from the actor's canonical coin items. Pulls from
+// the largest denomination that can cover what's left and breaks it
+// down on the way, mirroring how a player would hand over pocket
+// change. Throws when the actor can't cover the cost.
+async function spendCoins(actorId: string, items: readonly PreparedActorItem[], totalCp: number): Promise<void> {
+  const available = sumActorCoinsCp(items);
+  if (totalCp > available) {
+    throw new Error(`Not enough coin — costs ${totalCp.toString()} cp, have ${available.toString()} cp.`);
+  }
+  const coinStacks = coinItemsByDenom(items);
+  // Greedy drain: take from pp first, then gp, sp, cp. Converts larger
+  // stacks down to cp-equivalent before subtracting to avoid
+  // overshooting on small purchases ("change" mechanics).
+  const remainingBySlot: Partial<Record<Denom, number>> = {};
+  let remaining = totalCp;
+  for (const denom of ['pp', 'gp', 'sp', 'cp'] as const) {
+    const item = coinStacks[denom];
+    if (!item || remaining <= 0) {
+      if (item) remainingBySlot[denom] = item.system.quantity;
+      continue;
+    }
+    const stackCp = coinItemValueCp(item);
+    if (stackCp <= remaining) {
+      remainingBySlot[denom] = 0;
+      remaining -= stackCp;
+    } else {
+      // This stack more than covers the rest — subtract proportionally.
+      const unit = stackCp / item.system.quantity;
+      const coinsNeeded = Math.ceil(remaining / unit);
+      remainingBySlot[denom] = item.system.quantity - coinsNeeded;
+      remaining -= coinsNeeded * unit;
+    }
+  }
+  // Overpayment from rounding-up gets returned as change in smaller
+  // denominations. `remaining` is ≤ 0 after the loop above; the
+  // absolute value is the change owed back.
+  if (remaining < 0) {
+    const change = cpToDenominations(-remaining);
+    for (const denom of ['pp', 'gp', 'sp', 'cp'] as const) {
+      if (change[denom] > 0) {
+        remainingBySlot[denom] = (remainingBySlot[denom] ?? coinStacks[denom]?.system.quantity ?? 0) + change[denom];
+      }
+    }
+  }
+  await applyCoinChanges(actorId, coinStacks, remainingBySlot);
+}
+
+// Add `totalCp` worth of coins to the actor, preferring to merge into
+// existing canonical stacks and falling back to creating a new coin
+// item from the equipment pack when one is missing.
+async function grantCoins(actorId: string, items: readonly PreparedActorItem[], totalCp: number): Promise<void> {
+  const coinStacks = coinItemsByDenom(items);
+  const breakdown = cpToDenominations(totalCp);
+  const nextQuantities: Partial<Record<Denom, number>> = {};
+  for (const denom of ['pp', 'gp', 'sp', 'cp'] as const) {
+    const add = breakdown[denom];
+    if (add === 0) continue;
+    const existing = coinStacks[denom];
+    if (existing) nextQuantities[denom] = existing.system.quantity + add;
+  }
+  await applyCoinChanges(actorId, coinStacks, nextQuantities);
+  // Create stacks for denominations that don't exist on the actor yet.
+  // These aren't common on fresh characters but the sell flow can
+  // easily produce sp/cp that the actor doesn't carry a stack for.
+  for (const denom of ['pp', 'gp', 'sp', 'cp'] as const) {
+    const add = breakdown[denom];
+    if (add === 0 || coinStacks[denom]) continue;
+    await api.addItemFromCompendium(actorId, {
+      packId: 'pf2e.equipment-srd',
+      // The equipment-srd pack exposes each coin type as an item whose
+      // slug matches the canonical denomination. When the pack uses a
+      // different id, the server will surface a resolution error and
+      // we'll need to adjust — this is the simplest viable identifier.
+      itemId: coinSlugFor(denom),
+      quantity: add,
+    });
+  }
+}
+
+async function applyCoinChanges(
+  actorId: string,
+  coinStacks: Partial<Record<Denom, PhysicalItem>>,
+  next: Partial<Record<Denom, number>>,
+): Promise<void> {
+  for (const denom of ['pp', 'gp', 'sp', 'cp'] as const) {
+    const qty = next[denom];
+    if (qty === undefined) continue;
+    const item = coinStacks[denom];
+    if (!item) continue;
+    if (item.system.quantity === qty) continue;
+    await api.updateActorItem(actorId, item.id, { system: { quantity: Math.max(0, qty) } });
+  }
+}
+
+// Render the non-coin inventory grouped by category, with a
+// `SectionHeader` above each non-empty bucket. List view nests
+// container contents under their owning backpack row (reusing the
+// existing `ItemRow` branch); grid view flattens within a category
+// since tile layout doesn't carry the parent/child relationship.
+function CategorizedInventory({
+  view,
+  topLevelByCategory,
+  allByCategory,
+  byContainer,
+  sellContext,
+}: {
+  view: ViewMode;
+  topLevelByCategory: Map<InventoryCategory, PhysicalItem[]>;
+  allByCategory: Map<InventoryCategory, PhysicalItem[]>;
+  byContainer: Map<string, PhysicalItem[]>;
+  sellContext: SellContext | undefined;
+}): React.ReactElement {
+  const buckets = view === 'list' ? topLevelByCategory : allByCategory;
+  const presentCategories = CATEGORY_ORDER.filter((c) => (buckets.get(c)?.length ?? 0) > 0);
+  if (presentCategories.length === 0) {
+    return <p className="text-sm text-neutral-500">No items yet.</p>;
+  }
+  return (
+    <div className="space-y-4">
+      {presentCategories.map((category) => {
+        const bucket = buckets.get(category) ?? [];
+        return (
+          <div key={category} data-category={category}>
+            <SectionHeader>{CATEGORY_LABEL[category]}</SectionHeader>
+            {view === 'list' ? (
+              <ul className="space-y-1.5">
+                {bucket.map((item) => (
+                  <ItemRow
+                    key={item.id}
+                    item={item}
+                    contents={isContainer(item) ? (byContainer.get(item.id) ?? []) : []}
+                    sellContext={sellContext}
+                  />
+                ))}
+              </ul>
+            ) : (
+              <ul
+                className="grid gap-2"
+                style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(8rem, 1fr))' }}
+                data-view="grid"
+              >
+                {bucket.map((item) => (
+                  <GridTile key={item.id} item={item} sellContext={sellContext} />
+                ))}
+              </ul>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// Compact gear-menu variant of the shop debug controls. Lives inline
+// with the coins strip / shop-view toggle so it doesn't eat a whole
+// row of vertical space. Uses <details> for click-to-open without
+// having to wire up outside-click dismissal manually — and because
+// the browser handles focus-trap and keyboard behaviour for free.
+function ShopGearMenu({
+  shopMode,
+}: {
+  shopMode: ReturnType<typeof useShopMode>;
+}): React.ReactElement {
+  return (
+    <details className="relative" data-section="shop-debug">
+      <summary
+        className="flex h-8 w-8 cursor-pointer list-none items-center justify-center rounded border border-pf-border bg-white text-base leading-none text-pf-alt-dark hover:bg-pf-bg-dark/40"
+        title="Shop settings"
+        aria-label="Shop settings"
+        data-testid="shop-gear"
+      >
+        <span aria-hidden="true">⚙</span>
+      </summary>
+      <div
+        className="absolute right-0 top-full z-20 mt-1 w-64 rounded border border-pf-border bg-white p-3 text-xs text-pf-text shadow-lg"
+        data-role="shop-gear-menu"
+      >
+        <p className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark">
+          Debug · Shop Mode
+        </p>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={shopMode.enabled}
+            onChange={(e): void => {
+              shopMode.setEnabled(e.target.checked);
+            }}
+            data-testid="shop-mode-toggle"
+          />
+          <span>Enable shop mode</span>
+        </label>
+        <label className="mt-2 flex items-center gap-2">
+          <span className="w-16 shrink-0">Sell ratio</span>
+          <input
+            type="range"
+            min={0}
+            max={1}
+            step={0.05}
+            value={shopMode.sellRatio}
+            onChange={(e): void => {
+              shopMode.setSellRatio(Number(e.target.value));
+            }}
+            data-testid="sell-ratio-slider"
+            className="flex-1 accent-pf-primary"
+          />
+          <span className="w-10 text-right font-mono tabular-nums">{Math.round(shopMode.sellRatio * 100)}%</span>
+        </label>
+      </div>
+    </details>
+  );
+}
+
+function ShopViewToggle({
+  view,
+  onChange,
+}: {
+  view: ShopView;
+  onChange: (v: ShopView) => void;
+}): React.ReactElement {
+  const base = 'px-2 py-1 text-xs font-medium uppercase tracking-widest transition-colors';
+  const active = 'bg-pf-primary text-white';
+  const inactive = 'text-pf-alt-dark hover:bg-pf-bg-dark/60';
+  return (
+    <div
+      className="inline-flex shrink-0 overflow-hidden rounded border border-pf-border bg-white"
+      role="group"
+      aria-label="Shop view"
+      data-shop-view={view}
+    >
+      <button
+        type="button"
+        className={`${base} ${view === 'inventory' ? active : inactive}`}
+        aria-pressed={view === 'inventory'}
+        onClick={(): void => {
+          onChange('inventory');
+        }}
+      >
+        My Inventory
+      </button>
+      <button
+        type="button"
+        className={`${base} border-l border-pf-border ${view === 'shop' ? active : inactive}`}
+        aria-pressed={view === 'shop'}
+        onClick={(): void => {
+          onChange('shop');
+        }}
+      >
+        Shop
+      </button>
+    </div>
   );
 }
 
@@ -156,7 +568,15 @@ function CoinStrip({ coins }: { coins: PhysicalItem[] }): React.ReactElement {
 
 // ─── Item row ───────────────────────────────────────────────────────────
 
-function ItemRow({ item, contents }: { item: PhysicalItem; contents: PhysicalItem[] }): React.ReactElement {
+function ItemRow({
+  item,
+  contents,
+  sellContext,
+}: {
+  item: PhysicalItem;
+  contents: PhysicalItem[];
+  sellContext: SellContext | undefined;
+}): React.ReactElement {
   const isContainerRow = isContainer(item);
   const bulk = item.system.bulk;
   const capacityText =
@@ -184,6 +604,7 @@ function ItemRow({ item, contents }: { item: PhysicalItem; contents: PhysicalIte
           </div>
           <EquippedBadge item={item} />
           <BulkLabel value={bulk.value} />
+          {sellContext && <SellButton item={item} context={sellContext} />}
           <span className="ml-1 text-[10px] text-pf-alt-dark group-open:hidden">▸</span>
           <span className="ml-1 hidden text-[10px] text-pf-alt-dark group-open:inline">▾</span>
         </summary>
@@ -198,6 +619,49 @@ function ItemRow({ item, contents }: { item: PhysicalItem; contents: PhysicalIte
       )}
     </li>
   );
+}
+
+function SellButton({ item, context }: { item: PhysicalItem; context: SellContext }): React.ReactElement {
+  const busy = context.pending.has(item.id);
+  const unitPriceCp = priceToCp(item.system.price);
+  const payoutCp = Math.floor(unitPriceCp * item.system.quantity * context.sellRatio);
+  const payoutLabel = payoutCp > 0 ? formatShortCp(payoutCp) : '—';
+  return (
+    <button
+      type="button"
+      data-testid="sell-button"
+      disabled={busy}
+      onClick={(e): void => {
+        // Prevent the enclosing <summary> from toggling the details
+        // expand state when the user is aiming for the sell button.
+        e.preventDefault();
+        e.stopPropagation();
+        void context.onSell(item);
+      }}
+      className={[
+        'shrink-0 rounded border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wider',
+        busy
+          ? 'border-pf-primary bg-pf-primary/10 text-pf-primary'
+          : 'border-red-300 bg-red-50 text-red-800 hover:bg-red-100',
+      ].join(' ')}
+      title={`Sell for ${payoutLabel}`}
+    >
+      {busy ? 'Selling…' : `Sell ${payoutLabel}`}
+    </button>
+  );
+}
+
+// Compact denomination label for the sell button ("4 gp 8 sp"). The
+// full breakdown is already in formatCp; this keeps the chip narrow by
+// collapsing to the two largest non-zero denominations.
+function formatShortCp(cp: number): string {
+  const d = cpToDenominations(cp);
+  const parts: string[] = [];
+  for (const denom of ['pp', 'gp', 'sp', 'cp'] as const) {
+    if (d[denom] > 0) parts.push(`${d[denom].toString()}${denom}`);
+    if (parts.length === 2) break;
+  }
+  return parts.length === 0 ? '0cp' : parts.join(' ');
 }
 
 function ContainerChildRow({ item }: { item: PhysicalItem }): React.ReactElement {
@@ -220,7 +684,13 @@ function ContainerChildRow({ item }: { item: PhysicalItem }): React.ReactElement
   );
 }
 
-function GridTile({ item }: { item: PhysicalItem }): React.ReactElement {
+function GridTile({
+  item,
+  sellContext,
+}: {
+  item: PhysicalItem;
+  sellContext: SellContext | undefined;
+}): React.ReactElement {
   return (
     <li className="relative" data-item-id={item.id} data-item-type={item.type}>
       <details className="group">
@@ -239,6 +709,7 @@ function GridTile({ item }: { item: PhysicalItem }): React.ReactElement {
           <div className="flex min-h-[16px] flex-wrap justify-center gap-1">
             <EquippedBadge item={item} />
           </div>
+          {sellContext && <SellButton item={item} context={sellContext} />}
         </summary>
         {/* Floating detail card below the tile. Fixed 18rem width so
             descriptions stay readable even when the tile itself is
@@ -303,7 +774,13 @@ function EquippedBadge({ item }: { item: PhysicalItem }): React.ReactElement | n
   if (item.type === 'backpack' && eq.inSlot === true) {
     return <Badge color="sky">Worn</Badge>;
   }
-  if (eq.invested === true) {
+  // Investment is a pf2e-specific concept: only items with the
+  // `invested` trait (rings, cloaks, circlets, and similar worn
+  // magical gear) consume an investment slot. Consumables, weapons,
+  // and most other items can have `equipped.invested === true` left
+  // on them from Foundry defaults, so we gate the badge on the trait
+  // instead of trusting the flag alone.
+  if (eq.invested === true && item.system.traits.value.includes('invested')) {
     return <Badge color="violet">Invested</Badge>;
   }
   return null;

--- a/apps/character-creator/src/components/tabs/Progression.tsx
+++ b/apps/character-creator/src/components/tabs/Progression.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { api } from '../../api/client';
 import type {
@@ -10,7 +10,7 @@ import type {
   PreparedActorItem,
   ProficiencyRank,
 } from '../../api/types';
-import { isClassItem } from '../../api/types';
+import { isClassItem, isFeatItem } from '../../api/types';
 import { enrichDescription } from '../../lib/foundry-enrichers';
 import { useUuidHover } from '../../lib/useUuidHover';
 import type { CharacterContext } from '../../prereqs';
@@ -156,6 +156,38 @@ export function Progression({ characterLevel, items, characterContext }: Props):
     };
   }, [classItem]);
 
+  // Fast lookup from the actor's local feat id → feat item, so the
+  // picked-chip hover popover can resolve hydrated picks (whose uuids
+  // are actor-local placeholders, not compendium UUIDs) against the
+  // item on the character directly. Fresh picks out of the picker keep
+  // their real compendium uuid and hit the API as normal.
+  //
+  // Declared before the `!classItem` early return so React can call
+  // the hooks in the same order on every render.
+  const feathItemById = useMemo(() => {
+    const map = new Map<string, PreparedActorItem>();
+    for (const item of items) {
+      if (isFeatItem(item)) map.set(item.id, item);
+    }
+    return map;
+  }, [items]);
+  const resolveLocalPickDoc = useCallback(
+    (uuid: string): CompendiumDocument | undefined => {
+      const item = feathItemById.get(uuid);
+      if (!item) return undefined;
+      return {
+        id: item.id,
+        uuid: item.id,
+        name: item.name,
+        type: item.type,
+        img: item.img,
+        system: item.system,
+      };
+    },
+    [feathItemById],
+  );
+  const pickedHover = useUuidHover({ resolveLocal: resolveLocalPickDoc });
+
   if (!classItem) {
     return <p className="text-sm text-pf-alt-dark">No class item on this character.</p>;
   }
@@ -213,7 +245,7 @@ export function Progression({ characterLevel, items, characterContext }: Props):
           pick one; selections are held in memory until the scratch-actor flow lands.
         </p>
       </div>
-      <ol className="space-y-1.5">
+      <ol className="space-y-1.5" {...pickedHover.delegationHandlers}>
         {/* eslint-disable-next-line react-hooks/refs -- cache snapshot taken per render; docsVersion bump in useEffect re-renders whenever either cache mutates */}
         {LEVELS.map((level) => {
           const features = featuresByLevel.get(level) ?? [];
@@ -234,6 +266,7 @@ export function Progression({ characterLevel, items, characterContext }: Props):
           );
         })}
       </ol>
+      {pickedHover.popover}
       {pickerTarget && pickerFilters && (
         <FeatPicker
           title={pickerTitleFor(pickerTarget.slot, pickerTarget.level)}
@@ -366,7 +399,7 @@ function LevelRow({
       // row's opacity group — past-level popovers render full-
       // strength even when the row itself is dimmed.
       className={[
-        'grid grid-cols-[3rem_1fr] items-start gap-3 rounded border px-3 py-2',
+        'grid min-h-12 grid-cols-[3rem_1fr] items-center gap-3 rounded border px-3 py-2',
         state === 'current' ? 'border-pf-primary bg-pf-tertiary/30' : 'border-pf-border bg-white',
         state === 'past' ? 'opacity-60' : '',
       ].join(' ')}
@@ -423,6 +456,11 @@ function FeatureList({
 // constant the CSS (`w-[...]px`) and the JS positioning both read.
 const FEATURE_POPOVER_WIDTH = 420;
 const FEATURE_POPOVER_GAP = 6;
+// Preferred height of the popover; used by the flip-above check.
+// Actual height is capped by `maxHeight` so content scrolls internally
+// rather than overflowing the viewport.
+const FEATURE_POPOVER_PREFERRED_HEIGHT = 520;
+const FEATURE_POPOVER_VIEWPORT_MARGIN = 12;
 // Tiny delay before closing on mouseleave gives the cursor time to
 // bridge from chip → popover without the popover winking out.
 const HOVER_CLOSE_DELAY_MS = 120;
@@ -440,7 +478,7 @@ function FeatureChip({
   failed: boolean;
 }): React.ReactElement {
   const [open, setOpen] = useState(false);
-  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+  const [pos, setPos] = useState<{ top: number; left: number; maxHeight: number } | null>(null);
   const chipRef = useRef<HTMLLIElement>(null);
   const closeTimerRef = useRef<number | null>(null);
   const openTimerRef = useRef<number | null>(null);
@@ -476,9 +514,10 @@ function FeatureChip({
       const rect = chipRef.current.getBoundingClientRect();
       // Keep the popover inside the viewport — shift left if it'd overflow
       // the right edge, and snap a minimum margin on the left.
-      const maxLeft = window.innerWidth - FEATURE_POPOVER_WIDTH - 12;
-      const left = Math.max(12, Math.min(rect.left, maxLeft));
-      setPos({ top: rect.bottom + FEATURE_POPOVER_GAP, left });
+      const maxLeft = window.innerWidth - FEATURE_POPOVER_WIDTH - FEATURE_POPOVER_VIEWPORT_MARGIN;
+      const left = Math.max(FEATURE_POPOVER_VIEWPORT_MARGIN, Math.min(rect.left, maxLeft));
+      const vertical = pickFeaturePopoverVerticalSlot(rect);
+      setPos({ top: vertical.top, left, maxHeight: vertical.maxHeight });
       setOpen(true);
     }, HOVER_OPEN_DELAY_MS);
   };
@@ -510,7 +549,14 @@ function FeatureChip({
             data-testid="feature-tooltip"
             onMouseEnter={cancelClose}
             onMouseLeave={scheduleClose}
-            style={{ position: 'fixed', top: pos.top, left: pos.left, width: FEATURE_POPOVER_WIDTH }}
+            style={{
+              position: 'fixed',
+              top: pos.top,
+              left: pos.left,
+              width: FEATURE_POPOVER_WIDTH,
+              maxHeight: pos.maxHeight,
+              overflowY: 'auto',
+            }}
             className="z-50 rounded border border-pf-border bg-pf-bg p-4 text-left shadow-xl"
           >
             <div className="mb-2 flex items-center gap-2">
@@ -523,7 +569,7 @@ function FeatureChip({
             {description !== undefined && description.length > 0 ? (
               <div
                 {...uuidHover.delegationHandlers}
-                className="max-h-[28rem] overflow-y-auto pr-1 text-sm leading-relaxed text-pf-text [&_.pf-damage]:font-semibold [&_.pf-damage]:text-pf-primary [&_.pf-template]:italic [&_.pf-template]:text-pf-secondary [&_a]:cursor-pointer [&_a]:text-pf-primary [&_a]:underline [&_p]:my-2 [&_p]:leading-relaxed"
+                className="text-sm leading-relaxed text-pf-text [&_.pf-damage]:font-semibold [&_.pf-damage]:text-pf-primary [&_.pf-template]:italic [&_.pf-template]:text-pf-secondary [&_a]:cursor-pointer [&_a]:text-pf-primary [&_a]:underline [&_p]:my-2 [&_p]:leading-relaxed"
                 dangerouslySetInnerHTML={{ __html: enrichDescription(description) }}
               />
             ) : failed ? (
@@ -545,6 +591,30 @@ function extractDescription(doc: CompendiumDocument): string {
   const sys = doc.system as { description?: { value?: unknown } };
   const raw = sys.description?.value;
   return typeof raw === 'string' ? raw : '';
+}
+
+// Choose below vs above the anchor based on available viewport space,
+// and return a `maxHeight` so the popover caps itself to the space it
+// has and scrolls inside rather than overflowing the viewport.
+function pickFeaturePopoverVerticalSlot(anchor: DOMRect): { top: number; maxHeight: number } {
+  const viewportH = window.innerHeight;
+  const spaceBelow = viewportH - anchor.bottom - FEATURE_POPOVER_GAP - FEATURE_POPOVER_VIEWPORT_MARGIN;
+  const spaceAbove = anchor.top - FEATURE_POPOVER_GAP - FEATURE_POPOVER_VIEWPORT_MARGIN;
+
+  if (spaceBelow >= FEATURE_POPOVER_PREFERRED_HEIGHT) {
+    return { top: anchor.bottom + FEATURE_POPOVER_GAP, maxHeight: FEATURE_POPOVER_PREFERRED_HEIGHT };
+  }
+  if (spaceAbove >= FEATURE_POPOVER_PREFERRED_HEIGHT) {
+    return {
+      top: anchor.top - FEATURE_POPOVER_GAP - FEATURE_POPOVER_PREFERRED_HEIGHT,
+      maxHeight: FEATURE_POPOVER_PREFERRED_HEIGHT,
+    };
+  }
+  if (spaceBelow >= spaceAbove) {
+    return { top: anchor.bottom + FEATURE_POPOVER_GAP, maxHeight: Math.max(120, spaceBelow) };
+  }
+  const h = Math.max(120, spaceAbove);
+  return { top: Math.max(FEATURE_POPOVER_VIEWPORT_MARGIN, anchor.top - FEATURE_POPOVER_GAP - h), maxHeight: h };
 }
 
 // ─── Slot chips ────────────────────────────────────────────────────────
@@ -648,9 +718,16 @@ function SlotChips({
 function PickedChip({ slot, pick, onClear }: { slot: SlotType; pick: Pick; onClear: () => void }): React.ReactElement {
   const body = renderPickBody(pick);
   const title = renderPickTitle(slot, pick);
+  const featUuid = pick.kind === 'feat' ? pick.match.uuid : undefined;
   return (
     <span
-      data-pick-uuid={pick.kind === 'feat' ? pick.match.uuid : undefined}
+      // `data-uuid` triggers the rich hover popover wired at the
+      // Progression level (Parent <ol> holds the delegation handlers);
+      // the Progression-level resolver falls back to the actor-local
+      // feat item when the uuid isn't a compendium UUID, so hydrated
+      // picks show their description too.
+      data-pick-uuid={featUuid}
+      data-uuid={featUuid}
       className="inline-flex items-center gap-1 rounded border border-pf-border bg-white pl-1 pr-0.5 text-[11px] text-pf-text"
       title={title}
     >

--- a/apps/character-creator/src/lib/coins.test.ts
+++ b/apps/character-creator/src/lib/coins.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import amiri from '../fixtures/amiri-prepared.json';
+import type { PreparedActorItem } from '../api/types';
+import { coinItemsByDenom, cpToDenominations, formatCp, priceToCp, sumActorCoinsCp } from './coins';
+
+const items = (amiri as unknown as { items: PreparedActorItem[] }).items;
+
+describe('priceToCp', () => {
+  it('sums all denominations correctly', () => {
+    expect(priceToCp({ value: { gp: 1 } })).toBe(100);
+    expect(priceToCp({ value: { pp: 1 } })).toBe(1000);
+    expect(priceToCp({ value: { sp: 1 } })).toBe(10);
+    expect(priceToCp({ value: { cp: 1 } })).toBe(1);
+    expect(priceToCp({ value: { pp: 1, gp: 2, sp: 3, cp: 4 } })).toBe(1234);
+  });
+
+  it('honours the `per` field for stack prices', () => {
+    // 4 gp for a stack of 10 arrows = 0.4 gp each = 40 cp each.
+    expect(priceToCp({ value: { gp: 4 }, per: 10 })).toBe(40);
+  });
+
+  it('returns 0 for undefined / malformed price', () => {
+    expect(priceToCp(undefined)).toBe(0);
+    expect(priceToCp(null)).toBe(0);
+    expect(priceToCp({ value: {} })).toBe(0);
+  });
+});
+
+describe('cpToDenominations', () => {
+  it('breaks down a cp total into largest-first denominations', () => {
+    expect(cpToDenominations(1234)).toEqual({ pp: 1, gp: 2, sp: 3, cp: 4 });
+    expect(cpToDenominations(100)).toEqual({ pp: 0, gp: 1, sp: 0, cp: 0 });
+    expect(cpToDenominations(0)).toEqual({ pp: 0, gp: 0, sp: 0, cp: 0 });
+  });
+
+  it('floors fractional cp so denominations stay integral', () => {
+    expect(cpToDenominations(99.9)).toEqual({ pp: 0, gp: 0, sp: 9, cp: 9 });
+  });
+});
+
+describe('sumActorCoinsCp / coinItemsByDenom (Amiri fixture)', () => {
+  it('totals Amiri 5 sp + 6 gp = 650 cp', () => {
+    expect(sumActorCoinsCp(items)).toBe(650);
+  });
+
+  it('indexes coin items by denomination', () => {
+    const byDenom = coinItemsByDenom(items);
+    expect(byDenom.gp?.name).toBe('Gold Pieces');
+    expect(byDenom.gp?.system.quantity).toBe(6);
+    expect(byDenom.sp?.name).toBe('Silver Pieces');
+    expect(byDenom.sp?.system.quantity).toBe(5);
+    expect(byDenom.pp).toBeUndefined();
+    expect(byDenom.cp).toBeUndefined();
+  });
+});
+
+describe('formatCp', () => {
+  it('renders the largest-first breakdown, skipping zero denominations', () => {
+    expect(formatCp(1234)).toBe('1 pp 2 gp 3 sp 4 cp');
+    expect(formatCp(100)).toBe('1 gp');
+    expect(formatCp(0)).toBe('0 cp');
+  });
+});

--- a/apps/character-creator/src/lib/coins.ts
+++ b/apps/character-creator/src/lib/coins.ts
@@ -1,0 +1,111 @@
+import type { ItemPrice, PhysicalItem, PreparedActorItem } from '../api/types';
+import { isCoin, isPhysicalItem } from '../api/types';
+
+// All coin math flows through copper pieces (cp) so every denomination
+// fits on a single integer axis. Ratios are the pf2e core values:
+// 1 pp = 10 gp = 100 sp = 1000 cp.
+
+export type Denom = 'pp' | 'gp' | 'sp' | 'cp';
+
+export const COIN_DENOMS: readonly Denom[] = ['pp', 'gp', 'sp', 'cp'];
+
+const CP_PER: Record<Denom, number> = {
+  pp: 1000,
+  gp: 100,
+  sp: 10,
+  cp: 1,
+};
+
+const SLUG_BY_DENOM: Record<Denom, string> = {
+  pp: 'platinum-pieces',
+  gp: 'gold-pieces',
+  sp: 'silver-pieces',
+  cp: 'copper-pieces',
+};
+
+const DENOM_BY_SLUG: Record<string, Denom> = {
+  'platinum-pieces': 'pp',
+  'gold-pieces': 'gp',
+  'silver-pieces': 'sp',
+  'copper-pieces': 'cp',
+};
+
+// Total unit price in cp. Honours the `per` field (a stack price for N
+// units, e.g. arrows) by dividing — callers pass the unit price
+// returned here and multiply by purchase quantity as needed.
+export function priceToCp(price: ItemPrice | undefined | null): number {
+  if (!price) return 0;
+  const v = price.value;
+  const cp =
+    (v.pp ?? 0) * CP_PER.pp + (v.gp ?? 0) * CP_PER.gp + (v.sp ?? 0) * CP_PER.sp + (v.cp ?? 0) * CP_PER.cp;
+  const per = price.per && price.per > 0 ? price.per : 1;
+  return cp / per;
+}
+
+// Largest-first denomination breakdown. A cp amount of 0 returns all
+// zeros rather than nulls so callers can always read a full record.
+export function cpToDenominations(cp: number): Record<Denom, number> {
+  const normalized = Math.max(0, Math.floor(cp));
+  let remaining = normalized;
+  const out: Record<Denom, number> = { pp: 0, gp: 0, sp: 0, cp: 0 };
+  for (const denom of COIN_DENOMS) {
+    const unit = CP_PER[denom];
+    const count = Math.floor(remaining / unit);
+    out[denom] = count;
+    remaining -= count * unit;
+  }
+  return out;
+}
+
+// Flatten the actor's coin items into a cp total. Handles the
+// slug-based fast path plus a `price.value` fallback for custom coin
+// items that don't match one of the canonical slugs.
+export function sumActorCoinsCp(items: readonly PreparedActorItem[]): number {
+  let total = 0;
+  for (const item of items) {
+    if (!isPhysicalItem(item) || !isCoin(item)) continue;
+    total += coinItemValueCp(item);
+  }
+  return total;
+}
+
+export function coinItemValueCp(item: PhysicalItem): number {
+  const denom = coinDenomOf(item);
+  if (denom) return item.system.quantity * CP_PER[denom];
+  // Fallback: honour the raw price (per-unit value × quantity).
+  return priceToCp(item.system.price) * item.system.quantity;
+}
+
+export function coinDenomOf(item: PhysicalItem): Denom | undefined {
+  const slug = item.system.slug;
+  if (slug && slug in DENOM_BY_SLUG) return DENOM_BY_SLUG[slug];
+  return undefined;
+}
+
+// Group the actor's canonical coin items (platinum/gold/silver/copper)
+// by denomination so callers can inspect quantities and ids in one
+// step. Non-canonical coin items are ignored; they keep their raw
+// value via `sumActorCoinsCp` but don't participate in the add/remove
+// flow since we can't tell what denomination to update.
+export function coinItemsByDenom(items: readonly PreparedActorItem[]): Partial<Record<Denom, PhysicalItem>> {
+  const out: Partial<Record<Denom, PhysicalItem>> = {};
+  for (const item of items) {
+    if (!isPhysicalItem(item) || !isCoin(item)) continue;
+    const d = coinDenomOf(item);
+    if (d && out[d] === undefined) out[d] = item;
+  }
+  return out;
+}
+
+export function coinSlugFor(denom: Denom): string {
+  return SLUG_BY_DENOM[denom];
+}
+
+export function formatCp(cp: number): string {
+  const d = cpToDenominations(cp);
+  const parts: string[] = [];
+  for (const denom of COIN_DENOMS) {
+    if (d[denom] > 0) parts.push(`${d[denom].toString()} ${denom}`);
+  }
+  return parts.length === 0 ? '0 cp' : parts.join(' ');
+}

--- a/apps/character-creator/src/lib/useShopMode.test.tsx
+++ b/apps/character-creator/src/lib/useShopMode.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { act, render, cleanup, renderHook } from '@testing-library/react';
+import { getShopMode, setShopMode, useShopMode } from './useShopMode';
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('useShopMode', () => {
+  it('defaults to disabled / sellRatio 0.5', () => {
+    const { result } = renderHook(() => useShopMode());
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.sellRatio).toBe(0.5);
+  });
+
+  it('setEnabled updates state and persists to localStorage', () => {
+    const { result } = renderHook(() => useShopMode());
+    act(() => {
+      result.current.setEnabled(true);
+    });
+    expect(result.current.enabled).toBe(true);
+    expect(getShopMode().enabled).toBe(true);
+  });
+
+  it('setSellRatio clamps to [0, 1]', () => {
+    const { result } = renderHook(() => useShopMode());
+    act(() => {
+      result.current.setSellRatio(1.5);
+    });
+    expect(result.current.sellRatio).toBe(1);
+    act(() => {
+      result.current.setSellRatio(-0.2);
+    });
+    expect(result.current.sellRatio).toBe(0);
+  });
+
+  it('external setShopMode triggers a re-render in subscribed hooks', () => {
+    let renders = 0;
+    function Probe(): null {
+      useShopMode();
+      renders += 1;
+      return null as unknown as null;
+    }
+    render(<Probe />);
+    expect(renders).toBeGreaterThanOrEqual(1);
+    const before = renders;
+    act(() => {
+      setShopMode({ enabled: true });
+    });
+    expect(renders).toBeGreaterThan(before);
+    expect(getShopMode().enabled).toBe(true);
+  });
+});
+
+describe('window.__shopMode programmatic API', () => {
+  it('is exposed for the DM-side integration to flip', () => {
+    const api = (window as unknown as { __shopMode?: { set: typeof setShopMode; get: typeof getShopMode } })
+      .__shopMode;
+    expect(api).toBeDefined();
+    api?.set({ enabled: true, sellRatio: 0.25 });
+    expect(api?.get()).toEqual({ enabled: true, sellRatio: 0.25 });
+  });
+});

--- a/apps/character-creator/src/lib/useShopMode.ts
+++ b/apps/character-creator/src/lib/useShopMode.ts
@@ -1,0 +1,115 @@
+import { useEffect, useState } from 'react';
+
+// Shop mode state shared between the Inventory tab's debug panel and
+// whatever external DM-side integration eventually drives it. The
+// store lives in localStorage so a reload keeps the mode on, and
+// exposes a programmatic `window.__shopMode.set({...})` API for the
+// DM client to flip the flag remotely.
+
+export interface ShopModeState {
+  enabled: boolean;
+  // Fraction of an item's price that the player receives when selling.
+  // 0.5 is the pf2e baseline; rolled lower by haggle, up by lore.
+  sellRatio: number;
+}
+
+const STORAGE_KEY = 'shopMode';
+const CHANGE_EVENT = 'shopmode:change';
+
+const DEFAULT_STATE: ShopModeState = {
+  enabled: false,
+  sellRatio: 0.5,
+};
+
+function readState(): ShopModeState {
+  if (typeof window === 'undefined') return DEFAULT_STATE;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw === null) return DEFAULT_STATE;
+    const parsed = JSON.parse(raw) as Partial<ShopModeState>;
+    return {
+      enabled: typeof parsed.enabled === 'boolean' ? parsed.enabled : DEFAULT_STATE.enabled,
+      sellRatio:
+        typeof parsed.sellRatio === 'number' && Number.isFinite(parsed.sellRatio)
+          ? clampRatio(parsed.sellRatio)
+          : DEFAULT_STATE.sellRatio,
+    };
+  } catch {
+    return DEFAULT_STATE;
+  }
+}
+
+function writeState(next: ShopModeState): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // Private-browsing / quota errors — the in-memory state is still
+    // valid for this session, so just silently skip persistence.
+  }
+  window.dispatchEvent(new CustomEvent<ShopModeState>(CHANGE_EVENT, { detail: next }));
+}
+
+function clampRatio(r: number): number {
+  if (r < 0) return 0;
+  if (r > 1) return 1;
+  return r;
+}
+
+// External API surface for the DM-side integration. Calling this
+// updates localStorage and dispatches the change event, so every
+// subscribed hook instance re-renders immediately.
+export function setShopMode(patch: Partial<ShopModeState>): ShopModeState {
+  const current = readState();
+  const next: ShopModeState = {
+    enabled: patch.enabled ?? current.enabled,
+    sellRatio: patch.sellRatio !== undefined ? clampRatio(patch.sellRatio) : current.sellRatio,
+  };
+  writeState(next);
+  return next;
+}
+
+export function getShopMode(): ShopModeState {
+  return readState();
+}
+
+// Attach the programmatic API to `window` so the eventual DM-side
+// bridge (BroadcastChannel, websocket handler, etc.) can drive it
+// without depending on this module's imports.
+if (typeof window !== 'undefined') {
+  const globalTarget = window as unknown as { __shopMode?: { set: typeof setShopMode; get: typeof getShopMode } };
+  globalTarget.__shopMode = { set: setShopMode, get: getShopMode };
+}
+
+export function useShopMode(): ShopModeState & {
+  setEnabled: (v: boolean) => void;
+  setSellRatio: (r: number) => void;
+} {
+  const [state, setState] = useState<ShopModeState>(() => readState());
+
+  useEffect(() => {
+    const onChange = (e: Event): void => {
+      const detail = (e as CustomEvent<ShopModeState | undefined>).detail;
+      setState(detail ?? readState());
+    };
+    const onStorage = (e: StorageEvent): void => {
+      if (e.key === STORAGE_KEY) setState(readState());
+    };
+    window.addEventListener(CHANGE_EVENT, onChange);
+    window.addEventListener('storage', onStorage);
+    return (): void => {
+      window.removeEventListener(CHANGE_EVENT, onChange);
+      window.removeEventListener('storage', onStorage);
+    };
+  }, []);
+
+  return {
+    ...state,
+    setEnabled: (v: boolean): void => {
+      setShopMode({ enabled: v });
+    },
+    setSellRatio: (r: number): void => {
+      setShopMode({ sellRatio: r });
+    },
+  };
+}

--- a/apps/character-creator/src/lib/useUuidHover.tsx
+++ b/apps/character-creator/src/lib/useUuidHover.tsx
@@ -27,16 +27,32 @@ type DocState = { kind: 'loading' } | { kind: 'ready'; doc: CompendiumDocument }
 
 const POPOVER_WIDTH = 420;
 const POPOVER_GAP = 6;
+// Preferred height used for the "is there room below?" check. The
+// actual popover is capped via `maxHeight` on the outer element so
+// whatever the final content measures to, it can scroll internally
+// without escaping the viewport.
+const POPOVER_PREFERRED_HEIGHT = 520;
+const VIEWPORT_EDGE_MARGIN = 12;
 const HOVER_CLOSE_DELAY_MS = 140;
 const HOVER_OPEN_DELAY_MS = 300;
 
-export function useUuidHover(): {
+export interface UseUuidHoverOptions {
+  // Synchronously resolve a uuid to a CompendiumDocument *without*
+  // going through the API. Used for uuids that reference actor-local
+  // items (e.g. hydrated feat picks whose source compendium id has
+  // been stripped) so the hover still shows the item's own
+  // description instead of a failed fetch.
+  resolveLocal?: (uuid: string) => CompendiumDocument | undefined;
+}
+
+export function useUuidHover(opts?: UseUuidHoverOptions): {
   delegationHandlers: {
     onMouseOver: (e: React.MouseEvent<HTMLElement>) => void;
     onMouseOut: (e: React.MouseEvent<HTMLElement>) => void;
   };
   popover: React.ReactElement | null;
 } {
+  const resolveLocal = opts?.resolveLocal;
   const [stack, setStack] = useState<HoverLevel[]>([]);
   const [docs, setDocs] = useState<Map<string, DocState>>(new Map());
   const cacheRef = useRef<Map<string, DocState>>(new Map());
@@ -82,6 +98,14 @@ export function useUuidHover(): {
 
   const loadDoc = async (uuid: string): Promise<void> => {
     if (cacheRef.current.has(uuid)) return;
+    // Prefer a synchronous local resolution when the caller provides
+    // one. Skips the API entirely for actor-local uuids.
+    const local = resolveLocal?.(uuid);
+    if (local) {
+      cacheRef.current.set(uuid, { kind: 'ready', doc: local });
+      setDocs(new Map(cacheRef.current));
+      return;
+    }
     cacheRef.current.set(uuid, { kind: 'loading' });
     setDocs(new Map(cacheRef.current));
     try {
@@ -181,20 +205,24 @@ export function useUuidHover(): {
     handleMouseOut(e.target as Element, (e.relatedTarget as Element | null) ?? null);
   };
 
-  const positions = stack.reduce<Array<{ top: number; left: number }>>((acc, level, idx) => {
-    const maxLeft = window.innerWidth - POPOVER_WIDTH - 12;
+  const positions = stack.reduce<Array<{ top: number; left: number; maxHeight: number }>>((acc, level, idx) => {
+    const maxLeft = window.innerWidth - POPOVER_WIDTH - VIEWPORT_EDGE_MARGIN;
     if (idx === 0) {
+      const v = pickVerticalSlot(level.anchorRect);
       acc.push({
-        top: level.anchorRect.bottom + POPOVER_GAP,
-        left: Math.max(12, Math.min(level.anchorRect.left, maxLeft)),
+        top: v.top,
+        left: Math.max(VIEWPORT_EDGE_MARGIN, Math.min(level.anchorRect.left, maxLeft)),
+        maxHeight: v.maxHeight,
       });
       return acc;
     }
     const parent = acc[idx - 1];
     if (parent === undefined) {
+      const v = pickVerticalSlot(level.anchorRect);
       acc.push({
-        top: level.anchorRect.bottom + POPOVER_GAP,
-        left: Math.max(12, Math.min(level.anchorRect.left, maxLeft)),
+        top: v.top,
+        left: Math.max(VIEWPORT_EDGE_MARGIN, Math.min(level.anchorRect.left, maxLeft)),
+        maxHeight: v.maxHeight,
       });
       return acc;
     }
@@ -202,8 +230,8 @@ export function useUuidHover(): {
     // fall back to the left side so the preview stays reachable.
     const rightOfParent = parent.left + POPOVER_WIDTH + POPOVER_GAP;
     const leftOfParent = parent.left - POPOVER_WIDTH - POPOVER_GAP;
-    const left = rightOfParent <= maxLeft ? rightOfParent : Math.max(12, leftOfParent);
-    acc.push({ top: parent.top, left });
+    const left = rightOfParent <= maxLeft ? rightOfParent : Math.max(VIEWPORT_EDGE_MARGIN, leftOfParent);
+    acc.push({ top: parent.top, left, maxHeight: parent.maxHeight });
     return acc;
   }, []);
 
@@ -238,7 +266,14 @@ export function useUuidHover(): {
                 if (rel && rel.closest('[data-uuid-popover]')) return;
                 scheduleCloseToLength(0);
               }}
-              style={{ position: 'fixed', top: pos.top, left: pos.left, width: POPOVER_WIDTH }}
+              style={{
+                position: 'fixed',
+                top: pos.top,
+                left: pos.left,
+                width: POPOVER_WIDTH,
+                maxHeight: pos.maxHeight,
+                overflowY: 'auto',
+              }}
               className="z-50 rounded border border-pf-border bg-pf-bg p-4 text-left shadow-xl"
             >
               <PopoverBody state={state} />
@@ -253,6 +288,31 @@ export function useUuidHover(): {
     delegationHandlers: { onMouseOver, onMouseOut },
     popover,
   };
+}
+
+// Decide whether to open below the anchor (default) or flip above it
+// when there isn't enough room, and how tall the popover can be before
+// it should scroll internally. Falls back to the side with the most
+// room when neither fits the preferred height.
+function pickVerticalSlot(anchor: DOMRect): { top: number; maxHeight: number } {
+  const viewportH = window.innerHeight;
+  const spaceBelow = viewportH - anchor.bottom - POPOVER_GAP - VIEWPORT_EDGE_MARGIN;
+  const spaceAbove = anchor.top - POPOVER_GAP - VIEWPORT_EDGE_MARGIN;
+
+  if (spaceBelow >= POPOVER_PREFERRED_HEIGHT) {
+    return { top: anchor.bottom + POPOVER_GAP, maxHeight: POPOVER_PREFERRED_HEIGHT };
+  }
+  if (spaceAbove >= POPOVER_PREFERRED_HEIGHT) {
+    return { top: anchor.top - POPOVER_GAP - POPOVER_PREFERRED_HEIGHT, maxHeight: POPOVER_PREFERRED_HEIGHT };
+  }
+  // Neither side has preferred height — open on whichever side has
+  // more space and cap the popover to that space so the content
+  // becomes scrollable inside the viewport instead of getting clipped.
+  if (spaceBelow >= spaceAbove) {
+    return { top: anchor.bottom + POPOVER_GAP, maxHeight: Math.max(120, spaceBelow) };
+  }
+  const h = Math.max(120, spaceAbove);
+  return { top: Math.max(VIEWPORT_EDGE_MARGIN, anchor.top - POPOVER_GAP - h), maxHeight: h };
 }
 
 function PopoverBody({ state }: { state: DocState | undefined }): React.ReactElement {
@@ -305,7 +365,7 @@ function DocPreview({ doc }: { doc: CompendiumDocument }): React.ReactElement {
       </div>
       {description.length > 0 ? (
         <div
-          className="max-h-[28rem] overflow-y-auto pr-1 text-sm leading-relaxed text-pf-text [&_.pf-damage]:font-semibold [&_.pf-damage]:text-pf-primary [&_.pf-template]:italic [&_.pf-template]:text-pf-secondary [&_a]:cursor-pointer [&_a]:text-pf-primary [&_a]:underline [&_p]:my-2 [&_p]:leading-relaxed"
+          className="text-sm leading-relaxed text-pf-text [&_.pf-damage]:font-semibold [&_.pf-damage]:text-pf-primary [&_.pf-template]:italic [&_.pf-template]:text-pf-secondary [&_a]:cursor-pointer [&_a]:text-pf-primary [&_a]:underline [&_p]:my-2 [&_p]:leading-relaxed"
           dangerouslySetInnerHTML={{ __html: enrichDescription(description) }}
         />
       ) : (

--- a/apps/character-creator/src/pages/CharacterSheet.tsx
+++ b/apps/character-creator/src/pages/CharacterSheet.tsx
@@ -48,6 +48,10 @@ interface Props {
 export function CharacterSheet({ actorId, onBack }: Props): React.ReactElement {
   const [state, setState] = useState<State>({ kind: 'loading' });
   const [activeTab, setActiveTab] = useState<TabId>('character');
+  // Bumping this triggers a fresh `/prepared` fetch — used after buy/
+  // sell mutations from the Inventory tab so the sheet reflects the
+  // updated item list and coin totals without a full page reload.
+  const [reloadNonce, setReloadNonce] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -74,25 +78,39 @@ export function CharacterSheet({ actorId, onBack }: Props): React.ReactElement {
     return (): void => {
       cancelled = true;
     };
-  }, [actorId]);
+  }, [actorId, reloadNonce]);
+
+  const reloadActor = (): void => {
+    setReloadNonce((n) => n + 1);
+  };
 
   return (
     <div>
-      <div className="mb-4 flex items-center gap-3">
-        <button
-          type="button"
-          onClick={onBack}
-          className="rounded border border-neutral-300 bg-white px-2 py-1 text-xs text-neutral-700 hover:bg-neutral-50"
-        >
-          ← Actors
-        </button>
-      </div>
-
-      {state.kind === 'loading' && <p className="text-sm text-neutral-500">Loading character…</p>}
+      {state.kind === 'loading' && (
+        <div className="mb-4 flex items-center justify-between">
+          <p className="text-sm text-neutral-500">Loading character…</p>
+          <button
+            type="button"
+            onClick={onBack}
+            className="rounded border border-neutral-300 bg-white px-2 py-1 text-xs text-neutral-700 hover:bg-neutral-50"
+          >
+            ← Actors
+          </button>
+        </div>
+      )}
 
       {state.kind === 'error' && (
         <div className="rounded border border-red-200 bg-red-50 p-4 text-sm">
-          <p className="font-medium text-red-900">Couldn&apos;t load character</p>
+          <div className="flex items-start justify-between gap-3">
+            <p className="font-medium text-red-900">Couldn&apos;t load character</p>
+            <button
+              type="button"
+              onClick={onBack}
+              className="shrink-0 rounded border border-red-300 bg-white px-2 py-1 text-xs text-red-900 hover:bg-red-100"
+            >
+              ← Actors
+            </button>
+          </div>
           <p className="mt-1 text-red-800">{state.message}</p>
           {state.suggestion !== undefined && <p className="mt-2 text-red-700">{state.suggestion}</p>}
         </div>
@@ -100,14 +118,22 @@ export function CharacterSheet({ actorId, onBack }: Props): React.ReactElement {
 
       {state.kind === 'ready' && (
         <>
-          <SheetHeader character={state.actor} />
+          <SheetHeader character={state.actor} onBack={onBack} />
           <TabStrip tabs={TABS} active={activeTab} onChange={setActiveTab} />
           {activeTab === 'character' && <Character system={state.actor.system} />}
-          {activeTab === 'actions' && <Actions actions={state.actor.system.actions} items={state.actor.items} />}
+          {activeTab === 'actions' && (
+            <Actions
+              actions={state.actor.system.actions}
+              items={state.actor.items}
+              abilities={state.actor.system.abilities}
+            />
+          )}
           {activeTab === 'spells' && (
             <Spells items={state.actor.items} characterLevel={state.actor.system.details.level.value} />
           )}
-          {activeTab === 'inventory' && <Inventory items={state.actor.items} />}
+          {activeTab === 'inventory' && (
+            <Inventory items={state.actor.items} actorId={actorId} onActorChanged={reloadActor} />
+          )}
           {activeTab === 'feats' && <Feats items={state.actor.items} />}
           {activeTab === 'proficiencies' && <Proficiencies system={state.actor.system} />}
           {activeTab === 'progression' && (

--- a/apps/character-creator/src/styles/index.css
+++ b/apps/character-creator/src/styles/index.css
@@ -2,6 +2,12 @@
 @import 'tailwindcss';
 @import './pf2e/tokens.css';
 
+/* Reserve scrollbar-gutter space always so the page doesn't horizontally
+   shift when content grows past the viewport and a scrollbar appears. */
+html {
+  scrollbar-gutter: stable;
+}
+
 /* Sheet-wide base: cream parchment surface, Gelasio for long-form text.
    Individual components override via `font-sans` / `font-serif` utilities
    as needed. */

--- a/apps/foundry-api-bridge/src/commands/handlers/index.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/index.ts
@@ -105,6 +105,7 @@ export {
   listCompendiumPacksHandler,
   listCompendiumSourcesHandler,
   getCompendiumDocumentHandler,
+  dumpCompendiumPackHandler,
   findOrCreateFolderHandler,
 } from '@/commands/handlers/world';
 

--- a/apps/foundry-api-bridge/src/commands/handlers/world/DumpCompendiumPackHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/world/DumpCompendiumPackHandler.ts
@@ -1,0 +1,64 @@
+import type { CompendiumDocumentData, DumpCompendiumPackParams, DumpCompendiumPackResult } from '@/commands/types';
+import type { FoundryPackMetadata } from './worldTypes';
+
+// Foundry's CompendiumCollection exposes getDocuments() which walks
+// the pack in one async batch. That's dramatically faster than N
+// separate fromUuid() calls because it hits the pack's internal
+// hydration pipeline once and avoids the per-uuid WS round-trip.
+
+interface FoundryDocument {
+  id: string;
+  uuid: string;
+  name: string;
+  type: string;
+  img: string | null;
+  toObject(source?: boolean): { system: Record<string, unknown> };
+}
+
+interface FoundryBulkPack {
+  collection: string;
+  metadata: FoundryPackMetadata;
+  getDocuments(): Promise<FoundryDocument[]>;
+}
+
+interface FoundryPacksCollection {
+  get(id: string): FoundryBulkPack | undefined;
+}
+
+interface FoundryGame {
+  packs: FoundryPacksCollection | undefined;
+}
+
+function getGame(): FoundryGame {
+  return (globalThis as unknown as { game: FoundryGame }).game;
+}
+
+// Return every document in a pack as its serialized source form. Used
+// by the mcp-side compendium cache at warm-up time — lets the server
+// prime a full pack in one round-trip instead of N.
+export async function dumpCompendiumPackHandler(params: DumpCompendiumPackParams): Promise<DumpCompendiumPackResult> {
+  const { packs } = getGame();
+  if (!packs) {
+    throw new Error('Foundry game.packs is not available');
+  }
+  const pack = packs.get(params.packId);
+  if (!pack) {
+    throw new Error(`Compendium pack not found: ${params.packId}`);
+  }
+
+  const docs = await pack.getDocuments();
+  const documents: CompendiumDocumentData[] = docs.map((doc) => ({
+    id: doc.id,
+    uuid: doc.uuid,
+    name: doc.name,
+    type: doc.type,
+    img: doc.img ?? '',
+    system: doc.toObject(false).system,
+  }));
+
+  return {
+    packId: pack.collection,
+    packLabel: pack.metadata.label,
+    documents,
+  };
+}

--- a/apps/foundry-api-bridge/src/commands/handlers/world/FindInCompendiumHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/world/FindInCompendiumHandler.ts
@@ -76,7 +76,11 @@ export async function findInCompendiumHandler(params: FindInCompendiumParams): P
   const tokens = joinedQuery ? joinedQuery.split(/\s+/).filter((t) => t.length > 0) : [];
   const hasNameFilter = tokens.length > 0;
 
-  const limit = Math.max(1, Math.min(params.limit ?? 10, 100));
+  // Cap is sized so the mcp-side compendium cache can pull whole
+  // packs in one round-trip (pf2e.equipment-srd is the largest at
+  // ~5.6k items). The iteration below walks the pack index either
+  // way, so the cap only bounds response size, not server work.
+  const limit = Math.max(1, Math.min(params.limit ?? 10, 10_000));
 
   const requiredTraits = (params.traits ?? []).map((t) => t.toLowerCase()).filter((t) => t.length > 0);
   const hasTraitFilter = requiredTraits.length > 0;

--- a/apps/foundry-api-bridge/src/commands/handlers/world/index.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/world/index.ts
@@ -5,4 +5,5 @@ export { findInCompendiumHandler } from './FindInCompendiumHandler';
 export { listCompendiumPacksHandler } from './ListCompendiumPacksHandler';
 export { listCompendiumSourcesHandler } from './ListCompendiumSourcesHandler';
 export { getCompendiumDocumentHandler } from './GetCompendiumDocumentHandler';
+export { dumpCompendiumPackHandler } from './DumpCompendiumPackHandler';
 export { findOrCreateFolderHandler } from './FindOrCreateFolderHandler';

--- a/apps/foundry-api-bridge/src/commands/types.ts
+++ b/apps/foundry-api-bridge/src/commands/types.ts
@@ -93,6 +93,7 @@ export type CommandType =
   | 'list-compendium-packs'
   | 'list-compendium-sources'
   | 'get-compendium-document'
+  | 'dump-compendium-pack'
   | 'find-or-create-folder'
   | 'list-roll-tables'
   | 'get-roll-table'
@@ -1226,6 +1227,16 @@ export interface GetCompendiumDocumentResult {
   document: CompendiumDocumentData;
 }
 
+export interface DumpCompendiumPackParams {
+  packId: string; // e.g. 'pf2e.equipment-srd'
+}
+
+export interface DumpCompendiumPackResult {
+  packId: string;
+  packLabel: string;
+  documents: CompendiumDocumentData[];
+}
+
 /** Folder document types Foundry supports. The set mirrors
  *  CONST.FOLDER_DOCUMENT_TYPES in recent Foundry versions. */
 export type FolderDocumentType =
@@ -1542,6 +1553,7 @@ export interface CommandParamsMap {
   'list-compendium-packs': ListCompendiumPacksParams;
   'list-compendium-sources': ListCompendiumSourcesParams;
   'get-compendium-document': GetCompendiumDocumentParams;
+  'dump-compendium-pack': DumpCompendiumPackParams;
   'find-or-create-folder': FindOrCreateFolderParams;
   'list-roll-tables': ListRollTablesParams;
   'get-roll-table': GetRollTableParams;
@@ -1637,6 +1649,7 @@ export interface CommandResultMap {
   'list-compendium-packs': ListCompendiumPacksResult;
   'list-compendium-sources': ListCompendiumSourcesResult;
   'get-compendium-document': GetCompendiumDocumentResult;
+  'dump-compendium-pack': DumpCompendiumPackResult;
   'find-or-create-folder': FindOrCreateFolderResult;
   'list-roll-tables': RollTableSummary[];
   'get-roll-table': RollTableResult;

--- a/apps/foundry-api-bridge/src/main.ts
+++ b/apps/foundry-api-bridge/src/main.ts
@@ -32,6 +32,7 @@ import {
   listCompendiumPacksHandler,
   listCompendiumSourcesHandler,
   getCompendiumDocumentHandler,
+  dumpCompendiumPackHandler,
   findOrCreateFolderHandler,
   createJournalHandler,
   updateJournalHandler,
@@ -165,6 +166,7 @@ function initializeWebSocket(
   commandRouter.register('list-compendium-packs', listCompendiumPacksHandler);
   commandRouter.register('list-compendium-sources', listCompendiumSourcesHandler);
   commandRouter.register('get-compendium-document', getCompendiumDocumentHandler);
+  commandRouter.register('dump-compendium-pack', dumpCompendiumPackHandler);
   commandRouter.register('find-or-create-folder', findOrCreateFolderHandler);
   commandRouter.register('get-scene', getSceneHandler);
   commandRouter.register('get-scenes-list', getScenesListHandler);

--- a/apps/foundry-mcp/package.json
+++ b/apps/foundry-mcp/package.json
@@ -4,9 +4,9 @@
   "description": "Self-hosted MCP server that bridges Claude Code to a Foundry VTT instance over WebSocket",
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts",
+    "dev": "tsx --env-file-if-exists=.env src/index.ts",
     "build": "tsc",
-    "start": "node dist/index.js",
+    "start": "node --env-file-if-exists=.env dist/index.js",
     "lint": "eslint \"src/**/*.ts\"",
     "lint:fix": "eslint \"src/**/*.ts\" --fix",
     "test": "tsx --test test/**/*.test.ts"

--- a/apps/foundry-mcp/src/bridge.ts
+++ b/apps/foundry-mcp/src/bridge.ts
@@ -79,8 +79,22 @@ interface PendingCommand {
 let foundrySocket: WebSocket | null = null;
 const pendingCommands = new Map<string, PendingCommand>();
 
+// Side-effect subscribers for the module-connected event. Used by the
+// compendium cache to kick off warm-up once the module is reachable.
+const onConnectSubscribers = new Set<() => void>();
+
 export function isFoundryConnected(): boolean {
   return foundrySocket?.readyState === WebSocket.OPEN;
+}
+
+// Register a callback to fire each time the module reconnects. Called
+// synchronously during the ws.on('connection') handler, so any async
+// work should be fire-and-forget.
+export function onFoundryConnect(fn: () => void): () => void {
+  onConnectSubscribers.add(fn);
+  return () => {
+    onConnectSubscribers.delete(fn);
+  };
 }
 
 export function sendCommand(type: string, params: Record<string, unknown> = {}): Promise<unknown> {
@@ -186,6 +200,14 @@ wss.on('connection', (ws: WebSocket) => {
 
   foundrySocket = ws;
   log.info('Foundry module connected');
+
+  for (const fn of onConnectSubscribers) {
+    try {
+      fn();
+    } catch (err) {
+      log.warn(`onFoundryConnect subscriber threw: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
 
   // Re-sync active channels. SSE consumers held their subscriptions
   // through the Foundry disconnect, but the module's Hooks.on

--- a/apps/foundry-mcp/src/config.ts
+++ b/apps/foundry-mcp/src/config.ts
@@ -11,3 +11,14 @@ export const FOUNDRY_DATA_DIR = process.env.FOUNDRY_DATA_DIR ?? resolve(homedir(
 // an unknown endpoint. When on, arbitrary JS runs in the Foundry page;
 // only enable on trusted networks.
 export const ALLOW_EVAL = process.env.ALLOW_EVAL === '1';
+
+// Comma-separated list of compendium pack ids to pre-fetch on module
+// connection. Serves subsequent search/document requests for these
+// packs from an in-memory cache, sidestepping the per-item WS
+// round-trip. Keep empty to disable entirely.
+//
+// Example: COMPENDIUM_CACHE_PACK_IDS=pf2e.equipment-srd,pf2e.spells-srd
+export const COMPENDIUM_CACHE_PACK_IDS: readonly string[] = (process.env.COMPENDIUM_CACHE_PACK_IDS ?? '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter((s) => s.length > 0);

--- a/apps/foundry-mcp/src/http/compendium-cache-singleton.ts
+++ b/apps/foundry-mcp/src/http/compendium-cache-singleton.ts
@@ -1,0 +1,30 @@
+// Process-wide singleton for the compendium cache plus the warm-up
+// hook. Split from compendium-cache.ts so the class itself stays
+// testable without pulling in the bridge module.
+
+import { COMPENDIUM_CACHE_PACK_IDS } from '../config.js';
+import { onFoundryConnect, sendCommand } from '../bridge.js';
+import { log } from '../logger.js';
+import { CompendiumCache } from './compendium-cache.js';
+
+export const compendiumCache = new CompendiumCache(sendCommand);
+
+let registered = false;
+
+// Called once at server start. Subscribes the cache to module-
+// connection events so each (re)connect triggers a fresh warm of the
+// configured packs. No-op when COMPENDIUM_CACHE_PACK_IDS is empty.
+export function registerCompendiumCacheWarming(): void {
+  if (registered) return;
+  if (COMPENDIUM_CACHE_PACK_IDS.length === 0) {
+    log.info('compendium-cache: no packs configured — cache disabled');
+    return;
+  }
+  registered = true;
+  log.info(`compendium-cache: configured for ${COMPENDIUM_CACHE_PACK_IDS.join(', ')}`);
+  onFoundryConnect(() => {
+    log.info('compendium-cache: module connected — warming');
+    compendiumCache.clear();
+    void compendiumCache.warmAll(COMPENDIUM_CACHE_PACK_IDS);
+  });
+}

--- a/apps/foundry-mcp/src/http/compendium-cache.ts
+++ b/apps/foundry-mcp/src/http/compendium-cache.ts
@@ -1,0 +1,488 @@
+// In-memory cache of entire compendium packs, keyed by packId. Stores
+// the full documents returned by `get-compendium-document` so both
+// search and document-fetch requests can be served without a
+// round-trip to the Foundry bridge.
+//
+// Motivation: the shop-browsing UI in foundry-character-creator was
+// firing one `get-compendium-document` per search result to read
+// prices, which explodes in cost for anything beyond a narrow search.
+// Caching the whole pack collapses that into a constant-time lookup.
+//
+// The filter/sort logic here intentionally mirrors the bridge's
+// `FindInCompendiumHandler` so cached responses are indistinguishable
+// from bridge responses. Any pack that isn't warmed falls through to
+// the bridge unchanged.
+
+import { log } from '../logger.js';
+
+// Subset of a Foundry compendium document that we care about for
+// filtering. The cache stores the raw document as delivered by
+// `get-compendium-document`; this interface documents the fields we
+// *read* during filter/sort.
+export interface CompendiumDocument {
+  id: string;
+  uuid: string;
+  name: string;
+  type: string;
+  img: string;
+  system: Record<string, unknown>;
+}
+
+// Shape of the lean match emitted by the bridge's find-in-compendium
+// handler (plus the `price` field we add when responding from cache).
+export interface EnrichedMatch {
+  packId: string;
+  packLabel: string;
+  documentId: string;
+  uuid: string;
+  name: string;
+  type: string;
+  img: string;
+  level?: number;
+  traits?: string[];
+  isVersatile?: boolean;
+  price?: ItemPrice;
+}
+
+export interface ItemPrice {
+  value: Partial<Record<'pp' | 'gp' | 'sp' | 'cp', number>>;
+  per?: number;
+}
+
+export interface SearchOptions {
+  q?: string;
+  packIds?: string[];
+  documentType?: string;
+  traits?: string[];
+  anyTraits?: string[];
+  sources?: string[];
+  ancestrySlug?: string;
+  maxLevel?: number;
+  limit?: number;
+}
+
+interface CachedPack {
+  packId: string;
+  packLabel: string;
+  docs: Map<string, CompendiumDocument>;
+  docList: CompendiumDocument[];
+  warmedAt: number;
+  bytes: number;
+}
+
+export interface CompendiumCacheStats {
+  packs: string[];
+  docs: number;
+  bytes: number;
+  hits: number;
+  misses: number;
+  warmings: number;
+  warmFailures: number;
+}
+
+// Abstraction of the bridge `sendCommand` so the cache is testable
+// against a mock instead of a live WebSocket.
+export type SendCommand = (type: string, params?: Record<string, unknown>) => Promise<unknown>;
+
+// Cap for the single `dump-compendium-pack` call. Larger than any
+// current pf2e pack (equipment-srd is ~5.6k items) with headroom so a
+// single round-trip hydrates the whole pack. Falls back to per-item
+// `get-compendium-document` with bounded concurrency when the bridge
+// doesn't support the bulk command (older modules).
+const WARM_PACK_FETCH_LIMIT = 10_000;
+
+// Fallback concurrency when we have to stream individual
+// `get-compendium-document` calls (older bridge without the
+// dump-compendium-pack command). Foundry's main thread serializes
+// doc hydration, so raising this past ~8 doesn't help in practice.
+const WARM_DOC_FETCH_CONCURRENCY = 8;
+
+export class CompendiumCache {
+  private readonly packs = new Map<string, CachedPack>();
+  private readonly warming = new Map<string, Promise<void>>();
+  private hits = 0;
+  private misses = 0;
+  private warmings = 0;
+  private warmFailures = 0;
+
+  constructor(private readonly sendCommand: SendCommand) {}
+
+  // Fire-and-forget: warm multiple packs concurrently. Individual
+  // failures are swallowed (logged) so one missing pack doesn't halt
+  // the others.
+  warmAll(packIds: readonly string[]): Promise<void[]> {
+    return Promise.all(
+      packIds.map(async (packId) => {
+        try {
+          await this.warmPack(packId);
+        } catch (err) {
+          this.warmFailures++;
+          log.warn(`compendium-cache: warm failed for ${packId}: ${errMsg(err)}`);
+        }
+      }),
+    );
+  }
+
+  // Warm a single pack. Pulls the index via find-in-compendium with a
+  // high limit (no filters), then hydrates each entry through
+  // get-compendium-document with bounded concurrency. Idempotent:
+  // re-warming while a warm is in flight piggybacks on the existing
+  // promise.
+  warmPack(packId: string): Promise<void> {
+    const existing = this.warming.get(packId);
+    if (existing) return existing;
+    if (this.packs.has(packId)) return Promise.resolve();
+
+    const promise = this.doWarm(packId).finally(() => {
+      this.warming.delete(packId);
+    });
+    this.warming.set(packId, promise);
+    return promise;
+  }
+
+  private async doWarm(packId: string): Promise<void> {
+    this.warmings++;
+    const t0 = Date.now();
+    // Errors bubble to `warmAll` so they're logged in one place. An
+    // inner catch would produce duplicate messages.
+
+    // Preferred path: one `dump-compendium-pack` round-trip hydrates
+    // the whole pack in a single Foundry `pack.getDocuments()` call.
+    // Drops a 5.6k-item pack from 60-90s (one WS round-trip per doc)
+    // down to a handful of seconds — Foundry's bulk hydration is far
+    // cheaper than N × fromUuid. Falls back to individual fetches when
+    // the bridge is an older build without the command.
+    const fetched = await this.fetchPackFast(packId);
+    const documents = fetched.documents;
+    const packLabel = fetched.packLabel;
+
+    if (documents.length === 0) {
+      log.info(`compendium-cache: ${packId} has no matches — skipping warm`);
+      this.packs.set(packId, {
+        packId,
+        packLabel,
+        docs: new Map(),
+        docList: [],
+        warmedAt: Date.now(),
+        bytes: 0,
+      });
+      return;
+    }
+
+    const docs = new Map<string, CompendiumDocument>();
+    let bytes = 0;
+    for (const doc of documents) {
+      docs.set(doc.uuid, doc);
+      bytes += estimateBytes(doc);
+    }
+    const docList = [...documents].sort((a, b) => a.name.localeCompare(b.name));
+
+    this.packs.set(packId, {
+      packId,
+      packLabel,
+      docs,
+      docList,
+      warmedAt: Date.now(),
+      bytes,
+    });
+    log.info(
+      `compendium-cache: warmed ${packId} — ${docList.length.toString()} docs, ${(bytes / (1024 * 1024)).toFixed(1)} MiB, ${Date.now() - t0}ms`,
+    );
+  }
+
+  // Preferred path: one `dump-compendium-pack` round-trip hydrates
+  // the whole pack in a single Foundry `pack.getDocuments()` call.
+  // Drops a 5.6k-item pack from 60-90s (one WS round-trip per doc)
+  // down to a handful of seconds — Foundry's bulk hydration is far
+  // cheaper than N × fromUuid. Falls back to per-item fetches when
+  // the bridge is an older build without the command.
+  private async fetchPackFast(packId: string): Promise<{ packLabel: string; documents: CompendiumDocument[] }> {
+    try {
+      const dumpResult = (await this.sendCommand('dump-compendium-pack', { packId })) as {
+        packId: string;
+        packLabel: string;
+        documents: CompendiumDocument[];
+      };
+      return { packLabel: dumpResult.packLabel, documents: dumpResult.documents };
+    } catch (err) {
+      const msg = errMsg(err);
+      // "No handler registered..." / "Unknown command..." mean the
+      // bridge is a pre-dump build; fall back to the per-document
+      // path. Any other failure is a genuine error — rethrow.
+      if (!/no handler/i.test(msg) && !/unknown command/i.test(msg)) throw err;
+      log.info(`compendium-cache: bridge lacks dump-compendium-pack, falling back to per-doc warming`);
+      return this.fallbackFetchPack(packId);
+    }
+  }
+
+  // Legacy warm path: list uuids via find-in-compendium, then hydrate
+  // each one via get-compendium-document with bounded concurrency.
+  // Only hit when the bridge is too old to understand
+  // dump-compendium-pack.
+  private async fallbackFetchPack(packId: string): Promise<{ packLabel: string; documents: CompendiumDocument[] }> {
+    const indexResult = (await this.sendCommand('find-in-compendium', {
+      name: '',
+      packId,
+      limit: WARM_PACK_FETCH_LIMIT,
+    })) as { matches: Array<{ uuid: string; packId: string; packLabel: string }> };
+
+    if (!Array.isArray(indexResult.matches) || indexResult.matches.length === 0) {
+      return { packLabel: packId, documents: [] };
+    }
+
+    const packLabel = indexResult.matches[0]?.packLabel ?? packId;
+    const documents: CompendiumDocument[] = [];
+    const queue = [...indexResult.matches];
+    const workers = Array.from({ length: Math.min(WARM_DOC_FETCH_CONCURRENCY, queue.length) }, async () => {
+      while (queue.length > 0) {
+        const entry = queue.shift();
+        if (!entry) break;
+        try {
+          const result = (await this.sendCommand('get-compendium-document', { uuid: entry.uuid })) as {
+            document: CompendiumDocument;
+          };
+          if (!result.document) continue;
+          documents.push(result.document);
+        } catch (err) {
+          log.warn(`compendium-cache: failed to load ${entry.uuid}: ${errMsg(err)}`);
+        }
+      }
+    });
+    await Promise.all(workers);
+    return { packLabel, documents };
+  }
+
+  hasPack(packId: string): boolean {
+    return this.packs.has(packId);
+  }
+
+  // Serve a search request from cache. Returns null when ANY requested
+  // packId is not cached, so the caller can fall back to the bridge
+  // (partial cache-hits would return misleading results). Passing no
+  // packIds means "all cached packs"; if nothing is cached, returns
+  // null too so the caller still goes to the bridge.
+  search(opts: SearchOptions): { matches: EnrichedMatch[] } | null {
+    const requested = opts.packIds ?? Array.from(this.packs.keys());
+    if (requested.length === 0) {
+      this.misses++;
+      return null;
+    }
+    const packs: CachedPack[] = [];
+    for (const id of requested) {
+      const pack = this.packs.get(id);
+      if (!pack) {
+        this.misses++;
+        return null;
+      }
+      packs.push(pack);
+    }
+
+    this.hits++;
+    const matches = this.runFilter(packs, opts);
+    const limit = opts.limit ?? 100;
+    return { matches: matches.slice(0, limit) };
+  }
+
+  getDocument(uuid: string): CompendiumDocument | null {
+    for (const pack of this.packs.values()) {
+      const doc = pack.docs.get(uuid);
+      if (doc) {
+        this.hits++;
+        return doc;
+      }
+    }
+    this.misses++;
+    return null;
+  }
+
+  stats(): CompendiumCacheStats {
+    let docs = 0;
+    let bytes = 0;
+    for (const pack of this.packs.values()) {
+      docs += pack.docList.length;
+      bytes += pack.bytes;
+    }
+    return {
+      packs: Array.from(this.packs.keys()),
+      docs,
+      bytes,
+      hits: this.hits,
+      misses: this.misses,
+      warmings: this.warmings,
+      warmFailures: this.warmFailures,
+    };
+  }
+
+  /** Test/ops helper — drop everything. */
+  clear(): void {
+    this.packs.clear();
+    this.warming.clear();
+    this.hits = 0;
+    this.misses = 0;
+    this.warmings = 0;
+    this.warmFailures = 0;
+  }
+
+  // Filter + rank + sort, mirroring foundry-api-bridge's
+  // FindInCompendiumHandler. Keep the behaviour aligned: text tokens
+  // match in name OR traits, with a rank penalty for trait-only
+  // matches; AND-traits and OR-anyTraits filter, then level, source,
+  // ancestry.
+  private runFilter(packs: readonly CachedPack[], opts: SearchOptions): EnrichedMatch[] {
+    const tokens = (opts.q ?? '')
+      .toLowerCase()
+      .split(/\s+/)
+      .filter((t) => t.length > 0);
+    const requiredTraits = (opts.traits ?? []).map((t) => t.toLowerCase());
+    const anyTraits = (opts.anyTraits ?? []).map((t) => t.toLowerCase());
+    const allowedSources = (opts.sources ?? []).map((s) => s.toLowerCase());
+    const ancestrySlug = opts.ancestrySlug;
+    const maxLevel = opts.maxLevel;
+    const documentType = opts.documentType;
+
+    interface Scored extends EnrichedMatch {
+      rank: number;
+    }
+    const out: Scored[] = [];
+
+    for (const pack of packs) {
+      for (const doc of pack.docList) {
+        if (documentType !== undefined && doc.type !== documentType && documentType !== 'Item') {
+          // Bridge accepts 'Item' as a wildcard for every item
+          // subtype; any other documentType filters exactly.
+          continue;
+        }
+        const name = doc.name;
+        const lower = name.toLowerCase();
+        const traits = extractTraits(doc);
+        const loweredTraits = traits.map((t) => t.toLowerCase());
+
+        let allTokensInName = true;
+        if (tokens.length > 0) {
+          let ok = true;
+          for (const tok of tokens) {
+            const inName = lower.includes(tok);
+            const inTraits = loweredTraits.some((t) => t.includes(tok));
+            if (!inName && !inTraits) {
+              ok = false;
+              break;
+            }
+            if (!inName) allTokensInName = false;
+          }
+          if (!ok) continue;
+        }
+
+        if (requiredTraits.length > 0 && !requiredTraits.every((r) => loweredTraits.includes(r))) continue;
+        if (anyTraits.length > 0 && !loweredTraits.some((t) => anyTraits.includes(t))) continue;
+
+        const level = extractLevel(doc);
+        if (maxLevel !== undefined && level !== undefined && level > maxLevel) continue;
+
+        if (allowedSources.length > 0) {
+          const source = extractSource(doc);
+          if (source === undefined) continue;
+          if (!allowedSources.includes(source.toLowerCase())) continue;
+        }
+
+        if (ancestrySlug !== undefined) {
+          const entryAncestrySlug = extractAncestrySlug(doc);
+          if (entryAncestrySlug !== undefined && entryAncestrySlug !== null && entryAncestrySlug !== ancestrySlug) {
+            continue;
+          }
+        }
+
+        const match: Scored = {
+          packId: pack.packId,
+          packLabel: pack.packLabel,
+          documentId: doc.id,
+          uuid: doc.uuid,
+          name,
+          type: doc.type,
+          img: doc.img,
+          rank: tokens.length > 0 ? (allTokensInName ? score(lower, tokens.join(' ')) : 4) : 0,
+        };
+
+        if (level !== undefined) match.level = level;
+        if (traits.length > 0) match.traits = traits;
+        if (extractAncestrySlug(doc) === null) match.isVersatile = true;
+        const price = extractPrice(doc);
+        if (price) match.price = price;
+
+        out.push(match);
+      }
+    }
+
+    out.sort((a, b) => {
+      if (a.rank !== b.rank) return a.rank - b.rank;
+      return a.name.localeCompare(b.name);
+    });
+
+    // Strip the internal `rank` field from the outgoing matches.
+    return out.map(({ rank: _rank, ...rest }) => rest);
+  }
+}
+
+// Rank tiers, lower is better:
+//   0 — exact match
+//   1 — starts with the query
+//   2 — contains the query as a substring
+//   3 — all tokens appear somewhere in the name
+// The bridge uses the same 0-3 scale so our ordering matches.
+function score(name: string, query: string): number {
+  if (name === query) return 0;
+  if (name.startsWith(query)) return 1;
+  if (name.includes(query)) return 2;
+  return 3;
+}
+
+function extractTraits(doc: CompendiumDocument): string[] {
+  const raw = (doc.system as { traits?: { value?: unknown } }).traits?.value;
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((v): v is string => typeof v === 'string');
+}
+
+function extractLevel(doc: CompendiumDocument): number | undefined {
+  const sys = doc.system as { level?: unknown };
+  if (typeof sys.level === 'number') return sys.level;
+  const obj = sys.level as { value?: unknown } | undefined;
+  return typeof obj?.value === 'number' ? obj.value : undefined;
+}
+
+function extractSource(doc: CompendiumDocument): string | undefined {
+  const raw = (doc.system as { publication?: { title?: unknown } }).publication?.title;
+  return typeof raw === 'string' ? raw : undefined;
+}
+
+// Heritages/ancestry-bound items: returns the ancestry slug, `null`
+// for versatile heritages (pf2e sets `system.ancestry === null`), or
+// `undefined` for items that don't carry an ancestry field at all.
+function extractAncestrySlug(doc: CompendiumDocument): string | null | undefined {
+  const ancestry = (doc.system as { ancestry?: unknown }).ancestry;
+  if (ancestry === null) return null;
+  if (!ancestry || typeof ancestry !== 'object') return undefined;
+  const slug = (ancestry as { slug?: unknown }).slug;
+  return typeof slug === 'string' ? slug : undefined;
+}
+
+function extractPrice(doc: CompendiumDocument): ItemPrice | undefined {
+  const price = (doc.system as { price?: unknown }).price;
+  if (!price || typeof price !== 'object') return undefined;
+  const v = (price as { value?: unknown }).value;
+  if (!v || typeof v !== 'object') return undefined;
+  return price as ItemPrice;
+}
+
+function estimateBytes(doc: CompendiumDocument): number {
+  // Rough size estimate — good enough for ops/memory reporting.
+  // JSON.stringify is O(doc) and we only compute it once per doc at
+  // warm time, so the cost is acceptable.
+  try {
+    return JSON.stringify(doc).length;
+  } catch {
+    return 0;
+  }
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/apps/foundry-mcp/src/http/routes/compendium.ts
+++ b/apps/foundry-mcp/src/http/routes/compendium.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import { sendCommand } from '../../bridge.js';
+import { compendiumCache } from '../compendium-cache-singleton.js';
 import {
   compendiumSearchQuery,
   getCompendiumDocumentQuery,
@@ -11,6 +12,23 @@ export function registerCompendiumRoutes(app: FastifyInstance): void {
   app.get('/api/compendium/search', async (req) => {
     const { q, packId, documentType, traits, anyTraits, sources, ancestrySlug, maxLevel, limit } =
       compendiumSearchQuery.parse(req.query);
+
+    // Serve from cache when every requested pack is warmed. Partial
+    // hits fall through so the user doesn't see a surprising mix of
+    // cached and bridge-sourced results.
+    const cached = compendiumCache.search({
+      ...(q !== undefined ? { q } : {}),
+      ...(packId !== undefined ? { packIds: packId } : {}),
+      ...(documentType !== undefined ? { documentType } : {}),
+      ...(traits !== undefined ? { traits } : {}),
+      ...(anyTraits !== undefined ? { anyTraits } : {}),
+      ...(sources !== undefined ? { sources } : {}),
+      ...(ancestrySlug !== undefined ? { ancestrySlug } : {}),
+      ...(maxLevel !== undefined ? { maxLevel } : {}),
+      ...(limit !== undefined ? { limit } : {}),
+    });
+    if (cached) return cached;
+
     return sendCommand('find-in-compendium', {
       name: q ?? '',
       packId,
@@ -31,6 +49,8 @@ export function registerCompendiumRoutes(app: FastifyInstance): void {
 
   app.get('/api/compendium/document', async (req) => {
     const { uuid } = getCompendiumDocumentQuery.parse(req.query);
+    const cached = compendiumCache.getDocument(uuid);
+    if (cached) return { document: cached };
     return sendCommand('get-compendium-document', { uuid });
   });
 

--- a/apps/foundry-mcp/src/index.ts
+++ b/apps/foundry-mcp/src/index.ts
@@ -7,10 +7,16 @@ import { wss, isFoundryConnected } from './bridge.js';
 import { log } from './logger.js';
 import { registerTools } from './tools/index.js';
 import { buildHttpApp } from './http/app.js';
+import { registerCompendiumCacheWarming } from './http/compendium-cache-singleton.js';
 
 // Fastify app — handles /api/*, /healthz, static SPA assets, and SPA
 // fallback for unmatched GETs. Routed from the parent http.Server below.
 const httpApp = await buildHttpApp();
+
+// Subscribe the compendium cache to module-connect events. No-op when
+// COMPENDIUM_CACHE_PACK_IDS is empty, so environments that don't want
+// the cache pay nothing.
+registerCompendiumCacheWarming();
 
 // ---------------------------------------------------------------------------
 // Session management — one transport + McpServer per MCP client

--- a/apps/foundry-mcp/test/compendium-cache.test.ts
+++ b/apps/foundry-mcp/test/compendium-cache.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { CompendiumCache, type CompendiumDocument, type SendCommand } from '../src/http/compendium-cache.js';
+
+// Synthetic equipment pack — just enough items to exercise every
+// filter branch (tokens, traits, anyTraits, maxLevel, sources, price).
+const equipmentDocs: CompendiumDocument[] = [
+  {
+    id: 'javelin',
+    uuid: 'Compendium.pf2e.equipment-srd.Item.javelin',
+    name: 'Javelin',
+    type: 'weapon',
+    img: '/icons/javelin.webp',
+    system: {
+      level: { value: 0 },
+      traits: { value: ['thrown-30', 'agile'] },
+      publication: { title: 'Player Core' },
+      price: { value: { sp: 1 } },
+    },
+  },
+  {
+    id: 'bastard-sword',
+    uuid: 'Compendium.pf2e.equipment-srd.Item.bastard-sword',
+    name: 'Bastard Sword',
+    type: 'weapon',
+    img: '/icons/bastard-sword.webp',
+    system: {
+      level: { value: 0 },
+      traits: { value: ['two-hand-d12'] },
+      publication: { title: 'Player Core' },
+      price: { value: { gp: 4 } },
+    },
+  },
+  {
+    id: 'greater-healing-potion',
+    uuid: 'Compendium.pf2e.equipment-srd.Item.greater-healing-potion',
+    name: 'Healing Potion (Greater)',
+    type: 'consumable',
+    img: '/icons/potion.webp',
+    system: {
+      level: { value: 6 },
+      traits: { value: ['consumable', 'healing', 'potion'] },
+      publication: { title: 'Player Core' },
+      price: { value: { gp: 40 } },
+    },
+  },
+  {
+    id: 'backpack',
+    uuid: 'Compendium.pf2e.equipment-srd.Item.backpack',
+    name: 'Backpack',
+    type: 'backpack',
+    img: '/icons/backpack.webp',
+    system: {
+      level: { value: 0 },
+      traits: { value: [] },
+      publication: { title: 'Player Core' },
+      price: { value: { sp: 1 } },
+    },
+  },
+];
+
+// Default mock uses the bulk `dump-compendium-pack` command — the
+// path used by any current bridge build.
+function makeSendCommand(): SendCommand {
+  return async (type, params) => {
+    if (type === 'dump-compendium-pack') {
+      const packId = String(params?.['packId'] ?? '');
+      return { packId, packLabel: 'Equipment', documents: equipmentDocs };
+    }
+    if (type === 'find-in-compendium') {
+      const packId = String(params?.['packId'] ?? '');
+      return {
+        matches: equipmentDocs.map((d) => ({
+          packId,
+          packLabel: 'Equipment',
+          documentId: d.id,
+          uuid: d.uuid,
+          name: d.name,
+          type: d.type,
+          img: d.img,
+        })),
+      };
+    }
+    if (type === 'get-compendium-document') {
+      const uuid = String(params?.['uuid'] ?? '');
+      const doc = equipmentDocs.find((d) => d.uuid === uuid);
+      if (!doc) throw new Error(`doc not found: ${uuid}`);
+      return { document: doc };
+    }
+    throw new Error(`unexpected command: ${type}`);
+  };
+}
+
+// Legacy bridge that doesn't know about dump-compendium-pack — forces
+// the fallback path (find-in-compendium + per-doc get).
+function makeLegacySendCommand(): SendCommand {
+  return async (type, params) => {
+    if (type === 'dump-compendium-pack') {
+      throw new Error('No handler registered for command: dump-compendium-pack');
+    }
+    return makeSendCommand()(type, params);
+  };
+}
+
+async function makeWarmCache(): Promise<CompendiumCache> {
+  const cache = new CompendiumCache(makeSendCommand());
+  await cache.warmPack('pf2e.equipment-srd');
+  return cache;
+}
+
+describe('CompendiumCache — warm + getDocument', () => {
+  it('populates the cache and serves documents on hit', async () => {
+    const cache = await makeWarmCache();
+    const javelin = cache.getDocument('Compendium.pf2e.equipment-srd.Item.javelin');
+    assert.equal(javelin?.name, 'Javelin');
+  });
+
+  it('returns null for documents outside cached packs', async () => {
+    const cache = await makeWarmCache();
+    assert.equal(cache.getDocument('Compendium.pf2e.spells-srd.Item.fireball'), null);
+  });
+
+  it('reports stats after warm', async () => {
+    const cache = await makeWarmCache();
+    const s = cache.stats();
+    assert.equal(s.packs.length, 1);
+    assert.equal(s.docs, equipmentDocs.length);
+    assert.ok(s.bytes > 0);
+  });
+
+  it('is idempotent — warming twice doesn\'t double-fetch', async () => {
+    const cache = new CompendiumCache(makeSendCommand());
+    await Promise.all([cache.warmPack('pf2e.equipment-srd'), cache.warmPack('pf2e.equipment-srd')]);
+    assert.equal(cache.stats().warmings, 1);
+  });
+
+  it('falls back to per-document fetching when dump-compendium-pack is absent', async () => {
+    let dumpCalls = 0;
+    let findCalls = 0;
+    let docCalls = 0;
+    const legacy: SendCommand = async (type, params) => {
+      if (type === 'dump-compendium-pack') {
+        dumpCalls++;
+        throw new Error('No handler registered for command: dump-compendium-pack');
+      }
+      if (type === 'find-in-compendium') {
+        findCalls++;
+        return makeSendCommand()(type, params);
+      }
+      if (type === 'get-compendium-document') {
+        docCalls++;
+        return makeSendCommand()(type, params);
+      }
+      throw new Error(`unexpected ${type}`);
+    };
+    const cache = new CompendiumCache(legacy);
+    await cache.warmPack('pf2e.equipment-srd');
+    assert.equal(dumpCalls, 1, 'dump was attempted');
+    assert.equal(findCalls, 1, 'fell back to find-in-compendium for the index');
+    assert.equal(docCalls, equipmentDocs.length, 'fetched each doc individually');
+    // Sanity — same search results regardless of warm path.
+    const result = cache.search({ packIds: ['pf2e.equipment-srd'], q: 'bastard' });
+    assert.equal(result?.matches[0]?.name, 'Bastard Sword');
+  });
+
+  it('issues a single dump-compendium-pack on the fast path', async () => {
+    let dumpCalls = 0;
+    let otherCalls = 0;
+    const fast: SendCommand = async (type, params) => {
+      if (type === 'dump-compendium-pack') {
+        dumpCalls++;
+        return makeSendCommand()(type, params);
+      }
+      otherCalls++;
+      return makeSendCommand()(type, params);
+    };
+    const cache = new CompendiumCache(fast);
+    await cache.warmPack('pf2e.equipment-srd');
+    assert.equal(dumpCalls, 1);
+    assert.equal(otherCalls, 0, 'no per-doc fallback on the fast path');
+  });
+});
+
+describe('CompendiumCache — legacy bridge', () => {
+  it('search results match regardless of warm path', async () => {
+    const fastCache = new CompendiumCache(makeSendCommand());
+    await fastCache.warmPack('pf2e.equipment-srd');
+    const fastMatches = fastCache.search({ packIds: ['pf2e.equipment-srd'] })?.matches.map((m) => m.name);
+
+    const legacyCache = new CompendiumCache(makeLegacySendCommand());
+    await legacyCache.warmPack('pf2e.equipment-srd');
+    const legacyMatches = legacyCache.search({ packIds: ['pf2e.equipment-srd'] })?.matches.map((m) => m.name);
+
+    assert.deepEqual(fastMatches, legacyMatches);
+  });
+});
+
+describe('CompendiumCache.search — filters', () => {
+  let cache: CompendiumCache;
+  beforeEach(async () => {
+    cache = await makeWarmCache();
+  });
+
+  it('returns null when no matching packs are cached (caller falls through)', () => {
+    const result = cache.search({ packIds: ['pf2e.spells-srd'] });
+    assert.equal(result, null);
+  });
+
+  it('returns all items when no filters are set', () => {
+    const result = cache.search({ packIds: ['pf2e.equipment-srd'] });
+    assert.equal(result?.matches.length, equipmentDocs.length);
+  });
+
+  it('narrows to name tokens (q)', () => {
+    const result = cache.search({ packIds: ['pf2e.equipment-srd'], q: 'potion' });
+    assert.equal(result?.matches.length, 1);
+    assert.equal(result?.matches[0]?.name, 'Healing Potion (Greater)');
+  });
+
+  it('matches tokens against traits as a fallback', () => {
+    // "thrown" is in javelin's traits, not its name.
+    const result = cache.search({ packIds: ['pf2e.equipment-srd'], q: 'thrown' });
+    assert.equal(result?.matches.length, 1);
+    assert.equal(result?.matches[0]?.name, 'Javelin');
+  });
+
+  it('filters by required traits (AND)', () => {
+    const result = cache.search({ packIds: ['pf2e.equipment-srd'], traits: ['consumable', 'healing'] });
+    assert.equal(result?.matches.length, 1);
+    assert.equal(result?.matches[0]?.name, 'Healing Potion (Greater)');
+  });
+
+  it('filters by maxLevel', () => {
+    const result = cache.search({ packIds: ['pf2e.equipment-srd'], maxLevel: 1 });
+    const names = result?.matches.map((m) => m.name);
+    assert.ok(!names?.includes('Healing Potion (Greater)'), 'L6 potion should be excluded by maxLevel=1');
+    assert.ok(names?.includes('Javelin'));
+  });
+
+  it('filters by source', () => {
+    const result = cache.search({ packIds: ['pf2e.equipment-srd'], sources: ['Player Core'] });
+    assert.equal(result?.matches.length, equipmentDocs.length);
+    const emptyResult = cache.search({ packIds: ['pf2e.equipment-srd'], sources: ['Gamemastery Guide'] });
+    assert.equal(emptyResult?.matches.length, 0);
+  });
+
+  it('respects limit', () => {
+    const result = cache.search({ packIds: ['pf2e.equipment-srd'], limit: 2 });
+    assert.equal(result?.matches.length, 2);
+  });
+
+  it('enriches matches with price read from the cached document', () => {
+    const result = cache.search({ packIds: ['pf2e.equipment-srd'], q: 'bastard' });
+    const sword = result?.matches[0];
+    assert.deepEqual(sword?.price, { value: { gp: 4 } });
+  });
+
+  it('sorts alphabetically when no query is present', () => {
+    const result = cache.search({ packIds: ['pf2e.equipment-srd'] });
+    const names = result?.matches.map((m) => m.name) ?? [];
+    assert.deepEqual(names, [...names].sort((a, b) => a.localeCompare(b)));
+  });
+
+  it('ranks exact-name matches above substring matches', () => {
+    // Both "Bastard Sword" and "Healing Potion (Greater)" contain a
+    // space-separated token "sword" vs "healing" — exact-single-token
+    // match on "Bastard" should beat it.
+    const result = cache.search({ packIds: ['pf2e.equipment-srd'], q: 'bastard' });
+    assert.equal(result?.matches[0]?.name, 'Bastard Sword');
+  });
+});

--- a/packages/shared/src/foundry-api.ts
+++ b/packages/shared/src/foundry-api.ts
@@ -107,7 +107,7 @@ export interface CompendiumSearchOptions {
    *  through so the picker surfaces them; items without any
    *  `system.ancestry` field are unaffected. */
   ancestrySlug?: string;
-  /** Max results. Clamped server-side to 1-100, defaults to 10. */
+  /** Max results. Clamped server-side to 1-10_000, defaults to 10. */
   limit?: number;
 }
 
@@ -129,8 +129,11 @@ export interface CompendiumMatch {
    *  Absent for ancestry-specific heritages and for non-heritage items.
    *  The picker uses this to render a "Versatile Heritages" section. */
   isVersatile?: boolean;
-  /** Present on matches from cached packs (e.g. pf2e.equipment-srd)
-   *  served by dm-tool's local SQLite cache. */
+  /** Present only when the search was served from foundry-mcp's
+   *  compendium document cache (or dm-tool's local SQLite cache). Lets
+   *  the shop UI render per-tile prices without issuing a follow-up
+   *  get-compendium-document call per result. Absent for uncached
+   *  packs. */
   price?: ItemPrice;
 }
 

--- a/packages/shared/src/rpc/schemas.ts
+++ b/packages/shared/src/rpc/schemas.ts
@@ -38,7 +38,12 @@ export const compendiumSearchQuery = z.object({
   sources: csvParam,
   ancestrySlug: z.string().optional(),
   maxLevel: z.coerce.number().int().nonnegative().max(30).optional(),
-  limit: z.coerce.number().int().positive().max(100).optional(),
+  // Hard ceiling chosen so a single request can return every item in
+  // the largest cached pack (pf2e.equipment-srd ≈ 5.6k items) without
+  // pagination. The in-memory cache's filter/sort is microseconds on
+  // this size; uncached searches already iterate the full index on
+  // every call, so the bigger cap just widens the response payload.
+  limit: z.coerce.number().int().positive().max(10_000).optional(),
 });
 
 export const listCompendiumPacksQuery = z.object({


### PR DESCRIPTION
## Summary

Forward-ports three coordinated upstream PRs, all merged yesterday into the old single-repo trees but not carried across by the monorepo consolidation:

- [AlexDickerson/foundry-api-bridge#8](https://github.com/AlexDickerson/foundry-api-bridge/pull/8) — `dump-compendium-pack` bulk-dump command + `find-in-compendium` limit cap 100 → 10_000.
- [AlexDickerson/foundry-mcp#75](https://github.com/AlexDickerson/foundry-mcp/pull/75) — in-memory `CompendiumCache` warmed on each Foundry-module connect, with `price` enrichment on `/api/compendium/search` results and cached reads on `/api/compendium/document`.
- [AlexDickerson/foundry-character-creator#8](https://github.com/AlexDickerson/foundry-character-creator/pull/8) — Inventory shop mode (`ItemShopPicker`, `useShopMode`, coin-denomination sell flow) plus broad sheet polish (Progression rows, Actions strike damage incl. runes/ability/bonus, Background empty state, Inventory separators + widened `PhysicalItemType`, scrollbar-gutter, hover popover flip + `resolveLocal`).

## Monorepo adjustments

- `max(100)` → `max(10_000)` lands in `@foundry-toolkit/shared/rpc/schemas.ts` (the monorepo's schema home) rather than `apps/foundry-mcp/src/http/schemas.ts`, which now just re-exports the shared module.
- `CompendiumMatch.price` was already on the shared type (originally for dm-tool's SQLite cache); its comment is widened to cover the mcp cache path too. `limit` doc comment on `CompendiumSearchOptions` updated to reflect the new 10_000 ceiling.
- Types in `apps/character-creator/src/api/types.ts` consume `CompendiumMatch` / `ItemPrice` from `@foundry-toolkit/shared/foundry-api`, so the PR's local `price` addition is already covered. `StrikeItemSource`, `Strike`, `PhysicalItemType` + `PHYSICAL_ITEM_TYPES` updates applied.
- `npm --workspace` commands replace each app's standalone scripts. `dev` / `start` for foundry-mcp gain `--env-file-if-exists=.env` so `apps/foundry-mcp/.env` is still picked up (root `.env` stays in place for dm-tool/bridge).
- Cleaned up two monorepo-only lint regressions the port would have introduced: an unnecessary `system: item.system as unknown as Record<string, unknown>` cast in `Progression.tsx` (`PreparedActorItem.system` is already that type here) and a pair of now-unused `eslint-disable @typescript-eslint/no-unnecessary-condition` comments in `ItemShopPicker.tsx` (rule not enabled under monorepo config). Workspace lint is back to the same baseline as `main`.

## Test plan

- [x] `npm run typecheck` — all 8 workspaces clean
- [x] `npm run format:check` — clean
- [x] `npx eslint .` (root CI pass) — same 2 pre-existing warnings as `main`, 0 new
- [x] `npm test --workspace apps/foundry-api-bridge` — 614 pass
- [x] `npm test --workspace apps/foundry-mcp` — 52 pass (15 new covering cache warm / filter / fall-through / dump-vs-per-doc paths)
- [x] `npm test --workspace apps/character-creator` — 148 pass
- [x] `npm test --workspace packages/shared` — 50 pass
- [x] `npm run knip` — clean
- [ ] Manual: start mcp with `COMPENDIUM_CACHE_PACK_IDS=pf2e.equipment-srd`, confirm warm logs on Foundry connect, open character-creator shop mode and verify price-embedded tiles + no per-doc `getCompendiumDocument` bursts

🤖 Generated with [Claude Code](https://claude.com/claude-code)