### PR TITLE
Add adjust-actor-resource typed command + HP / hero point steppers

### DIFF
--- a/apps/character-creator/src/api/client.ts
+++ b/apps/character-creator/src/api/client.ts
@@ -1,5 +1,7 @@
 import type {
+  ActorResourceKey,
   AddItemFromCompendiumBody,
+  AdjustActorResourceResponse,
   CreateActorBody,
   UpdateActorBody,
   UpdateActorItemBody,
@@ -118,6 +120,19 @@ export const api = {
     request<{ success: boolean }>(`/actors/${id}/items/${itemId}`, { method: 'DELETE' }),
   updateActorItem: (id: string, itemId: string, patch: UpdateActorItemBody): Promise<ActorItemRef> =>
     request<ActorItemRef>(`/actors/${id}/items/${itemId}`, { method: 'PATCH', body: patch }),
+  // Signed stepper for HP / temp HP / hero points / focus points.
+  // Positive delta = heal / grant, negative = damage / spend. Server
+  // clamps into [0, max] and returns `{before, after, max}` so the
+  // caller can update its local view without a full /prepared refetch.
+  adjustActorResource: (
+    id: string,
+    resource: ActorResourceKey,
+    delta: number,
+  ): Promise<AdjustActorResourceResponse> =>
+    request<AdjustActorResourceResponse>(`/actors/${id}/resources/adjust`, {
+      method: 'POST',
+      body: { resource, delta },
+    }),
   resolvePrompt: (bridgeId: string, value: unknown): Promise<{ ok: boolean }> =>
     request<{ ok: boolean }>(`/prompts/${bridgeId}/resolve`, { method: 'POST', body: { value } }),
   uploadAsset: (body: UploadAssetBody): Promise<UploadAssetResult> =>

--- a/apps/character-creator/src/components/tabs/Character.test.tsx
+++ b/apps/character-creator/src/components/tabs/Character.test.tsx
@@ -15,7 +15,7 @@ describe('Character tab', () => {
   });
 
   it('renders the six ability modifiers with correct signs', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onRested={() => undefined} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
     const expected: Record<string, string> = {
       str: '+4',
       dex: '+2',
@@ -32,7 +32,7 @@ describe('Character tab', () => {
   });
 
   it("marks the character's key ability", () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onRested={() => undefined} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
     const strRow = container.querySelector('[data-attribute="str"]');
     expect(strRow?.textContent).toContain('KEY');
     // Non-key abilities should not carry the KEY badge.
@@ -41,7 +41,7 @@ describe('Character tab', () => {
   });
 
   it('renders the headline stats (AC, HP, Perception)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onRested={() => undefined} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
     expect(container.querySelector('[data-stat="hp"]')?.textContent).toContain('22');
     expect(container.querySelector('[data-stat="perception"]')?.textContent).toContain('+5');
     // AC 18 is in the StatTile without data-stat but in the first StatsBlock row.
@@ -50,28 +50,28 @@ describe('Character tab', () => {
   });
 
   it('renders the three saves with correct modifiers', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onRested={() => undefined} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
     expect(container.querySelector('[data-stat="save-fortitude"]')?.textContent).toContain('+7');
     expect(container.querySelector('[data-stat="save-reflex"]')?.textContent).toContain('+5');
     expect(container.querySelector('[data-stat="save-will"]')?.textContent).toContain('+5');
   });
 
   it('renders the class DC (Barbarian @ 17)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onRested={() => undefined} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
     const dc = container.querySelector('[data-stat="class-dc"]');
     expect(dc, 'class DC tile').toBeTruthy();
     expect(dc?.textContent).toContain('17');
   });
 
   it('renders hero points pips (1 of 3)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onRested={() => undefined} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
     const hp = container.querySelector('[data-stat="hero-points"]');
     expect(hp, 'hero points tile').toBeTruthy();
     expect(hp?.textContent).toContain('1/3');
   });
 
   it('renders languages (Hallit, Common)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onRested={() => undefined} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
     const langs = container.querySelector('[data-section="languages"]');
     expect(langs, 'languages section').toBeTruthy();
     expect(langs?.textContent).toContain('Hallit');
@@ -79,26 +79,26 @@ describe('Character tab', () => {
   });
 
   it('renders traits (Human, Humanoid)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onRested={() => undefined} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
     const traits = container.querySelector('[data-section="traits"]');
     expect(traits?.textContent).toContain('Human');
     expect(traits?.textContent).toContain('Humanoid');
   });
 
   it("renders Amiri's land speed (25 ft)", () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onRested={() => undefined} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
     expect(container.textContent).toContain('25 ft');
   });
 
   it('renders the initiative tile (+5 for Amiri)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onRested={() => undefined} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
     const tile = container.querySelector('[data-stat="initiative"]');
     expect(tile, 'initiative tile').toBeTruthy();
     expect(tile?.textContent).toContain('+5');
   });
 
   it('renders the conditions row (Dying/Wounded/Doomed)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onRested={() => undefined} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
     const row = container.querySelector('[data-section="conditions"]');
     expect(row, 'conditions row').toBeTruthy();
     for (const stat of ['dying', 'wounded', 'doomed']) {
@@ -110,7 +110,7 @@ describe('Character tab', () => {
   });
 
   it('shows investiture resource for Amiri (0/10)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onRested={() => undefined} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
     const inv = container.querySelector('[data-stat="investiture"]');
     expect(inv, 'investiture').toBeTruthy();
     expect(inv?.textContent).toContain('0');
@@ -118,13 +118,13 @@ describe('Character tab', () => {
   });
 
   it('omits Focus and Mythic resources when max is zero', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onRested={() => undefined} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
     expect(container.querySelector('[data-stat="focus"]')).toBeNull();
     expect(container.querySelector('[data-stat="mythic-points"]')).toBeNull();
   });
 
   it('renders all populated speeds (Land + Travel for Amiri)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onRested={() => undefined} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
     expect(container.querySelector('[data-speed="land"]')).toBeTruthy();
     expect(container.querySelector('[data-speed="travel"]')).toBeTruthy();
     // Unpopulated speeds should not render.
@@ -133,7 +133,7 @@ describe('Character tab', () => {
   });
 
   it('hides the Defenses block when IWR are all empty (Amiri)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onRested={() => undefined} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
     expect(container.querySelector('[data-section="iwr"]')).toBeNull();
   });
 
@@ -147,7 +147,7 @@ describe('Character tab', () => {
         resistances: [{ type: 'physical', value: 2, exceptions: ['adamantine'] }],
       },
     } as CharacterSystem;
-    const { container } = render(<Character system={custom} actorId="test-actor" onRested={() => undefined} />);
+    const { container } = render(<Character system={custom} actorId="test-actor" onActorChanged={() => undefined} />);
     expect(container.querySelector('[data-section="iwr"]')).toBeTruthy();
     expect(container.querySelector('[data-iwr="immunities"]')?.textContent).toContain('Fire');
     expect(container.querySelector('[data-iwr="weaknesses"]')?.textContent).toContain('Cold 5');
@@ -155,14 +155,14 @@ describe('Character tab', () => {
   });
 
   it('shows handsFree value (2 for Amiri)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onRested={() => undefined} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
     const hf = container.querySelector('[data-stat="hands-free"]');
     expect(hf, 'hands-free tile').toBeTruthy();
     expect(hf?.textContent).toBe('2');
   });
 
   it('hides Reach when base is 5 and manipulate matches (Amiri default)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onRested={() => undefined} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
     expect(container.querySelector('[data-stat="reach"]')).toBeNull();
   });
 
@@ -171,14 +171,14 @@ describe('Character tab', () => {
       ...system,
       attributes: { ...system.attributes, reach: { base: 10, manipulate: 10 } },
     };
-    const { container } = render(<Character system={reachy} actorId="test-actor" onRested={() => undefined} />);
+    const { container } = render(<Character system={reachy} actorId="test-actor" onActorChanged={() => undefined} />);
     const reach = container.querySelector('[data-stat="reach"]');
     expect(reach, 'reach tile').toBeTruthy();
     expect(reach?.textContent).toContain('10 ft');
   });
 
   it('hides Deity when deity.value is empty (Amiri)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onRested={() => undefined} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
     expect(container.querySelector('[data-stat="deity"]')).toBeNull();
   });
 
