### PR TITLE
Add Strike + Use buttons to Actions tab

### DIFF
--- a/apps/character-creator/src/api/client.ts
+++ b/apps/character-creator/src/api/client.ts
@@ -151,6 +151,55 @@ export const api = {
         return { ok: true, messageCount: messages.length };
       `,
     }),
+  // Rolls a single MAP variant of a Strike. variantIndex 0/1/2 maps to
+  // first attack / second (MAP) / third (MAP2). The PF2e `StrikeData`
+  // lives at `actor.system.actions[i]` and each variant exposes its
+  // own `roll()` that bakes in the MAP penalty.
+  rollStrike: (id: string, strikeSlug: string, variantIndex: number): Promise<{ ok: boolean }> =>
+    api.runActorScript<{ ok: boolean }>({
+      actorId: id,
+      requireType: 'character',
+      body: `
+        const strike = actor.system.actions.find(s => s.slug === ${JSON.stringify(strikeSlug)});
+        if (!strike) throw new Error('Strike not found: ' + ${JSON.stringify(strikeSlug)});
+        const variant = strike.variants?.[${variantIndex.toString()}];
+        if (!variant) throw new Error('Strike variant ${variantIndex.toString()} not available');
+        await variant.roll({});
+        return { ok: true };
+      `,
+    }),
+  rollStrikeDamage: (id: string, strikeSlug: string, critical: boolean): Promise<{ ok: boolean }> =>
+    api.runActorScript<{ ok: boolean }>({
+      actorId: id,
+      requireType: 'character',
+      body: `
+        const strike = actor.system.actions.find(s => s.slug === ${JSON.stringify(strikeSlug)});
+        if (!strike) throw new Error('Strike not found: ' + ${JSON.stringify(strikeSlug)});
+        if (${critical.toString()}) {
+          if (typeof strike.critical !== 'function') throw new Error('Strike has no critical roll');
+          await strike.critical({});
+        } else {
+          if (typeof strike.damage !== 'function') throw new Error('Strike has no damage roll');
+          await strike.damage({});
+        }
+        return { ok: true };
+      `,
+    }),
+  // Posts an item's action card to chat — the same behaviour as the
+  // pf2e sheet's "send to chat" button on an action/reaction/free
+  // action. Consumable charge consumption is left to whoever clicks
+  // the roll buttons inside the posted card.
+  useItem: (id: string, itemId: string): Promise<{ ok: boolean }> =>
+    api.runActorScript<{ ok: boolean }>({
+      actorId: id,
+      requireType: 'character',
+      body: `
+        const item = actor.items.get(${JSON.stringify(itemId)});
+        if (!item) throw new Error('Item not found: ' + ${JSON.stringify(itemId)});
+        await item.toMessage();
+        return { ok: true };
+      `,
+    }),
   listCompendiumSources: (
     opts: {
       documentType?: string;

--- a/apps/character-creator/src/components/tabs/Actions.test.tsx
+++ b/apps/character-creator/src/components/tabs/Actions.test.tsx
@@ -23,7 +23,7 @@ describe('Actions tab — strikes', () => {
   });
 
   it('renders a card per visible strike', () => {
-    const { container } = render(<Actions actions={actions} items={items} />);
+    const { container } = render(<Actions actorId="test-actor" onItemUsed={() => undefined}actions={actions} items={items} />);
     for (const slug of Object.keys(EXPECTED_STRIKES)) {
       const card = container.querySelector(`[data-strike-slug="${slug}"]`);
       expect(card, `strike card for ${slug}`).toBeTruthy();
@@ -31,7 +31,7 @@ describe('Actions tab — strikes', () => {
   });
 
   it('renders each strike label', () => {
-    const { container } = render(<Actions actions={actions} items={items} />);
+    const { container } = render(<Actions actorId="test-actor" onItemUsed={() => undefined}actions={actions} items={items} />);
     for (const [slug, { label }] of Object.entries(EXPECTED_STRIKES)) {
       const card = container.querySelector(`[data-strike-slug="${slug}"]`);
       expect(within(card as HTMLElement).getByText(label)).toBeTruthy();
@@ -39,7 +39,7 @@ describe('Actions tab — strikes', () => {
   });
 
   it("renders each strike's three attack variants with MAP labels", () => {
-    const { container } = render(<Actions actions={actions} items={items} />);
+    const { container } = render(<Actions actorId="test-actor" onItemUsed={() => undefined}actions={actions} items={items} />);
     for (const [slug, { variants }] of Object.entries(EXPECTED_STRIKES)) {
       const card = container.querySelector(`[data-strike-slug="${slug}"]`);
       for (const label of variants) {
@@ -49,13 +49,13 @@ describe('Actions tab — strikes', () => {
   });
 
   it('shows weapon traits on the Bastard Sword card', () => {
-    const { container } = render(<Actions actions={actions} items={items} />);
+    const { container } = render(<Actions actorId="test-actor" onItemUsed={() => undefined}actions={actions} items={items} />);
     const card = container.querySelector('[data-strike-slug="bastard-sword"]');
     expect(card?.textContent).toContain('Two-Hand d12');
   });
 
   it("shows Amiri's javelin quantity (4)", () => {
-    const { container } = render(<Actions actions={actions} items={items} />);
+    const { container } = render(<Actions actorId="test-actor" onItemUsed={() => undefined}actions={actions} items={items} />);
     const card = container.querySelector('[data-strike-slug="javelin"]');
     expect(card?.textContent).toContain('×4');
   });
@@ -65,7 +65,7 @@ describe('Actions tab — strikes', () => {
   //   Bastard Sword (melee): 1d8+4 slashing
   //   Javelin (ranged+thrown): 1d6+4 piercing
   it('folds STR into melee strike damage when abilities are provided', () => {
-    const { container } = render(<Actions actions={actions} items={items} abilities={abilities} />);
+    const { container } = render(<Actions actorId="test-actor" onItemUsed={() => undefined}actions={actions} items={items} abilities={abilities} />);
     const unarmed = container.querySelector('[data-strike-slug="basic-unarmed"] [data-role="strike-damage"]');
     const bastard = container.querySelector('[data-strike-slug="bastard-sword"] [data-role="strike-damage"]');
     expect(unarmed?.textContent).toBe('1d4+4 bludgeoning');
@@ -73,13 +73,13 @@ describe('Actions tab — strikes', () => {
   });
 
   it('adds STR to a thrown ranged weapon (javelin)', () => {
-    const { container } = render(<Actions actions={actions} items={items} abilities={abilities} />);
+    const { container } = render(<Actions actorId="test-actor" onItemUsed={() => undefined}actions={actions} items={items} abilities={abilities} />);
     const javelin = container.querySelector('[data-strike-slug="javelin"] [data-role="strike-damage"]');
     expect(javelin?.textContent).toBe('1d6+4 piercing');
   });
 
   it('falls back to base-die damage when abilities are not provided', () => {
-    const { container } = render(<Actions actions={actions} items={items} />);
+    const { container } = render(<Actions actorId="test-actor" onItemUsed={() => undefined}actions={actions} items={items} />);
     const bastard = container.querySelector('[data-strike-slug="bastard-sword"] [data-role="strike-damage"]');
     expect(bastard?.textContent).toBe('1d8 slashing');
   });
@@ -98,7 +98,7 @@ describe('Actions tab — strikes', () => {
         },
       };
     });
-    const { container } = render(<Actions actions={buffed} items={items} abilities={abilities} />);
+    const { container } = render(<Actions actorId="test-actor" onItemUsed={() => undefined}actions={buffed} items={items} abilities={abilities} />);
     const bastard = container.querySelector('[data-strike-slug="bastard-sword"] [data-role="strike-damage"]');
     expect(bastard?.textContent).toBe('2d8+4 slashing');
   });
@@ -110,7 +110,7 @@ describe('Actions tab — action items', () => {
   });
 
   it('renders the Actions section with Rage and Demoralize (both 1-action)', () => {
-    const { container } = render(<Actions actions={actions} items={items} />);
+    const { container } = render(<Actions actorId="test-actor" onItemUsed={() => undefined}actions={actions} items={items} />);
     const section = container.querySelector('[data-action-section="action"]');
     expect(section, 'Actions section').toBeTruthy();
     expect(section?.textContent).toContain('Rage');
@@ -123,7 +123,7 @@ describe('Actions tab — action items', () => {
   });
 
   it('renders the Free Actions section with Quick-Tempered', () => {
-    const { container } = render(<Actions actions={actions} items={items} />);
+    const { container } = render(<Actions actorId="test-actor" onItemUsed={() => undefined}actions={actions} items={items} />);
     const section = container.querySelector('[data-action-section="free"]');
     expect(section, 'Free Actions section').toBeTruthy();
     expect(section?.textContent).toContain('Quick-Tempered');
@@ -131,18 +131,18 @@ describe('Actions tab — action items', () => {
   });
 
   it('omits the Reactions section when Amiri has no reactions', () => {
-    const { container } = render(<Actions actions={actions} items={items} />);
+    const { container } = render(<Actions actorId="test-actor" onItemUsed={() => undefined}actions={actions} items={items} />);
     const section = container.querySelector('[data-action-section="reaction"]');
     expect(section).toBeNull();
   });
 
   it('renders empty-state when no strikes and no action items', () => {
-    const { container } = render(<Actions actions={[]} items={[]} />);
+    const { container } = render(<Actions actorId="test-actor" onItemUsed={() => undefined}actions={[]} items={[]} />);
     expect(container.textContent).toContain('No actions available');
   });
 
   it('collapses action cards by default and expands on click', () => {
-    const { container } = render(<Actions actions={actions} items={items} />);
+    const { container } = render(<Actions actorId="test-actor" onItemUsed={() => undefined}actions={actions} items={items} />);
     const section = container.querySelector('[data-action-section="action"]') as HTMLElement;
     const rage = within(section)
       .getAllByText(/Rage/i)[0]

--- a/apps/character-creator/src/components/tabs/Actions.tsx
+++ b/apps/character-creator/src/components/tabs/Actions.tsx
@@ -1,20 +1,27 @@
 import { useState } from 'react';
+import { api } from '../../api/client';
 import type { Ability, AbilityKey, ActionItem, PreparedActorItem, Strike } from '../../api/types';
 import { isActionItem } from '../../api/types';
 import { enrichDescription } from '../../lib/foundry-enrichers';
+import { useActorAction, type ActorActionState } from '../../lib/useActorAction';
 import { SectionHeader } from '../common/SectionHeader';
 
 interface Props {
   actions: Strike[];
   items: PreparedActorItem[];
   abilities?: Record<AbilityKey, Ability>;
+  actorId: string;
+  /** Called after an item use succeeds — Strike rolls are chat-only and
+   *  don't trigger this. Wire to the parent's `reloadActor` so any charge
+   *  / quantity updates show up. */
+  onItemUsed: () => void;
 }
 
 // Actions tab — strikes (from system.actions[]) plus action-type items
 // split into Actions / Reactions / Free Actions. pf2e's full Actions tab
 // also has Encounter/Exploration/Downtime sub-tabs, which we skip since
 // the split mostly mirrors the same item data with a sub-trait filter.
-export function Actions({ actions, items, abilities }: Props): React.ReactElement {
+export function Actions({ actions, items, abilities, actorId, onItemUsed }: Props): React.ReactElement {
   const strikes = actions.filter((a) => a.type === 'strike' && a.visible);
   const actionItems = items.filter(isActionItem);
   const regularActions = actionItems.filter((a) => a.system.actionType.value === 'action');
@@ -33,15 +40,21 @@ export function Actions({ actions, items, abilities }: Props): React.ReactElemen
           <SectionHeader>Strikes</SectionHeader>
           <ul className="space-y-2">
             {strikes.map((strike) => (
-              <StrikeCard key={strike.slug} strike={strike} abilities={abilities} />
+              <StrikeCard key={strike.slug} strike={strike} abilities={abilities} actorId={actorId} />
             ))}
           </ul>
         </div>
       )}
 
-      <ActionSection title="Actions" kind="action" items={regularActions} />
-      <ActionSection title="Reactions" kind="reaction" items={reactions} />
-      <ActionSection title="Free Actions" kind="free" items={freeActions} />
+      <ActionSection title="Actions" kind="action" items={regularActions} actorId={actorId} onUsed={onItemUsed} />
+      <ActionSection title="Reactions" kind="reaction" items={reactions} actorId={actorId} onUsed={onItemUsed} />
+      <ActionSection
+        title="Free Actions"
+        kind="free"
+        items={freeActions}
+        actorId={actorId}
+        onUsed={onItemUsed}
+      />
     </section>
   );
 }
@@ -51,13 +64,20 @@ export function Actions({ actions, items, abilities }: Props): React.ReactElemen
 function StrikeCard({
   strike,
   abilities,
+  actorId,
 }: {
   strike: Strike;
   abilities: Record<AbilityKey, Ability> | undefined;
+  actorId: string;
 }): React.ReactElement {
   const allTraits = [...strike.traits, ...strike.weaponTraits];
   const damageText = formatStrikeDamage(strike, abilities);
   const range = strike.item.system.range;
+
+  const attack = useActorAction({ run: (variantIndex: number) => api.rollStrike(actorId, strike.slug, variantIndex) });
+  const damage = useActorAction({ run: () => api.rollStrikeDamage(actorId, strike.slug, false) });
+  const crit = useActorAction({ run: () => api.rollStrikeDamage(actorId, strike.slug, true) });
+  const error = firstError(attack.state, damage.state, crit.state);
 
   return (
     <li
@@ -88,7 +108,32 @@ function StrikeCard({
               </span>
             )}
           </div>
-          <VariantStrip variants={strike.variants} />
+          <VariantStrip
+            variants={strike.variants}
+            onVariant={(i) => void attack.trigger(i)}
+            pending={attack.state === 'pending'}
+          />
+          <div className="mt-1.5 flex flex-wrap gap-1.5" data-role="strike-damage-actions">
+            <button
+              type="button"
+              onClick={() => void damage.trigger()}
+              disabled={damage.state === 'pending'}
+              className="rounded border border-neutral-300 bg-white px-2 py-0.5 text-[11px] font-semibold text-neutral-800 hover:bg-neutral-100 disabled:opacity-50"
+              data-role="strike-damage-roll"
+            >
+              {damage.state === 'pending' ? 'Rolling…' : 'Damage'}
+            </button>
+            <button
+              type="button"
+              onClick={() => void crit.trigger()}
+              disabled={crit.state === 'pending'}
+              className="rounded border border-rose-300 bg-rose-50 px-2 py-0.5 text-[11px] font-semibold text-rose-900 hover:bg-rose-100 disabled:opacity-50"
+              data-role="strike-damage-crit"
+            >
+              {crit.state === 'pending' ? 'Rolling…' : 'Crit'}
+            </button>
+          </div>
+          {error !== null && <p className="mt-1 text-[11px] text-red-700">{error}</p>}
           {allTraits.length > 0 && <TraitChips traits={allTraits} />}
           {range !== null && range !== undefined && (
             <p className="mt-1 text-[10px] text-neutral-500">Range: {range} ft</p>
@@ -97,6 +142,13 @@ function StrikeCard({
       </div>
     </li>
   );
+}
+
+function firstError(...states: ActorActionState[]): string | null {
+  for (const s of states) {
+    if (typeof s === 'object') return s.error;
+  }
+  return null;
 }
 
 // Compose the damage string from the weapon's static `system.damage`
@@ -163,20 +215,35 @@ function computeDamageAbilityMod(
   return 0;
 }
 
-function VariantStrip({ variants }: { variants: { label: string }[] }): React.ReactElement {
+function VariantStrip({
+  variants,
+  onVariant,
+  pending,
+}: {
+  variants: { label: string }[];
+  onVariant: (index: number) => void;
+  pending: boolean;
+}): React.ReactElement {
   return (
     <ul className="mt-1 flex flex-wrap gap-1.5" role="group" aria-label="Attack variants">
       {variants.map((v, i) => (
-        <li
-          key={`${i.toString()}-${v.label}`}
-          className={[
-            'rounded border px-1.5 py-0.5 font-mono text-xs tabular-nums',
-            i === 0
-              ? 'border-emerald-300 bg-emerald-50 text-emerald-900'
-              : 'border-neutral-200 bg-neutral-50 text-neutral-700',
-          ].join(' ')}
-        >
-          {v.label}
+        <li key={`${i.toString()}-${v.label}`}>
+          <button
+            type="button"
+            onClick={() => {
+              onVariant(i);
+            }}
+            disabled={pending}
+            data-variant-index={i}
+            className={[
+              'rounded border px-1.5 py-0.5 font-mono text-xs tabular-nums disabled:opacity-50',
+              i === 0
+                ? 'border-emerald-300 bg-emerald-50 text-emerald-900 hover:bg-emerald-100'
+                : 'border-neutral-200 bg-neutral-50 text-neutral-700 hover:bg-neutral-100',
+            ].join(' ')}
+          >
+            {v.label}
+          </button>
         </li>
       ))}
     </ul>
@@ -189,10 +256,14 @@ function ActionSection({
   title,
   kind,
   items,
+  actorId,
+  onUsed,
 }: {
   title: string;
   kind: string;
   items: ActionItem[];
+  actorId: string;
+  onUsed: () => void;
 }): React.ReactElement | null {
   if (items.length === 0) return null;
   return (
@@ -200,14 +271,22 @@ function ActionSection({
       <SectionHeader>{title}</SectionHeader>
       <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
         {items.map((item) => (
-          <ActionCard key={item.id} item={item} />
+          <ActionCard key={item.id} item={item} actorId={actorId} onUsed={onUsed} />
         ))}
       </ul>
     </div>
   );
 }
 
-function ActionCard({ item }: { item: ActionItem }): React.ReactElement {
+function ActionCard({
+  item,
+  actorId,
+  onUsed,
+}: {
+  item: ActionItem;
+  actorId: string;
+  onUsed: () => void;
+}): React.ReactElement {
   const kind = item.system.actionType.value;
   const count = item.system.actions.value;
   const traits = item.system.traits.value;
@@ -215,6 +294,10 @@ function ActionCard({ item }: { item: ActionItem }): React.ReactElement {
   const description = item.system.description?.value ?? '';
   const hasDescription = description.trim() !== '';
   const enriched = hasDescription ? enrichDescription(description) : '';
+  const use = useActorAction({
+    run: () => api.useItem(actorId, item.id),
+    onSuccess: onUsed,
+  });
 
   const toggle = (): void => {
     setExpanded((v) => !v);
@@ -227,13 +310,7 @@ function ActionCard({ item }: { item: ActionItem }): React.ReactElement {
       data-action-kind={kind}
       data-expanded={expanded ? 'true' : 'false'}
     >
-      <button
-        type="button"
-        onClick={toggle}
-        aria-expanded={expanded}
-        className="flex w-full items-start gap-3 px-3 py-2 text-left hover:bg-pf-bg-dark/40"
-        data-testid="action-card-toggle"
-      >
+      <div className="flex items-start gap-3 px-3 py-2">
         <img
           src={item.img}
           alt=""
@@ -241,12 +318,37 @@ function ActionCard({ item }: { item: ActionItem }): React.ReactElement {
         />
         <div className="min-w-0 flex-1">
           <div className="flex items-baseline gap-2">
-            <span className="truncate text-sm font-medium text-neutral-900">{item.name}</span>
+            <button
+              type="button"
+              onClick={toggle}
+              aria-expanded={expanded}
+              className="min-w-0 truncate text-left text-sm font-medium text-neutral-900 hover:underline"
+              data-testid="action-card-toggle"
+            >
+              {item.name}
+            </button>
             <ActionCostBadge kind={kind} count={count} />
-            <span className="ml-auto text-[10px] text-neutral-500" aria-hidden="true">
+            <button
+              type="button"
+              onClick={() => void use.trigger()}
+              disabled={use.state === 'pending'}
+              className="ml-auto rounded border border-sky-300 bg-sky-50 px-2 py-0.5 text-[11px] font-semibold text-sky-900 hover:bg-sky-100 disabled:opacity-50"
+              data-role="action-use"
+            >
+              {use.state === 'pending' ? 'Using…' : 'Use'}
+            </button>
+            <button
+              type="button"
+              onClick={toggle}
+              aria-label={expanded ? 'Collapse' : 'Expand'}
+              className="text-[10px] text-neutral-500 hover:text-neutral-800"
+            >
               {expanded ? '▾' : '▸'}
-            </span>
+            </button>
           </div>
+          {typeof use.state === 'object' && (
+            <p className="mt-1 text-[11px] text-red-700">{use.state.error}</p>
+          )}
           {traits.length > 0 && (
             <ul className="mt-1 flex flex-wrap gap-1">
               {traits.map((slug) => (
@@ -260,7 +362,7 @@ function ActionCard({ item }: { item: ActionItem }): React.ReactElement {
             </ul>
           )}
         </div>
-      </button>
+      </div>
       {expanded && (
         <div
           className="border-t border-neutral-200 bg-pf-bg/60 px-3 py-2 text-sm text-pf-text"

--- a/apps/character-creator/src/lib/useActorAction.ts
+++ b/apps/character-creator/src/lib/useActorAction.ts
@@ -3,28 +3,32 @@ import { ApiRequestError } from '../api/client';
 
 export type ActorActionState = 'idle' | 'pending' | { error: string };
 
-interface UseActorActionOptions<T> {
-  run: () => Promise<T>;
+// Any async function — trigger's signature mirrors it so callers can
+// pass per-click args like a Strike's MAP variant index.
+type AsyncFn = (...args: never[]) => Promise<unknown>;
+
+interface UseActorActionOptions<TRun extends AsyncFn> {
+  run: TRun;
   confirm?: string;
-  onSuccess?: (result: T) => void;
+  onSuccess?: (result: Awaited<ReturnType<TRun>>) => void;
 }
 
 // Generic state machine for "click button → maybe confirm → fire request →
 // show pending → surface success or error" actions against a character
-// actor. Used by the Character tab's Long Rest button and any future
-// gameplay buttons that follow the same shell.
-export function useActorAction<T>(opts: UseActorActionOptions<T>): {
+// actor. Used by Long Rest, Strike + Use on the Actions tab, and any
+// future gameplay buttons that follow the same shell.
+export function useActorAction<TRun extends AsyncFn>(opts: UseActorActionOptions<TRun>): {
   state: ActorActionState;
-  trigger: () => Promise<void>;
+  trigger: (...args: Parameters<TRun>) => Promise<void>;
 } {
   const [state, setState] = useState<ActorActionState>('idle');
 
-  const trigger = async (): Promise<void> => {
+  const trigger = async (...args: Parameters<TRun>): Promise<void> => {
     if (state === 'pending') return;
     if (opts.confirm !== undefined && !window.confirm(opts.confirm)) return;
     setState('pending');
     try {
-      const result = await opts.run();
+      const result = (await opts.run(...args)) as Awaited<ReturnType<TRun>>;
       setState('idle');
       opts.onSuccess?.(result);
     } catch (err) {

--- a/apps/character-creator/src/pages/CharacterSheet.tsx
+++ b/apps/character-creator/src/pages/CharacterSheet.tsx
@@ -163,6 +163,8 @@ export function CharacterSheet({ actorId, onBack, preferences }: Props): React.R
               actions={state.actor.system.actions}
               items={state.actor.items}
               abilities={state.actor.system.abilities}
+              actorId={actorId}
+              onItemUsed={reloadActor}
             />
           )}
           {activeTab === 'spells' && (


### PR DESCRIPTION
## Summary

Exposes native PF2e character-sheet gameplay on the Actions tab:

- **Clickable Strike variants** — the existing `VariantStrip` chips (MAP 0 / −5 / −10) become buttons; each rolls `actor.system.actions[…].variants[i].roll()`.
- **Strike Damage / Crit** — two small buttons below each variant strip for `strike.damage()` / `strike.critical()`.
- **Use button per action item** — on each Actions/Reactions/Free Actions card; calls `item.toMessage()` to post the card to chat (matches pf2e's "send to chat" sheet button).

## Implementation notes

- Continues on `/api/eval` (ALLOW_EVAL=1) — the bridge's typed `roll-attack` / `roll-damage` handlers don't support MAP variant selection, so they can't back the chips without bridge work.
- `useActorAction` is now variadic — `trigger(...args)` mirrors `run`'s parameters so a single hook instance can handle all 3 MAP variants (variant index is the arg). Long Rest's call site still works unchanged.
- `ActionCard` restructured so the Use button isn't nested inside the toggle button (browsers tolerate it, but it's invalid HTML). Action name + chevron now each own their own `<button>`; `data-testid=\"action-card-toggle\"` is still present and still expands the card.
- Strike rolls are chat-only → no refetch. Use rolls may consume a charge → wired to `reloadActor`.

## Stacked on [#21](https://github.com/AlexDickerson/foundry-toolkit/pull/21)

This branch is based on `long-rest-button` (PR #21) for `useActorAction` + `api.runActorScript`. Merge #21 first.

## Test plan

- [x] `npm run typecheck --workspace=apps/character-creator` passes
- [x] `npm run test --workspace=apps/character-creator` passes (148/148)
- [x] Mock-mode preview: 3 Strike cards render with 3 clickable variant buttons each + Damage + Crit, and 3 action items render with a Use button each
- [x] Clicking a variant / Damage / Crit / Use fires /api/eval and surfaces the 404 error inline (expected in mock mode without foundry-mcp)
- [ ] Against live Foundry + ALLOW_EVAL=1:
  - [ ] Clicking variant 0 rolls the primary strike with no MAP penalty
  - [ ] Clicking variant 1 / 2 rolls with −5 / −10 (or −4 / −8 on agile) in the chat card
  - [ ] Damage button rolls standard damage; Crit button rolls doubled + crit effects
  - [ ] Use on Rage posts the action card to chat