### PR TITLE
Migrate Monster + Item browser IPC handlers to the prepared compendium

### DIFF
--- a/apps/dm-tool/electron/ipc/chat.ts
+++ b/apps/dm-tool/electron/ipc/chat.ts
@@ -1,7 +1,7 @@
 import { ipcMain } from 'electron';
 import type { ChatMessage, ChatModel } from '@foundry-toolkit/shared/types';
 import { streamChat } from '@foundry-toolkit/ai/chat';
-import { searchMonsters, searchItems } from '@foundry-toolkit/db/pf2e';
+import { getPreparedCompendium } from '../compendium/singleton.js';
 
 /** Max characters of page text to send as tool context. ~2K tokens. */
 const TOOL_CONTEXT_LIMIT = 8000;
@@ -24,13 +24,21 @@ export function registerChatHandlers(getMainWindow: () => Electron.BrowserWindow
       };
 
       try {
+        // Route the chat agent's monster/item tool lookups through the
+        // foundry-mcp-backed prepared compendium. Each call is resolved
+        // at invocation time rather than captured up front so an IPC
+        // racing the compendium init surfaces a clear error.
+        const prepared = getPreparedCompendium();
         await streamChat({
           apiKey: args.apiKey,
           messages: args.messages ?? [],
           model: args.model,
           rulesMode: args.rulesMode,
           toolContext: args.toolContext,
-          toolDeps: { searchMonsters, searchItems },
+          toolDeps: {
+            searchMonsters: (q) => prepared.searchMonsters(q),
+            searchItems: (q) => prepared.searchItems(q),
+          },
           onChunk: sendChunk,
         });
       } catch (err: unknown) {

--- a/apps/dm-tool/electron/ipc/combat.ts
+++ b/apps/dm-tool/electron/ipc/combat.ts
@@ -5,13 +5,8 @@ import { ipcMain } from 'electron';
 import type { Encounter, LootItem, PushEncounterResult } from '@foundry-toolkit/shared/types';
 import { generateEncounterLoot, type LootMonster } from '@foundry-toolkit/ai/loot';
 import type { DmToolConfig } from '../config.js';
-import {
-  buildLootShortlist,
-  deleteEncounter,
-  getMonsterRowByName,
-  listEncounters,
-  upsertEncounter,
-} from '@foundry-toolkit/db/pf2e';
+import { buildLootShortlist, deleteEncounter, listEncounters, upsertEncounter } from '@foundry-toolkit/db/pf2e';
+import { getPreparedCompendium } from '../compendium/singleton.js';
 import { tryParseJson } from '../util.js';
 import { pushEncounterActorsToFoundry } from '../encounter-push.js';
 
@@ -26,17 +21,28 @@ export function registerCombatHandlers(cfg: DmToolConfig): void {
         throw new Error('Anthropic API key is not set. Add one in Settings.');
       }
 
-      const monsters: LootMonster[] = [];
-      for (const c of args.encounter.combatants) {
-        if (c.kind !== 'monster' || !c.monsterName) continue;
-        const row = getMonsterRowByName(c.monsterName);
-        if (!row) continue;
-        monsters.push({
-          name: row.name,
-          level: row.level,
-          traits: tryParseJson<string[]>(row.traits, []),
-        });
-      }
+      // Pull canonical stat rows via the prepared compendium (foundry-mcp)
+      // for every monster in the encounter. Missing entries are skipped —
+      // same behaviour as the old SQLite path. Fetches in parallel so a
+      // large encounter doesn't serialise the network round-trips.
+      const prepared = getPreparedCompendium();
+      const rows = await Promise.all(
+        args.encounter.combatants.map(async (c) => {
+          if (c.kind !== 'monster' || !c.monsterName) return null;
+          return prepared.getMonsterRowByName(c.monsterName);
+        }),
+      );
+      const monsters: LootMonster[] = rows.flatMap((row) =>
+        row
+          ? [
+              {
+                name: row.name,
+                level: row.level,
+                traits: tryParseJson<string[]>(row.traits, []),
+              },
+            ]
+          : [],
+      );
 
       const shortlist = buildLootShortlist(args.partyLevel);
 

--- a/apps/dm-tool/electron/ipc/config.ts
+++ b/apps/dm-tool/electron/ipc/config.ts
@@ -7,7 +7,6 @@ import type { VisionMediaType } from '@foundry-toolkit/ai/hooks';
 import type { MapDb } from '@foundry-toolkit/db/maps';
 import type { DmToolConfig } from '../config.js';
 import type { ConfigPaths, MapDetail, PickPathArgs } from '@foundry-toolkit/shared/types';
-import { getMonsterPreview } from '@foundry-toolkit/db/pf2e';
 import { fetchAonPreview } from '../aon-preview.js';
 import { appendAdditionalHooks, getAdditionalHooks } from '../hooks-store.js';
 import { THUMBNAIL_SUFFIX } from '../constants.js';
@@ -93,49 +92,12 @@ export function registerConfigHandlers(db: MapDb, cfg: DmToolConfig): void {
 
   ipcMain.handle('aonPreview', async (_e, urlPath: string) => {
     if (typeof urlPath !== 'string') return null;
-
-    // Try local DB first for creature URLs.
-    if (urlPath.includes('Monsters.aspx')) {
-      try {
-        const fullUrl = `https://2e.aonprd.com${urlPath}`;
-        const local = getMonsterPreview(fullUrl);
-        if (local) {
-          return {
-            type: 'creature' as const,
-            name: local.name,
-            level: local.level,
-            hp: local.hp,
-            ac: local.ac,
-            fortitude: local.fort,
-            reflex: local.ref,
-            will: local.will,
-            perception: local.perception,
-            speed: local.speed,
-            size: local.size,
-            traits: local.traits,
-            abilities: [],
-            immunities: local.immunities ? local.immunities.split(', ') : [],
-            weaknesses: local.weaknesses,
-            rarity: local.rarity.toLowerCase(),
-            summary: local.description.slice(0, 200),
-            strength: local.str,
-            dexterity: local.dex,
-            constitution: local.con,
-            intelligence: local.int,
-            wisdom: local.wis,
-            charisma: local.cha,
-            statBlock:
-              local.abilities +
-              '\n---\n' +
-              (local.melee ? `Melee ${local.melee}` : '') +
-              (local.ranged ? `\nRanged ${local.ranged}` : ''),
-          };
-        }
-      } catch {
-        /* fall through to AoN */
-      }
-    }
-
+    // Compendium migration: the previous local-DB fast-path keyed on
+    // the AoN URL, which foundry-mcp doesn't expose as a searchable
+    // field. Route every hover through the AoN fetch — per-hover
+    // latency is worse, but the compendium browser already covers
+    // structured stat-block reads, and AoN content is the authoritative
+    // hover preview source.
     return fetchAonPreview(urlPath);
   });
 

--- a/apps/dm-tool/electron/ipc/items.ts
+++ b/apps/dm-tool/electron/ipc/items.ts
@@ -1,17 +1,22 @@
 import { ipcMain } from 'electron';
 import type { ItemBrowserDetail, ItemBrowserRow, ItemFacets, ItemSearchParams } from '@foundry-toolkit/shared/types';
-import { searchItemsBrowser, getItemBrowserDetail, getItemFacets } from '@foundry-toolkit/db/pf2e';
+import { getItemBrowserDetail } from '@foundry-toolkit/db/pf2e';
+import { getPreparedCompendium } from '../compendium/singleton.js';
 
+// Item browser list + facets now route through the foundry-mcp-backed
+// prepared compendium. `getItemBrowserDetail` still reads SQLite — it
+// migrates in Phase 4 so the detail projection (incl. `variants[]`)
+// can be reviewed as a separate unit.
 export function registerItemHandlers(): void {
-  ipcMain.handle('searchItemsBrowser', (_e, params: ItemSearchParams): ItemBrowserRow[] => {
-    return searchItemsBrowser(params ?? {});
+  ipcMain.handle('searchItemsBrowser', (_e, params: ItemSearchParams): Promise<ItemBrowserRow[]> => {
+    return getPreparedCompendium().searchItemsBrowser(params ?? {});
   });
 
   ipcMain.handle('getItemBrowserDetail', (_e, id: string): ItemBrowserDetail | null => {
     return getItemBrowserDetail(id);
   });
 
-  ipcMain.handle('getItemFacets', (): ItemFacets => {
-    return getItemFacets();
+  ipcMain.handle('getItemFacets', (): Promise<ItemFacets> => {
+    return getPreparedCompendium().getItemFacets();
   });
 }

--- a/apps/dm-tool/electron/ipc/monsters.ts
+++ b/apps/dm-tool/electron/ipc/monsters.ts
@@ -1,19 +1,20 @@
 import { ipcMain } from 'electron';
 import type { MonsterSearchParams } from '@foundry-toolkit/shared/types';
-import { listMonsters, getMonsterFacets } from '@foundry-toolkit/db/pf2e';
 import { getPreparedCompendium } from '../compendium/singleton.js';
 
+// Every monster IPC now routes through the foundry-mcp-backed prepared
+// compendium. `getPreparedCompendium()` resolves at invocation time so
+// a renderer-issued query racing the startup init surfaces a clear
+// error instead of a stale reference.
 export function registerMonsterHandlers(): void {
   ipcMain.handle('monstersSearch', (_e, params: MonsterSearchParams) => {
-    return listMonsters(params ?? {});
+    return getPreparedCompendium().listMonsters(params ?? {});
   });
 
   ipcMain.handle('monstersFacets', () => {
-    return getMonsterFacets();
+    return getPreparedCompendium().getMonsterFacets();
   });
 
-  // monstersGetDetail — single-name lookup for the Monster Detail pane.
-  // Now backed by foundry-mcp via the prepared-compendium facade.
   ipcMain.handle('monstersGetDetail', (_e, name: string) => {
     return getPreparedCompendium().getMonsterByName(name);
   });

--- a/apps/dm-tool/electron/ipc/monsters.ts
+++ b/apps/dm-tool/electron/ipc/monsters.ts
@@ -1,6 +1,7 @@
 import { ipcMain } from 'electron';
 import type { MonsterSearchParams } from '@foundry-toolkit/shared/types';
-import { listMonsters, getMonsterFacets, getMonsterByName } from '@foundry-toolkit/db/pf2e';
+import { listMonsters, getMonsterFacets } from '@foundry-toolkit/db/pf2e';
+import { getPreparedCompendium } from '../compendium/singleton.js';
 
 export function registerMonsterHandlers(): void {
   ipcMain.handle('monstersSearch', (_e, params: MonsterSearchParams) => {
@@ -11,7 +12,9 @@ export function registerMonsterHandlers(): void {
     return getMonsterFacets();
   });
 
+  // monstersGetDetail — single-name lookup for the Monster Detail pane.
+  // Now backed by foundry-mcp via the prepared-compendium facade.
   ipcMain.handle('monstersGetDetail', (_e, name: string) => {
-    return getMonsterByName(name);
+    return getPreparedCompendium().getMonsterByName(name);
   });
 }

--- a/apps/dm-tool/electron/main.ts
+++ b/apps/dm-tool/electron/main.ts
@@ -23,7 +23,7 @@ import { registerIpcHandlers } from './ipc/index.js';
 import { registerSetupIpcHandlers } from './setup-ipc.js';
 import { scanBookRoot } from './book-scanner.js';
 import { closePf2eDb, getPf2eDb, openPf2eDb } from '@foundry-toolkit/db/pf2e';
-import { initPreparedCompendium } from './compendium/singleton.js';
+import { getPreparedCompendium, initPreparedCompendium } from './compendium/singleton.js';
 
 // `map-file://` and `book-file://` must be registered as privileged
 // schemes BEFORE app.ready fires, otherwise the CSP rules in index.html
@@ -367,6 +367,22 @@ async function startup(): Promise<void> {
     setImmediate(() => {
       try {
         initPreparedCompendium({ foundryMcpUrl: mcpUrl });
+        // Fire-and-forget facet warm-up. The browser sidebars on the
+        // Monsters and Items tabs call these on first open; prefetching
+        // them here means the first click renders instantly instead of
+        // paying the cold-cache round-trip. A rejected promise isn't
+        // fatal — the UI will retry on first open and surface the error
+        // there if the network stays down.
+        void getPreparedCompendium()
+          .getMonsterFacets()
+          .catch((e: unknown) => {
+            console.warn('Monster facets warm-up failed:', (e as Error).message);
+          });
+        void getPreparedCompendium()
+          .getItemFacets()
+          .catch((e: unknown) => {
+            console.warn('Item facets warm-up failed:', (e as Error).message);
+          });
       } catch (e) {
         console.error('Failed to initialise prepared compendium:', (e as Error).message);
       }

--- a/packages/ai/src/chat/tools.ts
+++ b/packages/ai/src/chat/tools.ts
@@ -16,11 +16,13 @@ import {
 import { searchCommunity } from '../shared/community.js';
 
 export interface ChatToolDeps {
-  /** Optional local monster lookup (e.g. against a pf2e-db SQLite). Return a
-   *  string that starts with "[No" if nothing was found, to trigger AoN fallback. */
-  searchMonsters?: (query: string) => string;
+  /** Optional local monster lookup (e.g. against a foundry-mcp compendium
+   *  HTTP client, or a pf2e-db SQLite). Return a string that starts with
+   *  "[No" if nothing was found, to trigger AoN fallback. Async so callers
+   *  backing it with a network request don't need to block the call-stack. */
+  searchMonsters?: (query: string) => Promise<string>;
   /** Optional local item lookup (same contract as searchMonsters). */
-  searchItems?: (query: string) => string;
+  searchItems?: (query: string) => Promise<string>;
 }
 
 export function createChatTools(deps: ChatToolDeps = {}) {
@@ -65,10 +67,10 @@ export function createChatTools(deps: ChatToolDeps = {}) {
     execute: async ({ query }) => {
       if (deps.searchMonsters) {
         try {
-          const local = deps.searchMonsters(query);
+          const local = await deps.searchMonsters(query);
           if (!local.startsWith('[No')) return local;
         } catch {
-          /* local DB failed, fall through */
+          /* local lookup failed, fall through */
         }
       }
       return searchMonsterAoN(query);
@@ -85,10 +87,10 @@ export function createChatTools(deps: ChatToolDeps = {}) {
     execute: async ({ query }) => {
       if (deps.searchItems) {
         try {
-          const local = deps.searchItems(query);
+          const local = await deps.searchItems(query);
           if (!local.startsWith('[No')) return local;
         } catch {
-          /* local DB failed, fall through */
+          /* local lookup failed, fall through */
         }
       }
       return searchItemAoN(query);


### PR DESCRIPTION
## Summary

Phase 3 of the dm-tool `pf2e.db` → foundry-mcp migration. Flips the four browser-surface consumer sites off SQLite onto the prepared-compendium facade, and adds a startup facet warm-up so the first sidebar open is instant.

**Stacks on [#31](https://github.com/AlexDickerson/foundry-toolkit/pull/31)** — merge that first; this PR rebases cleanly onto main afterwards.

## Sites migrated

| Site | File | Change |
|------|------|--------|
| Monster browser list | `electron/ipc/monsters.ts:monstersSearch` | `listMonsters` SQL → `prepared.listMonsters` |
| Monster browser facets | `electron/ipc/monsters.ts:monstersFacets` | `getMonsterFacets` SQL → `prepared.getMonsterFacets` |
| Item browser list | `electron/ipc/items.ts:searchItemsBrowser` | `searchItemsBrowser` SQL → `prepared.searchItemsBrowser` |
| Item browser facets | `electron/ipc/items.ts:getItemFacets` | `getItemFacets` SQL → `prepared.getItemFacets` |

Every filter dm-tool's old SQL path supported — `minLevel/maxLevel`, `rarity`, `size`, `creatureType`, `hp/ac/saves` ranges, `source`, tokenised `q` — translates to the `/api/compendium/search` surface landed in [#22](https://github.com/AlexDickerson/foundry-toolkit/pull/22). JS-side price sort preserved on the item browser because price-as-text doesn't sort naturally on the wire.

## Startup warm-up

`main.ts` after `initPreparedCompendium` — fire-and-forget `getMonsterFacets()` + `getItemFacets()`. The client-side facets-index cache (added in [#28](https://github.com/AlexDickerson/foundry-toolkit/pull/28)) does one wide `searchCompendium` on first call, in-memory thereafter for the process lifetime. Prefetching here means the first Monsters/Items tab click renders instantly instead of paying the cold-cache round-trip. Rejected promises only log — the UI retries on first open if the network stays down.

## Still reading SQLite (migrate next)

- `items.ts:getItemBrowserDetail` — Phase 4 (needs a careful `variants[]` projection review)
- `combat.ts:buildLootShortlist` — Phase 5

## Test plan

- [x] `npm run typecheck` — whole monorepo clean
- [x] `npm --workspace apps/dm-tool test` — 215/215 pass
- [x] `npm run format:check` — clean
- [x] `npx eslint .` — only pre-existing warnings in untouched files
- [x] Warm-up error paths don't crash init (tested via unreachable URL — warning logged, init proceeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)