@@ -187,13 +187,13 @@ describe('Character tab', () => {
       ...system,
       details: { ...system.details, deity: { image: 'x.svg', value: 'Iomedae' } },
     };
-    const { container } = render(<Character system={faithful} actorId="test-actor" onRested={() => undefined} />);
+    const { container } = render(<Character system={faithful} actorId="test-actor" onActorChanged={() => undefined} />);
     const deity = container.querySelector('[data-stat="deity"]');
     expect(deity?.textContent).toBe('Iomedae');
   });
 
   it('hides Shield tile when no shield is equipped (Amiri)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onRested={() => undefined} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
     expect(container.querySelector('[data-stat="shield"]')).toBeNull();
   });
 
@@ -216,7 +216,7 @@ describe('Character tab', () => {
         },
       },
     };
-    const { container } = render(<Character system={shielded} actorId="test-actor" onRested={() => undefined} />);
+    const { container } = render(<Character system={shielded} actorId="test-actor" onActorChanged={() => undefined} />);
     const tile = container.querySelector('[data-stat="shield"]');
     expect(tile, 'shield tile').toBeTruthy();
     expect(tile?.textContent).toContain('Steel Shield');

--- a/apps/character-creator/src/components/tabs/Character.tsx
+++ b/apps/character-creator/src/components/tabs/Character.tsx
@@ -10,14 +10,17 @@ import { SectionHeader } from '../common/SectionHeader';
 interface Props {
   system: CharacterSystem;
   actorId: string;
-  onRested: () => void;
+  /** Fired after any server-acknowledged mutation from this tab — long
+   *  rest, HP adjust, hero-point adjust — so the parent can refetch
+   *  `/prepared` and redraw. */
+  onActorChanged: () => void;
 }
 
 // Character landing tab — ability scores, headline defensive/offensive
 // stats, hero points, speeds, languages, traits. Ported in structure
 // from pf2e's static/templates/actors/character/tabs/character.hbs, but
 // read-only (no input widgets) and Tailwind-styled.
