### PR TITLE
Migrate simple-lookup IPC handlers to the prepared compendium

### DIFF
--- a/apps/dm-tool/electron/ipc/chat.ts
+++ b/apps/dm-tool/electron/ipc/chat.ts
@@ -1,7 +1,7 @@
 import { ipcMain } from 'electron';
 import type { ChatMessage, ChatModel } from '@foundry-toolkit/shared/types';
 import { streamChat } from '@foundry-toolkit/ai/chat';
-import { searchMonsters, searchItems } from '@foundry-toolkit/db/pf2e';
+import { getPreparedCompendium } from '../compendium/singleton.js';
 
 /** Max characters of page text to send as tool context. ~2K tokens. */
 const TOOL_CONTEXT_LIMIT = 8000;
@@ -24,13 +24,21 @@ export function registerChatHandlers(getMainWindow: () => Electron.BrowserWindow
       };
 
       try {
+        // Route the chat agent's monster/item tool lookups through the
+        // foundry-mcp-backed prepared compendium. Each call is resolved
+        // at invocation time rather than captured up front so an IPC
+        // racing the compendium init surfaces a clear error.
+        const prepared = getPreparedCompendium();
         await streamChat({
           apiKey: args.apiKey,
           messages: args.messages ?? [],
           model: args.model,
           rulesMode: args.rulesMode,
           toolContext: args.toolContext,
-          toolDeps: { searchMonsters, searchItems },
+          toolDeps: {
+            searchMonsters: (q) => prepared.searchMonsters(q),
+            searchItems: (q) => prepared.searchItems(q),
+          },
           onChunk: sendChunk,
         });
       } catch (err: unknown) {

--- a/apps/dm-tool/electron/ipc/combat.ts
+++ b/apps/dm-tool/electron/ipc/combat.ts
@@ -5,13 +5,8 @@ import { ipcMain } from 'electron';
 import type { Encounter, LootItem, PushEncounterResult } from '@foundry-toolkit/shared/types';
 import { generateEncounterLoot, type LootMonster } from '@foundry-toolkit/ai/loot';
 import type { DmToolConfig } from '../config.js';
-import {
-  buildLootShortlist,
-  deleteEncounter,
-  getMonsterRowByName,
-  listEncounters,
-  upsertEncounter,
-} from '@foundry-toolkit/db/pf2e';
+import { buildLootShortlist, deleteEncounter, listEncounters, upsertEncounter } from '@foundry-toolkit/db/pf2e';
+import { getPreparedCompendium } from '../compendium/singleton.js';
 import { tryParseJson } from '../util.js';
 import { pushEncounterActorsToFoundry } from '../encounter-push.js';
 
@@ -26,17 +21,28 @@ export function registerCombatHandlers(cfg: DmToolConfig): void {
         throw new Error('Anthropic API key is not set. Add one in Settings.');
       }
 
-      const monsters: LootMonster[] = [];
-      for (const c of args.encounter.combatants) {
-        if (c.kind !== 'monster' || !c.monsterName) continue;
-        const row = getMonsterRowByName(c.monsterName);
-        if (!row) continue;
-        monsters.push({
-          name: row.name,
-          level: row.level,
-          traits: tryParseJson<string[]>(row.traits, []),
-        });
-      }
+      // Pull canonical stat rows via the prepared compendium (foundry-mcp)
+      // for every monster in the encounter. Missing entries are skipped —
+      // same behaviour as the old SQLite path. Fetches in parallel so a
+      // large encounter doesn't serialise the network round-trips.
+      const prepared = getPreparedCompendium();
+      const rows = await Promise.all(
+        args.encounter.combatants.map(async (c) => {
+          if (c.kind !== 'monster' || !c.monsterName) return null;
+          return prepared.getMonsterRowByName(c.monsterName);
+        }),
+      );
+      const monsters: LootMonster[] = rows.flatMap((row) =>
+        row
+          ? [
+              {
+                name: row.name,
+                level: row.level,
+                traits: tryParseJson<string[]>(row.traits, []),
+              },
+            ]
+          : [],
+      );
 
       const shortlist = buildLootShortlist(args.partyLevel);
 

--- a/apps/dm-tool/electron/ipc/config.ts
+++ b/apps/dm-tool/electron/ipc/config.ts
@@ -7,7 +7,6 @@ import type { VisionMediaType } from '@foundry-toolkit/ai/hooks';
 import type { MapDb } from '@foundry-toolkit/db/maps';
 import type { DmToolConfig } from '../config.js';
 import type { ConfigPaths, MapDetail, PickPathArgs } from '@foundry-toolkit/shared/types';
-import { getMonsterPreview } from '@foundry-toolkit/db/pf2e';
 import { fetchAonPreview } from '../aon-preview.js';
 import { appendAdditionalHooks, getAdditionalHooks } from '../hooks-store.js';
 import { THUMBNAIL_SUFFIX } from '../constants.js';
@@ -93,49 +92,12 @@ export function registerConfigHandlers(db: MapDb, cfg: DmToolConfig): void {
 
   ipcMain.handle('aonPreview', async (_e, urlPath: string) => {
     if (typeof urlPath !== 'string') return null;
-
-    // Try local DB first for creature URLs.
-    if (urlPath.includes('Monsters.aspx')) {
-      try {
-        const fullUrl = `https://2e.aonprd.com${urlPath}`;
-        const local = getMonsterPreview(fullUrl);
-        if (local) {
-          return {
-            type: 'creature' as const,
-            name: local.name,
-            level: local.level,
-            hp: local.hp,
-            ac: local.ac,
-            fortitude: local.fort,
-            reflex: local.ref,
-            will: local.will,
-            perception: local.perception,
-            speed: local.speed,
-            size: local.size,
-            traits: local.traits,
-            abilities: [],
-            immunities: local.immunities ? local.immunities.split(', ') : [],
-            weaknesses: local.weaknesses,
-            rarity: local.rarity.toLowerCase(),
-            summary: local.description.slice(0, 200),
-            strength: local.str,
-            dexterity: local.dex,
-            constitution: local.con,
-            intelligence: local.int,
-            wisdom: local.wis,
-            charisma: local.cha,
-            statBlock:
-              local.abilities +
-              '\n---\n' +
-              (local.melee ? `Melee ${local.melee}` : '') +
-              (local.ranged ? `\nRanged ${local.ranged}` : ''),
-          };
-        }
-      } catch {
-        /* fall through to AoN */
-      }
-    }
-
+    // Compendium migration: the previous local-DB fast-path keyed on
+    // the AoN URL, which foundry-mcp doesn't expose as a searchable
+    // field. Route every hover through the AoN fetch — per-hover
+    // latency is worse, but the compendium browser already covers
+    // structured stat-block reads, and AoN content is the authoritative
+    // hover preview source.
     return fetchAonPreview(urlPath);
   });
 

--- a/apps/dm-tool/electron/ipc/monsters.ts
+++ b/apps/dm-tool/electron/ipc/monsters.ts
@@ -1,6 +1,7 @@
 import { ipcMain } from 'electron';
 import type { MonsterSearchParams } from '@foundry-toolkit/shared/types';
-import { listMonsters, getMonsterFacets, getMonsterByName } from '@foundry-toolkit/db/pf2e';
+import { listMonsters, getMonsterFacets } from '@foundry-toolkit/db/pf2e';
+import { getPreparedCompendium } from '../compendium/singleton.js';
 
 export function registerMonsterHandlers(): void {
   ipcMain.handle('monstersSearch', (_e, params: MonsterSearchParams) => {
@@ -11,7 +12,9 @@ export function registerMonsterHandlers(): void {
     return getMonsterFacets();
   });
 
+  // monstersGetDetail — single-name lookup for the Monster Detail pane.
+  // Now backed by foundry-mcp via the prepared-compendium facade.
   ipcMain.handle('monstersGetDetail', (_e, name: string) => {
-    return getMonsterByName(name);
+    return getPreparedCompendium().getMonsterByName(name);
   });
 }

--- a/packages/ai/src/chat/tools.ts
+++ b/packages/ai/src/chat/tools.ts
@@ -16,11 +16,13 @@ import {
 import { searchCommunity } from '../shared/community.js';
 
 export interface ChatToolDeps {
-  /** Optional local monster lookup (e.g. against a pf2e-db SQLite). Return a
-   *  string that starts with "[No" if nothing was found, to trigger AoN fallback. */
-  searchMonsters?: (query: string) => string;
+  /** Optional local monster lookup (e.g. against a foundry-mcp compendium
+   *  HTTP client, or a pf2e-db SQLite). Return a string that starts with
+   *  "[No" if nothing was found, to trigger AoN fallback. Async so callers
+   *  backing it with a network request don't need to block the call-stack. */
+  searchMonsters?: (query: string) => Promise<string>;
   /** Optional local item lookup (same contract as searchMonsters). */
-  searchItems?: (query: string) => string;
+  searchItems?: (query: string) => Promise<string>;
 }
 
 export function createChatTools(deps: ChatToolDeps = {}) {
@@ -65,10 +67,10 @@ export function createChatTools(deps: ChatToolDeps = {}) {
     execute: async ({ query }) => {
       if (deps.searchMonsters) {
         try {
-          const local = deps.searchMonsters(query);
+          const local = await deps.searchMonsters(query);
           if (!local.startsWith('[No')) return local;
         } catch {
-          /* local DB failed, fall through */
+          /* local lookup failed, fall through */
         }
       }
       return searchMonsterAoN(query);
@@ -85,10 +87,10 @@ export function createChatTools(deps: ChatToolDeps = {}) {
     execute: async ({ query }) => {
       if (deps.searchItems) {
         try {
-          const local = deps.searchItems(query);
+          const local = await deps.searchItems(query);
           if (!local.startsWith('[No')) return local;
         } catch {
-          /* local DB failed, fall through */
+          /* local lookup failed, fall through */
         }
       }
       return searchItemAoN(query);


### PR DESCRIPTION
## Summary

Phase 2 of the dm-tool `pf2e.db` → foundry-mcp migration. Flips five single-document / keyword-search consumer sites off the SQLite compendium onto the prepared-compendium facade from [#28](https://github.com/AlexDickerson/foundry-toolkit/pull/28).

## Sites migrated

| Site | File | Change |
|------|------|--------|
| Chat monster search | `electron/ipc/chat.ts` | `toolDeps.searchMonsters` → `prepared.searchMonsters` |
| Chat item search | `electron/ipc/chat.ts` | `toolDeps.searchItems` → `prepared.searchItems` |
| Monster detail pane | `electron/ipc/monsters.ts:monstersGetDetail` | → `prepared.getMonsterByName` |
| Loot-gen monster stat rows | `electron/ipc/combat.ts:generateEncounterLoot` | → `prepared.getMonsterRowByName` (parallel `Promise.all`) |
| AoN hover preview | `electron/ipc/config.ts:aonPreview` | SQLite fast-path dropped; always fetches from AoN |

## Contract change in `@foundry-toolkit/ai/chat`

`ChatToolDeps.searchMonsters` / `searchItems` changed from sync `(q: string) => string` to async `(q: string) => Promise<string>`. The in-tool `execute` callback was already async; only the call site needed an `await`. Unblocks any backing implementation that needs a network round-trip.

## Behaviour notes

- AoN hover card: per-hover latency now always includes the AoN round-trip (the SQLite fast-path used an `aon_url` column foundry-mcp doesn't index). The compendium browser remains the authoritative path for structured stat-block reads; AoN is authoritative for the live page-rendered hover content either way.
- Loot-gen monster lookups now parallel-fetch via `Promise.all` — for a 5-monster encounter that's 5 concurrent requests vs 5 serial SQLite calls. Tolerable cold, instant with the document cache warm.
- Every prepared-compendium consumer resolves `getPreparedCompendium()` at invocation time rather than capturing it up front, so a call racing the async init fires a clean error instead of a stale reference.

## What's not in this PR

- Monster + Item browser list & facets — Phase 3
- Item detail pane — Phase 4
- Loot-gen item shortlist (`buildLootShortlist` in `combat.ts`) — Phase 5
- Final deletion of `packages/db/src/pf2e/compendium.ts` — Phase 6

## Test plan

- [x] `npm run typecheck` — whole monorepo clean
- [x] `npm run test` — all workspace suites green: dm-tool 148, character-creator 215, foundry-api-bridge 655, foundry-mcp 77, pf2e-rules 11, shared 50
- [x] `npx eslint .` — only pre-existing warnings in untouched files
- [x] `npm run format:check` — clean
- [x] Chat tool `deps` async contract change propagates cleanly; no consumer breakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)