### PR TITLE
Skip missing packs in multi-pack find-in-compendium requests

### DIFF
--- a/apps/foundry-api-bridge/src/commands/handlers/world/FindInCompendiumHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/world/FindInCompendiumHandler.ts
@@ -126,7 +126,15 @@ export async function findInCompendiumHandler(params: FindInCompendiumParams): P
     for (const id of requestedPackIds) {
       const pack = game.packs.get(id);
       if (!pack) {
-        throw new Error(`Compendium pack not found: ${id}`);
+        // A missing pack in a multi-pack request contributes zero matches
+        // rather than aborting the whole search. Callers commonly pass
+        // the union of stock bestiaries (bestiary-1 + bestiary-2 +
+        // monster-core + nature-core …) and want results from whichever
+        // are installed. Callers that need to verify a specific pack
+        // exists should use `list-compendium-packs`. Logged at warn so
+        // ops can spot a typo'd packId without the request failing.
+        console.warn(`[find-in-compendium] Skipping missing pack: ${id}`);
+        continue;
       }
       if (params.documentType !== undefined && pack.metadata.type !== params.documentType) {
         // A single pack being of the wrong type is a no-op contribution;

--- a/apps/foundry-api-bridge/src/commands/handlers/world/__tests__/FindInCompendiumHandler.test.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/world/__tests__/FindInCompendiumHandler.test.ts
@@ -132,12 +132,31 @@ describe('findInCompendiumHandler', () => {
     expect(result.matches[0]?.packId).toBe('pack.b');
   });
 
-  it('throws when an explicit packId is not found', async () => {
+  it('returns empty matches when the only requested pack is missing', async () => {
     setGame([]);
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
-    await expect(findInCompendiumHandler({ name: 'anything', packId: 'missing.pack' })).rejects.toThrow(
-      'Compendium pack not found: missing.pack',
-    );
+    const result = await findInCompendiumHandler({ name: 'anything', packId: 'missing.pack' });
+
+    expect(result.matches).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('missing.pack'));
+    warn.mockRestore();
+  });
+
+  it('skips missing packs in a multi-pack request and searches the rest', async () => {
+    const p1 = createPack('real.pack', [{ _id: '1', name: 'Goblin', type: 'npc' }]);
+    setGame([p1]);
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await findInCompendiumHandler({
+      name: 'goblin',
+      packId: ['missing.pack', 'real.pack', 'also-missing.pack'],
+    });
+
+    expect(result.matches.map((m) => m.name)).toEqual(['Goblin']);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('missing.pack'));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('also-missing.pack'));
+    warn.mockRestore();
   });
 
   it('filters by documentType', async () => {


### PR DESCRIPTION
## Problem

Bug report from a live install — the Monster Browser is returning 404 from mcp:

```
GET /api/compendium/search?packId=pf2e.pathfinder-bestiary,...,pf2e.pathfinder-nature-core,... 404
  "Compendium pack not found: pf2e.pathfinder-nature-core"
```

After [#42](https://github.com/AlexDickerson/foundry-toolkit/pull/42) expanded `MONSTER_PACK_IDS` to include every stock remaster pack, dm-tool sends the union of them as a multi-pack search. One missing pack (Nature Core — a remaster-era pack not in every pf2e system version) aborts the whole search.

## Root cause

`apps/foundry-api-bridge/src/commands/handlers/world/FindInCompendiumHandler.ts:129` threw on the first missing pack instead of skipping it. That's the right behavior when a caller requests one specific pack, but wrong when the caller sends a union of "every bestiary that might be installed" — the dm-tool Monster Browser pattern after #42.

## Fix

Skip missing packs with a `console.warn` and continue searching the real ones. Over the wire the Zod-parsed `packId` is always `string[]`, so this consistently applies to both single and multi-pack requests. Callers that need to verify a specific pack exists should use `list-compendium-packs`.

## Behaviour impact

| Caller | Before | After |
|--------|--------|-------|
| dm-tool Monster Browser (multi-pack) | 404 aborts the browser | Returns matches from whichever packs are installed |
| dm-tool chat creature tool | Same 404 | Same fix — graceful |
| Caller passing one missing pack | 404 | Empty matches + warn log |
| Caller passing all real packs | Unchanged | Unchanged |

The "caller passing one missing pack" case was arguably a legitimate error signal before. Callers who want that signal can now use `list-compendium-packs` to verify, or check whether `matches` is empty.

## Test plan

- [x] New case: multi-pack request with one real + two missing packs → returns matches from the real pack, logs warns for each missing pack.
- [x] Replaced old "throws on missing packId" test with "returns empty + warns" (the single-pack path now matches the multi-pack path).
- [x] `npm --workspace apps/foundry-api-bridge test` — 680/680 pass
- [x] `npm run typecheck` — whole monorepo clean
- [x] `npm run format:check` — clean

## Deploy note

Since this is the Foundry module (not the mcp server), the fix rolls out when users update the bridge module image. Temporary workaround for GMs hitting this before the module updates: Settings → Monsters → untick Nature Core (or any other pack `/api/compendium/packs` confirms isn't installed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)