-export function Character({ system, actorId, onRested }: Props): React.ReactElement {
+export function Character({ system, actorId, onActorChanged }: Props): React.ReactElement {
   const keyAbility = system.details.keyability.value;
   const classDC = system.attributes.classDC;
   const speeds = populatedSpeeds(system.movement.speeds);
@@ -30,7 +33,7 @@ export function Character({ system, actorId, onRested }: Props): React.ReactElem
     <section className="space-y-6">
       <AbilityBlock abilities={system.abilities} keyAbility={keyAbility} />
 
-      <StatsBlock system={system} />
+      <StatsBlock system={system} actorId={actorId} onActorChanged={onActorChanged} />
 
       <ConditionsRow
         dying={system.attributes.dying}
@@ -41,8 +44,8 @@ export function Character({ system, actorId, onRested }: Props): React.ReactElem
       {system.attributes.shield.itemId !== null && <ShieldTile shield={system.attributes.shield} />}
 
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <ResourcesRow resources={system.resources} />
-        <LongRestButton actorId={actorId} onRested={onRested} />
+        <ResourcesRow resources={system.resources} actorId={actorId} onActorChanged={onActorChanged} />
+        <LongRestButton actorId={actorId} onRested={onActorChanged} />
       </div>
 
       <MetaRow>
@@ -145,7 +148,15 @@ function AbilityBlock({
   );
 }
 
-function StatsBlock({ system }: { system: CharacterSystem }): React.ReactElement {
+function StatsBlock({
+  system,
+  actorId,
+  onActorChanged,
+}: {
+  system: CharacterSystem;
+  actorId: string;
+  onActorChanged: () => void;
+}): React.ReactElement {
   const { ac, hp } = system.attributes;
   const { perception, initiative } = system;
   const saves = system.saves;
@@ -155,16 +166,7 @@ function StatsBlock({ system }: { system: CharacterSystem }): React.ReactElement
       <SectionHeader>Key Stats</SectionHeader>
       <div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
         <StatTile label="AC" value={ac.value.toString()} title={ac.breakdown} />
-        <StatTile
-          label="HP"
-          value={
-            hp.temp > 0
-              ? `${hp.value.toString()} (+${hp.temp.toString()})`
-              : `${hp.value.toString()} / ${hp.max.toString()}`
-          }
-          title={hp.breakdown}
-          data-stat="hp"
-        />
+        <HpTile hp={hp} actorId={actorId} onActorChanged={onActorChanged} />
         <StatTile
           label="Perception"
           value={formatSignedInt(perception.value)}
@@ -187,6 +189,65 @@ function StatsBlock({ system }: { system: CharacterSystem }): React.ReactElement
         <SaveTile save={saves.will} />
       </div>
     </div>
+  );
+}
+
+// Replaces the plain HP `StatTile` with a stepper. Keeps the stat-card
+// shape (label + value on top) and tucks −5 / −1 / +1 / +5 buttons
+// below so the tile still sits flush with the other stats in the grid.
+function HpTile({
+  hp,
+  actorId,
+  onActorChanged,
+}: {
+  hp: CharacterSystem['attributes']['hp'];
+  actorId: string;
+  onActorChanged: () => void;
+}): React.ReactElement {
+  const value = hp.temp > 0 ? `${hp.value.toString()} (+${hp.temp.toString()})` : `${hp.value.toString()} / ${hp.max.toString()}`;
+  const { state, trigger } = useActorAction({
+    run: (delta: number) => api.adjustActorResource(actorId, 'hp', delta),
+    onSuccess: onActorChanged,
+  });
+  const isError = typeof state === 'object';
+
+  return (
+    <div
+      className="flex flex-col items-center rounded border border-pf-border bg-white px-2 py-2"
+      title={hp.breakdown}
+      data-stat="hp"
+    >
+      <span className="text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark">HP</span>
+      <span className="mt-0.5 font-mono text-xl font-semibold tabular-nums text-pf-text">{value}</span>
+      <div className="mt-1 flex gap-0.5" data-role="hp-stepper">
+        <StepButton label="−5" disabled={state === 'pending'} onClick={() => void trigger(-5)} />
+        <StepButton label="−1" disabled={state === 'pending'} onClick={() => void trigger(-1)} />
+        <StepButton label="+1" disabled={state === 'pending'} onClick={() => void trigger(1)} />
+        <StepButton label="+5" disabled={state === 'pending'} onClick={() => void trigger(5)} />
+      </div>
+      {isError && <span className="mt-1 text-[10px] text-red-700">{state.error}</span>}
+    </div>
+  );
+}
+
+function StepButton({
+  label,
+  onClick,
+  disabled,
+}: {
+  label: string;
+  onClick: () => void;
+  disabled: boolean;
+}): React.ReactElement {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="rounded border border-neutral-300 bg-white px-1 py-0.5 font-mono text-[10px] text-neutral-700 hover:bg-neutral-100 disabled:opacity-50"
+    >
+      {label}
+    </button>
   );
 }
 
@@ -242,38 +303,71 @@ function StatTile({
   );
 }
 
-function ResourcesRow({ resources }: { resources: CharacterSystem['resources'] }): React.ReactElement {
+function ResourcesRow({
+  resources,
+  actorId,
+  onActorChanged,
+}: {
+  resources: CharacterSystem['resources'];
+  actorId: string;
+  onActorChanged: () => void;
+}): React.ReactElement {
   const { heroPoints, focus, investiture, mythicPoints } = resources;
+  const adjustHero = useActorAction({
+    run: (delta: number) => api.adjustActorResource(actorId, 'hero-points', delta),
+    onSuccess: onActorChanged,
+  });
+  const adjustFocus = useActorAction({
+    run: (delta: number) => api.adjustActorResource(actorId, 'focus-points', delta),
+    onSuccess: onActorChanged,
+  });
+  const error =
+    typeof adjustHero.state === 'object'
+      ? adjustHero.state.error
+      : typeof adjustFocus.state === 'object'
+        ? adjustFocus.state.error
+        : null;
   return (
-    <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
-      <PipResource
-        label="Hero Points"
-        value={heroPoints.value}
-        max={heroPoints.max}
-        colorOn="border-rose-400 bg-rose-500"
-        data-stat="hero-points"
-      />
-      {focus.max > 0 && (
+    <div className="flex flex-col gap-1">
+      <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
         <PipResource
-          label="Focus"
-          value={focus.value}
-          max={focus.max}
-          colorOn="border-indigo-400 bg-indigo-500"
-          title={`Cap ${focus.cap.toString()}`}
-          data-stat="focus"
+          label="Hero Points"
+          value={heroPoints.value}
+          max={heroPoints.max}
+          colorOn="border-rose-400 bg-rose-500"
+          data-stat="hero-points"
+          onAdjust={(delta) => void adjustHero.trigger(delta)}
+          pending={adjustHero.state === 'pending'}
         />
-      )}
-      {mythicPoints.max > 0 && (
-        <PipResource
-          label="Mythic"
-          value={mythicPoints.value}
-          max={mythicPoints.max}
-          colorOn="border-amber-400 bg-amber-500"
-          data-stat="mythic-points"
-        />
-      )}
-      {investiture.max > 0 && (
-        <CountResource label="Invested" value={investiture.value} max={investiture.max} data-stat="investiture" />
+        {focus.max > 0 && (
+          <PipResource
+            label="Focus"
+            value={focus.value}
+            max={focus.max}
+            colorOn="border-indigo-400 bg-indigo-500"
+            title={`Cap ${focus.cap.toString()}`}
+            data-stat="focus"
+            onAdjust={(delta) => void adjustFocus.trigger(delta)}
+            pending={adjustFocus.state === 'pending'}
+          />
+        )}
+        {mythicPoints.max > 0 && (
+          <PipResource
+            label="Mythic"
+            value={mythicPoints.value}
+            max={mythicPoints.max}
+            colorOn="border-amber-400 bg-amber-500"
+            data-stat="mythic-points"
+          />
+        )}
+        {investiture.max > 0 && (
+          <CountResource label="Invested" value={investiture.value} max={investiture.max} data-stat="investiture" />
+        )}
+      </div>
+      {error !== null && (
+        <p className="text-[11px] text-red-700" data-role="resources-error">
+          {error}
+        </p>
       )}
     </div>
   );
@@ -285,6 +379,8 @@ function PipResource({
   max,
   colorOn,
   title,
+  onAdjust,
+  pending,
   ...rest
 }: {
   label: string;
@@ -292,11 +388,18 @@ function PipResource({
   max: number;
   colorOn: string;
   title?: string;
+  /** When set, renders −/+ buttons that call `onAdjust(delta)` with
+   *  ±1. Omit to keep the resource read-only. */
+  onAdjust?: (delta: number) => void;
+  pending?: boolean;
   'data-stat'?: string;
 }): React.ReactElement {
   return (
     <div className="flex items-center gap-2" title={title} {...rest}>
       <span className="text-[11px] font-semibold uppercase tracking-widest text-neutral-500">{label}</span>
+      {onAdjust !== undefined && (
+        <StepButton label="−" disabled={pending ?? false} onClick={() => onAdjust(-1)} />
+      )}
       <div className="flex gap-1" aria-label={`${value.toString()} of ${max.toString()}`}>
         {Array.from({ length: max }, (_, i) => (
           <span
@@ -308,6 +411,9 @@ function PipResource({
           />
         ))}
       </div>
+      {onAdjust !== undefined && (
+        <StepButton label="+" disabled={pending ?? false} onClick={() => onAdjust(1)} />
+      )}
       <span className="font-mono text-xs tabular-nums text-neutral-500">
         {value}/{max}
       </span>

--- a/apps/character-creator/src/pages/CharacterSheet.tsx
+++ b/apps/character-creator/src/pages/CharacterSheet.tsx
@@ -156,7 +156,7 @@ export function CharacterSheet({ actorId, onBack, preferences }: Props): React.R
           />
           <TabStrip tabs={TABS} active={activeTab} onChange={setActiveTab} />
           {activeTab === 'character' && (
-            <Character system={state.actor.system} actorId={actorId} onRested={reloadActor} />
+            <Character system={state.actor.system} actorId={actorId} onActorChanged={reloadActor} />
           )}
           {activeTab === 'actions' && (
             <Actions

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/AdjustActorResourceHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/AdjustActorResourceHandler.ts
@@ -1,0 +1,103 @@
+import type {
+  ActorResourceKey,
+  AdjustActorResourceParams,
+  AdjustActorResourceResult,
+} from '@/commands/types';
+
+interface FoundryActor {
+  id: string;
+  system: Record<string, unknown>;
+  update(data: Record<string, unknown>): Promise<FoundryActor>;
+}
+
+interface ActorsCollection {
+  get(id: string): FoundryActor | undefined;
+}
+
+interface FoundryGame {
+  actors: ActorsCollection;
+}
+
+declare const game: FoundryGame;
+
+interface ResourceConfig {
+  /** Dot-path passed to `actor.update()`. */
+  path: string;
+  /** Steps under `actor.system` used to read the current value. */
+  valuePath: readonly string[];
+  /** Steps under `actor.system` used to read the max, or null when
+   *  the resource has no natural cap (e.g. temp HP). */
+  maxPath: readonly string[] | null;
+}
+
+const RESOURCES: Record<ActorResourceKey, ResourceConfig> = {
+  hp: {
+    path: 'system.attributes.hp.value',
+    valuePath: ['attributes', 'hp', 'value'],
+    maxPath: ['attributes', 'hp', 'max'],
+  },
+  'hp-temp': {
+    path: 'system.attributes.hp.temp',
+    valuePath: ['attributes', 'hp', 'temp'],
+    maxPath: null,
+  },
+  'hero-points': {
+    path: 'system.resources.heroPoints.value',
+    valuePath: ['resources', 'heroPoints', 'value'],
+    maxPath: ['resources', 'heroPoints', 'max'],
+  },
+  'focus-points': {
+    path: 'system.resources.focus.value',
+    valuePath: ['resources', 'focus', 'value'],
+    maxPath: ['resources', 'focus', 'max'],
+  },
+};
+
+function readNumber(root: Record<string, unknown>, path: readonly string[]): number {
+  let cursor: unknown = root;
+  for (const key of path) {
+    if (cursor === null || typeof cursor !== 'object') return 0;
+    cursor = (cursor as Record<string, unknown>)[key];
+  }
+  return typeof cursor === 'number' && Number.isFinite(cursor) ? cursor : 0;
+}
+
+// Signed stepper against an actor's numeric resource. Writes the
+// clamped result straight to the field via `actor.update()` — no
+// damage pipeline, no IWR, no dying cascade. Matches the plain
+// behaviour of the pf2e sheet's +/- buttons; callers that want
+// full damage semantics should use a dedicated apply-damage
+// command (not yet typed).
+export async function adjustActorResourceHandler(
+  params: AdjustActorResourceParams,
+): Promise<AdjustActorResourceResult> {
+  const actor = game.actors.get(params.actorId);
+  if (!actor) {
+    throw new Error(`Actor not found: ${params.actorId}`);
+  }
+
+  const config = RESOURCES[params.resource];
+  // Defence in depth: zod rejects unknown keys at the HTTP edge, but
+  // the bridge command path has no such guard, so we check here too.
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (!config) {
+    throw new Error(`Unknown resource: ${String(params.resource)}`);
+  }
+
+  const before = readNumber(actor.system, config.valuePath);
+  const max = config.maxPath !== null ? readNumber(actor.system, config.maxPath) : null;
+  const upperBound = max ?? Number.POSITIVE_INFINITY;
+  const after = Math.max(0, Math.min(upperBound, before + params.delta));
+
+  if (after !== before) {
+    await actor.update({ [config.path]: after });
+  }
+
+  return {
+    actorId: params.actorId,
+    resource: params.resource,
+    before,
+    after,
+    max,
+  };
+}

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/__tests__/AdjustActorResourceHandler.test.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/__tests__/AdjustActorResourceHandler.test.ts
@@ -1,0 +1,192 @@
+import { adjustActorResourceHandler } from '../AdjustActorResourceHandler';
+
+type Actor = {
+  id: string;
+  system: {
+    attributes: { hp: { value: number; max: number; temp: number } };
+    resources: {
+      heroPoints: { value: number; max: number };
+      focus: { value: number; max: number };
+    };
+  };
+  update: jest.Mock;
+};
+
+function makeActor(overrides: Partial<Actor['system']> = {}): Actor {
+  return {
+    id: 'actor-1',
+    system: {
+      attributes: { hp: { value: 10, max: 22, temp: 0 } },
+      resources: {
+        heroPoints: { value: 1, max: 3 },
+        focus: { value: 0, max: 2 },
+      },
+      ...overrides,
+    },
+    update: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+const mockGame = { actors: { get: jest.fn() } };
+(global as Record<string, unknown>)['game'] = mockGame;
+
+describe('adjustActorResourceHandler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('heals HP by positive delta and clamps at max', async () => {
+    const actor = makeActor();
+    mockGame.actors.get.mockReturnValue(actor);
+
+    const result = await adjustActorResourceHandler({
+      actorId: 'actor-1',
+      resource: 'hp',
+      delta: 20,
+    });
+
+    expect(actor.update).toHaveBeenCalledWith({ 'system.attributes.hp.value': 22 });
+    expect(result).toEqual({
+      actorId: 'actor-1',
+      resource: 'hp',
+      before: 10,
+      after: 22,
+      max: 22,
+    });
+  });
+
+  it('damages HP by negative delta and clamps at 0', async () => {
+    const actor = makeActor();
+    mockGame.actors.get.mockReturnValue(actor);
+
+    const result = await adjustActorResourceHandler({
+      actorId: 'actor-1',
+      resource: 'hp',
+      delta: -25,
+    });
+
+    expect(actor.update).toHaveBeenCalledWith({ 'system.attributes.hp.value': 0 });
+    expect(result.after).toBe(0);
+  });
+
+  it('skips update when delta would not change the value', async () => {
+    const actor = makeActor();
+    actor.system.attributes.hp.value = 22;
+    mockGame.actors.get.mockReturnValue(actor);
+
+    const result = await adjustActorResourceHandler({
+      actorId: 'actor-1',
+      resource: 'hp',
+      delta: 10, // would heal past max; clamps to 22 = same as current
+    });
+
+    expect(actor.update).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      actorId: 'actor-1',
+      resource: 'hp',
+      before: 22,
+      after: 22,
+      max: 22,
+    });
+  });
+
+  it('adjusts hero points within 0..max', async () => {
+    const actor = makeActor();
+    mockGame.actors.get.mockReturnValue(actor);
+
+    const result = await adjustActorResourceHandler({
+      actorId: 'actor-1',
+      resource: 'hero-points',
+      delta: 5,
+    });
+
+    expect(actor.update).toHaveBeenCalledWith({ 'system.resources.heroPoints.value': 3 });
+    expect(result).toEqual({
+      actorId: 'actor-1',
+      resource: 'hero-points',
+      before: 1,
+      after: 3,
+      max: 3,
+    });
+  });
+
+  it('adjusts focus points within 0..max', async () => {
+    const actor = makeActor();
+    actor.system.resources.focus.value = 2;
+    mockGame.actors.get.mockReturnValue(actor);
+
+    const result = await adjustActorResourceHandler({
+      actorId: 'actor-1',
+      resource: 'focus-points',
+      delta: -1,
+    });
+
+    expect(actor.update).toHaveBeenCalledWith({ 'system.resources.focus.value': 1 });
+    expect(result.after).toBe(1);
+  });
+
+  it('reports null max and has no upper clamp for hp-temp', async () => {
+    const actor = makeActor();
+    actor.system.attributes.hp.temp = 5;
+    mockGame.actors.get.mockReturnValue(actor);
+
+    const result = await adjustActorResourceHandler({
+      actorId: 'actor-1',
+      resource: 'hp-temp',
+      delta: 50,
+    });
+
+    expect(actor.update).toHaveBeenCalledWith({ 'system.attributes.hp.temp': 55 });
+    expect(result).toEqual({
+      actorId: 'actor-1',
+      resource: 'hp-temp',
+      before: 5,
+      after: 55,
+      max: null,
+    });
+  });
+
+  it('clamps hp-temp at 0 for negative delta', async () => {
+    const actor = makeActor();
+    actor.system.attributes.hp.temp = 3;
+    mockGame.actors.get.mockReturnValue(actor);
+
+    const result = await adjustActorResourceHandler({
+      actorId: 'actor-1',
+      resource: 'hp-temp',
+      delta: -10,
+    });
+
+    expect(actor.update).toHaveBeenCalledWith({ 'system.attributes.hp.temp': 0 });
+    expect(result.after).toBe(0);
+  });
+
+  it('treats missing fields as 0 rather than throwing', async () => {
+    mockGame.actors.get.mockReturnValue({
+      id: 'sparse',
+      system: {},
+      update: jest.fn().mockResolvedValue(undefined),
+    });
+
+    const result = await adjustActorResourceHandler({
+      actorId: 'sparse',
+      resource: 'hero-points',
+      delta: 1,
+    });
+
+    expect(result.before).toBe(0);
+    expect(result.max).toBe(0);
+    expect(result.after).toBe(0); // clamped to max=0
+  });
+
+  it('throws when the actor does not exist', async () => {
+    mockGame.actors.get.mockReturnValue(undefined);
+    await expect(
+      adjustActorResourceHandler({
+        actorId: 'ghost',
+        resource: 'hp',
+        delta: 1,
+      }),
+    ).rejects.toThrow('Actor not found: ghost');
+  });
+});

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/index.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/index.ts
@@ -7,6 +7,7 @@ export { createActorHandler } from './CreateActorHandler';
 export { createActorFromCompendiumHandler } from './CreateActorFromCompendiumHandler';
 export { updateActorHandler } from './UpdateActorHandler';
 export { deleteActorHandler } from './DeleteActorHandler';
+export { adjustActorResourceHandler } from './AdjustActorResourceHandler';
 export { getActorsHandler } from './GetActorsHandler';
 export { getActorHandler } from './GetActorHandler';
 export { getPreparedActorHandler } from './GetPreparedActorHandler';

--- a/apps/foundry-api-bridge/src/commands/handlers/index.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/index.ts
@@ -15,6 +15,7 @@ export {
   createActorFromCompendiumHandler,
   updateActorHandler,
   deleteActorHandler,
+  adjustActorResourceHandler,
   getActorsHandler,
   getActorHandler,
   getPreparedActorHandler,

--- a/apps/foundry-api-bridge/src/commands/types.ts
+++ b/apps/foundry-api-bridge/src/commands/types.ts
@@ -30,6 +30,7 @@ export type CommandType =
   | 'create-actor-from-compendium'
   | 'update-actor'
   | 'delete-actor'
+  | 'adjust-actor-resource'
   | 'send-chat-message'
   | 'create-journal'
   | 'update-journal'
@@ -178,6 +179,44 @@ export interface UpdateActorParams {
 
 export interface DeleteActorParams {
   actorId: string;
+}
+
+// Adjustable numeric fields on a character/NPC that UI steppers care
+// about. Each maps to a dot-path under `actor.system`:
+//   hp            → attributes.hp.value
+//   hp-temp       → attributes.hp.temp
+//   hero-points   → resources.heroPoints.value
+//   focus-points  → resources.focus.value
+// Extend conservatively — new keys here mean new UI + new clamp rules.
+export type ActorResourceKey = 'hp' | 'hp-temp' | 'hero-points' | 'focus-points';
+
+export const ACTOR_RESOURCE_KEYS: readonly ActorResourceKey[] = [
+  'hp',
+  'hp-temp',
+  'hero-points',
+  'focus-points',
+];
+
+export interface AdjustActorResourceParams {
+  actorId: string;
+  resource: ActorResourceKey;
+  /** Signed delta applied to the current value (positive = gain,
+   *  negative = loss). Result is clamped into `[0, max]` — 'hp-temp'
+   *  has no upper clamp since temp HP's cap varies with the granting
+   *  effect. No damage-cascade side effects (dying pipe etc.): this
+   *  is a bare field write, matching how the sheet's +/- stepper
+   *  behaves. Use `actor.applyDamage` elsewhere when the full pipeline
+   *  is wanted. */
+  delta: number;
+}
+
+export interface AdjustActorResourceResult {
+  actorId: string;
+  resource: ActorResourceKey;
+  before: number;
+  after: number;
+  /** null when the resource has no natural cap (currently only 'hp-temp'). */
+  max: number | null;
 }
 
 // Actor Results
@@ -1496,6 +1535,7 @@ export interface CommandParamsMap {
   'create-actor-from-compendium': CreateActorFromCompendiumParams;
   'update-actor': UpdateActorParams;
   'delete-actor': DeleteActorParams;
+  'adjust-actor-resource': AdjustActorResourceParams;
   'send-chat-message': SendChatMessageParams;
   'create-journal': CreateJournalParams;
   'update-journal': UpdateJournalParams;
@@ -1592,6 +1632,7 @@ export interface CommandResultMap {
   'create-actor-from-compendium': ActorResult;
   'update-actor': ActorResult;
   'delete-actor': DeleteResult;
+  'adjust-actor-resource': AdjustActorResourceResult;
   'send-chat-message': SendChatMessageResult;
   'create-journal': JournalResult;
   'update-journal': JournalResult;

--- a/apps/foundry-api-bridge/src/main.ts
+++ b/apps/foundry-api-bridge/src/main.ts
@@ -24,6 +24,7 @@ import {
   createActorFromCompendiumHandler,
   updateActorHandler,
   deleteActorHandler,
+  adjustActorResourceHandler,
   getActorsHandler,
   getActorHandler,
   getPreparedActorHandler,
@@ -199,6 +200,7 @@ function initializeWebSocket(
   commandRouter.register('create-actor-from-compendium', createActorFromCompendiumHandler);
   commandRouter.register('update-actor', updateActorHandler);
   commandRouter.register('delete-actor', deleteActorHandler);
+  commandRouter.register('adjust-actor-resource', adjustActorResourceHandler);
 
   // Journal CRUD
   commandRouter.register('create-journal', createJournalHandler);

--- a/apps/foundry-mcp/src/http/routes/actors.ts
+++ b/apps/foundry-mcp/src/http/routes/actors.ts
@@ -5,6 +5,7 @@ import {
   actorItemIdParams,
   actorTraceParams,
   addItemFromCompendiumBody,
+  adjustActorResourceBody,
   createActorBody,
   updateActorBody,
   updateActorItemBody,
@@ -62,5 +63,16 @@ export function registerActorRoutes(app: FastifyInstance): void {
     const { id, itemId } = actorItemIdParams.parse(req.params);
     const body = updateActorItemBody.parse(req.body);
     return sendCommand('update-actor-item', { actorId: id, itemId, ...body });
+  });
+
+  // Stepper for numeric resources (HP, temp HP, hero points, focus
+  // points). Body picks the field; positive delta heals / grants,
+  // negative damages / spends. The bridge clamps into [0, max] and
+  // reports `{before, after, max}` so clients don't have to
+  // refetch the prepared actor just to update a pip display.
+  app.post('/api/actors/:id/resources/adjust', async (req) => {
+    const { id } = actorIdParam.parse(req.params);
+    const body = adjustActorResourceBody.parse(req.body);
+    return sendCommand('adjust-actor-resource', { actorId: id, ...body });
   });
 }

--- a/packages/shared/src/rpc/index.ts
+++ b/packages/shared/src/rpc/index.ts
@@ -8,6 +8,7 @@ import type { z } from 'zod/v4';
 
 import type {
   addItemFromCompendiumBody,
+  adjustActorResourceBody,
   createActorBody,
   resolvePromptBody,
   updateActorBody,
@@ -23,6 +24,17 @@ export type AddItemFromCompendiumBody = z.infer<typeof addItemFromCompendiumBody
 export type UpdateActorItemBody = z.infer<typeof updateActorItemBody>;
 export type ResolvePromptBody = z.infer<typeof resolvePromptBody>;
 export type UploadAssetBody = z.infer<typeof uploadAssetBody>;
+export type AdjustActorResourceBody = z.infer<typeof adjustActorResourceBody>;
+export type ActorResourceKey = AdjustActorResourceBody['resource'];
+
+export interface AdjustActorResourceResponse {
+  actorId: string;
+  resource: ActorResourceKey;
+  before: number;
+  after: number;
+  /** null when the resource has no natural cap (currently only 'hp-temp'). */
+  max: number | null;
+}
 
 // Error response shape for `/api/*` — mirrored in `foundry-api.ts` as
 // `ApiError` (same shape). Re-exported here for callers that want to

--- a/packages/shared/src/rpc/schemas.ts
+++ b/packages/shared/src/rpc/schemas.ts
@@ -153,6 +153,20 @@ export const updateActorBody = z.object({
   flags: z.record(z.string(), z.record(z.string(), z.unknown())).optional(),
 });
 
+// Steppable numeric fields on an actor. Kept narrow — each key maps
+// to a known path under `actor.system` on the module side, with
+// resource-specific clamping. New keys require a matching branch
+// in the bridge handler (AdjustActorResourceHandler.ts).
+export const ACTOR_RESOURCE_KEYS = ['hp', 'hp-temp', 'hero-points', 'focus-points'] as const;
+
+export const adjustActorResourceBody = z.object({
+  resource: z.enum(ACTOR_RESOURCE_KEYS),
+  // Signed integer delta. Bound is wide enough for "heal to full"
+  // on any reasonable HP pool; the handler clamps to [0, max] so
+  // oversized requests are harmless.
+  delta: z.number().int().min(-10_000).max(10_000),
+});
+
 // Item-on-actor operations for the wizard's piecemeal picks
 // (ancestry, heritage, class, background, deity). Copies the source
 // document out of the compendium, strips its `_id`, and attaches it


### PR DESCRIPTION
## Summary

- First typed command to replace `/api/eval` for a gameplay button: `adjust-actor-resource` covers HP, temp HP, hero points, and focus points.
- `POST /api/actors/:id/resources/adjust` with `{resource, delta}`; server clamps to `[0, max]` and responds with `{before, after, max}`.
- Character tab:
  - HP StatTile → interactive **HpTile** with −5 / −1 / +1 / +5 steppers below the value.
  - **PipResource** gained optional `onAdjust(delta)` + `pending` props; hero points and focus now have −/+ buttons.
  - `onRested` → `onActorChanged` (generalised now that multiple mutations share the callback).

## Bridge behaviour

- Bare field write via `actor.update()` — no damage pipeline, no IWR, no dying cascade. Matches the plain behaviour of the pf2e sheet's +/- buttons.
- `hp-temp` has no upper clamp (max varies by granting effect); others clamp to their `.max` field.
- Missing fields read as `0` rather than throwing, so a sparse actor responds predictably.

## Follow-ups (deferred)

- Text-input "damage / heal X" field — keyboard flow is faster than clicking −5 four times. Out of scope for v1.
- `apply-damage` command that runs the full PF2e damage pipeline (IWR, shield-block, dying).
- Optimistic local update to skip the `/prepared` refetch on every stepper click.

## Test plan

- [x] Bridge: `AdjustActorResourceHandler.test.ts` — 9 cases covering heal, damage, clamps, hp-temp, sparse actor, missing actor.
- [x] `npm run test --workspace=apps/foundry-api-bridge` — 664/664 pass.
- [x] `npm run typecheck --workspace=apps/character-creator` — clean.
- [x] `npm run test --workspace=apps/character-creator` — 148/148 pass.
- [x] Mock-mode preview: HP stepper + hero-point stepper render, clicking fires the API call, 404 surfaces inline.
- [ ] Against live Foundry: HP ±1 / ±5, hero point ±1, focus ±1 all round-trip; sheet reflects the new value.