### PR TITLE
Support multiple MCP servers in foundry-api-bridge

### DIFF
--- a/apps/foundry-api-bridge/src/commands/handlers/events/SetEventSubscriptionHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/events/SetEventSubscriptionHandler.ts
@@ -1,19 +1,25 @@
-import type { EventChannelController } from '@/events/EventChannelController';
+import type { EventChannelController, SubscriberId } from '@/events/EventChannelController';
 import type { SetEventSubscriptionParams, SetEventSubscriptionResult } from '@/commands/types';
 
 /**
  * Server asked the module to enable or disable forwarding for an event
  * channel. The controller owns hook state; this handler just dispatches
  * and echoes the decision back so the server can log the ack.
+ *
+ * Each connected client gets its own handler closing over its own
+ * SubscriberId so the controller can refcount channel subscriptions
+ * per-connection — running two MCP servers against one Foundry world
+ * doesn't drop a channel when one of them unsubscribes.
  */
 export function createSetEventSubscriptionHandler(
   controller: EventChannelController,
+  subscriber: SubscriberId,
 ): (params: SetEventSubscriptionParams) => Promise<SetEventSubscriptionResult> {
   return async (params) => {
     if (params.active) {
-      controller.enable(params.channel);
+      controller.enable(params.channel, subscriber);
     } else {
-      controller.disable(params.channel);
+      controller.disable(params.channel, subscriber);
     }
     return Promise.resolve({ channel: params.channel, active: params.active });
   };

--- a/apps/foundry-api-bridge/src/creator/__tests__/prompt-intercept.test.ts
+++ b/apps/foundry-api-bridge/src/creator/__tests__/prompt-intercept.test.ts
@@ -1,0 +1,159 @@
+import { installPromptInterception } from '@/creator/prompt-intercept';
+import type { WebSocketClient } from '@/transport/WebSocketClient';
+
+interface HookRecord {
+  name: string;
+  fn: (...args: unknown[]) => void;
+}
+
+class HooksMock {
+  registered: HookRecord[] = [];
+  on(name: string, fn: (...args: unknown[]) => void): number {
+    this.registered.push({ name, fn });
+    return this.registered.length;
+  }
+  off(): void {
+    // Unused for these tests; controller tear-down is exercised elsewhere.
+  }
+  fire(name: string, ...args: unknown[]): void {
+    for (const h of this.registered.filter((h) => h.name === name)) {
+      h.fn(...args);
+    }
+  }
+}
+
+let hooksMock: HooksMock;
+
+beforeEach(() => {
+  hooksMock = new HooksMock();
+  (global as unknown as Record<string, unknown>)['Hooks'] = hooksMock;
+});
+
+interface FakeClient {
+  stub: WebSocketClient;
+  sendEvent: jest.Mock;
+  resolve: (value: unknown) => void;
+  reject: (err: Error) => void;
+}
+
+function makeClient(connected = true): FakeClient {
+  let resolve!: (value: unknown) => void;
+  let reject!: (err: Error) => void;
+  const pending = new Promise<unknown>((r, rj) => {
+    resolve = r;
+    reject = rj;
+  });
+  const sendEvent = jest.fn(() => pending);
+  const stub = {
+    isConnected: () => connected,
+    sendEvent,
+  } as unknown as WebSocketClient;
+  return { stub, sendEvent, resolve, reject };
+}
+
+function makePromptApp(): {
+  app: { choices: { value: string; label: string }[]; prompt: string; selection: unknown; close: jest.Mock };
+  choices: { value: string; label: string }[];
+} {
+  const choices = [
+    { value: 'a', label: 'A' },
+    { value: 'b', label: 'B' },
+  ];
+  return {
+    app: {
+      choices,
+      prompt: 'Pick',
+      selection: null,
+      close: jest.fn().mockResolvedValue(undefined),
+    },
+    choices,
+  };
+}
+
+// Yield long enough for all pending Promise.any resolution to land.
+// Two microtask cycles cover: (1) sendEvent mock resolution, (2)
+// Promise.any internal await.
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('installPromptInterception', () => {
+  it('takes the first fulfilled response across clients', async () => {
+    const slow = makeClient();
+    const fast = makeClient();
+    installPromptInterception([slow.stub, fast.stub]);
+
+    const { app, choices } = makePromptApp();
+    hooksMock.fire('renderPickAThingPrompt', app);
+
+    expect(slow.sendEvent).toHaveBeenCalledTimes(1);
+    expect(fast.sendEvent).toHaveBeenCalledTimes(1);
+
+    fast.resolve({ value: 'b' });
+    await flushMicrotasks();
+
+    expect(app.selection).toBe(choices[1]);
+    expect(app.close).toHaveBeenCalled();
+  });
+
+  it('ignores rejections as long as one client responds', async () => {
+    const failing = makeClient();
+    const winner = makeClient();
+    installPromptInterception([failing.stub, winner.stub]);
+
+    const { app, choices } = makePromptApp();
+    hooksMock.fire('renderPickAThingPrompt', app);
+
+    failing.reject(new Error('disconnected'));
+    winner.resolve({ value: 'a' });
+    await flushMicrotasks();
+
+    expect(app.selection).toBe(choices[0]);
+  });
+
+  it('falls through to the native dialog when no clients are connected', async () => {
+    const offline = makeClient(false);
+    installPromptInterception([offline.stub]);
+
+    const { app } = makePromptApp();
+    hooksMock.fire('renderPickAThingPrompt', app);
+    await flushMicrotasks();
+
+    expect(offline.sendEvent).not.toHaveBeenCalled();
+    expect(app.close).not.toHaveBeenCalled();
+    expect(app.selection).toBeNull();
+  });
+
+  it('leaves the native dialog alone when every client rejects', async () => {
+    const a = makeClient();
+    const b = makeClient();
+    installPromptInterception([a.stub, b.stub]);
+
+    const { app } = makePromptApp();
+    hooksMock.fire('renderPickAThingPrompt', app);
+
+    a.reject(new Error('gone'));
+    b.reject(new Error('gone'));
+    await flushMicrotasks();
+
+    // Promise.any → AggregateError → caught → native dialog survives.
+    expect(app.close).not.toHaveBeenCalled();
+    expect(app.selection).toBeNull();
+  });
+
+  it('closes without a selection when the winning response says value=null', async () => {
+    const a = makeClient();
+    installPromptInterception([a.stub]);
+
+    const { app } = makePromptApp();
+    hooksMock.fire('renderPickAThingPrompt', app);
+
+    a.resolve({ value: null });
+    await flushMicrotasks();
+
+    expect(app.close).toHaveBeenCalled();
+    expect(app.selection).toBeNull();
+  });
+});

--- a/apps/foundry-api-bridge/src/creator/prompt-intercept.ts
+++ b/apps/foundry-api-bridge/src/creator/prompt-intercept.ts
@@ -55,16 +55,17 @@ interface PromptResponse {
 
 const HOOK_NAME = 'renderPickAThingPrompt';
 
-export function installPromptInterception(wsClient: WebSocketClient): void {
+export function installPromptInterception(wsClients: readonly WebSocketClient[]): void {
   // @ts-expect-error — Foundry's Hooks global is untyped in this module
   Hooks.on(HOOK_NAME, (app: PickAThingPromptApp) => {
-    void handlePrompt(app, wsClient);
+    void handlePrompt(app, wsClients);
   });
   console.log('Foundry API Bridge | ChoiceSet prompt interception installed');
 }
 
-async function handlePrompt(app: PickAThingPromptApp, wsClient: WebSocketClient): Promise<void> {
-  if (!wsClient.isConnected()) {
+async function handlePrompt(app: PickAThingPromptApp, wsClients: readonly WebSocketClient[]): Promise<void> {
+  const connected = wsClients.filter((c) => c.isConnected());
+  if (connected.length === 0) {
     // No frontend listening — fall back to the native dialog.
     return;
   }
@@ -87,7 +88,11 @@ async function handlePrompt(app: PickAThingPromptApp, wsClient: WebSocketClient)
   };
 
   try {
-    const raw = await wsClient.sendEvent('prompt-request', payload);
+    // First-response-wins across every connected client. Promise.any
+    // resolves with the first fulfillment and only rejects (with
+    // AggregateError) if *every* client rejects, in which case we
+    // fall through to the native dialog like the single-client case.
+    const raw = await Promise.any(connected.map((c) => c.sendEvent('prompt-request', payload)));
     const response = raw as PromptResponse | null;
     if (!response || response.value === null) {
       // User skipped — let pf2e's close-without-selection path run.

--- a/apps/foundry-api-bridge/src/events/EventChannelController.ts
+++ b/apps/foundry-api-bridge/src/events/EventChannelController.ts
@@ -1,4 +1,4 @@
-import type { WebSocketClient } from '@/transport/WebSocketClient';
+import type { EventPublisher } from '@/transport/Broadcaster';
 
 // Minimal local Foundry type snippets for the documents we read in hook
 // callbacks. Kept here rather than pulled from shared types because
@@ -88,28 +88,68 @@ interface HookHandle {
 // `set-event-subscription` for channels it doesn't switch on below.
 const KNOWN_CHANNELS = new Set(['rolls', 'chat', 'combat']);
 
+// Opaque handle used to refcount subscriptions per connected client.
+// Each `WebSocketClient` instance is passed in for reference equality;
+// tests can pass any object. Multiple enables with the same
+// SubscriberId are a no-op; cleanup walks every channel on disconnect.
+export type SubscriberId = object;
+
 /**
- * Owns Foundry Hook registrations for every active event channel. The
- * server's ChannelManager calls `enable` on 0→1 subscriber transitions
- * and `disable` on 1→0, so Hook callbacks exist only while somebody is
- * listening. `createChatMessage` is shared between the rolls and chat
- * channels and torn down only when both go idle.
+ * Owns Foundry Hook registrations for every active event channel.
+ * Enables on the first subscriber for a channel (0→1) and tears the
+ * Foundry hooks down only when the last subscriber disables (1→0), so
+ * running multiple MCP servers against one Foundry world doesn't drop
+ * a channel when one of them unsubscribes. `createChatMessage` is
+ * shared between the rolls and chat channels and torn down only when
+ * both go idle.
  */
 export class EventChannelController {
-  private readonly active = new Set<string>();
+  private readonly subscribers = new Map<string, Set<SubscriberId>>();
   private readonly hookHandles = new Map<string, HookHandle[]>();
   private chatMsgHookHandle: number | null = null;
 
-  constructor(private readonly wsClient: WebSocketClient) {}
+  constructor(private readonly publisher: EventPublisher) {}
 
-  enable(channel: string): void {
-    if (this.active.has(channel)) return;
+  enable(channel: string, subscriber: SubscriberId): void {
     if (!KNOWN_CHANNELS.has(channel)) {
       console.warn(`Foundry API Bridge | Unknown event channel: ${channel}`);
       return;
     }
-    this.active.add(channel);
 
+    const existing = this.subscribers.get(channel);
+    if (existing) {
+      existing.add(subscriber);
+      return;
+    }
+
+    // 0→1 transition: this is the first subscriber for the channel,
+    // so register Foundry hooks now.
+    this.subscribers.set(channel, new Set([subscriber]));
+    this.registerHooks(channel);
+    console.log(`Foundry API Bridge | Event channel enabled: ${channel}`);
+  }
+
+  disable(channel: string, subscriber: SubscriberId): void {
+    const subs = this.subscribers.get(channel);
+    if (!subs || !subs.delete(subscriber)) return;
+    if (subs.size > 0) return;
+
+    // 1→0 transition: tear down hooks for this channel.
+    this.subscribers.delete(channel);
+    this.teardownHooks(channel);
+    console.log(`Foundry API Bridge | Event channel disabled: ${channel}`);
+  }
+
+  // Remove every subscription belonging to a single connection. Invoked
+  // when a client disconnects so phantom subscriptions don't keep
+  // shared hooks alive after the server drops.
+  removeSubscriber(subscriber: SubscriberId): void {
+    for (const channel of [...this.subscribers.keys()]) {
+      this.disable(channel, subscriber);
+    }
+  }
+
+  private registerHooks(channel: string): void {
     const handles: HookHandle[] = [];
 
     switch (channel) {
@@ -122,13 +162,13 @@ export class EventChannelController {
         handles.push(
           this.reg('deleteChatMessage', (raw) => {
             if (!isFoundryChatMessage(raw)) return;
-            this.wsClient.pushEvent('chat', { eventType: 'delete', data: { id: raw.id } });
+            this.publisher.pushEvent('chat', { eventType: 'delete', data: { id: raw.id } });
           }),
         );
         handles.push(
           this.reg('updateChatMessage', (raw) => {
             if (!isFoundryChatMessage(raw)) return;
-            this.wsClient.pushEvent('chat', { eventType: 'update', data: serializeChatMessage(raw) });
+            this.publisher.pushEvent('chat', { eventType: 'update', data: serializeChatMessage(raw) });
           }),
         );
         break;
@@ -138,7 +178,7 @@ export class EventChannelController {
           (eventType: 'start' | 'turn' | 'round') =>
           (raw: unknown): void => {
             if (!isFoundryCombat(raw)) return;
-            this.wsClient.pushEvent('combat', { eventType, ...serializeCombat(raw) });
+            this.publisher.pushEvent('combat', { eventType, ...serializeCombat(raw) });
           };
         handles.push(this.reg('combatStart', combatPush('start')));
         handles.push(this.reg('combatTurn', combatPush('turn')));
@@ -146,7 +186,7 @@ export class EventChannelController {
         handles.push(
           this.reg('createCombatant', (raw) => {
             if (!isCombatantWithParent(raw) || !raw.combat) return;
-            this.wsClient.pushEvent('combat', {
+            this.publisher.pushEvent('combat', {
               eventType: 'combatant-add',
               encounterId: raw.combat.id,
               combatant: serializeCombatant(raw),
@@ -156,7 +196,7 @@ export class EventChannelController {
         handles.push(
           this.reg('deleteCombatant', (raw) => {
             if (!isCombatantWithParent(raw) || !raw.combat) return;
-            this.wsClient.pushEvent('combat', {
+            this.publisher.pushEvent('combat', {
               eventType: 'combatant-remove',
               encounterId: raw.combat.id,
               combatant: serializeCombatant(raw),
@@ -166,7 +206,7 @@ export class EventChannelController {
         handles.push(
           this.reg('deleteCombat', (raw) => {
             if (!isFoundryCombat(raw)) return;
-            this.wsClient.pushEvent('combat', { eventType: 'end', encounterId: raw.id });
+            this.publisher.pushEvent('combat', { eventType: 'end', encounterId: raw.id });
           }),
         );
         break;
@@ -176,13 +216,9 @@ export class EventChannelController {
     if (handles.length > 0) {
       this.hookHandles.set(channel, handles);
     }
-    console.log(`Foundry API Bridge | Event channel enabled: ${channel}`);
   }
 
-  disable(channel: string): void {
-    if (!this.active.has(channel)) return;
-    this.active.delete(channel);
-
+  private teardownHooks(channel: string): void {
     const handles = this.hookHandles.get(channel);
     if (handles) {
       for (const { name, id } of handles) {
@@ -195,15 +231,13 @@ export class EventChannelController {
     // when both channels have gone idle.
     if (
       (channel === 'rolls' || channel === 'chat') &&
-      !this.active.has('rolls') &&
-      !this.active.has('chat') &&
+      !this.subscribers.has('rolls') &&
+      !this.subscribers.has('chat') &&
       this.chatMsgHookHandle !== null
     ) {
       Hooks.off('createChatMessage', this.chatMsgHookHandle);
       this.chatMsgHookHandle = null;
     }
-
-    console.log(`Foundry API Bridge | Event channel disabled: ${channel}`);
   }
 
   private reg(name: string, fn: HookCallback): HookHandle {
@@ -219,14 +253,14 @@ export class EventChannelController {
   }
 
   private handleChatMessage(message: FoundryChatMessage): void {
-    if (this.active.has('rolls')) {
+    if (this.subscribers.has('rolls')) {
       const roll = message.rolls?.[0];
       if (message.isRoll && roll) {
-        this.wsClient.pushEvent('rolls', serializeRoll(message, roll));
+        this.publisher.pushEvent('rolls', serializeRoll(message, roll));
       }
     }
-    if (this.active.has('chat')) {
-      this.wsClient.pushEvent('chat', { eventType: 'create', data: serializeChatMessage(message) });
+    if (this.subscribers.has('chat')) {
+      this.publisher.pushEvent('chat', { eventType: 'create', data: serializeChatMessage(message) });
     }
   }
 }

--- a/apps/foundry-api-bridge/src/events/__tests__/EventChannelController.test.ts
+++ b/apps/foundry-api-bridge/src/events/__tests__/EventChannelController.test.ts
@@ -1,0 +1,220 @@
+import { EventChannelController } from '@/events/EventChannelController';
+import type { EventPublisher } from '@/transport/Broadcaster';
+
+// Tiny Foundry Hooks shim that lets us assert which hook names the
+// controller registered and tore down, and drive callbacks manually.
+interface HookRecord {
+  name: string;
+  id: number;
+  fn: (...args: unknown[]) => void;
+}
+
+class HooksMock {
+  private nextId = 1;
+  registered: HookRecord[] = [];
+
+  on(name: string, fn: (...args: unknown[]) => void): number {
+    const id = this.nextId++;
+    this.registered.push({ name, id, fn });
+    return id;
+  }
+
+  off(name: string, id: number): void {
+    this.registered = this.registered.filter((h) => !(h.name === name && h.id === id));
+  }
+
+  activeNames(): string[] {
+    return this.registered.map((h) => h.name).sort();
+  }
+
+  activeCount(name: string): number {
+    return this.registered.filter((h) => h.name === name).length;
+  }
+
+  fire(name: string, ...args: unknown[]): void {
+    for (const h of this.registered.filter((h) => h.name === name)) {
+      h.fn(...args);
+    }
+  }
+}
+
+let hooksMock: HooksMock;
+
+beforeEach(() => {
+  hooksMock = new HooksMock();
+  (global as unknown as Record<string, unknown>)['Hooks'] = hooksMock;
+});
+
+function makePublisher(): { publisher: EventPublisher; pushEvent: jest.Mock } {
+  const pushEvent = jest.fn();
+  return { publisher: { pushEvent }, pushEvent };
+}
+
+describe('EventChannelController', () => {
+  describe('subscriber refcounting', () => {
+    it('registers hooks on the first subscriber and tears down on the last', () => {
+      const { publisher } = makePublisher();
+      const controller = new EventChannelController(publisher);
+      const subA = {};
+      const subB = {};
+
+      controller.enable('combat', subA);
+      expect(hooksMock.activeCount('combatStart')).toBe(1);
+
+      // Second subscriber must not re-register the hooks.
+      controller.enable('combat', subB);
+      expect(hooksMock.activeCount('combatStart')).toBe(1);
+
+      // Losing one subscriber keeps hooks alive for the other.
+      controller.disable('combat', subA);
+      expect(hooksMock.activeCount('combatStart')).toBe(1);
+
+      // Last subscriber leaves — tear down.
+      controller.disable('combat', subB);
+      expect(hooksMock.activeCount('combatStart')).toBe(0);
+    });
+
+    it('ignores enable with an unknown channel', () => {
+      const { publisher } = makePublisher();
+      const controller = new EventChannelController(publisher);
+      controller.enable('bogus', {});
+      expect(hooksMock.registered).toHaveLength(0);
+    });
+
+    it('no-ops when disabling a channel the subscriber never enabled', () => {
+      const { publisher } = makePublisher();
+      const controller = new EventChannelController(publisher);
+      expect(() => {
+        controller.disable('combat', {});
+      }).not.toThrow();
+      expect(hooksMock.registered).toHaveLength(0);
+    });
+
+    it('repeated enable from the same subscriber is idempotent', () => {
+      const { publisher } = makePublisher();
+      const controller = new EventChannelController(publisher);
+      const sub = {};
+      controller.enable('combat', sub);
+      controller.enable('combat', sub);
+      expect(hooksMock.activeCount('combatStart')).toBe(1);
+
+      controller.disable('combat', sub);
+      expect(hooksMock.activeCount('combatStart')).toBe(0);
+    });
+  });
+
+  describe('shared createChatMessage hook', () => {
+    it('registers once for rolls and chat combined', () => {
+      const { publisher } = makePublisher();
+      const controller = new EventChannelController(publisher);
+      const sub = {};
+
+      controller.enable('rolls', sub);
+      expect(hooksMock.activeCount('createChatMessage')).toBe(1);
+
+      controller.enable('chat', sub);
+      expect(hooksMock.activeCount('createChatMessage')).toBe(1);
+    });
+
+    it('keeps the shared hook alive while either rolls or chat has any subscriber', () => {
+      const { publisher } = makePublisher();
+      const controller = new EventChannelController(publisher);
+      const a = {};
+      const b = {};
+
+      controller.enable('rolls', a);
+      controller.enable('chat', b);
+
+      controller.disable('rolls', a);
+      expect(hooksMock.activeCount('createChatMessage')).toBe(1);
+
+      controller.disable('chat', b);
+      expect(hooksMock.activeCount('createChatMessage')).toBe(0);
+    });
+
+    it('tears down shared hook only after every subscriber across rolls+chat has left', () => {
+      const { publisher } = makePublisher();
+      const controller = new EventChannelController(publisher);
+      const a = {};
+      const b = {};
+
+      // Two subscribers on rolls, one on chat.
+      controller.enable('rolls', a);
+      controller.enable('rolls', b);
+      controller.enable('chat', a);
+
+      controller.disable('rolls', a);
+      expect(hooksMock.activeCount('createChatMessage')).toBe(1);
+      controller.disable('chat', a);
+      expect(hooksMock.activeCount('createChatMessage')).toBe(1);
+      controller.disable('rolls', b);
+      expect(hooksMock.activeCount('createChatMessage')).toBe(0);
+    });
+  });
+
+  describe('removeSubscriber', () => {
+    it('drops every subscription for a client and tears down channels they alone held', () => {
+      const { publisher } = makePublisher();
+      const controller = new EventChannelController(publisher);
+      const a = {};
+      const b = {};
+
+      controller.enable('combat', a);
+      controller.enable('chat', a);
+      controller.enable('combat', b);
+
+      controller.removeSubscriber(a);
+
+      // `a` only held chat solo → torn down.
+      expect(hooksMock.activeCount('deleteChatMessage')).toBe(0);
+      // combat still has `b` → alive.
+      expect(hooksMock.activeCount('combatStart')).toBe(1);
+    });
+  });
+
+  describe('event publishing', () => {
+    it('publishes a rolls payload when a chat message with a roll fires', () => {
+      const { publisher, pushEvent } = makePublisher();
+      const controller = new EventChannelController(publisher);
+      controller.enable('rolls', {});
+
+      hooksMock.fire('createChatMessage', {
+        id: 'msg1',
+        isRoll: true,
+        rolls: [{ total: 17, formula: '1d20+5', dice: [{ faces: 20, results: [{ result: 12, active: true }] }] }],
+        author: { id: 'u1', name: 'GM' },
+      });
+
+      expect(pushEvent).toHaveBeenCalledWith(
+        'rolls',
+        expect.objectContaining({ id: 'msg1', formula: '1d20+5', rollTotal: 17 }),
+      );
+    });
+
+    it('does not publish to rolls for non-roll chat messages', () => {
+      const { publisher, pushEvent } = makePublisher();
+      const controller = new EventChannelController(publisher);
+      controller.enable('rolls', {});
+
+      hooksMock.fire('createChatMessage', { id: 'msg1', isRoll: false });
+
+      expect(pushEvent).not.toHaveBeenCalled();
+    });
+
+    it('publishes create/update/delete for the chat channel', () => {
+      const { publisher, pushEvent } = makePublisher();
+      const controller = new EventChannelController(publisher);
+      controller.enable('chat', {});
+
+      hooksMock.fire('createChatMessage', { id: 'msg1', isRoll: false, content: 'hi' });
+      hooksMock.fire('updateChatMessage', { id: 'msg1', isRoll: false, content: 'hi edit' });
+      hooksMock.fire('deleteChatMessage', { id: 'msg1', isRoll: false });
+
+      expect(pushEvent.mock.calls).toEqual([
+        ['chat', { eventType: 'create', data: expect.objectContaining({ id: 'msg1' }) }],
+        ['chat', { eventType: 'update', data: expect.objectContaining({ content: 'hi edit' }) }],
+        ['chat', { eventType: 'delete', data: { id: 'msg1' } }],
+      ]);
+    });
+  });
+});

--- a/apps/foundry-api-bridge/src/main.ts
+++ b/apps/foundry-api-bridge/src/main.ts
@@ -1,8 +1,16 @@
 import { ConfigManager } from '@/config/ConfigManager';
 import { installPromptInterception } from '@/creator/prompt-intercept';
 import { EventChannelController } from '@/events/EventChannelController';
-import { registerSettings, registerMenu, getWsUrl, getApiKey } from '@/settings/SettingsManager';
-import { WebSocketClient } from '@/transport';
+import {
+  registerSettings,
+  registerMenu,
+  getWsUrl,
+  getApiKey,
+  getAdditionalWsUrls,
+  parseServerConfigs,
+  type ServerConfig,
+} from '@/settings/SettingsManager';
+import { Broadcaster, WebSocketClient } from '@/transport';
 import {
   CommandRouter,
   rollDiceHandler,
@@ -98,11 +106,12 @@ import {
   updateRollTableHandler,
   deleteRollTableHandler,
   createSetEventSubscriptionHandler,
+  type SetEventSubscriptionParams,
 } from '@/commands';
 
 const MODULE_VERSION = '7.7.0';
 
-let wsClient: WebSocketClient | null = null;
+let wsClients: WebSocketClient[] = [];
 let commandRouter: CommandRouter | null = null;
 
 Hooks.once('init', () => {
@@ -125,18 +134,19 @@ function initializeModule(): void {
     ConfigManager.initialize();
     const config = ConfigManager.getConfig();
 
-    const wsUrl = getWsUrl();
-    const apiKey = getApiKey();
+    const servers = parseServerConfigs(getWsUrl(), getApiKey(), getAdditionalWsUrls());
 
-    if (!wsUrl || !apiKey) {
+    if (servers.length === 0) {
       console.log(
         `Foundry API Bridge | v${MODULE_VERSION} loaded. Configure WebSocket URL and API Key in module settings to connect.`,
       );
       return;
     }
 
-    initializeWebSocket(config.webSocket, wsUrl, apiKey);
-    console.log(`Foundry API Bridge | v${MODULE_VERSION} initialized`);
+    initializeWebSocket(config.webSocket, servers);
+    console.log(
+      `Foundry API Bridge | v${MODULE_VERSION} initialized (${String(servers.length)} server${servers.length === 1 ? '' : 's'})`,
+    );
   } catch (error: unknown) {
     console.error('Foundry API Bridge | Initialization failed:', error);
   }
@@ -144,8 +154,7 @@ function initializeModule(): void {
 
 function initializeWebSocket(
   wsConfig: { reconnectInterval: number; maxReconnectAttempts: number },
-  wsUrl: string,
-  apiKey: string,
+  servers: readonly ServerConfig[],
 ): void {
   commandRouter = new CommandRouter();
 
@@ -261,49 +270,95 @@ function initializeWebSocket(
   commandRouter.register('get-scene-background', getSceneBackgroundHandler);
   commandRouter.register('update-scene', updateSceneHandler);
 
-  const wsConnectUrl = `${wsUrl}?apiKey=${encodeURIComponent(apiKey)}`;
-  wsClient = new WebSocketClient({
-    url: wsConnectUrl,
-    reconnectInterval: wsConfig.reconnectInterval,
-    maxReconnectAttempts: wsConfig.maxReconnectAttempts,
-  });
+  wsClients = servers.map(
+    (server) =>
+      new WebSocketClient({
+        url: `${server.url}?apiKey=${encodeURIComponent(server.apiKey)}`,
+        reconnectInterval: wsConfig.reconnectInterval,
+        maxReconnectAttempts: wsConfig.maxReconnectAttempts,
+      }),
+  );
 
-  // Event channels own Hooks.on registrations on behalf of the
-  // server's ChannelManager. Created after wsClient so the controller
-  // can push event payloads without a circular dependency.
-  const eventChannels = new EventChannelController(wsClient);
-  commandRouter.register('set-event-subscription', createSetEventSubscriptionHandler(eventChannels));
+  // One controller shared across every client. The Broadcaster fans
+  // channel events to whichever clients are currently connected; the
+  // controller refcounts subscriptions per-client so one server
+  // unsubscribing doesn't drop the hook while another still wants it.
+  const broadcaster = new Broadcaster(wsClients);
+  const eventChannels = new EventChannelController(broadcaster);
 
-  wsClient.onConnect(() => {
-    console.log('Foundry API Bridge | WebSocket connected to server');
-    if (ui.notifications) {
-      ui.notifications.info('Foundry API Bridge | Connected to server');
-    }
-  });
+  for (let i = 0; i < wsClients.length; i++) {
+    const client = wsClients[i];
+    const server = servers[i];
+    // Indices line up by construction (wsClients built from servers).
+    if (!client || !server) continue;
+    const label = describeServer(server);
+    const subscriptionHandler = createSetEventSubscriptionHandler(eventChannels, client);
 
-  wsClient.onDisconnect(() => {
-    console.log('Foundry API Bridge | WebSocket disconnected from server');
-    if (ui.notifications) {
-      ui.notifications.warn('Foundry API Bridge | Disconnected from server');
-    }
-  });
+    client.onConnect(() => {
+      console.log(`Foundry API Bridge | WebSocket connected (${label})`);
+      if (ui.notifications) {
+        ui.notifications.info(`Foundry API Bridge | Connected (${label})`);
+      }
+    });
 
-  wsClient.onMessage((command) => {
-    if (!commandRouter || !wsClient) return;
+    client.onDisconnect(() => {
+      console.log(`Foundry API Bridge | WebSocket disconnected (${label})`);
+      // Drop subscriptions owned by this connection so phantom subs
+      // don't keep hooks alive while the server is gone. On reconnect
+      // the server re-requests subscription state.
+      eventChannels.removeSubscriber(client);
+      if (ui.notifications) {
+        ui.notifications.warn(`Foundry API Bridge | Disconnected (${label})`);
+      }
+    });
 
-    commandRouter
-      .execute(command)
-      .then((response) => {
-        wsClient?.send(response);
-      })
-      .catch((error: unknown) => {
-        console.error('Foundry API Bridge | Command execution failed:', error);
-      });
-  });
+    client.onMessage((command) => {
+      if (!commandRouter) return;
 
-  installPromptInterception(wsClient);
+      // set-event-subscription needs per-client identity for the
+      // controller's refcount; route it inline instead of through the
+      // shared router, which has no notion of which socket sent a
+      // command.
+      if (command.type === 'set-event-subscription') {
+        subscriptionHandler(command.params as SetEventSubscriptionParams)
+          .then((data) => {
+            client.send({ id: command.id, success: true, data });
+          })
+          .catch((error: unknown) => {
+            client.send({
+              id: command.id,
+              success: false,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          });
+        return;
+      }
 
-  wsClient.connect();
+      commandRouter
+        .execute(command)
+        .then((response) => {
+          client.send(response);
+        })
+        .catch((error: unknown) => {
+          console.error('Foundry API Bridge | Command execution failed:', error);
+        });
+    });
+  }
+
+  installPromptInterception(wsClients);
+
+  for (const client of wsClients) {
+    client.connect();
+  }
+}
+
+function describeServer(server: ServerConfig): string {
+  try {
+    const parsed = new URL(server.url);
+    return `${parsed.host}${parsed.pathname}`;
+  } catch {
+    return server.url;
+  }
 }
 
 export {};

--- a/apps/foundry-api-bridge/src/settings/SettingsManager.ts
+++ b/apps/foundry-api-bridge/src/settings/SettingsManager.ts
@@ -39,6 +39,17 @@ export function registerSettings(): void {
     default: '',
     requiresReload: true,
   });
+
+  // @ts-expect-error v13 types narrowed namespace to 'core'; our custom module namespace is valid at runtime
+  game.settings.register(MODULE_ID, 'additionalWsUrls', {
+    name: 'Additional WebSocket URLs (dev)',
+    hint: 'Extra servers, one per line. Format: ws://host:port/foundry (uses primary API Key) or ws://host:port/foundry|pk_xxx (explicit key). Blank lines and # comments ignored.',
+    scope: 'world',
+    config: true,
+    type: String,
+    default: '',
+    requiresReload: true,
+  });
 }
 
 export async function registerMenu(): Promise<void> {
@@ -73,6 +84,51 @@ export function getApiKey(): string {
   }
   // @ts-expect-error v13 types narrowed namespace to 'core'; our custom module namespace is valid at runtime
   return game.settings.get(MODULE_ID, 'apiKey') as string;
+}
+
+export function getAdditionalWsUrls(): string {
+  if (!game.settings) {
+    throw new Error('game.settings is not available');
+  }
+  // @ts-expect-error v13 types narrowed namespace to 'core'; our custom module namespace is valid at runtime
+  return game.settings.get(MODULE_ID, 'additionalWsUrls') as string;
+}
+
+export interface ServerConfig {
+  url: string;
+  apiKey: string;
+}
+
+// Parse the combined primary + additional server list. Additional
+// entries are `url` or `url|apiKey`, one per line; blank lines and
+// `#` comments are skipped. Entries without a pipe inherit the
+// primary apiKey so dev servers sharing a key only need the URL.
+// Callers get an empty list when primary is missing either field
+// *and* additional has no fully-specified entries.
+export function parseServerConfigs(
+  primaryUrl: string,
+  primaryApiKey: string,
+  additionalWsUrls: string,
+): ServerConfig[] {
+  const configs: ServerConfig[] = [];
+
+  if (primaryUrl && primaryApiKey) {
+    configs.push({ url: primaryUrl, apiKey: primaryApiKey });
+  }
+
+  for (const rawLine of additionalWsUrls.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+
+    const pipe = line.indexOf('|');
+    const url = pipe === -1 ? line : line.slice(0, pipe).trim();
+    const key = pipe === -1 ? primaryApiKey : line.slice(pipe + 1).trim();
+    if (!url || !key) continue;
+
+    configs.push({ url, apiKey: key });
+  }
+
+  return configs;
 }
 
 export function getConfig(): ModuleConfig {

--- a/apps/foundry-api-bridge/src/settings/__tests__/SettingsManager.test.ts
+++ b/apps/foundry-api-bridge/src/settings/__tests__/SettingsManager.test.ts
@@ -5,7 +5,7 @@ jest.mock('@/ui/ApiConfigForm', () => ({
   ApiConfigForm: class MockApiConfigForm {},
 }));
 
-import { registerSettings, registerMenu, getConfig, setConfig } from '@/settings/SettingsManager';
+import { registerSettings, registerMenu, getConfig, setConfig, parseServerConfigs } from '@/settings/SettingsManager';
 
 const mockSettings = {
   register: jest.fn(),
@@ -105,6 +105,54 @@ describe('SettingsManager', () => {
       await setConfig(newConfig);
 
       expect(mockSettings.set).toHaveBeenCalledWith('foundry-api-bridge', 'config', newConfig);
+    });
+  });
+
+  describe('parseServerConfigs', () => {
+    it('returns primary when only primary is configured', () => {
+      expect(parseServerConfigs('ws://a/foundry', 'pk_a', '')).toEqual([{ url: 'ws://a/foundry', apiKey: 'pk_a' }]);
+    });
+
+    it('returns empty when primary is missing url or key', () => {
+      expect(parseServerConfigs('', 'pk_a', '')).toEqual([]);
+      expect(parseServerConfigs('ws://a/foundry', '', '')).toEqual([]);
+    });
+
+    it('inherits primary apiKey for additional URLs without pipe', () => {
+      expect(parseServerConfigs('ws://a/foundry', 'pk_a', 'ws://b/foundry\nws://c/foundry')).toEqual([
+        { url: 'ws://a/foundry', apiKey: 'pk_a' },
+        { url: 'ws://b/foundry', apiKey: 'pk_a' },
+        { url: 'ws://c/foundry', apiKey: 'pk_a' },
+      ]);
+    });
+
+    it('accepts explicit apiKey per additional entry via pipe', () => {
+      expect(parseServerConfigs('ws://a/foundry', 'pk_a', 'ws://b/foundry|pk_b\nws://c/foundry|pk_c')).toEqual([
+        { url: 'ws://a/foundry', apiKey: 'pk_a' },
+        { url: 'ws://b/foundry', apiKey: 'pk_b' },
+        { url: 'ws://c/foundry', apiKey: 'pk_c' },
+      ]);
+    });
+
+    it('skips blank lines and # comments', () => {
+      const additional = ['', '# primary is defined above', 'ws://b/foundry', '   ', '# another server'].join('\n');
+      expect(parseServerConfigs('ws://a/foundry', 'pk_a', additional)).toEqual([
+        { url: 'ws://a/foundry', apiKey: 'pk_a' },
+        { url: 'ws://b/foundry', apiKey: 'pk_a' },
+      ]);
+    });
+
+    it('drops additional entries that have no key after inheritance', () => {
+      expect(parseServerConfigs('', '', 'ws://b/foundry')).toEqual([]);
+      expect(parseServerConfigs('', '', 'ws://b/foundry|pk_b')).toEqual([{ url: 'ws://b/foundry', apiKey: 'pk_b' }]);
+    });
+
+    it('handles CRLF line endings', () => {
+      expect(parseServerConfigs('ws://a/foundry', 'pk_a', 'ws://b/foundry\r\nws://c/foundry')).toEqual([
+        { url: 'ws://a/foundry', apiKey: 'pk_a' },
+        { url: 'ws://b/foundry', apiKey: 'pk_a' },
+        { url: 'ws://c/foundry', apiKey: 'pk_a' },
+      ]);
     });
   });
 });

--- a/apps/foundry-api-bridge/src/transport/Broadcaster.ts
+++ b/apps/foundry-api-bridge/src/transport/Broadcaster.ts
@@ -1,0 +1,23 @@
+import type { WebSocketClient } from '@/transport/WebSocketClient';
+
+// Fire-and-forget push surface for channel events. Matches the subset
+// of `WebSocketClient` used by `EventChannelController` so a single
+// controller can drive either one connection or many.
+export interface EventPublisher {
+  pushEvent(channel: string, data: unknown): void;
+}
+
+// Fans channel events across every connected client. Disconnected
+// clients are skipped silently — pushEvent on a dead socket is a
+// no-op today, so iterating doesn't surface errors either way.
+export class Broadcaster implements EventPublisher {
+  constructor(private readonly clients: readonly WebSocketClient[]) {}
+
+  pushEvent(channel: string, data: unknown): void {
+    for (const client of this.clients) {
+      if (client.isConnected()) {
+        client.pushEvent(channel, data);
+      }
+    }
+  }
+}

--- a/apps/foundry-api-bridge/src/transport/__tests__/Broadcaster.test.ts
+++ b/apps/foundry-api-bridge/src/transport/__tests__/Broadcaster.test.ts
@@ -1,0 +1,58 @@
+import { Broadcaster } from '@/transport/Broadcaster';
+import type { WebSocketClient } from '@/transport/WebSocketClient';
+
+// Minimal stand-in that implements only what the broadcaster reads
+// (pushEvent, isConnected) — avoids spinning up the full
+// WebSocketClient machinery just to verify fan-out.
+function makeStub(connected: boolean): {
+  stub: WebSocketClient;
+  pushEvent: jest.Mock;
+} {
+  const pushEvent = jest.fn();
+  const stub = {
+    isConnected: () => connected,
+    pushEvent,
+  } as unknown as WebSocketClient;
+  return { stub, pushEvent };
+}
+
+describe('Broadcaster', () => {
+  it('fans pushEvent to every connected client', () => {
+    const a = makeStub(true);
+    const b = makeStub(true);
+    const broadcaster = new Broadcaster([a.stub, b.stub]);
+
+    broadcaster.pushEvent('rolls', { x: 1 });
+
+    expect(a.pushEvent).toHaveBeenCalledWith('rolls', { x: 1 });
+    expect(b.pushEvent).toHaveBeenCalledWith('rolls', { x: 1 });
+  });
+
+  it('skips disconnected clients', () => {
+    const live = makeStub(true);
+    const dead = makeStub(false);
+    const broadcaster = new Broadcaster([live.stub, dead.stub]);
+
+    broadcaster.pushEvent('chat', { id: 'abc' });
+
+    expect(live.pushEvent).toHaveBeenCalledTimes(1);
+    expect(dead.pushEvent).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when nothing is connected', () => {
+    const a = makeStub(false);
+    const broadcaster = new Broadcaster([a.stub]);
+
+    expect(() => {
+      broadcaster.pushEvent('combat', {});
+    }).not.toThrow();
+    expect(a.pushEvent).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op with zero clients', () => {
+    const broadcaster = new Broadcaster([]);
+    expect(() => {
+      broadcaster.pushEvent('combat', {});
+    }).not.toThrow();
+  });
+});

--- a/apps/foundry-api-bridge/src/transport/index.ts
+++ b/apps/foundry-api-bridge/src/transport/index.ts
@@ -1,2 +1,4 @@
 export { WebSocketClient } from '@/transport/WebSocketClient';
 export type { WebSocketClientConfig, WebSocketLike, WebSocketFactory } from '@/transport/WebSocketClient';
+export { Broadcaster } from '@/transport/Broadcaster';
+export type { EventPublisher } from '@/transport/Broadcaster';


### PR DESCRIPTION
## Summary
- Add `additionalWsUrls` setting (newline-separated `url` or `url|apiKey` entries) that spins up one `WebSocketClient` per server, sharing a single `CommandRouter` and `EventChannelController`. Zero-config change for single-server users.
- `EventChannelController` now refcounts channel subscriptions per-client (via a new `SubscriberId` handle), with `removeSubscriber()` firing on disconnect. Fixes the latent single-server case too, where a second subscriber on the same channel could tear down hooks for the first.
- `installPromptInterception` races `sendEvent('prompt-request', ...)` across every connected client via `Promise.any`; first fulfillment wins, falls through to the native dialog only if every client rejects.

## Motivation
Dev ergonomics — run a prod MCP server + a local dev MCP server against the same Foundry world without swapping settings.

## Implementation notes
- `set-event-subscription` bypasses the shared `CommandRouter` and is routed inline in each client's `onMessage` so the controller sees which socket it came from — threading per-client context through every handler would be invasive for the one command that needs it.
- New `Broadcaster` transport implements a minimal `EventPublisher` interface, iterating connected clients only. The controller sees a publisher, not a client, so one-vs-many is transparent to the hook layer.
- On client disconnect, `removeSubscriber(client)` drops that client's subs; on reconnect the server re-requests subscription state.

## Test plan
- [x] 27 new Jest tests (44 → 641 total, all passing): `parseServerConfigs` (7), `Broadcaster` (4), `EventChannelController` refcount + shared-hook + publish (11), prompt race (5).
- [x] `npm run type-check`, `npm run build`, `npm run format:check` clean.
- [x] Pre-existing lint errors in unrelated `*Handler.ts` files are untouched per the monorepo's no-lint-edits-to-vendored-apps convention.
- [ ] Manual: point a second MCP server at the same Foundry instance via `additionalWsUrls`; verify both receive command replies, chat/rolls events fan to both, and prompts are answered by whichever frontend responds first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)