### PR TITLE
Add adjust-actor-condition + dying/wounded/doomed steppers

### DIFF
--- a/apps/character-creator/src/api/client.ts
+++ b/apps/character-creator/src/api/client.ts
@@ -1,6 +1,8 @@
 import type {
+  ActorConditionKey,
   ActorResourceKey,
   AddItemFromCompendiumBody,
+  AdjustActorConditionResponse,
   AdjustActorResourceResponse,
   CreateActorBody,
   UpdateActorBody,
@@ -132,6 +134,18 @@ export const api = {
     request<AdjustActorResourceResponse>(`/actors/${id}/resources/adjust`, {
       method: 'POST',
       body: { resource, delta },
+    }),
+  // Signed stepper for dying / wounded / doomed. Each |delta| unit
+  // triggers one increase/decreaseCondition call on the bridge, so
+  // PF2e's cascade rules fire (dying→wounded, auto-death at cap).
+  adjustActorCondition: (
+    id: string,
+    condition: ActorConditionKey,
+    delta: number,
+  ): Promise<AdjustActorConditionResponse> =>
+    request<AdjustActorConditionResponse>(`/actors/${id}/conditions/adjust`, {
+      method: 'POST',
+      body: { condition, delta },
     }),
   resolvePrompt: (bridgeId: string, value: unknown): Promise<{ ok: boolean }> =>
     request<{ ok: boolean }>(`/prompts/${bridgeId}/resolve`, { method: 'POST', body: { value } }),

--- a/apps/character-creator/src/components/tabs/Character.tsx
+++ b/apps/character-creator/src/components/tabs/Character.tsx
@@ -39,6 +39,8 @@ export function Character({ system, actorId, onActorChanged }: Props): React.Rea
         dying={system.attributes.dying}
         wounded={system.attributes.wounded}
         doomed={system.attributes.doomed}
+        actorId={actorId}
+        onActorChanged={onActorChanged}
       />
 
       {system.attributes.shield.itemId !== null && <ShieldTile shield={system.attributes.shield} />}
@@ -492,35 +494,72 @@ function ConditionsRow({
   dying,
   wounded,
   doomed,
+  actorId,
+  onActorChanged,
 }: {
   dying: CharacterSystem['attributes']['dying'];
   wounded: CharacterSystem['attributes']['wounded'];
   doomed: CharacterSystem['attributes']['doomed'];
+  actorId: string;
+  onActorChanged: () => void;
 }): React.ReactElement {
+  const adjustDying = useActorAction({
+    run: (delta: number) => api.adjustActorCondition(actorId, 'dying', delta),
+    onSuccess: onActorChanged,
+  });
+  const adjustWounded = useActorAction({
+    run: (delta: number) => api.adjustActorCondition(actorId, 'wounded', delta),
+    onSuccess: onActorChanged,
+  });
+  const adjustDoomed = useActorAction({
+    run: (delta: number) => api.adjustActorCondition(actorId, 'doomed', delta),
+    onSuccess: onActorChanged,
+  });
+  const error =
+    typeof adjustDying.state === 'object'
+      ? adjustDying.state.error
+      : typeof adjustWounded.state === 'object'
+        ? adjustWounded.state.error
+        : typeof adjustDoomed.state === 'object'
+          ? adjustDoomed.state.error
+          : null;
   return (
-    <div className="flex flex-wrap items-center gap-x-6 gap-y-2" data-section="conditions">
-      <Condition
-        label="Dying"
-        value={dying.value}
-        max={dying.max}
-        colorOn="border-red-500 bg-red-600"
-        title={`Recovery DC ${dying.recoveryDC.toString()}`}
-        data-stat="dying"
-      />
-      <Condition
-        label="Wounded"
-        value={wounded.value}
-        max={wounded.max}
-        colorOn="border-amber-500 bg-amber-600"
-        data-stat="wounded"
-      />
-      <Condition
-        label="Doomed"
-        value={doomed.value}
-        max={doomed.max}
-        colorOn="border-violet-500 bg-violet-700"
-        data-stat="doomed"
-      />
+    <div className="flex flex-col gap-1">
+      <div className="flex flex-wrap items-center gap-x-6 gap-y-2" data-section="conditions">
+        <Condition
+          label="Dying"
+          value={dying.value}
+          max={dying.max}
+          colorOn="border-red-500 bg-red-600"
+          title={`Recovery DC ${dying.recoveryDC.toString()}`}
+          data-stat="dying"
+          onAdjust={(delta) => void adjustDying.trigger(delta)}
+          pending={adjustDying.state === 'pending'}
+        />
+        <Condition
+          label="Wounded"
+          value={wounded.value}
+          max={wounded.max}
+          colorOn="border-amber-500 bg-amber-600"
+          data-stat="wounded"
+          onAdjust={(delta) => void adjustWounded.trigger(delta)}
+          pending={adjustWounded.state === 'pending'}
+        />
+        <Condition
+          label="Doomed"
+          value={doomed.value}
+          max={doomed.max}
+          colorOn="border-violet-500 bg-violet-700"
+          data-stat="doomed"
+          onAdjust={(delta) => void adjustDoomed.trigger(delta)}
+          pending={adjustDoomed.state === 'pending'}
+        />
+      </div>
+      {error !== null && (
+        <p className="text-[11px] text-red-700" data-role="conditions-error">
+          {error}
+        </p>
+      )}
     </div>
   );
 }
@@ -531,6 +570,8 @@ function Condition({
   max,
   colorOn,
   title,
+  onAdjust,
+  pending,
   ...rest
 }: {
   label: string;
@@ -538,11 +579,18 @@ function Condition({
   max: number;
   colorOn: string;
   title?: string;
+  /** When set, renders −/+ buttons that call `onAdjust(delta)` with
+   *  ±1. Omit to keep the condition read-only. */
+  onAdjust?: (delta: number) => void;
+  pending?: boolean;
   'data-stat'?: string;
 }): React.ReactElement {
   return (
     <div className="flex items-center gap-2" title={title} {...rest}>
       <span className="text-[11px] font-semibold uppercase tracking-widest text-neutral-500">{label}</span>
+      {onAdjust !== undefined && (
+        <StepButton label="−" disabled={pending ?? false} onClick={() => onAdjust(-1)} />
+      )}
       <div className="flex gap-1" aria-label={`${value.toString()} of ${max.toString()}`}>
         {Array.from({ length: max }, (_, i) => (
           <span
@@ -554,6 +602,9 @@ function Condition({
           />
         ))}
       </div>
+      {onAdjust !== undefined && (
+        <StepButton label="+" disabled={pending ?? false} onClick={() => onAdjust(1)} />
+      )}
       <span className="font-mono text-xs tabular-nums text-neutral-500">
         {value}/{max}
       </span>

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/AdjustActorConditionHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/AdjustActorConditionHandler.ts
@@ -1,0 +1,91 @@
+import type {
+  ActorConditionKey,
+  AdjustActorConditionParams,
+  AdjustActorConditionResult,
+} from '@/commands/types';
+
+interface FoundryActor {
+  id: string;
+  system: Record<string, unknown>;
+  /** PF2e-specific: bumps the condition by 1 (creates the effect at
+   *  value 1 if absent). Returns the condition item or null. */
+  increaseCondition?: (slug: string) => Promise<unknown>;
+  /** PF2e-specific: drops the condition value by 1; removes the
+   *  effect when it hits 0. */
+  decreaseCondition?: (slug: string) => Promise<unknown>;
+}
+
+interface ActorsCollection {
+  get(id: string): FoundryActor | undefined;
+}
+
+interface FoundryGame {
+  actors: ActorsCollection;
+}
+
+declare const game: FoundryGame;
+
+const VALUE_PATH: Record<ActorConditionKey, readonly string[]> = {
+  dying: ['attributes', 'dying', 'value'],
+  wounded: ['attributes', 'wounded', 'value'],
+  doomed: ['attributes', 'doomed', 'value'],
+};
+
+const MAX_PATH: Record<ActorConditionKey, readonly string[]> = {
+  dying: ['attributes', 'dying', 'max'],
+  wounded: ['attributes', 'wounded', 'max'],
+  doomed: ['attributes', 'doomed', 'max'],
+};
+
+function readNumber(root: Record<string, unknown>, path: readonly string[]): number {
+  let cursor: unknown = root;
+  for (const key of path) {
+    if (cursor === null || typeof cursor !== 'object') return 0;
+    cursor = (cursor as Record<string, unknown>)[key];
+  }
+  return typeof cursor === 'number' && Number.isFinite(cursor) ? cursor : 0;
+}
+
+// Signed stepper for the three persistent PF2e conditions. Deltas are
+// applied via repeated `increase`/`decreaseCondition` calls so the
+// system's lifecycle fires — dying crossing max kills the character,
+// decreasing dying past 0 leaves a wounded stack, etc.
+export async function adjustActorConditionHandler(
+  params: AdjustActorConditionParams,
+): Promise<AdjustActorConditionResult> {
+  const actor = game.actors.get(params.actorId);
+  if (!actor) {
+    throw new Error(`Actor not found: ${params.actorId}`);
+  }
+
+  if (typeof actor.increaseCondition !== 'function' || typeof actor.decreaseCondition !== 'function') {
+    throw new Error(
+      `Actor ${params.actorId} doesn't expose PF2e condition methods — is this a pf2e system actor?`,
+    );
+  }
+
+  const before = readNumber(actor.system, VALUE_PATH[params.condition]);
+
+  if (params.delta > 0) {
+    for (let i = 0; i < params.delta; i++) {
+      await actor.increaseCondition(params.condition);
+    }
+  } else if (params.delta < 0) {
+    for (let i = 0; i < -params.delta; i++) {
+      await actor.decreaseCondition(params.condition);
+    }
+  }
+
+  // Max can shift in the same call (dying's cap moves with doomed),
+  // so re-read after the writes.
+  const after = readNumber(actor.system, VALUE_PATH[params.condition]);
+  const max = readNumber(actor.system, MAX_PATH[params.condition]);
+
+  return {
+    actorId: params.actorId,
+    condition: params.condition,
+    before,
+    after,
+    max,
+  };
+}

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/__tests__/AdjustActorConditionHandler.test.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/__tests__/AdjustActorConditionHandler.test.ts
@@ -1,0 +1,145 @@
+import { adjustActorConditionHandler } from '../AdjustActorConditionHandler';
+
+type ActorSystem = {
+  attributes: {
+    dying: { value: number; max: number };
+    wounded: { value: number; max: number };
+    doomed: { value: number; max: number };
+  };
+};
+
+type Actor = {
+  id: string;
+  system: ActorSystem;
+  increaseCondition: jest.Mock;
+  decreaseCondition: jest.Mock;
+};
+
+function makeActor(): Actor {
+  return {
+    id: 'actor-1',
+    system: {
+      attributes: {
+        dying: { value: 0, max: 4 },
+        wounded: { value: 0, max: 3 },
+        doomed: { value: 0, max: 3 },
+      },
+    },
+    increaseCondition: jest.fn(),
+    decreaseCondition: jest.fn(),
+  };
+}
+
+const mockGame = { actors: { get: jest.fn() } };
+(global as Record<string, unknown>)['game'] = mockGame;
+
+describe('adjustActorConditionHandler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls increaseCondition once per positive delta', async () => {
+    const actor = makeActor();
+    // Simulate the PF2e behaviour: each call bumps value by 1.
+    actor.increaseCondition.mockImplementation(async () => {
+      actor.system.attributes.dying.value += 1;
+    });
+    mockGame.actors.get.mockReturnValue(actor);
+
+    const result = await adjustActorConditionHandler({
+      actorId: 'actor-1',
+      condition: 'dying',
+      delta: 2,
+    });
+
+    expect(actor.increaseCondition).toHaveBeenCalledTimes(2);
+    expect(actor.increaseCondition).toHaveBeenCalledWith('dying');
+    expect(actor.decreaseCondition).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      actorId: 'actor-1',
+      condition: 'dying',
+      before: 0,
+      after: 2,
+      max: 4,
+    });
+  });
+
+  it('calls decreaseCondition once per unit of negative delta', async () => {
+    const actor = makeActor();
+    actor.system.attributes.wounded.value = 3;
+    actor.decreaseCondition.mockImplementation(async () => {
+      actor.system.attributes.wounded.value -= 1;
+    });
+    mockGame.actors.get.mockReturnValue(actor);
+
+    const result = await adjustActorConditionHandler({
+      actorId: 'actor-1',
+      condition: 'wounded',
+      delta: -2,
+    });
+
+    expect(actor.decreaseCondition).toHaveBeenCalledTimes(2);
+    expect(actor.decreaseCondition).toHaveBeenCalledWith('wounded');
+    expect(actor.increaseCondition).not.toHaveBeenCalled();
+    expect(result.before).toBe(3);
+    expect(result.after).toBe(1);
+  });
+
+  it('no-ops on zero delta and still reports current state', async () => {
+    const actor = makeActor();
+    actor.system.attributes.doomed.value = 2;
+    mockGame.actors.get.mockReturnValue(actor);
+
+    const result = await adjustActorConditionHandler({
+      actorId: 'actor-1',
+      condition: 'doomed',
+      delta: 0,
+    });
+
+    expect(actor.increaseCondition).not.toHaveBeenCalled();
+    expect(actor.decreaseCondition).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      actorId: 'actor-1',
+      condition: 'doomed',
+      before: 2,
+      after: 2,
+      max: 3,
+    });
+  });
+
+  it('reports the post-call max (matters for dying as doomed shifts its cap)', async () => {
+    const actor = makeActor();
+    // Simulate doomed's effect on dying.max: after increase, max grows.
+    actor.increaseCondition.mockImplementation(async () => {
+      actor.system.attributes.dying.value += 1;
+      actor.system.attributes.dying.max = 5; // e.g. doomed 1 bumped cap to 5
+    });
+    mockGame.actors.get.mockReturnValue(actor);
+
+    const result = await adjustActorConditionHandler({
+      actorId: 'actor-1',
+      condition: 'dying',
+      delta: 1,
+    });
+
+    expect(result.max).toBe(5);
+  });
+
+  it('throws when the actor does not exist', async () => {
+    mockGame.actors.get.mockReturnValue(undefined);
+    await expect(
+      adjustActorConditionHandler({ actorId: 'ghost', condition: 'dying', delta: 1 }),
+    ).rejects.toThrow('Actor not found: ghost');
+  });
+
+  it('throws a clear error on non-pf2e actors that lack increaseCondition', async () => {
+    mockGame.actors.get.mockReturnValue({
+      id: 'vanilla',
+      system: {},
+      // No condition methods — simulates a 5e or other-system actor.
+    });
+    await expect(
+      adjustActorConditionHandler({ actorId: 'vanilla', condition: 'dying', delta: 1 }),
+    ).rejects.toThrow(/pf2e system actor/);
+  });
+});

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/index.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/index.ts
@@ -8,6 +8,7 @@ export { createActorFromCompendiumHandler } from './CreateActorFromCompendiumHan
 export { updateActorHandler } from './UpdateActorHandler';
 export { deleteActorHandler } from './DeleteActorHandler';
 export { adjustActorResourceHandler } from './AdjustActorResourceHandler';
+export { adjustActorConditionHandler } from './AdjustActorConditionHandler';
 export { getActorsHandler } from './GetActorsHandler';
 export { getActorHandler } from './GetActorHandler';
 export { getPreparedActorHandler } from './GetPreparedActorHandler';

--- a/apps/foundry-api-bridge/src/commands/handlers/index.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/index.ts
@@ -16,6 +16,7 @@ export {
   updateActorHandler,
   deleteActorHandler,
   adjustActorResourceHandler,
+  adjustActorConditionHandler,
   getActorsHandler,
   getActorHandler,
   getPreparedActorHandler,

--- a/apps/foundry-api-bridge/src/commands/types.ts
+++ b/apps/foundry-api-bridge/src/commands/types.ts
@@ -31,6 +31,7 @@ export type CommandType =
   | 'update-actor'
   | 'delete-actor'
   | 'adjust-actor-resource'
+  | 'adjust-actor-condition'
   | 'send-chat-message'
   | 'create-journal'
   | 'update-journal'
@@ -217,6 +218,34 @@ export interface AdjustActorResourceResult {
   after: number;
   /** null when the resource has no natural cap (currently only 'hp-temp'). */
   max: number | null;
+}
+
+// PF2e persistent-count conditions. Unlike HP / hero points these aren't
+// raw numeric fields — they're tracked via active effects with their
+// own lifecycle (dying → wounded cascade, auto-death at dying max).
+// The handler goes through `actor.increaseCondition` / `decreaseCondition`
+// to keep that lifecycle intact.
+export type ActorConditionKey = 'dying' | 'wounded' | 'doomed';
+
+export const ACTOR_CONDITION_KEYS: readonly ActorConditionKey[] = ['dying', 'wounded', 'doomed'];
+
+export interface AdjustActorConditionParams {
+  actorId: string;
+  condition: ActorConditionKey;
+  /** Signed count applied via repeated increase/decreaseCondition
+   *  calls. +2 calls increase twice; -3 calls decrease three times.
+   *  The PF2e condition code handles floor/ceiling and cascades. */
+  delta: number;
+}
+
+export interface AdjustActorConditionResult {
+  actorId: string;
+  condition: ActorConditionKey;
+  before: number;
+  after: number;
+  /** Reported at response time; max may shift (e.g. dying's cap
+   *  increases with doomed) so clients shouldn't cache it. */
+  max: number;
 }
 
 // Actor Results
@@ -1536,6 +1565,7 @@ export interface CommandParamsMap {
   'update-actor': UpdateActorParams;
   'delete-actor': DeleteActorParams;
   'adjust-actor-resource': AdjustActorResourceParams;
+  'adjust-actor-condition': AdjustActorConditionParams;
   'send-chat-message': SendChatMessageParams;
   'create-journal': CreateJournalParams;
   'update-journal': UpdateJournalParams;
@@ -1633,6 +1663,7 @@ export interface CommandResultMap {
   'update-actor': ActorResult;
   'delete-actor': DeleteResult;
   'adjust-actor-resource': AdjustActorResourceResult;
+  'adjust-actor-condition': AdjustActorConditionResult;
   'send-chat-message': SendChatMessageResult;
   'create-journal': JournalResult;
   'update-journal': JournalResult;

--- a/apps/foundry-api-bridge/src/main.ts
+++ b/apps/foundry-api-bridge/src/main.ts
@@ -25,6 +25,7 @@ import {
   updateActorHandler,
   deleteActorHandler,
   adjustActorResourceHandler,
+  adjustActorConditionHandler,
   getActorsHandler,
   getActorHandler,
   getPreparedActorHandler,
@@ -201,6 +202,7 @@ function initializeWebSocket(
   commandRouter.register('update-actor', updateActorHandler);
   commandRouter.register('delete-actor', deleteActorHandler);
   commandRouter.register('adjust-actor-resource', adjustActorResourceHandler);
+  commandRouter.register('adjust-actor-condition', adjustActorConditionHandler);
 
   // Journal CRUD
   commandRouter.register('create-journal', createJournalHandler);

--- a/apps/foundry-mcp/src/http/routes/actors.ts
+++ b/apps/foundry-mcp/src/http/routes/actors.ts
@@ -5,6 +5,7 @@ import {
   actorItemIdParams,
   actorTraceParams,
   addItemFromCompendiumBody,
+  adjustActorConditionBody,
   adjustActorResourceBody,
   createActorBody,
   updateActorBody,
@@ -74,5 +75,17 @@ export function registerActorRoutes(app: FastifyInstance): void {
     const { id } = actorIdParam.parse(req.params);
     const body = adjustActorResourceBody.parse(req.body);
     return sendCommand('adjust-actor-resource', { actorId: id, ...body });
+  });
+
+  // Stepper for PF2e persistent-count conditions (dying, wounded,
+  // doomed). Positive delta = apply N stacks via increaseCondition;
+  // negative = peel N stacks via decreaseCondition. Handler goes
+  // through PF2e's condition API rather than raw updates, so the
+  // system's cascade behaviour (dying → wounded, auto-death at cap)
+  // stays intact.
+  app.post('/api/actors/:id/conditions/adjust', async (req) => {
+    const { id } = actorIdParam.parse(req.params);
+    const body = adjustActorConditionBody.parse(req.body);
+    return sendCommand('adjust-actor-condition', { actorId: id, ...body });
   });
 }

--- a/packages/shared/src/rpc/index.ts
+++ b/packages/shared/src/rpc/index.ts
@@ -8,6 +8,7 @@ import type { z } from 'zod/v4';
 
 import type {
   addItemFromCompendiumBody,
+  adjustActorConditionBody,
   adjustActorResourceBody,
   createActorBody,
   resolvePromptBody,
@@ -34,6 +35,18 @@ export interface AdjustActorResourceResponse {
   after: number;
   /** null when the resource has no natural cap (currently only 'hp-temp'). */
   max: number | null;
+}
+
+export type AdjustActorConditionBody = z.infer<typeof adjustActorConditionBody>;
+export type ActorConditionKey = AdjustActorConditionBody['condition'];
+
+export interface AdjustActorConditionResponse {
+  actorId: string;
+  condition: ActorConditionKey;
+  before: number;
+  after: number;
+  /** Re-read after the writes — dying's cap shifts with doomed. */
+  max: number;
 }
 
 // Error response shape for `/api/*` — mirrored in `foundry-api.ts` as

--- a/packages/shared/src/rpc/schemas.ts
+++ b/packages/shared/src/rpc/schemas.ts
@@ -167,6 +167,21 @@ export const adjustActorResourceBody = z.object({
   delta: z.number().int().min(-10_000).max(10_000),
 });
 
+// PF2e persistent conditions that carry a stack count. Handler goes
+// through `actor.increaseCondition` / `decreaseCondition` (not raw
+// updates) so the system's cascade rules fire — dying crossing its
+// cap kills the character, dying decreasing past 0 leaves a wounded
+// stack behind.
+export const ACTOR_CONDITION_KEYS = ['dying', 'wounded', 'doomed'] as const;
+
+export const adjustActorConditionBody = z.object({
+  condition: z.enum(ACTOR_CONDITION_KEYS),
+  // Each unit of |delta| maps to one increase/decrease call. Kept
+  // small because nobody clicks +10 dying in practice, and small
+  // deltas keep the lifecycle cascade predictable.
+  delta: z.number().int().min(-10).max(10),
+});
+
 // Item-on-actor operations for the wizard's piecemeal picks
 // (ancestry, heritage, class, background, deity). Copies the source
 // document out of the compendium, strips its `_id`, and attaches it


### PR DESCRIPTION
## Summary

- New typed command `adjust-actor-condition` that applies a signed stack delta to the three persistent PF2e conditions (`dying`, `wounded`, `doomed`).
- Goes through `actor.increaseCondition` / `decreaseCondition` rather than raw `actor.update()` so the system's cascade rules fire: dying crossing its cap kills the character, decreasing dying past 0 leaves a wounded stack, doomed shifts dying's cap.
- `POST /api/actors/:id/conditions/adjust` with `{condition, delta}`; returns `{actorId, condition, before, after, max}` (max re-read after writes because doomed shifts it).
- `ConditionsRow` on the Character tab now has −/+ buttons next to each stat; shared error line below matches the resources-row style.

## Implementation notes

- Kept separate from `adjust-actor-resource` on purpose. The resource handler does a bare `actor.update()` (no side effects, matches sheet +/-) while this goes through the condition lifecycle (different domain, different failure modes). Forcing both through one command would hide that distinction.
- Delta bound is `[-10, 10]` since nobody clicks +10 dying in practice, and small deltas keep the cascade predictable.
- Handler falls back with a clear error when called against non-pf2e actors that don't expose `increaseCondition` — a safety net if someone wires this to a 5e sheet later.

## Test plan

- [x] `AdjustActorConditionHandler.test.ts` — 6 cases: positive delta → N increaseCondition calls, negative → N decreaseCondition, zero no-op, post-call max re-read, missing actor, non-pf2e actor.
- [x] `npm run test --workspace=apps/foundry-api-bridge` — 670/670 pass (up from 664).
- [x] `npm run typecheck --workspace=apps/character-creator` — clean.
- [x] `npm run test --workspace=apps/character-creator` — 148/148 pass.
- [x] Mock-mode preview: −/+ buttons render on Dying / Wounded / Doomed; clicking fires the API and 404 surfaces inline.
- [ ] Against live Foundry: click Dying + — PF2e applies the dying condition; click + again to 4 — character dies. Click Wounded − when dying is 0 — wounded stack decrements normally.