### PR TITLE
Migrate item detail pane + loot-gen shortlist to prepared compendium

### DIFF
--- a/apps/dm-tool/electron/ipc/combat.ts
+++ b/apps/dm-tool/electron/ipc/combat.ts
@@ -5,7 +5,7 @@ import { ipcMain } from 'electron';
 import type { Encounter, LootItem, PushEncounterResult } from '@foundry-toolkit/shared/types';
 import { generateEncounterLoot, type LootMonster } from '@foundry-toolkit/ai/loot';
 import type { DmToolConfig } from '../config.js';
-import { buildLootShortlist, deleteEncounter, listEncounters, upsertEncounter } from '@foundry-toolkit/db/pf2e';
+import { deleteEncounter, listEncounters, upsertEncounter } from '@foundry-toolkit/db/pf2e';
 import { getPreparedCompendium } from '../compendium/singleton.js';
 import { tryParseJson } from '../util.js';
 import { pushEncounterActorsToFoundry } from '../encounter-push.js';
@@ -44,7 +44,11 @@ export function registerCombatHandlers(cfg: DmToolConfig): void {
           : [],
       );
 
-      const shortlist = buildLootShortlist(args.partyLevel);
+      // buildLootShortlist pulls a random-80 level-range sample via
+      // `api.searchCompendium({ minLevel, maxLevel, limit: 500 })` and
+      // shuffles client-side. The prepared layer owns both the network
+      // fetch and the shuffle — see electron/compendium/prepared.ts.
+      const shortlist = await prepared.buildLootShortlist(args.partyLevel);
 
       return generateEncounterLoot({
         apiKey: args.apiKey,

--- a/apps/dm-tool/electron/ipc/items.ts
+++ b/apps/dm-tool/electron/ipc/items.ts
@@ -1,19 +1,18 @@
 import { ipcMain } from 'electron';
 import type { ItemBrowserDetail, ItemBrowserRow, ItemFacets, ItemSearchParams } from '@foundry-toolkit/shared/types';
-import { getItemBrowserDetail } from '@foundry-toolkit/db/pf2e';
 import { getPreparedCompendium } from '../compendium/singleton.js';
 
-// Item browser list + facets now route through the foundry-mcp-backed
-// prepared compendium. `getItemBrowserDetail` still reads SQLite — it
-// migrates in Phase 4 so the detail projection (incl. `variants[]`)
-// can be reviewed as a separate unit.
+// Every item IPC now routes through the foundry-mcp-backed prepared
+// compendium. `getItemBrowserDetail` reads the full document + parses
+// `variants[]` from `system.variants` via the projection layer in
+// projection.ts.
 export function registerItemHandlers(): void {
   ipcMain.handle('searchItemsBrowser', (_e, params: ItemSearchParams): Promise<ItemBrowserRow[]> => {
     return getPreparedCompendium().searchItemsBrowser(params ?? {});
   });
 
-  ipcMain.handle('getItemBrowserDetail', (_e, id: string): ItemBrowserDetail | null => {
-    return getItemBrowserDetail(id);
+  ipcMain.handle('getItemBrowserDetail', (_e, id: string): Promise<ItemBrowserDetail | null> => {
+    return getPreparedCompendium().getItemBrowserDetail(id);
   });
 
   ipcMain.handle('getItemFacets', (): Promise<ItemFacets> => {


### PR DESCRIPTION
## Summary

Phase 4+5 of the dm-tool `pf2e.db` → foundry-mcp migration. Two small, independent consumer-site swaps bundled into one PR since both are single-line-per-call changes with no new projection work.

**Stacks on [#31](https://github.com/AlexDickerson/foundry-toolkit/pull/31) + [#33](https://github.com/AlexDickerson/foundry-toolkit/pull/33)** — both are green and awaiting merge. Base is `main` so CI runs; diff will show Phase 2 + 3 + 4+5 commits until those merge.

## Sites migrated

| Site | File | Change |
|------|------|--------|
| Item detail pane | `electron/ipc/items.ts:getItemBrowserDetail` | SQLite → `prepared.getItemBrowserDetail(id)`. Variants parsed in projection.ts (#28). |
| Loot-gen item shortlist | `electron/ipc/combat.ts:generateEncounterLoot` | SQLite `ORDER BY RANDOM() LIMIT 80` → `prepared.buildLootShortlist(partyLevel)`: wide `searchCompendium({minLevel, maxLevel, limit: 500})` + client-side shuffle-sample to 80. |

## Shortlist sampling note

Server-side random sampling is deferred (mcp Phase C, optional). Client-side sampling over a 500-row window (~250 KB) completes inside the facets warm-up. If we ever want bit-exact reproducibility or lower payload, add `sort=random&seed=<int>` to mcp. Not blocking.

## Side effect: trimmed pf2e imports

Both files' `@foundry-toolkit/db/pf2e` imports drop to the mutable-state-only set (`listEncounters/upsertEncounter/deleteEncounter`). After Phase 6 deletes `compendium.ts`, the pf2e barrel re-exports only state CRUD + compendium cache primitives.

## Test plan

- [x] `npm run typecheck` — whole monorepo clean
- [x] `npm --workspace apps/dm-tool test` — 215/215 pass
- [x] `npm run format:check` — clean
- [x] `npx eslint .` — only pre-existing warnings in untouched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)