### PR TITLE
Expand MONSTER_PACK_IDS to cover every stock pf2e bestiary

### DIFF
--- a/apps/dm-tool/electron/compendium/prepared.test.ts
+++ b/apps/dm-tool/electron/compendium/prepared.test.ts
@@ -101,12 +101,14 @@ describe('searchMonsters', () => {
     const out = await createPreparedCompendium(api).searchMonsters('dragon');
     expect(out).toContain('--- Creature Result 1: Young Red Dragon (Level 10) ---');
     expect(out).toContain('HP 180 | AC 30');
-    expect(search).toHaveBeenCalledWith({
-      q: 'dragon',
-      documentType: 'npc',
-      packIds: ['pf2e.pathfinder-bestiary'],
-      limit: 3,
-    });
+    expect(search).toHaveBeenCalledWith(
+      expect.objectContaining({
+        q: 'dragon',
+        documentType: 'npc',
+        limit: 3,
+        packIds: expect.arrayContaining(['pf2e.pathfinder-bestiary']),
+      }),
+    );
   });
 
   it('returns a "no results" message when the search is empty', async () => {
@@ -129,7 +131,11 @@ describe('listMonsters', () => {
     const out = await createPreparedCompendium(api).listMonsters({ levels: [3, 7] });
     expect(out.map((s) => s.name)).toEqual(['B']);
     expect(search).toHaveBeenCalledWith(
-      expect.objectContaining({ documentType: 'npc', maxLevel: 7, packIds: ['pf2e.pathfinder-bestiary'] }),
+      expect.objectContaining({
+        documentType: 'npc',
+        maxLevel: 7,
+        packIds: expect.arrayContaining(['pf2e.pathfinder-bestiary']),
+      }),
     );
   });
 

--- a/apps/dm-tool/electron/compendium/prepared.ts
+++ b/apps/dm-tool/electron/compendium/prepared.ts
@@ -48,7 +48,24 @@ import {
 } from './projection.js';
 import type { CompendiumMatch } from './types.js';
 
-const MONSTER_PACK_IDS = ['pf2e.pathfinder-bestiary'];
+// Every stock pf2e bestiary + NPC compendium the Monster Browser / loot
+// generator / chat-tool monster lookup should see. Entries absent from
+// the user's Foundry install are simply empty at warm time — the mcp
+// cache skips them with a log warning, so a slimmer pf2e setup doesn't
+// break anything. Adventure-path bestiaries (Kingmaker, Abomination
+// Vaults, Pathfinder Society seasons, Lost Omens sourcebook bestiaries)
+// aren't in this default set — add them to mcp's COMPENDIUM_CACHE_PACK_IDS
+// and they'll be picked up by any search that omits `packIds`, but the
+// dm-tool constants here stay explicit so the Monster Browser has a
+// stable scope across installs.
+const MONSTER_PACK_IDS = [
+  'pf2e.pathfinder-bestiary',
+  'pf2e.pathfinder-bestiary-2',
+  'pf2e.pathfinder-bestiary-3',
+  'pf2e.pathfinder-monster-core',
+  'pf2e.pathfinder-nature-core',
+  'pf2e.pathfinder-npcs',
+];
 const ITEM_PACK_IDS = ['pf2e.equipment-srd'];
 
 // ---------------------------------------------------------------------------

--- a/package-lock.json
+++ b/package-lock.json
@@ -21708,7 +21708,6 @@
       "name": "@foundry-toolkit/db",
       "version": "1.0.0",
       "dependencies": {
-        "@foundry-toolkit/ai": "*",
         "@foundry-toolkit/shared": "*",
         "better-sqlite3": "^12.9.0"
       },


### PR DESCRIPTION
## Summary

Fix: dm-tool's Monster Browser and chat-tool monster lookup were scoped to `pf2e.pathfinder-bestiary` only — Bestiary 1 (~450 creatures). Every other stock bestiary was invisible even if the user had it installed in Foundry.

## Change

`MONSTER_PACK_IDS` in `apps/dm-tool/electron/compendium/prepared.ts` goes from 1 entry to 6:

```ts
const MONSTER_PACK_IDS = [
  'pf2e.pathfinder-bestiary',
  'pf2e.pathfinder-bestiary-2',
  'pf2e.pathfinder-bestiary-3',
  'pf2e.pathfinder-monster-core',
  'pf2e.pathfinder-nature-core',
  'pf2e.pathfinder-npcs',
];
```

All six affected accessors pick up the wider scope automatically: `searchMonsters` (chat tool), `listMonsters` (browser), `getMonsterFacets` (facets via facets-index), `getMonsterByName` (detail pane), `getMonsterPreview` (hover card), `getMonsterRowByName` (loot gen).

## Graceful fallback for slim installs

Packs absent from a given Foundry install are skipped cleanly — the mcp compendium cache logs a warning at warm time and returns empty matches. A slimmer pf2e setup keeps working; it just sees the packs it actually has.

## Not included in the default

Adventure-path bestiaries (Kingmaker, Abomination Vaults, PFS seasons, Lost Omens sourcebook bestiaries) aren't added. GMs who want them either extend the constant in a follow-up or drop the `packIds` filter entirely. Keeping an explicit list preserves a stable Monster Browser scope across installs.

## Operator note

To avoid paying the cold-warm round-trip on first query per new pack, add the IDs to `COMPENDIUM_CACHE_PACK_IDS` on your foundry-mcp server:

```env
COMPENDIUM_CACHE_PACK_IDS=pf2e.pathfinder-bestiary,pf2e.pathfinder-bestiary-2,pf2e.pathfinder-bestiary-3,pf2e.pathfinder-monster-core,pf2e.pathfinder-nature-core,pf2e.pathfinder-npcs,pf2e.equipment-srd
```

## Test plan

- [x] `npm --workspace apps/dm-tool test` — 215/215 pass. Two `prepared.test.ts` assertions that pinned the whole `packIds` array to a single-entry list updated to use `expect.arrayContaining(['pf2e.pathfinder-bestiary'])` so future pack additions don't keep breaking them.
- [x] `npm run typecheck` — whole monorepo clean
- [x] `npm run format:check` — clean
- [x] `npx eslint .` — only pre-existing warnings in untouched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)