### PR TITLE
Add roll-actor-statistic + click-to-roll Perception / saves

### DIFF
--- a/apps/character-creator/src/api/client.ts
+++ b/apps/character-creator/src/api/client.ts
@@ -5,6 +5,9 @@ import type {
   AdjustActorConditionResponse,
   AdjustActorResourceResponse,
   CreateActorBody,
+  Pf2eRollMode,
+  Pf2eStatisticSlug,
+  RollActorStatisticResponse,
   UpdateActorBody,
   UpdateActorItemBody,
   UploadAssetBody,
@@ -146,6 +149,19 @@ export const api = {
     request<AdjustActorConditionResponse>(`/actors/${id}/conditions/adjust`, {
       method: 'POST',
       body: { condition, delta },
+    }),
+  // Click-to-roll for any PF2e `Statistic` — Perception, Fort/Ref/Will,
+  // or any skill. Chat card lands in Foundry as a side effect; the
+  // response carries `{total, formula, dice, chatMessageId?}` for
+  // optional SPA-side display.
+  rollActorStatistic: (
+    id: string,
+    statistic: Pf2eStatisticSlug,
+    rollMode?: Pf2eRollMode,
+  ): Promise<RollActorStatisticResponse> =>
+    request<RollActorStatisticResponse>(`/actors/${id}/rolls/statistic`, {
+      method: 'POST',
+      body: { statistic, ...(rollMode !== undefined ? { rollMode } : {}) },
     }),
   resolvePrompt: (bridgeId: string, value: unknown): Promise<{ ok: boolean }> =>
     request<{ ok: boolean }>(`/prompts/${bridgeId}/resolve`, { method: 'POST', body: { value } }),

--- a/apps/character-creator/src/components/tabs/Character.tsx
+++ b/apps/character-creator/src/components/tabs/Character.tsx
@@ -3,7 +3,7 @@ import type { AbilityKey, CharacterSystem, IWREntry, Save, Shield, Speed } from 
 import { ABILITY_KEYS } from '../../api/types';
 import { t } from '../../i18n/t';
 import { formatSignedInt } from '../../lib/format';
-import { useActorAction } from '../../lib/useActorAction';
+import { useActorAction, type ActorActionState } from '../../lib/useActorAction';
 import { RankChip } from '../common/RankChip';
 import { SectionHeader } from '../common/SectionHeader';
 
@@ -163,6 +163,21 @@ function StatsBlock({
   const { perception, initiative } = system;
   const saves = system.saves;
 
+  const rollPerception = useActorAction({
+    run: () => api.rollActorStatistic(actorId, 'perception'),
+  });
+  const rollFortitude = useActorAction({
+    run: () => api.rollActorStatistic(actorId, 'fortitude'),
+  });
+  const rollReflex = useActorAction({
+    run: () => api.rollActorStatistic(actorId, 'reflex'),
+  });
+  const rollWill = useActorAction({
+    run: () => api.rollActorStatistic(actorId, 'will'),
+  });
+  const error =
+    firstError(rollPerception.state, rollFortitude.state, rollReflex.state, rollWill.state);
+
   return (
     <div>
       <SectionHeader>Key Stats</SectionHeader>
@@ -175,6 +190,8 @@ function StatsBlock({
           title={perception.breakdown}
           rank={perception.rank}
           data-stat="perception"
+          onRoll={() => void rollPerception.trigger()}
+          pending={rollPerception.state === 'pending'}
         />
         <StatTile
           label="Initiative"
@@ -186,12 +203,36 @@ function StatsBlock({
       </div>
 
       <div className="mt-2 grid grid-cols-3 gap-2">
-        <SaveTile save={saves.fortitude} />
-        <SaveTile save={saves.reflex} />
-        <SaveTile save={saves.will} />
+        <SaveTile
+          save={saves.fortitude}
+          onRoll={() => void rollFortitude.trigger()}
+          pending={rollFortitude.state === 'pending'}
+        />
+        <SaveTile
+          save={saves.reflex}
+          onRoll={() => void rollReflex.trigger()}
+          pending={rollReflex.state === 'pending'}
+        />
+        <SaveTile
+          save={saves.will}
+          onRoll={() => void rollWill.trigger()}
+          pending={rollWill.state === 'pending'}
+        />
       </div>
+      {error !== null && (
+        <p className="mt-1 text-[11px] text-red-700" data-role="stats-roll-error">
+          {error}
+        </p>
+      )}
     </div>
   );
+}
+
+function firstError(...states: ActorActionState[]): string | null {
+  for (const s of states) {
+    if (typeof s === 'object') return s.error;
+  }
+  return null;
 }
 
 // Replaces the plain HP `StatTile` with a stepper. Keeps the stat-card
@@ -267,7 +308,15 @@ function classDCTile(system: CharacterSystem): React.ReactElement {
   );
 }
 
-function SaveTile({ save }: { save: Save }): React.ReactElement {
+function SaveTile({
+  save,
+  onRoll,
+  pending,
+}: {
+  save: Save;
+  onRoll: () => void;
+  pending: boolean;
+}): React.ReactElement {
   return (
     <StatTile
       label={t(save.label)}
@@ -275,6 +324,8 @@ function SaveTile({ save }: { save: Save }): React.ReactElement {
       title={save.breakdown}
       rank={save.rank}
       data-stat={`save-${save.slug}`}
+      onRoll={onRoll}
+      pending={pending}
     />
   );
 }
@@ -284,24 +335,53 @@ function StatTile({
   value,
   title,
   rank,
+  onRoll,
+  pending,
   ...rest
 }: {
   label: string;
   value: string;
   title?: string;
   rank?: import('../../api/types').ProficiencyRank;
+  /** When set, the tile becomes a clickable button that fires a
+   *  roll. Omit to keep it as a display-only stat card. */
+  onRoll?: () => void;
+  pending?: boolean;
   'data-stat'?: string;
 }): React.ReactElement {
+  const contents = (
+    <>
+      <span className="text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark">{label}</span>
+      <span className="mt-0.5 font-mono text-xl font-semibold tabular-nums text-pf-text">
+        {pending === true ? '…' : value}
+      </span>
+      {rank !== undefined && <RankChip rank={rank} className="mt-1" />}
+    </>
+  );
+
+  if (onRoll === undefined) {
+    return (
+      <div
+        className="flex flex-col items-center rounded border border-pf-border bg-white px-3 py-2"
+        title={title}
+        {...rest}
+      >
+        {contents}
+      </div>
+    );
+  }
+
   return (
-    <div
-      className="flex flex-col items-center rounded border border-pf-border bg-white px-3 py-2"
+    <button
+      type="button"
+      onClick={onRoll}
+      disabled={pending === true}
       title={title}
+      className="flex flex-col items-center rounded border border-pf-border bg-white px-3 py-2 hover:border-pf-tertiary-dark hover:bg-pf-tertiary/40 disabled:opacity-60 disabled:hover:bg-white"
       {...rest}
     >
-      <span className="text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark">{label}</span>
-      <span className="mt-0.5 font-mono text-xl font-semibold tabular-nums text-pf-text">{value}</span>
-      {rank !== undefined && <RankChip rank={rank} className="mt-1" />}
-    </div>
+      {contents}
+    </button>
   );
 }
 

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/RollActorStatisticHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/RollActorStatisticHandler.ts
@@ -1,0 +1,98 @@
+import type {
+  Pf2eRollMode,
+  RollActorStatisticParams,
+  RollActorStatisticResult,
+} from '@/commands/types';
+import { extractDiceResults } from './actorTypes';
+import type { FoundryD20Roll } from './actorTypes';
+
+interface RolledMessage {
+  id: string;
+}
+
+interface Pf2eStatistic {
+  /** Unified roll entry point. Returns the Roll object — and, when
+   *  `createMessage: true`, creates a chat card as a side effect. */
+  roll(args: {
+    skipDialog?: boolean;
+    createMessage?: boolean;
+    rollMode?: Pf2eRollMode;
+  }): Promise<FoundryD20Roll | null>;
+}
+
+interface Pf2eActor {
+  id: string;
+  /** PF2e unified statistic accessor. Supports perception, saves,
+   *  and every skill slug. Returns null when the statistic isn't
+   *  defined on this actor (e.g. loot actors). */
+  getStatistic?: (slug: string) => Pf2eStatistic | null;
+}
+
+interface ActorsCollection {
+  get(id: string): Pf2eActor | undefined;
+}
+
+interface FoundryGame {
+  actors: ActorsCollection;
+  messages?: { contents: Array<{ id: string; isRoll?: boolean }> };
+}
+
+declare const game: FoundryGame;
+
+// Click-to-roll for any PF2e `Statistic` (Perception, saves, skills).
+// Uses the unified `actor.getStatistic(slug).roll()` path so one
+// handler covers every check the character sheet can surface.
+//
+// Chat dialog is skipped — if we want a modifier prompt later we'll
+// surface an SPA-side picker and pass the resolved DC/traits through
+// here explicitly. `createMessage` is true so the roll card actually
+// lands in the Foundry chat log for players watching.
+export async function rollActorStatisticHandler(
+  params: RollActorStatisticParams,
+): Promise<RollActorStatisticResult> {
+  const actor = game.actors.get(params.actorId);
+  if (!actor) {
+    throw new Error(`Actor not found: ${params.actorId}`);
+  }
+
+  if (typeof actor.getStatistic !== 'function') {
+    throw new Error(
+      `Actor ${params.actorId} doesn't expose getStatistic — is this a pf2e system actor?`,
+    );
+  }
+
+  const statistic = actor.getStatistic(params.statistic);
+  if (!statistic) {
+    throw new Error(`Statistic "${params.statistic}" not available on actor ${params.actorId}`);
+  }
+
+  const roll = await statistic.roll({
+    skipDialog: true,
+    createMessage: true,
+    rollMode: params.rollMode,
+  });
+
+  if (!roll) {
+    throw new Error(`Roll for "${params.statistic}" returned no result (cancelled?)`);
+  }
+
+  const dice = extractDiceResults(roll.terms);
+  const result: RollActorStatisticResult = {
+    statistic: params.statistic,
+    total: roll.total,
+    formula: roll.formula,
+    dice,
+  };
+  if (roll.isCritical) result.isCritical = true;
+  if (roll.isFumble) result.isFumble = true;
+
+  // Best-effort: match the just-created chat message so callers can
+  // cite it (e.g. a live sheet can highlight the row). We don't
+  // require the messages collection — if it's missing, just omit.
+  const lastMessage = game.messages?.contents.at(-1);
+  if (lastMessage?.isRoll === true) {
+    result.chatMessageId = lastMessage.id;
+  }
+
+  return result;
+}

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/__tests__/RollActorStatisticHandler.test.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/__tests__/RollActorStatisticHandler.test.ts
@@ -1,0 +1,157 @@
+import { rollActorStatisticHandler } from '../RollActorStatisticHandler';
+
+type Roll = {
+  total: number;
+  formula: string;
+  terms: Array<{ faces?: number; number?: number; results?: Array<{ result: number }> }>;
+  isCritical: boolean;
+  isFumble: boolean;
+};
+
+function makeRoll(overrides: Partial<Roll> = {}): Roll {
+  return {
+    total: 15,
+    formula: '1d20+8',
+    terms: [{ faces: 20, number: 1, results: [{ result: 7 }] }],
+    isCritical: false,
+    isFumble: false,
+    ...overrides,
+  };
+}
+
+type Actor = {
+  id: string;
+  getStatistic: jest.Mock;
+};
+
+function makeActor(rollResult: Roll | null = makeRoll()): Actor {
+  const statistic = { roll: jest.fn().mockResolvedValue(rollResult) };
+  return {
+    id: 'actor-1',
+    getStatistic: jest.fn().mockReturnValue(statistic),
+  };
+}
+
+const mockGame: { actors: { get: jest.Mock }; messages?: { contents: Array<{ id: string; isRoll?: boolean }> } } = {
+  actors: { get: jest.fn() },
+  messages: { contents: [] },
+};
+(global as Record<string, unknown>)['game'] = mockGame;
+
+describe('rollActorStatisticHandler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    if (mockGame.messages) mockGame.messages.contents = [];
+  });
+
+  it('rolls via actor.getStatistic(slug).roll() and returns the formatted result', async () => {
+    const actor = makeActor();
+    mockGame.actors.get.mockReturnValue(actor);
+
+    const result = await rollActorStatisticHandler({
+      actorId: 'actor-1',
+      statistic: 'perception',
+    });
+
+    expect(actor.getStatistic).toHaveBeenCalledWith('perception');
+    const statistic = actor.getStatistic.mock.results[0].value as { roll: jest.Mock };
+    expect(statistic.roll).toHaveBeenCalledWith({
+      skipDialog: true,
+      createMessage: true,
+      rollMode: undefined,
+    });
+    expect(result).toEqual({
+      statistic: 'perception',
+      total: 15,
+      formula: '1d20+8',
+      dice: [{ type: 'd20', count: 1, results: [7] }],
+    });
+  });
+
+  it('forwards rollMode when provided', async () => {
+    const actor = makeActor();
+    mockGame.actors.get.mockReturnValue(actor);
+
+    await rollActorStatisticHandler({
+      actorId: 'actor-1',
+      statistic: 'stealth',
+      rollMode: 'blindroll',
+    });
+
+    const statistic = actor.getStatistic.mock.results[0].value as { roll: jest.Mock };
+    expect(statistic.roll).toHaveBeenCalledWith({
+      skipDialog: true,
+      createMessage: true,
+      rollMode: 'blindroll',
+    });
+  });
+
+  it('reports isCritical and isFumble flags when the roll surfaces them', async () => {
+    const actor = makeActor(makeRoll({ total: 30, isCritical: true }));
+    mockGame.actors.get.mockReturnValue(actor);
+
+    const crit = await rollActorStatisticHandler({ actorId: 'actor-1', statistic: 'fortitude' });
+    expect(crit.isCritical).toBe(true);
+    expect(crit.isFumble).toBeUndefined();
+
+    const fumbleActor = makeActor(makeRoll({ total: 1, isFumble: true }));
+    mockGame.actors.get.mockReturnValue(fumbleActor);
+    const fumble = await rollActorStatisticHandler({ actorId: 'actor-1', statistic: 'reflex' });
+    expect(fumble.isFumble).toBe(true);
+  });
+
+  it('echoes the latest chat message id when it was a roll message', async () => {
+    const actor = makeActor();
+    mockGame.actors.get.mockReturnValue(actor);
+    if (mockGame.messages) {
+      mockGame.messages.contents = [{ id: 'msg-abc', isRoll: true }];
+    }
+
+    const result = await rollActorStatisticHandler({ actorId: 'actor-1', statistic: 'will' });
+    expect(result.chatMessageId).toBe('msg-abc');
+  });
+
+  it('omits chatMessageId when the latest message is not a roll', async () => {
+    const actor = makeActor();
+    mockGame.actors.get.mockReturnValue(actor);
+    if (mockGame.messages) {
+      mockGame.messages.contents = [{ id: 'msg-plain', isRoll: false }];
+    }
+
+    const result = await rollActorStatisticHandler({ actorId: 'actor-1', statistic: 'will' });
+    expect(result.chatMessageId).toBeUndefined();
+  });
+
+  it('throws when the actor does not exist', async () => {
+    mockGame.actors.get.mockReturnValue(undefined);
+    await expect(
+      rollActorStatisticHandler({ actorId: 'ghost', statistic: 'perception' }),
+    ).rejects.toThrow('Actor not found: ghost');
+  });
+
+  it('throws a clear error on non-pf2e actors that lack getStatistic', async () => {
+    mockGame.actors.get.mockReturnValue({ id: 'vanilla' });
+    await expect(
+      rollActorStatisticHandler({ actorId: 'vanilla', statistic: 'perception' }),
+    ).rejects.toThrow(/pf2e system actor/);
+  });
+
+  it('throws when the statistic is not defined on the actor', async () => {
+    const actor = makeActor();
+    actor.getStatistic.mockReturnValue(null);
+    mockGame.actors.get.mockReturnValue(actor);
+
+    await expect(
+      rollActorStatisticHandler({ actorId: 'actor-1', statistic: 'athletics' }),
+    ).rejects.toThrow('Statistic "athletics" not available');
+  });
+
+  it('throws when roll() returns null (e.g. user cancel)', async () => {
+    const actor = makeActor(null);
+    mockGame.actors.get.mockReturnValue(actor);
+
+    await expect(
+      rollActorStatisticHandler({ actorId: 'actor-1', statistic: 'perception' }),
+    ).rejects.toThrow('Roll for "perception" returned no result');
+  });
+});

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/index.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/index.ts
@@ -9,6 +9,7 @@ export { updateActorHandler } from './UpdateActorHandler';
 export { deleteActorHandler } from './DeleteActorHandler';
 export { adjustActorResourceHandler } from './AdjustActorResourceHandler';
 export { adjustActorConditionHandler } from './AdjustActorConditionHandler';
+export { rollActorStatisticHandler } from './RollActorStatisticHandler';
 export { getActorsHandler } from './GetActorsHandler';
 export { getActorHandler } from './GetActorHandler';
 export { getPreparedActorHandler } from './GetPreparedActorHandler';

--- a/apps/foundry-api-bridge/src/commands/handlers/index.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/index.ts
@@ -17,6 +17,7 @@ export {
   deleteActorHandler,
   adjustActorResourceHandler,
   adjustActorConditionHandler,
+  rollActorStatisticHandler,
   getActorsHandler,
   getActorHandler,
   getPreparedActorHandler,

--- a/apps/foundry-api-bridge/src/commands/types.ts
+++ b/apps/foundry-api-bridge/src/commands/types.ts
@@ -32,6 +32,7 @@ export type CommandType =
   | 'delete-actor'
   | 'adjust-actor-resource'
   | 'adjust-actor-condition'
+  | 'roll-actor-statistic'
   | 'send-chat-message'
   | 'create-journal'
   | 'update-journal'
@@ -246,6 +247,72 @@ export interface AdjustActorConditionResult {
   /** Reported at response time; max may shift (e.g. dying's cap
    *  increases with doomed) so clients shouldn't cache it. */
   max: number;
+}
+
+// PF2e `Statistic` slugs exposed for click-to-roll on the character
+// sheet: Perception, the three saves, and the full skill list.
+// Any unified `actor.getStatistic(slug)` target works; we keep the
+// set narrow so the Zod enum at the HTTP edge stays small and the
+// UI only offers things it understands.
+export type Pf2eStatisticSlug =
+  | 'perception'
+  | 'fortitude'
+  | 'reflex'
+  | 'will'
+  | 'acrobatics'
+  | 'arcana'
+  | 'athletics'
+  | 'crafting'
+  | 'deception'
+  | 'diplomacy'
+  | 'intimidation'
+  | 'medicine'
+  | 'nature'
+  | 'occultism'
+  | 'performance'
+  | 'religion'
+  | 'society'
+  | 'stealth'
+  | 'survival'
+  | 'thievery';
+
+export const PF2E_STATISTIC_SLUGS: readonly Pf2eStatisticSlug[] = [
+  'perception',
+  'fortitude',
+  'reflex',
+  'will',
+  'acrobatics',
+  'arcana',
+  'athletics',
+  'crafting',
+  'deception',
+  'diplomacy',
+  'intimidation',
+  'medicine',
+  'nature',
+  'occultism',
+  'performance',
+  'religion',
+  'society',
+  'stealth',
+  'survival',
+  'thievery',
+];
+
+export type Pf2eRollMode = 'publicroll' | 'gmroll' | 'blindroll' | 'selfroll';
+
+export interface RollActorStatisticParams {
+  actorId: string;
+  statistic: Pf2eStatisticSlug;
+  /** Override Foundry's default roll mode for this single roll.
+   *  When omitted, the user's current chat-mode setting applies. */
+  rollMode?: Pf2eRollMode;
+}
+
+export interface RollActorStatisticResult extends RollResult {
+  statistic: Pf2eStatisticSlug;
+  /** The resolved chat message id, when `create: true` produced one. */
+  chatMessageId?: string;
 }
 
 // Actor Results
@@ -1566,6 +1633,7 @@ export interface CommandParamsMap {
   'delete-actor': DeleteActorParams;
   'adjust-actor-resource': AdjustActorResourceParams;
   'adjust-actor-condition': AdjustActorConditionParams;
+  'roll-actor-statistic': RollActorStatisticParams;
   'send-chat-message': SendChatMessageParams;
   'create-journal': CreateJournalParams;
   'update-journal': UpdateJournalParams;
@@ -1664,6 +1732,7 @@ export interface CommandResultMap {
   'delete-actor': DeleteResult;
   'adjust-actor-resource': AdjustActorResourceResult;
   'adjust-actor-condition': AdjustActorConditionResult;
+  'roll-actor-statistic': RollActorStatisticResult;
   'send-chat-message': SendChatMessageResult;
   'create-journal': JournalResult;
   'update-journal': JournalResult;

--- a/apps/foundry-api-bridge/src/main.ts
+++ b/apps/foundry-api-bridge/src/main.ts
@@ -26,6 +26,7 @@ import {
   deleteActorHandler,
   adjustActorResourceHandler,
   adjustActorConditionHandler,
+  rollActorStatisticHandler,
   getActorsHandler,
   getActorHandler,
   getPreparedActorHandler,
@@ -203,6 +204,7 @@ function initializeWebSocket(
   commandRouter.register('delete-actor', deleteActorHandler);
   commandRouter.register('adjust-actor-resource', adjustActorResourceHandler);
   commandRouter.register('adjust-actor-condition', adjustActorConditionHandler);
+  commandRouter.register('roll-actor-statistic', rollActorStatisticHandler);
 
   // Journal CRUD
   commandRouter.register('create-journal', createJournalHandler);

--- a/apps/foundry-mcp/src/http/routes/actors.ts
+++ b/apps/foundry-mcp/src/http/routes/actors.ts
@@ -8,6 +8,7 @@ import {
   adjustActorConditionBody,
   adjustActorResourceBody,
   createActorBody,
+  rollActorStatisticBody,
   updateActorBody,
   updateActorItemBody,
 } from '../schemas.js';
@@ -87,5 +88,15 @@ export function registerActorRoutes(app: FastifyInstance): void {
     const { id } = actorIdParam.parse(req.params);
     const body = adjustActorConditionBody.parse(req.body);
     return sendCommand('adjust-actor-condition', { actorId: id, ...body });
+  });
+
+  // Click-to-roll for any PF2e `Statistic` — Perception, the three
+  // saves, any skill. Skips the modifier dialog and posts the roll
+  // card to chat via the configured rollMode (or the user's current
+  // default if omitted).
+  app.post('/api/actors/:id/rolls/statistic', async (req) => {
+    const { id } = actorIdParam.parse(req.params);
+    const body = rollActorStatisticBody.parse(req.body);
+    return sendCommand('roll-actor-statistic', { actorId: id, ...body });
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21708,7 +21708,6 @@
       "name": "@foundry-toolkit/db",
       "version": "1.0.0",
       "dependencies": {
-        "@foundry-toolkit/ai": "*",
         "@foundry-toolkit/shared": "*",
         "better-sqlite3": "^12.9.0"
       },

--- a/packages/shared/src/rpc/index.ts
+++ b/packages/shared/src/rpc/index.ts
@@ -12,6 +12,7 @@ import type {
   adjustActorResourceBody,
   createActorBody,
   resolvePromptBody,
+  rollActorStatisticBody,
   updateActorBody,
   updateActorItemBody,
   uploadAssetBody,
@@ -47,6 +48,20 @@ export interface AdjustActorConditionResponse {
   after: number;
   /** Re-read after the writes — dying's cap shifts with doomed. */
   max: number;
+}
+
+export type RollActorStatisticBody = z.infer<typeof rollActorStatisticBody>;
+export type Pf2eStatisticSlug = RollActorStatisticBody['statistic'];
+export type Pf2eRollMode = NonNullable<RollActorStatisticBody['rollMode']>;
+
+export interface RollActorStatisticResponse {
+  statistic: Pf2eStatisticSlug;
+  total: number;
+  formula: string;
+  dice: Array<{ type: string; count: number; results: number[] }>;
+  isCritical?: boolean;
+  isFumble?: boolean;
+  chatMessageId?: string;
 }
 
 // Error response shape for `/api/*` — mirrored in `foundry-api.ts` as

--- a/packages/shared/src/rpc/schemas.ts
+++ b/packages/shared/src/rpc/schemas.ts
@@ -182,6 +182,39 @@ export const adjustActorConditionBody = z.object({
   delta: z.number().int().min(-10).max(10),
 });
 
+// Slugs resolvable by PF2e's unified `actor.getStatistic()` accessor:
+// Perception, the three saves, and every skill. Mirrored on the bridge
+// side — any additions need the UI to know what it's offering anyway.
+export const PF2E_STATISTIC_SLUGS = [
+  'perception',
+  'fortitude',
+  'reflex',
+  'will',
+  'acrobatics',
+  'arcana',
+  'athletics',
+  'crafting',
+  'deception',
+  'diplomacy',
+  'intimidation',
+  'medicine',
+  'nature',
+  'occultism',
+  'performance',
+  'religion',
+  'society',
+  'stealth',
+  'survival',
+  'thievery',
+] as const;
+
+export const PF2E_ROLL_MODES = ['publicroll', 'gmroll', 'blindroll', 'selfroll'] as const;
+
+export const rollActorStatisticBody = z.object({
+  statistic: z.enum(PF2E_STATISTIC_SLUGS),
+  rollMode: z.enum(PF2E_ROLL_MODES).optional(),
+});
+
 // Item-on-actor operations for the wizard's piecemeal picks
 // (ancestry, heritage, class, background, deity). Copies the source
 // document out of the compendium, strips its `_id`, and attaches it


### PR DESCRIPTION
## Summary

First typed-command coverage of PF2e rolls over HTTP. Unifies Perception, the three saves, and all 16 skills behind one bridge command via `actor.getStatistic(slug).roll()` so one handler covers 20 click targets.

- **Bridge**: `roll-actor-statistic` command + handler + 9 Jest cases.
- **Shared**: `rollActorStatisticBody` schema + `Pf2eStatisticSlug` / `Pf2eRollMode` / `RollActorStatisticResponse` types.
- **foundry-mcp**: `POST /api/actors/:id/rolls/statistic`.
- **character-creator**:
  - `api.rollActorStatistic(id, slug, rollMode?)` client method.
  - `StatTile` gained optional `onRoll` + `pending` props; when set the tile renders as a `<button>` with hover affordance and "…" during pending.
  - Perception tile + all three Save tiles wired as click-to-roll; shared error line below the stats block.

## Why a new command, not HTTP-exposing `roll-skill` / `roll-save`

The existing `roll-skill` handler takes D&D 5e abbreviations (`acr`, `ath`) and calls `actor.rollSkill({skill})`; `roll-save` uses D&D ability keys. Neither matches PF2e's API, which is unified at `actor.getStatistic(slug)` with lowercase spelled-out slugs. Forcing the old handlers to be PF2e-aware would break their MCP consumers; a new command is the cleaner path.

## Deferred

- **Initiative tile** stays display-only. `actor.initiative` isn't exposed through `getStatistic()` in PF2e — it's its own property with separate methods. Picking it up needs either a second typed command or extending `getStatistic` coverage on the bridge. Comment noted; small follow-up PR.
- **Skill tab click-to-roll**: `Proficiencies.tsx` and other skill displays could use the same hook; this PR only wires the Character tab.

## Test plan

- [x] `RollActorStatisticHandler.test.ts` — 9 cases: happy path, rollMode forwarded, crit/fumble flags, chat message id echo, missing actor, non-pf2e actor, missing statistic, cancelled roll.
- [x] `npm run test --workspace=apps/foundry-api-bridge` — 679/679 pass (up from 670).
- [x] `npm run typecheck --workspace=apps/character-creator` — clean.
- [x] `npm run test --workspace=apps/character-creator` — 148/148 pass.
- [x] Mock-mode preview: Perception + all three saves render as `<button>`; AC stays a `<div>`; clicking surfaces the expected `HTTP 404` inline.
- [ ] Against live Foundry: click Perception — chat shows a Perception roll card. Click Fortitude — Fort save card. Click crit or nat-1 → response reports `isCritical`/`isFumble`.