### PR TITLE
Make monster compendium packs configurable from Settings \u2192 Monsters

### DIFF
--- a/apps/dm-tool/electron/compendium/prepared.test.ts
+++ b/apps/dm-tool/electron/compendium/prepared.test.ts
@@ -116,6 +116,27 @@ describe('searchMonsters', () => {
     const out = await createPreparedCompendium(api).searchMonsters('xyz');
     expect(out).toBe('[No creatures found for "xyz"]');
   });
+
+  it('honors a resolveMonsterPackIds override on each call', async () => {
+    const search = vi.fn().mockResolvedValue({ matches: [] });
+    const api = fakeApi({ searchCompendium: search });
+    // Simulate a Settings → Monsters override: first call sees one pack,
+    // second call sees two (e.g. the user ticked another box between
+    // calls). The resolver must fire per call, not at factory time.
+    let current: readonly string[] = ['pf2e.pathfinder-bestiary'];
+    const prepared = createPreparedCompendium(api, {
+      resolveMonsterPackIds: () => current,
+    });
+
+    await prepared.searchMonsters('a');
+    expect(search).toHaveBeenLastCalledWith(expect.objectContaining({ packIds: ['pf2e.pathfinder-bestiary'] }));
+
+    current = ['pf2e.pathfinder-bestiary', 'pf2e.pathfinder-bestiary-2'];
+    await prepared.searchMonsters('b');
+    expect(search).toHaveBeenLastCalledWith(
+      expect.objectContaining({ packIds: ['pf2e.pathfinder-bestiary', 'pf2e.pathfinder-bestiary-2'] }),
+    );
+  });
 });
 
 describe('listMonsters', () => {

--- a/apps/dm-tool/electron/compendium/prepared.ts
+++ b/apps/dm-tool/electron/compendium/prepared.ts
@@ -48,17 +48,17 @@ import {
 } from './projection.js';
 import type { CompendiumMatch } from './types.js';
 
-// Every stock pf2e bestiary + NPC compendium the Monster Browser / loot
-// generator / chat-tool monster lookup should see. Entries absent from
-// the user's Foundry install are simply empty at warm time — the mcp
-// cache skips them with a log warning, so a slimmer pf2e setup doesn't
-// break anything. Adventure-path bestiaries (Kingmaker, Abomination
-// Vaults, Pathfinder Society seasons, Lost Omens sourcebook bestiaries)
-// aren't in this default set — add them to mcp's COMPENDIUM_CACHE_PACK_IDS
-// and they'll be picked up by any search that omits `packIds`, but the
-// dm-tool constants here stay explicit so the Monster Browser has a
-// stable scope across installs.
-const MONSTER_PACK_IDS = [
+// Default pack scope used when the user hasn't customized monster packs
+// in Settings → Monsters. Every stock pf2e bestiary + NPC compendium the
+// Monster Browser, loot generator, and chat-tool monster lookup should
+// see. Entries absent from a given Foundry install are simply empty at
+// warm time — the mcp cache skips them with a log warning, so a slimmer
+// pf2e setup doesn't break anything. Adventure-path bestiaries (Kingmaker,
+// Abomination Vaults, Pathfinder Society seasons, Lost Omens sourcebook
+// bestiaries) aren't in this default list — GMs who want them should
+// pick them from Settings → Monsters → Compendium packs (stored as
+// `compendiumMonsterPackIds` in pf2e.db).
+export const DEFAULT_MONSTER_PACK_IDS: readonly string[] = [
   'pf2e.pathfinder-bestiary',
   'pf2e.pathfinder-bestiary-2',
   'pf2e.pathfinder-bestiary-3',
@@ -66,6 +66,11 @@ const MONSTER_PACK_IDS = [
   'pf2e.pathfinder-nature-core',
   'pf2e.pathfinder-npcs',
 ];
+
+// Item-pack scope stays a constant for now — the Item Browser's entire
+// surface is `pf2e.equipment-srd` and tuning this hasn't been a
+// reported pain point. Flip this to a resolver + setting when that
+// changes.
 const ITEM_PACK_IDS = ['pf2e.equipment-srd'];
 
 // ---------------------------------------------------------------------------
@@ -92,16 +97,27 @@ export interface PreparedCompendium {
   buildLootShortlist(partyLevel: number): Promise<LootShortlistItem[]>;
 }
 
-export function createPreparedCompendium(api: CompendiumApi): PreparedCompendium {
+export interface PreparedCompendiumOptions {
+  /** Resolver called at each monster-facing query to decide which
+   *  compendium packs to search. Invoked once per outer call so changes
+   *  (e.g. via Settings → Monsters) take effect immediately — no
+   *  cache-priming or re-init required beyond a facets-index reset.
+   *  Defaults to `DEFAULT_MONSTER_PACK_IDS` when omitted. */
+  resolveMonsterPackIds?: () => readonly string[];
+}
+
+export function createPreparedCompendium(api: CompendiumApi, opts?: PreparedCompendiumOptions): PreparedCompendium {
+  const getMonsterPacks = opts?.resolveMonsterPackIds ?? (() => DEFAULT_MONSTER_PACK_IDS);
+
   return {
-    searchMonsters: (q) => searchMonsters(api, q),
+    searchMonsters: (q) => searchMonsters(api, getMonsterPacks(), q),
     searchItems: (q) => searchItems(api, q),
 
-    listMonsters: (p) => listMonsters(api, p),
-    getMonsterFacets: () => getMonsterFacetsIndex(api, { packIds: MONSTER_PACK_IDS }),
-    getMonsterByName: (name) => getMonsterByName(api, name),
-    getMonsterPreview: (input) => getMonsterPreview(api, input),
-    getMonsterRowByName: (name) => getMonsterRowByName(api, name),
+    listMonsters: (p) => listMonsters(api, getMonsterPacks(), p),
+    getMonsterFacets: () => getMonsterFacetsIndex(api, { packIds: [...getMonsterPacks()] }),
+    getMonsterByName: (name) => getMonsterByName(api, getMonsterPacks(), name),
+    getMonsterPreview: (input) => getMonsterPreview(api, getMonsterPacks(), input),
+    getMonsterRowByName: (name) => getMonsterRowByName(api, getMonsterPacks(), name),
 
     searchItemsBrowser: (p) => searchItemsBrowser(api, p),
     getItemFacets: () => getItemFacetsIndex(api, { packIds: ITEM_PACK_IDS }),
@@ -138,11 +154,11 @@ function formatMonsterForChat(r: MonsterResult, idx: number): string {
     .join('\n');
 }
 
-async function searchMonsters(api: CompendiumApi, query: string): Promise<string> {
+async function searchMonsters(api: CompendiumApi, packIds: readonly string[], query: string): Promise<string> {
   const { matches } = await api.searchCompendium({
     q: query,
     documentType: 'npc',
-    packIds: MONSTER_PACK_IDS,
+    packIds: [...packIds],
     limit: 3,
   });
 
@@ -184,13 +200,17 @@ function filterMatchesClientSide(matches: CompendiumMatch[], params: MonsterSear
   });
 }
 
-async function listMonsters(api: CompendiumApi, params: MonsterSearchParams): Promise<MonsterSummary[]> {
+async function listMonsters(
+  api: CompendiumApi,
+  packIds: readonly string[],
+  params: MonsterSearchParams,
+): Promise<MonsterSummary[]> {
   // The server's `/api/compendium/search` speaks q/traits/maxLevel/limit.
   // Anything beyond that we enforce client-side after the network hop.
   const { matches } = await api.searchCompendium({
     q: params.keywords,
     documentType: 'npc',
-    packIds: MONSTER_PACK_IDS,
+    packIds: [...packIds],
     traits: params.traits,
     maxLevel: params.levels?.[1],
     limit: params.limit ?? 5000,
@@ -222,13 +242,14 @@ async function listMonsters(api: CompendiumApi, params: MonsterSearchParams): Pr
 
 async function fetchMonsterDocByName<T>(
   api: CompendiumApi,
+  packIds: readonly string[],
   name: string,
   map: (d: import('./types.js').CompendiumDocument) => T,
 ): Promise<T | null> {
   const { matches } = await api.searchCompendium({
     q: name,
     documentType: 'npc',
-    packIds: MONSTER_PACK_IDS,
+    packIds: [...packIds],
     limit: 5,
   });
   // Prefer an exact case-insensitive name match over the top fuzzy hit;
@@ -240,25 +261,29 @@ async function fetchMonsterDocByName<T>(
   return map(document);
 }
 
-function getMonsterByName(api: CompendiumApi, name: string): Promise<MonsterDetail | null> {
-  return fetchMonsterDocByName(api, name, monsterDocToDetail);
+function getMonsterByName(api: CompendiumApi, packIds: readonly string[], name: string): Promise<MonsterDetail | null> {
+  return fetchMonsterDocByName(api, packIds, name, monsterDocToDetail);
 }
 
-function getMonsterRowByName(api: CompendiumApi, name: string): Promise<MonsterRow | null> {
-  return fetchMonsterDocByName(api, name, monsterDocToRow);
+function getMonsterRowByName(api: CompendiumApi, packIds: readonly string[], name: string): Promise<MonsterRow | null> {
+  return fetchMonsterDocByName(api, packIds, name, monsterDocToRow);
 }
 
 /** Hover preview. The legacy implementation keyed on an AoN URL; the
  *  projection layer drops AoN enrichment, so we treat the input as a
  *  creature name. If the caller accidentally passes a URL we strip it
  *  back to a sensible name (last path segment, spaces restored). */
-function getMonsterPreview(api: CompendiumApi, input: string): Promise<MonsterResult | null> {
+function getMonsterPreview(
+  api: CompendiumApi,
+  packIds: readonly string[],
+  input: string,
+): Promise<MonsterResult | null> {
   let name = input;
   if (input.includes('://') || input.startsWith('/')) {
     const trailing = input.replace(/\/$/, '').split('/').pop() ?? '';
     name = decodeURIComponent(trailing).replace(/[-_]/g, ' ');
   }
-  return fetchMonsterDocByName(api, name, monsterDocToResult);
+  return fetchMonsterDocByName(api, packIds, name, monsterDocToResult);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/dm-tool/electron/compendium/singleton.ts
+++ b/apps/dm-tool/electron/compendium/singleton.ts
@@ -14,8 +14,14 @@
 // rest of the app (maps, books, chat without rules, etc.) keep working
 // against a local-only configuration.
 
+import { getSetting, setSetting } from '@foundry-toolkit/db/pf2e';
+import { resetFacetsIndex } from './facets-index.js';
 import { createCompendiumApi, type CompendiumApi } from './index.js';
-import { createPreparedCompendium, type PreparedCompendium } from './prepared.js';
+import { createPreparedCompendium, DEFAULT_MONSTER_PACK_IDS, type PreparedCompendium } from './prepared.js';
+
+/** pf2e.db settings key for the Settings → Monsters pack override.
+ *  Stored as `JSON.stringify(string[])`. Absent = use defaults. */
+export const MONSTER_PACK_IDS_SETTING = 'compendiumMonsterPackIds';
 
 let api: CompendiumApi | null = null;
 let prepared: PreparedCompendium | null = null;
@@ -27,6 +33,34 @@ export interface InitPreparedCompendiumOptions {
   /** Override the 30-day TTL used by the underlying document cache. Rarely
    *  needed — exposed so tests can exercise the cache-expiry path. */
   documentTtlMs?: number;
+}
+
+/** Read the user's monster-pack override from pf2e.db settings, falling
+ *  back to the defaults when unset, malformed, or empty. Public so tests
+ *  and IPC handlers can share one source of truth for the current scope. */
+export function readMonsterPackIds(): readonly string[] {
+  const raw = getSetting(MONSTER_PACK_IDS_SETTING);
+  if (!raw) return DEFAULT_MONSTER_PACK_IDS;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return DEFAULT_MONSTER_PACK_IDS;
+    const ids = parsed.filter((p): p is string => typeof p === 'string' && p.length > 0);
+    // Treat an explicit empty array as "user cleared the list" — fall back
+    // to defaults rather than return an empty search scope that would make
+    // the Monster Browser silently empty.
+    if (ids.length === 0) return DEFAULT_MONSTER_PACK_IDS;
+    return ids;
+  } catch {
+    return DEFAULT_MONSTER_PACK_IDS;
+  }
+}
+
+/** Persist a new monster-pack override and invalidate any memoized state
+ *  that depends on the prior scope. Called from the Settings → Monsters
+ *  IPC handler. */
+export function writeMonsterPackIds(ids: readonly string[]): void {
+  setSetting(MONSTER_PACK_IDS_SETTING, JSON.stringify(ids));
+  resetFacetsIndex();
 }
 
 /** Idempotent — calling twice with the same options is a no-op, which is
@@ -42,7 +76,9 @@ export function initPreparedCompendium(opts: InitPreparedCompendiumOptions): voi
     baseUrl: opts.foundryMcpUrl,
     documentTtlMs: opts.documentTtlMs,
   });
-  prepared = createPreparedCompendium(api);
+  prepared = createPreparedCompendium(api, {
+    resolveMonsterPackIds: readMonsterPackIds,
+  });
 }
 
 export function getPreparedCompendium(): PreparedCompendium {

--- a/apps/dm-tool/electron/ipc/compendium.ts
+++ b/apps/dm-tool/electron/ipc/compendium.ts
@@ -1,0 +1,55 @@
+// IPC for Settings → Compendium configuration.
+//
+// Three handlers:
+//   - `compendiumListPacks(documentType?)` proxies foundry-mcp's
+//     `GET /api/compendium/packs` so the Settings dialog can render a
+//     live list of packs the user's Foundry actually has installed.
+//   - `compendiumGetMonsterPackIds()` returns the currently-active
+//     list (user override OR defaults).
+//   - `compendiumSetMonsterPackIds(ids)` persists a new override and
+//     invalidates any memoized facets that depended on the prior scope.
+//
+// These are thin — the heavy lifting lives in
+// `electron/compendium/singleton.ts` and the `CompendiumApi` wired up
+// there.
+
+import { ipcMain } from 'electron';
+import type { CompendiumPack } from '../compendium/index.js';
+import { DEFAULT_MONSTER_PACK_IDS } from '../compendium/prepared.js';
+import {
+  getCompendiumApi,
+  isPreparedCompendiumInitialized,
+  readMonsterPackIds,
+  writeMonsterPackIds,
+} from '../compendium/singleton.js';
+
+export function registerCompendiumHandlers(): void {
+  ipcMain.handle('compendiumListPacks', async (_e, documentType?: string): Promise<CompendiumPack[]> => {
+    if (!isPreparedCompendiumInitialized()) {
+      throw new Error('Compendium API not available — set a foundry-mcp URL in Settings → Paths and restart the app.');
+    }
+    const { packs } = await getCompendiumApi().listCompendiumPacks(
+      documentType !== undefined ? { documentType } : undefined,
+    );
+    return packs;
+  });
+
+  ipcMain.handle('compendiumGetMonsterPackIds', (): string[] => {
+    return [...readMonsterPackIds()];
+  });
+
+  ipcMain.handle('compendiumSetMonsterPackIds', (_e, ids: string[]): string[] => {
+    if (!Array.isArray(ids) || !ids.every((id) => typeof id === 'string')) {
+      throw new Error('compendiumSetMonsterPackIds: ids must be a string[]');
+    }
+    writeMonsterPackIds(ids);
+    // Echo the value readMonsterPackIds would return next — an empty
+    // input resolves to the defaults, so the renderer can update its
+    // local state without a follow-up read.
+    return [...readMonsterPackIds()];
+  });
+
+  ipcMain.handle('compendiumGetDefaultMonsterPackIds', (): string[] => {
+    return [...DEFAULT_MONSTER_PACK_IDS];
+  });
+}

--- a/apps/dm-tool/electron/ipc/index.ts
+++ b/apps/dm-tool/electron/ipc/index.ts
@@ -13,6 +13,7 @@ import { registerBookHandlers } from './books.js';
 import { registerChatHandlers } from './chat.js';
 import { registerMonsterHandlers } from './monsters.js';
 import { registerItemHandlers } from './items.js';
+import { registerCompendiumHandlers } from './compendium.js';
 import { registerTaggerHandlers } from './tagger.js';
 import { registerAutoWallHandlers } from './auto-wall.js';
 import { registerFoundryHandlers } from './foundry.js';
@@ -34,6 +35,7 @@ export function registerIpcHandlers(
   registerChatHandlers(getMainWindow);
   registerMonsterHandlers();
   registerItemHandlers();
+  registerCompendiumHandlers();
   registerTaggerHandlers(cfg, getMainWindow);
   registerAutoWallHandlers(cfg);
   registerFoundryHandlers(db, cfg);

--- a/apps/dm-tool/electron/preload.ts
+++ b/apps/dm-tool/electron/preload.ts
@@ -19,6 +19,7 @@ import type {
   ChatChunk,
   ChatMessage,
   ChatModel,
+  CompendiumPackSummary,
   ConfigPaths,
   ElectronAPI,
   Facets,
@@ -138,6 +139,14 @@ const api: ElectronAPI = {
     ipcRenderer.invoke('monstersSearch', params),
   monstersFacets: (): Promise<MonsterFacets> => ipcRenderer.invoke('monstersFacets'),
   monstersGetDetail: (name: string): Promise<MonsterDetail | null> => ipcRenderer.invoke('monstersGetDetail', name),
+
+  // Compendium configuration (Settings → Monsters)
+  compendiumListPacks: (documentType?: string): Promise<CompendiumPackSummary[]> =>
+    ipcRenderer.invoke('compendiumListPacks', documentType),
+  compendiumGetMonsterPackIds: (): Promise<string[]> => ipcRenderer.invoke('compendiumGetMonsterPackIds'),
+  compendiumSetMonsterPackIds: (ids: string[]): Promise<string[]> =>
+    ipcRenderer.invoke('compendiumSetMonsterPackIds', ids),
+  compendiumGetDefaultMonsterPackIds: (): Promise<string[]> => ipcRenderer.invoke('compendiumGetDefaultMonsterPackIds'),
 
   // Globe pins
   globePinsList: (): Promise<GlobePin[]> => ipcRenderer.invoke('globePinsList'),

--- a/apps/dm-tool/src/features/settings/MonsterPacksSettings.tsx
+++ b/apps/dm-tool/src/features/settings/MonsterPacksSettings.tsx
@@ -1,0 +1,187 @@
+// Settings → Monsters panel: live multi-select of the PF2e compendium
+// packs the Monster Browser, loot generator, and chat monster tool
+// should search.
+//
+// Fetches three things on mount:
+//   - Available packs   → foundry-mcp's /api/compendium/packs?documentType=Actor
+//   - Current selection → pf2e.db `compendiumMonsterPackIds` setting (or defaults)
+//   - Defaults          → the hardcoded DEFAULT_MONSTER_PACK_IDS constant
+//
+// Save persists the selection and invalidates the facets-index cache so
+// filter panels pick up the new scope on next open. No app restart.
+//
+// When foundry-mcp is unreachable we surface a one-line error + a
+// retry button; the rest of the settings dialog keeps working.
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { RefreshCw, RotateCcw } from 'lucide-react';
+import type { CompendiumPackSummary } from '@foundry-toolkit/shared/types';
+import { Button } from '../../components/ui/button';
+import { Label } from '../../components/ui/label';
+import { cn } from '../../lib/utils';
+
+type LoadState =
+  | { kind: 'loading' }
+  | { kind: 'error'; message: string }
+  | { kind: 'ready'; packs: CompendiumPackSummary[]; defaults: string[]; saved: string[] };
+
+export function MonsterPacksSettings() {
+  const [state, setState] = useState<LoadState>({ kind: 'loading' });
+  const [selection, setSelection] = useState<string[] | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saveMessage, setSaveMessage] = useState<{ kind: 'ok' | 'error'; text: string } | null>(null);
+
+  const load = useCallback(async () => {
+    setState({ kind: 'loading' });
+    try {
+      const [packs, saved, defaults] = await Promise.all([
+        window.electronAPI.compendiumListPacks('Actor'),
+        window.electronAPI.compendiumGetMonsterPackIds(),
+        window.electronAPI.compendiumGetDefaultMonsterPackIds(),
+      ]);
+      // Stable sort for display: by label, with defaults pinned to the top
+      // so the most common packs are immediately visible.
+      const defaultSet = new Set(defaults);
+      const sorted = [...packs].sort((a, b) => {
+        const aDefault = defaultSet.has(a.id) ? 0 : 1;
+        const bDefault = defaultSet.has(b.id) ? 0 : 1;
+        if (aDefault !== bDefault) return aDefault - bDefault;
+        return a.label.localeCompare(b.label);
+      });
+      setState({ kind: 'ready', packs: sorted, defaults, saved });
+      setSelection(saved);
+      setSaveMessage(null);
+    } catch (e) {
+      setState({ kind: 'error', message: (e as Error).message });
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const toggle = useCallback((id: string) => {
+    setSelection((prev) => {
+      if (!prev) return prev;
+      return prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id];
+    });
+  }, []);
+
+  const reset = useCallback(() => {
+    if (state.kind !== 'ready') return;
+    setSelection([...state.defaults]);
+  }, [state]);
+
+  const save = useCallback(async () => {
+    if (!selection || state.kind !== 'ready') return;
+    setSaving(true);
+    setSaveMessage(null);
+    try {
+      const next = await window.electronAPI.compendiumSetMonsterPackIds(selection);
+      setState({ ...state, saved: next });
+      setSelection(next);
+      setSaveMessage({ kind: 'ok', text: 'Saved. Open the Monsters tab to see the new scope.' });
+    } catch (e) {
+      setSaveMessage({ kind: 'error', text: (e as Error).message });
+    } finally {
+      setSaving(false);
+    }
+  }, [selection, state]);
+
+  const changed = useMemo(() => {
+    if (!selection || state.kind !== 'ready') return false;
+    const savedSorted = [...state.saved].sort();
+    const currentSorted = [...selection].sort();
+    if (savedSorted.length !== currentSorted.length) return true;
+    return savedSorted.some((id, i) => id !== currentSorted[i]);
+  }, [selection, state]);
+
+  if (state.kind === 'loading') {
+    return <p className="text-xs text-muted-foreground">Loading compendium packs…</p>;
+  }
+
+  if (state.kind === 'error') {
+    return (
+      <div className="space-y-2">
+        <p className="text-xs text-destructive">Couldn&apos;t load compendium packs: {state.message}</p>
+        <p className="text-[11px] leading-snug text-muted-foreground">
+          Is foundry-mcp running and reachable at the URL in Settings → Paths?
+        </p>
+        <Button variant="outline" size="sm" onClick={() => void load()} className="gap-1.5">
+          <RefreshCw className="h-3.5 w-3.5" />
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  const currentSelection = selection ?? [];
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <Label className="text-xs font-medium">Compendium packs</Label>
+        <p className="pt-0.5 text-[11px] leading-snug text-muted-foreground">
+          Packs to search for the Monster Browser, loot generator, and chat creature lookup. Defaults are listed first.
+          Everything else from your Foundry install is available — tick any you want to include.
+        </p>
+      </div>
+
+      <div className="max-h-72 overflow-y-auto rounded-md border border-border">
+        <ul className="divide-y divide-border text-xs">
+          {state.packs.map((pack) => {
+            const checked = currentSelection.includes(pack.id);
+            const isDefault = state.defaults.includes(pack.id);
+            return (
+              <li key={pack.id}>
+                <label className="flex cursor-pointer items-center gap-2 px-3 py-1.5 hover:bg-accent/40">
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => toggle(pack.id)}
+                    className="h-3.5 w-3.5 cursor-pointer"
+                  />
+                  <span className="flex-1 truncate">{pack.label}</span>
+                  {isDefault && (
+                    <span className="rounded bg-accent px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                      default
+                    </span>
+                  )}
+                  <span className="font-mono text-[10px] text-muted-foreground">{pack.id}</span>
+                </label>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+
+      {currentSelection.length === 0 && (
+        <p className="text-[11px] text-amber-500">
+          No packs selected — saving an empty list resets the scope to defaults.
+        </p>
+      )}
+
+      <div className="flex items-center gap-2">
+        <Button variant="outline" size="sm" onClick={reset} disabled={saving} className="gap-1.5">
+          <RotateCcw className="h-3.5 w-3.5" />
+          Reset to default
+        </Button>
+        <Button variant="default" size="sm" onClick={() => void save()} disabled={!changed || saving}>
+          {saving ? 'Saving…' : 'Save'}
+        </Button>
+      </div>
+
+      {saveMessage && (
+        <p
+          className={cn(
+            'text-[11px] leading-snug',
+            saveMessage.kind === 'ok' ? 'text-emerald-500' : 'text-destructive',
+          )}
+        >
+          {saveMessage.kind === 'ok' ? '✓ ' : '✗ '}
+          {saveMessage.text}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/dm-tool/src/features/settings/SettingsDialog.tsx
+++ b/apps/dm-tool/src/features/settings/SettingsDialog.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { ClipboardCopy, FolderOpen, Plus, RefreshCw, RotateCcw, Settings, X } from 'lucide-react';
 import { PathField } from '../../components/PathField';
 import { cn } from '../../lib/utils';
+import { MonsterPacksSettings } from './MonsterPacksSettings';
 import {
   Dialog,
   DialogContent,
@@ -579,7 +580,7 @@ export function SettingsDialog({
                 </div>
               )}
 
-              {tab === 'monsters' && <p className="text-xs text-muted-foreground">No monster settings yet.</p>}
+              {tab === 'monsters' && <MonsterPacksSettings />}
 
               {tab === 'items' && <p className="text-xs text-muted-foreground">No item settings yet.</p>}
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -197,6 +197,22 @@ export interface ItemFacets {
   usageCategories: string[];
 }
 
+/** Renderer-facing compendium pack descriptor. Mirrors the subset of
+ *  foundry-mcp's `CompendiumPack` that the Settings → Monsters dialog
+ *  needs — enough to render each pack as a labeled checkbox. */
+export interface CompendiumPackSummary {
+  /** Foundry pack id, e.g. `pf2e.pathfinder-bestiary`. Canonical key
+   *  for the monster-pack override setting. */
+  id: string;
+  /** Human-readable label from Foundry's pack metadata, e.g. "Pathfinder
+   *  Bestiary". Shown as the checkbox label. */
+  label: string;
+  /** 'Actor' for bestiaries/NPCs, 'Item' for equipment/feats/etc. */
+  type: string;
+  /** Game system name. Usually `'pf2e'` for the packs this dialog lists. */
+  system?: string;
+}
+
 // ---------------------------------------------------------------------------
 // Chat
 // ---------------------------------------------------------------------------
@@ -684,6 +700,27 @@ export interface ElectronAPI {
   monstersFacets(): Promise<MonsterFacets>;
   /** Full stat block for a single monster by name. */
   monstersGetDetail(name: string): Promise<MonsterDetail | null>;
+
+  // -----------------------------------------------------------------------
+  // Compendium configuration (Settings → Monsters)
+  // -----------------------------------------------------------------------
+
+  /** List every compendium pack foundry-mcp knows about. Optionally
+   *  narrowed by `documentType` ('Actor' for bestiaries, 'Item' for
+   *  equipment/feats/etc). Used by the Settings dialog to render a live
+   *  multi-select of the packs the user actually has installed. */
+  compendiumListPacks(documentType?: string): Promise<CompendiumPackSummary[]>;
+  /** Currently-active monster pack list — either the user's saved
+   *  override or the hardcoded defaults. */
+  compendiumGetMonsterPackIds(): Promise<string[]>;
+  /** Replace the monster pack list. Passing `[]` resets to defaults.
+   *  Returns the post-save active list so the renderer can update state
+   *  without a follow-up read. */
+  compendiumSetMonsterPackIds(ids: string[]): Promise<string[]>;
+  /** The hardcoded default monster pack list. Exposed so Settings can
+   *  offer a "Reset to default" button that shows the default tick set
+   *  without hard-coding it in the renderer. */
+  compendiumGetDefaultMonsterPackIds(): Promise<string[]>;
 
   // -----------------------------------------------------------------------
   // Globe pins


### PR DESCRIPTION
## Summary

Expose `MONSTER_PACK_IDS` as a user-configurable setting. GMs can now tick which PF2e bestiary / NPC compendia the Monster Browser, loot generator, and chat creature tool should search — including adventure-path bestiaries (Kingmaker, Abomination Vaults, PFS seasons, Lost Omens sourcebook bestiaries, homebrew) that aren't in the stock-install defaults.

**Stacks on [#42](https://github.com/AlexDickerson/foundry-toolkit/pull/42)** (the monster-pack-expansion fix). Rebases cleanly onto main once that merges — the default list this PR introduces is the same 6-pack set that #42 hardcodes.

## Backend

| File | Change |
|------|--------|
| `compendium/prepared.ts` | Exports `DEFAULT_MONSTER_PACK_IDS`. `createPreparedCompendium` accepts an optional `resolveMonsterPackIds` callback that fires once per outer call, so Settings changes take effect immediately without restart. Every monster accessor threads the pack list through the factory closure. |
| `compendium/singleton.ts` | `readMonsterPackIds()` reads `compendiumMonsterPackIds` from `pf2e.db` (fallback: defaults on absent / malformed / explicitly empty). `writeMonsterPackIds()` persists + calls `resetFacetsIndex()` so the filter panel picks up the new scope on next open. Init wires the resolver. |
| `ipc/compendium.ts` (new) | Four thin handlers: `compendiumListPacks(documentType?)` proxies `/api/compendium/packs`; get / set / getDefault for the monster pack id list. |
| `preload.ts` + `shared/types.ts` | New `CompendiumPackSummary` type + four ElectronAPI methods matching the IPC. |

## UI (`MonsterPacksSettings.tsx`)

- Loading state — parallel fetch of pack list + saved selection + defaults on tab open.
- Checkbox list with defaults pinned to the top and labeled with a `default` chip. Pack ID shown in monospace so slug mismatches are easy to spot.
- **Reset to default** button — selects the default tick set (user still confirms via Save).
- **Save** button — disabled until the ticked set differs from saved; shows a success toast afterwards.
- Clear recovery path when foundry-mcp is unreachable: one-line error + Retry button; the rest of the Settings dialog keeps working.

Empty selection on save = reset to defaults (prevents "I cleared everything and now the Monster Browser is blank").

## Not in scope

- **Item packs** stay a constant (`['pf2e.equipment-srd']`) — only one relevant pack, no reported use case. Flip to resolver + setting if/when that changes.
- **Per-consumer overrides** — all three consumers (Monster Browser, loot gen, chat tool) share the same setting. Different scopes per surface would be over-engineered for current use.

## Test plan

- [x] New resolver test in `prepared.test.ts` — confirms resolver fires per-call (first call sees one pack, second call sees two after the backing state changes)
- [x] `npm --workspace apps/dm-tool test` — 216/216 pass
- [x] `npm run typecheck` — whole monorepo clean
- [x] `npm run format:check` — clean
- [x] `npx eslint .` — only pre-existing warnings in untouched files
- [x] `npm run knip` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)