### PR TITLE
Render crafting abilities on the Crafting tab

### DIFF
--- a/apps/character-creator/src/api/types.ts
+++ b/apps/character-creator/src/api/types.ts
@@ -306,12 +306,45 @@ export interface CraftingFormulaEntry {
   expended?: { nth?: number; day?: string } | null;
 }
 
+// A formula prepared into a crafting ability's slot (alchemist infused
+// reagent, herbalist remedy, etc.). Matches pf2e's `PreparedFormulaData`
+// on the upstream actor. `expended` tracks whether the slot has been
+// consumed today; `isSignatureItem` flags an alchemist's chosen
+// signature item for free heightening.
+export interface PreparedFormulaData {
+  uuid: string;
+  quantity?: number;
+  expended?: boolean;
+  isSignatureItem?: boolean;
+}
+
+// A crafting ability on a character (pf2e's `CraftingAbilityData`),
+// keyed by slug in `system.crafting.entries`. Represents a class/feat
+// that grants crafting: alchemist's "Infused Reagents", herbalist's
+// remedies, magical crafting, etc. `fieldDiscovery` and `craftableItems`
+// carry predicate data we don't render yet — kept loose.
+export interface CraftingAbilityData {
+  slug: string;
+  label: string;
+  resource: string | null;
+  isAlchemical: boolean;
+  isDailyPrep: boolean;
+  isPrepared: boolean;
+  maxSlots: number | null;
+  batchSize: number;
+  maxItemLevel: number;
+  preparedFormulaData: PreparedFormulaData[];
+  fieldDiscovery?: unknown;
+  fieldDiscoveryBatchSize?: number;
+  craftableItems?: unknown[];
+}
+
 export interface CraftingField {
   formulas: CraftingFormulaEntry[];
-  // Daily-prep slots keyed by entry id (alchemist, herbalist, etc.).
-  // Shape varies by class; we don't render these yet — they belong with
-  // the daily-prep sub-app this port intentionally skips.
-  entries: Record<string, unknown>;
+  // Crafting abilities keyed by slug. Each ability tracks its own
+  // prepared-formula list plus metadata (daily prep, alchemical,
+  // max item level, etc.). Shape matches pf2e's `CraftingAbilityData`.
+  entries: Record<string, CraftingAbilityData>;
 }
 
 export interface CharacterSystem {

--- a/apps/character-creator/src/components/tabs/Crafting.tsx
+++ b/apps/character-creator/src/components/tabs/Crafting.tsx
@@ -1,6 +1,12 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { api, ApiRequestError } from '../../api/client';
-import type { CompendiumDocument, CraftingField, CraftingFormulaEntry } from '../../api/types';
+import type {
+  CompendiumDocument,
+  CraftingAbilityData,
+  CraftingField,
+  CraftingFormulaEntry,
+  PreparedFormulaData,
+} from '../../api/types';
 import { SectionHeader } from '../common/SectionHeader';
 
 interface Props {
@@ -12,15 +18,25 @@ type Resolution =
   | { kind: 'ok'; document: CompendiumDocument }
   | { kind: 'error'; message: string };
 
-// Crafting tab — read-only formula book. pf2e's formulas are compendium
-// UUID references, so we resolve each via `/api/compendium/document` to
-// show a name/image. Daily-prep entries (alchemist bombs, herbalist
-// remedies, etc.) live on `system.crafting.entries` but intentionally
-// aren't rendered here — they belong with the daily-prep sub-app that
-// the sheet port plan defers.
+// Crafting tab — read-only view of the character's formula book plus
+// each crafting ability (alchemist infused reagents, herbalist remedies,
+// magical crafting, etc.). pf2e stores abilities on
+// `system.crafting.entries` keyed by slug; each one has its own prepared
+// formula list plus metadata. We render generically — no class-specific
+// logic — so new abilities from future class features show up without
+// code changes. Daily-prep mutations (prep/expend slots) aren't part of
+// this read-only phase; see the standalone-play-surface plan for the
+// outbound-actions step.
 export function Crafting({ crafting }: Props): React.ReactElement {
   const formulas = crafting.formulas;
-  const resolutions = useFormulaResolutions(formulas);
+  const entries = useMemo(
+    // Sort by label for deterministic rendering — Object.values order
+    // is insertion-order which varies by how pf2e built the entries map.
+    () => Object.values(crafting.entries).sort((a, b) => a.label.localeCompare(b.label)),
+    [crafting.entries],
+  );
+  const uuids = useMemo(() => collectUuids(formulas, entries), [formulas, entries]);
+  const resolutions = useUuidResolutions(uuids);
 
   return (
     <section className="space-y-6">
@@ -36,6 +52,17 @@ export function Crafting({ crafting }: Props): React.ReactElement {
           </ul>
         )}
       </div>
+
+      {entries.length > 0 && (
+        <div>
+          <SectionHeader>Crafting Abilities</SectionHeader>
+          <ul className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+            {entries.map((entry) => (
+              <CraftingAbilityCard key={entry.slug} entry={entry} resolutions={resolutions} />
+            ))}
+          </ul>
+        </div>
+      )}
     </section>
   );
 }
@@ -86,17 +113,125 @@ function FormulaCard({
   );
 }
 
+function CraftingAbilityCard({
+  entry,
+  resolutions,
+}: {
+  entry: CraftingAbilityData;
+  resolutions: Map<string, Resolution>;
+}): React.ReactElement {
+  const prepared = entry.preparedFormulaData;
+  const slotsUsed = prepared.length;
+  const slotsMax = entry.maxSlots;
+
+  return (
+    <li className="rounded border border-pf-border bg-white p-3" data-ability-slug={entry.slug}>
+      <div className="flex items-start justify-between gap-2">
+        <h3 className="text-sm font-semibold text-pf-text">{entry.label}</h3>
+        <div className="flex flex-shrink-0 flex-wrap items-start justify-end gap-1">
+          {entry.isAlchemical && <Badge>Alchemical</Badge>}
+          {entry.isDailyPrep && <Badge>Daily Prep</Badge>}
+        </div>
+      </div>
+      <dl className="mt-2 grid grid-cols-[auto,1fr] gap-x-3 gap-y-0.5 text-xs text-pf-alt-dark">
+        <dt className="font-semibold uppercase tracking-wide">Max level</dt>
+        <dd>Lv {entry.maxItemLevel}</dd>
+        {entry.batchSize > 1 && (
+          <>
+            <dt className="font-semibold uppercase tracking-wide">Batch size</dt>
+            <dd>×{entry.batchSize}</dd>
+          </>
+        )}
+        {entry.resource !== null && (
+          <>
+            <dt className="font-semibold uppercase tracking-wide">Resource</dt>
+            <dd>{humanizeSlug(entry.resource)}</dd>
+          </>
+        )}
+        <dt className="font-semibold uppercase tracking-wide">Slots</dt>
+        <dd>
+          {slotsUsed}
+          {slotsMax !== null ? ` / ${slotsMax}` : ''}
+        </dd>
+      </dl>
+
+      {prepared.length > 0 ? (
+        <ul className="mt-3 space-y-1 border-t border-pf-border pt-2">
+          {prepared.map((pf, i) => (
+            <PreparedFormulaRow key={`${pf.uuid}-${i}`} prepared={pf} resolution={resolutions.get(pf.uuid)} />
+          ))}
+        </ul>
+      ) : (
+        <p className="mt-3 border-t border-pf-border pt-2 text-xs italic text-neutral-400">No slots prepared.</p>
+      )}
+    </li>
+  );
+}
+
+function PreparedFormulaRow({
+  prepared,
+  resolution,
+}: {
+  prepared: PreparedFormulaData;
+  resolution: Resolution | undefined;
+}): React.ReactElement {
+  const state = resolution ?? { kind: 'loading' as const };
+  const name = state.kind === 'ok' ? state.document.name : null;
+  const img = state.kind === 'ok' ? state.document.img : null;
+
+  return (
+    <li
+      className={`flex items-center gap-2 text-xs ${prepared.expended === true ? 'opacity-50 line-through' : ''}`}
+      data-prepared-uuid={prepared.uuid}
+    >
+      {img !== null ? (
+        <img src={img} alt="" className="h-5 w-5 flex-shrink-0 rounded border border-pf-border bg-pf-bg-dark" />
+      ) : (
+        <div className="h-5 w-5 flex-shrink-0 rounded border border-pf-border bg-pf-bg-dark" />
+      )}
+      <span className="min-w-0 flex-1 truncate text-pf-text">
+        {state.kind === 'ok' && name !== null ? name : prepared.uuid}
+      </span>
+      {prepared.isSignatureItem === true && (
+        <span className="font-mono text-[10px] text-pf-primary" title="Signature item">
+          ★
+        </span>
+      )}
+      {prepared.quantity !== undefined && prepared.quantity > 1 && (
+        <span className="font-mono text-[10px] text-pf-alt-dark">×{prepared.quantity}</span>
+      )}
+    </li>
+  );
+}
+
+function Badge({ children }: { children: React.ReactNode }): React.ReactElement {
+  return (
+    <span className="rounded-full border border-pf-tertiary-dark bg-pf-tertiary/40 px-1.5 py-0.5 text-[10px] uppercase tracking-widest text-pf-alt-dark">
+      {children}
+    </span>
+  );
+}
+
 // ─── Helpers ───────────────────────────────────────────────────────────
 
-function useFormulaResolutions(formulas: readonly CraftingFormulaEntry[]): Map<string, Resolution> {
+// Collect every compendium UUID we need to resolve across the formula
+// book + every crafting ability's prepared slots. Deduped so a formula
+// that's also prepared only triggers one lookup.
+function collectUuids(formulas: readonly CraftingFormulaEntry[], entries: readonly CraftingAbilityData[]): string[] {
+  const set = new Set<string>();
+  for (const f of formulas) set.add(f.uuid);
+  for (const e of entries) for (const p of e.preparedFormulaData) set.add(p.uuid);
+  return Array.from(set);
+}
+
+function useUuidResolutions(uuids: readonly string[]): Map<string, Resolution> {
   const [resolutions, setResolutions] = useState<Map<string, Resolution>>(() => new Map());
-  // Re-run whenever the set of uuids changes. Joining into a string keys
-  // the effect on value rather than array identity.
-  const uuidsKey = formulas.map((f) => f.uuid).join('|');
+  // Key the effect on value rather than array identity so a new array
+  // with the same contents doesn't retrigger the fetch.
+  const uuidsKey = uuids.join('|');
 
   useEffect(() => {
     let cancelled = false;
-    const uuids = formulas.map((f) => f.uuid);
     if (uuids.length === 0) {
       setResolutions(new Map());
       return;
@@ -136,4 +271,11 @@ function readLevel(doc: CompendiumDocument): number | null {
     if (typeof lvl === 'object' && lvl !== null && typeof lvl.value === 'number') return lvl.value;
   }
   return null;
+}
+
+function humanizeSlug(slug: string): string {
+  return slug
+    .split('-')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
 }


### PR DESCRIPTION
## Summary

Phase 2 of the [standalone play-surface plan](https://github.com/AlexDickerson/foundry-toolkit/pull/24). Surfaces `system.crafting.entries` (daily-prep slots — alchemist reagents, herbalist remedies, magical crafting, snare specialist, etc.) on the Crafting tab, read-only.

- **Types** (`apps/character-creator/src/api/types.ts`): `CraftingField.entries` narrows from `Record<string, unknown>` to `Record<string, CraftingAbilityData>`. Added `CraftingAbilityData` and `PreparedFormulaData` matching pf2e's upstream (`src/module/actor/character/crafting/types.ts` on `v14-dev`). `fieldDiscovery` and `craftableItems` stay loose — not rendered yet.
- **UI** (`apps/character-creator/src/components/tabs/Crafting.tsx`): new "Crafting Abilities" section below the Formula Book, one card per entry. Shows Alchemical / Daily Prep badges, max-item-level, batch size, resource, slots used / max, and each prepared slot (image, name, expended via strikethrough, signature ★, quantity ×N). Generic over slug so future abilities land without code changes.
- **Shared UUID resolution**: `useUuidResolutions` de-dupes compendium lookups across both sections.

No bridge/server changes — `actor.toObject(false).system` already ships `system.crafting.entries` through `/prepared` unmodified.

## Test plan
- [x] `npm run typecheck` — clean across all workspaces
- [x] `npm run format:check` — clean
- [x] `npm run test --workspace apps/character-creator` — 148/148 pass
- [x] Mock preview against a temporarily-augmented Amiri fixture (formulas + two entries: `infused-reagents` w/ 3 prepared slots exercising expended/signature/quantity states + `magical-crafting` empty-state). Screenshot confirmed all branches render; fixture reverted before commit.
- [ ] **Live E2E** — deferred until a real alchemist/herbalist actor is available on the dev Foundry instance (Amiri has empty `entries`).

## Follow-ups (phase 3+)
- `POST /api/actors/:id/crafting/craft` → `game.pf2e.actions.craft(…)` for outbound craft actions (SPA craft button).
- Formula book management (add/remove) via compendium picker.
- Daily-prep mutations (prep / expend slots) — the complex one; class-specific rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)