### PR TITLE
Port eval-based actor actions to the generic registry + Craft button (redo of #46)

### DIFF
--- a/apps/foundry-api-bridge/src/commands/handlers/actor/InvokeActorActionHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/InvokeActorActionHandler.ts
@@ -12,7 +12,13 @@ interface FoundryActor {
   id: string;
   uuid: string;
   type: string;
-  system: Record<string, unknown>;
+  system: Record<string, unknown> & {
+    /** PF2e system caches prepared strike/action objects on the
+     *  character here. Shape is `{slug, variants: [{roll()}], damage(),
+     *  critical()}`. Loose typing because the surface's runtime-only. */
+    actions?: Pf2eStrike[];
+  };
+  items: FoundryItemCollection;
   update(data: Record<string, unknown>): Promise<FoundryActor>;
   /** PF2e-specific: bumps a condition by 1 (creates the effect at
    *  value 1 if absent). */
@@ -34,13 +40,40 @@ interface Pf2eStatistic {
   }): Promise<FoundryD20Roll | null>;
 }
 
+interface Pf2eStrikeVariant {
+  roll(args: Record<string, unknown>): Promise<unknown>;
+}
+
+interface Pf2eStrike {
+  slug: string;
+  variants?: Pf2eStrikeVariant[];
+  damage?: (args: Record<string, unknown>) => Promise<unknown>;
+  critical?: (args: Record<string, unknown>) => Promise<unknown>;
+}
+
+interface FoundryItem {
+  id: string;
+  name: string;
+  type: string;
+  toMessage(args?: Record<string, unknown>): Promise<unknown>;
+}
+
+interface FoundryItemCollection {
+  get(id: string): FoundryItem | undefined;
+}
+
 interface ActorsCollection {
   get(id: string): FoundryActor | undefined;
 }
 
+type PF2eActionFn = (options: Record<string, unknown>) => Promise<unknown> | unknown;
+
 interface FoundryGame {
   actors: ActorsCollection;
   messages?: { contents: Array<{ id: string; isRoll?: boolean }> };
+  pf2e?: {
+    actions?: Record<string, PF2eActionFn | undefined>;
+  };
 }
 
 interface FoundryGlobals {
@@ -64,6 +97,16 @@ const ACTION_HANDLERS: Record<string, ActionHandler> = {
   'adjust-resource': adjustResourceAction,
   'adjust-condition': adjustConditionAction,
   'roll-statistic': rollStatisticAction,
+  craft: craftAction,
+  'rest-for-the-night': restForTheNightAction,
+  'roll-strike': rollStrikeAction,
+  'roll-strike-damage': rollStrikeDamageAction,
+  // Simple "send the item's action card to chat" — same behaviour as
+  // the pf2e sheet's "post to chat" button. Distinct from the typed
+  // `use-item` command, which runs the full activation pipeline
+  // (activities, scaling, consumable charges) and has its own
+  // MCP/IPC consumers.
+  'post-item-to-chat': postItemToChatAction,
 };
 
 // ─── adjust-resource ───────────────────────────────────────────────────
@@ -298,6 +341,162 @@ async function rollStatisticAction(
   }
 
   return result;
+}
+
+// ─── craft ─────────────────────────────────────────────────────────────
+
+// pf2e's `game.pf2e.actions.craft` accepts `uuid` directly and
+// resolves it internally — we don't need to `fromUuid` ourselves.
+// The action fires a Crafting skill check chat card; SPA state
+// refreshes via the `actors` event channel if the roll mutates the
+// actor (on success it creates an item in inventory).
+async function craftAction(
+  actor: FoundryActor,
+  params: Record<string, unknown>,
+): Promise<InvokeActorActionResult> {
+  const itemUuid = params['itemUuid'];
+  if (typeof itemUuid !== 'string' || itemUuid.length === 0) {
+    throw new Error('craft: params.itemUuid is required');
+  }
+  const quantityRaw = params['quantity'];
+  const quantity = typeof quantityRaw === 'number' && quantityRaw > 0 ? Math.floor(quantityRaw) : 1;
+
+  const craftFn = getFoundry().game.pf2e?.actions?.['craft'];
+  if (typeof craftFn !== 'function') {
+    throw new Error('craft: game.pf2e.actions.craft is unavailable (pf2e system not installed?)');
+  }
+
+  await craftFn({ uuid: itemUuid, actors: [actor], quantity });
+
+  return { ok: true };
+}
+
+// ─── rest-for-the-night ────────────────────────────────────────────────
+
+// pf2e's Rest for the Night — daily preparations, HP/heal, spell
+// slot reset, resource refresh. `skipDialog` suppresses the native
+// confirmation popup so the SPA can drive it silently. Returns the
+// chat message count so the SPA can echo "N recovery results" if it
+// wants to, matching the prior eval-based shape.
+async function restForTheNightAction(
+  actor: FoundryActor,
+  _params: Record<string, unknown>,
+): Promise<InvokeActorActionResult> {
+  if (actor.type !== 'character') {
+    throw new Error(`rest-for-the-night: actor ${actor.id} is a ${actor.type}, not a character`);
+  }
+  const restFn = getFoundry().game.pf2e?.actions?.['restForTheNight'];
+  if (typeof restFn !== 'function') {
+    throw new Error(
+      'rest-for-the-night: game.pf2e.actions.restForTheNight is unavailable (pf2e system not installed?)',
+    );
+  }
+
+  const result = (await restFn({ actors: [actor], skipDialog: true })) as unknown;
+  const messageCount = Array.isArray(result) ? result.length : 0;
+
+  return { ok: true, messageCount };
+}
+
+// ─── roll-strike ───────────────────────────────────────────────────────
+
+// Rolls a single MAP variant of a PF2e strike. `variantIndex` 0/1/2
+// maps to first attack / second (−5 MAP) / third (−10 MAP). The
+// PF2e `StrikeData` lives at `actor.system.actions[i]` and each
+// variant exposes its own `roll()` that bakes in the MAP penalty.
+async function rollStrikeAction(
+  actor: FoundryActor,
+  params: Record<string, unknown>,
+): Promise<InvokeActorActionResult> {
+  if (actor.type !== 'character') {
+    throw new Error(`roll-strike: actor ${actor.id} is a ${actor.type}, not a character`);
+  }
+  const strikeSlug = params['strikeSlug'];
+  if (typeof strikeSlug !== 'string' || strikeSlug.length === 0) {
+    throw new Error('roll-strike: params.strikeSlug is required');
+  }
+  const variantIndex = params['variantIndex'];
+  if (typeof variantIndex !== 'number' || !Number.isInteger(variantIndex) || variantIndex < 0) {
+    throw new Error('roll-strike: params.variantIndex must be a non-negative integer');
+  }
+
+  const strike = resolveStrike(actor, strikeSlug);
+  const variant = strike.variants?.[variantIndex];
+  if (!variant) {
+    throw new Error(`roll-strike: strike "${strikeSlug}" has no variant ${variantIndex.toString()}`);
+  }
+  await variant.roll({});
+  return { ok: true };
+}
+
+// ─── roll-strike-damage ────────────────────────────────────────────────
+
+// Rolls either regular damage or critical damage for a strike
+// (whichever was appropriate for the attack outcome). Critical vs.
+// normal is client-driven since the SPA reads the outcome from the
+// attack's chat card.
+async function rollStrikeDamageAction(
+  actor: FoundryActor,
+  params: Record<string, unknown>,
+): Promise<InvokeActorActionResult> {
+  if (actor.type !== 'character') {
+    throw new Error(`roll-strike-damage: actor ${actor.id} is a ${actor.type}, not a character`);
+  }
+  const strikeSlug = params['strikeSlug'];
+  if (typeof strikeSlug !== 'string' || strikeSlug.length === 0) {
+    throw new Error('roll-strike-damage: params.strikeSlug is required');
+  }
+  const critical = params['critical'] === true;
+
+  const strike = resolveStrike(actor, strikeSlug);
+  if (critical) {
+    if (typeof strike.critical !== 'function') {
+      throw new Error(`roll-strike-damage: strike "${strikeSlug}" has no critical roll`);
+    }
+    await strike.critical({});
+  } else {
+    if (typeof strike.damage !== 'function') {
+      throw new Error(`roll-strike-damage: strike "${strikeSlug}" has no damage roll`);
+    }
+    await strike.damage({});
+  }
+  return { ok: true };
+}
+
+function resolveStrike(actor: FoundryActor, slug: string): Pf2eStrike {
+  const actions = actor.system.actions;
+  if (!Array.isArray(actions)) {
+    throw new Error(`actor ${actor.id} has no system.actions — is this a pf2e character?`);
+  }
+  const strike = actions.find((s) => s.slug === slug);
+  if (!strike) {
+    throw new Error(`strike "${slug}" not found on actor ${actor.id}`);
+  }
+  return strike;
+}
+
+// ─── post-item-to-chat ─────────────────────────────────────────────────
+
+// Posts an owned item's action card to chat — mirrors the pf2e sheet's
+// "send to chat" button on an action / reaction / free action.
+// Consumable charge consumption is left to whoever clicks the roll
+// buttons inside the posted card. Distinct from the typed `use-item`
+// command, which runs the full activation pipeline (activities,
+// scaling, auto-consume) and has its own MCP/IPC consumers.
+async function postItemToChatAction(
+  actor: FoundryActor,
+  params: Record<string, unknown>,
+): Promise<InvokeActorActionResult> {
+  const itemId = params['itemId'];
+  if (typeof itemId !== 'string' || itemId.length === 0) {
+    throw new Error('post-item-to-chat: params.itemId is required');
+  }
+  const item = actor.items.get(itemId);
+  if (!item) {
+    throw new Error(`post-item-to-chat: item ${itemId} not found on actor ${actor.id}`);
+  }
+  await item.toMessage();
+  return { ok: true, itemId: item.id, itemName: item.name };
 }
 
 // ─── Router ────────────────────────────────────────────────────────────

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/__tests__/InvokeActorActionHandler.test.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/__tests__/InvokeActorActionHandler.test.ts
@@ -8,11 +8,19 @@ interface MockRoll {
   isFumble: boolean;
 }
 
+interface MockItem {
+  id: string;
+  name: string;
+  type: string;
+  toMessage: jest.Mock;
+}
+
 interface MockActor {
   id: string;
   uuid: string;
   type: string;
   system: Record<string, unknown>;
+  items: { get: jest.Mock };
   update: jest.Mock;
   increaseCondition?: jest.Mock;
   decreaseCondition?: jest.Mock;
@@ -22,6 +30,7 @@ interface MockActor {
 function setupFoundry(opts: {
   actor: MockActor | null;
   messages?: Array<{ id: string; isRoll?: boolean }>;
+  pf2eActions?: Record<string, jest.Mock>;
 }): void {
   const actors = new Map<string, MockActor>();
   if (opts.actor) actors.set(opts.actor.id, opts.actor);
@@ -31,6 +40,7 @@ function setupFoundry(opts: {
       get: (id: string): MockActor | undefined => actors.get(id),
     },
     messages: { contents: opts.messages ?? [] },
+    pf2e: { actions: opts.pf2eActions ?? {} },
   };
 }
 
@@ -62,10 +72,21 @@ function makeActor(overrides: Partial<MockActor> = {}): MockActor {
         focus: { value: 0, max: 2 },
       },
     },
+    items: { get: jest.fn() },
     update: jest.fn().mockResolvedValue(undefined),
     increaseCondition: jest.fn().mockResolvedValue(undefined),
     decreaseCondition: jest.fn().mockResolvedValue(undefined),
     getStatistic: jest.fn().mockReturnValue({ roll: jest.fn().mockResolvedValue(makeRoll()) }),
+    ...overrides,
+  };
+}
+
+function makeItem(overrides: Partial<MockItem> = {}): MockItem {
+  return {
+    id: 'item1',
+    name: 'Potion of Healing',
+    type: 'consumable',
+    toMessage: jest.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }
@@ -75,9 +96,18 @@ afterEach(() => {
 });
 
 describe('invokeActorActionHandler — dispatch', () => {
-  it('exposes adjust-resource, adjust-condition, roll-statistic in KNOWN_ACTIONS', () => {
+  it('exposes every registered action slug in KNOWN_ACTIONS', () => {
     expect(KNOWN_ACTIONS).toEqual(
-      expect.arrayContaining(['adjust-resource', 'adjust-condition', 'roll-statistic']),
+      expect.arrayContaining([
+        'adjust-resource',
+        'adjust-condition',
+        'roll-statistic',
+        'craft',
+        'rest-for-the-night',
+        'roll-strike',
+        'roll-strike-damage',
+        'post-item-to-chat',
+      ]),
     );
   });
 
@@ -497,5 +527,332 @@ describe('invokeActorActionHandler — roll-statistic', () => {
         params: { statistic: 'perception', rollMode: 'whisper' },
       }),
     ).rejects.toThrow(/params\.rollMode must be one of/);
+  });
+});
+
+describe('invokeActorActionHandler — craft', () => {
+  it('invokes game.pf2e.actions.craft with uuid + actors + quantity', async () => {
+    const craftMock = jest.fn().mockResolvedValue(undefined);
+    const actor = makeActor();
+    setupFoundry({ actor, pf2eActions: { craft: craftMock } });
+
+    const result = await invokeActorActionHandler({
+      actorId: 'actor1',
+      action: 'craft',
+      params: { itemUuid: 'Compendium.pf2e.equipment-srd.Item.abc', quantity: 3 },
+    });
+
+    expect(craftMock).toHaveBeenCalledWith({
+      uuid: 'Compendium.pf2e.equipment-srd.Item.abc',
+      actors: [actor],
+      quantity: 3,
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('defaults quantity to 1 when omitted / invalid', async () => {
+    const craftMock = jest.fn().mockResolvedValue(undefined);
+    setupFoundry({ actor: makeActor(), pf2eActions: { craft: craftMock } });
+
+    for (const quantity of [undefined, -5, 'two', 0]) {
+      craftMock.mockClear();
+      await invokeActorActionHandler({
+        actorId: 'actor1',
+        action: 'craft',
+        params: { itemUuid: 'Compendium.pf2e.equipment-srd.Item.abc', quantity },
+      });
+      expect(craftMock.mock.calls[0]?.[0]).toMatchObject({ quantity: 1 });
+    }
+  });
+
+  it('floors non-integer positive quantities', async () => {
+    const craftMock = jest.fn().mockResolvedValue(undefined);
+    setupFoundry({ actor: makeActor(), pf2eActions: { craft: craftMock } });
+
+    await invokeActorActionHandler({
+      actorId: 'actor1',
+      action: 'craft',
+      params: { itemUuid: 'Compendium.pf2e.equipment-srd.Item.abc', quantity: 2.7 },
+    });
+    expect(craftMock.mock.calls[0]?.[0]).toMatchObject({ quantity: 2 });
+  });
+
+  it('requires itemUuid', async () => {
+    setupFoundry({ actor: makeActor(), pf2eActions: { craft: jest.fn() } });
+    await expect(
+      invokeActorActionHandler({ actorId: 'actor1', action: 'craft', params: {} }),
+    ).rejects.toThrow(/params\.itemUuid is required/);
+  });
+
+  it('errors when pf2e system is not installed', async () => {
+    const actor = makeActor();
+    (globalThis as unknown as Record<string, unknown>)['game'] = {
+      actors: { get: () => actor },
+      // No pf2e.actions at all.
+    };
+    await expect(
+      invokeActorActionHandler({
+        actorId: 'actor1',
+        action: 'craft',
+        params: { itemUuid: 'Compendium.pf2e.equipment-srd.Item.abc' },
+      }),
+    ).rejects.toThrow(/pf2e system not installed/);
+  });
+});
+
+describe('invokeActorActionHandler — rest-for-the-night', () => {
+  it('calls game.pf2e.actions.restForTheNight with the actor and skipDialog', async () => {
+    const restMock = jest.fn().mockResolvedValue([]);
+    const actor = makeActor();
+    setupFoundry({ actor, pf2eActions: { restForTheNight: restMock } });
+
+    const result = await invokeActorActionHandler({
+      actorId: 'actor1',
+      action: 'rest-for-the-night',
+      params: {},
+    });
+
+    expect(restMock).toHaveBeenCalledWith({ actors: [actor], skipDialog: true });
+    expect(result).toEqual({ ok: true, messageCount: 0 });
+  });
+
+  it('reports the returned chat message count', async () => {
+    const restMock = jest.fn().mockResolvedValue([{ id: 'm1' }, { id: 'm2' }, { id: 'm3' }]);
+    setupFoundry({ actor: makeActor(), pf2eActions: { restForTheNight: restMock } });
+
+    const result = await invokeActorActionHandler({
+      actorId: 'actor1',
+      action: 'rest-for-the-night',
+      params: {},
+    });
+    expect(result).toMatchObject({ messageCount: 3 });
+  });
+
+  it('refuses to rest a non-character actor', async () => {
+    setupFoundry({
+      actor: makeActor({ type: 'npc' }),
+      pf2eActions: { restForTheNight: jest.fn() },
+    });
+    await expect(
+      invokeActorActionHandler({ actorId: 'actor1', action: 'rest-for-the-night', params: {} }),
+    ).rejects.toThrow(/is a npc, not a character/);
+  });
+
+  it('errors when pf2e system is not installed', async () => {
+    const actor = makeActor();
+    (globalThis as unknown as Record<string, unknown>)['game'] = {
+      actors: { get: () => actor },
+    };
+    await expect(
+      invokeActorActionHandler({ actorId: 'actor1', action: 'rest-for-the-night', params: {} }),
+    ).rejects.toThrow(/pf2e system not installed/);
+  });
+});
+
+describe('invokeActorActionHandler — roll-strike', () => {
+  function makeStrikeActor(): MockActor {
+    const variantRoll = jest.fn().mockResolvedValue(undefined);
+    return makeActor({
+      system: {
+        actions: [
+          {
+            slug: 'longsword',
+            variants: [{ roll: variantRoll }, { roll: variantRoll }, { roll: variantRoll }],
+            damage: jest.fn().mockResolvedValue(undefined),
+            critical: jest.fn().mockResolvedValue(undefined),
+          },
+          {
+            slug: 'bow-composite',
+            variants: [{ roll: variantRoll }],
+          },
+        ],
+      },
+    });
+  }
+
+  it('finds the strike by slug and rolls the requested variant', async () => {
+    const actor = makeStrikeActor();
+    setupFoundry({ actor });
+
+    const result = await invokeActorActionHandler({
+      actorId: 'actor1',
+      action: 'roll-strike',
+      params: { strikeSlug: 'longsword', variantIndex: 1 },
+    });
+
+    const strike = (actor.system as { actions: Array<{ variants: Array<{ roll: jest.Mock }> }> }).actions[0]!;
+    expect(strike.variants[1]!.roll).toHaveBeenCalledWith({});
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('throws when the strike slug is unknown', async () => {
+    setupFoundry({ actor: makeStrikeActor() });
+    await expect(
+      invokeActorActionHandler({
+        actorId: 'actor1',
+        action: 'roll-strike',
+        params: { strikeSlug: 'greatclub', variantIndex: 0 },
+      }),
+    ).rejects.toThrow(/strike "greatclub" not found/);
+  });
+
+  it('throws when the variant index is out of range', async () => {
+    setupFoundry({ actor: makeStrikeActor() });
+    await expect(
+      invokeActorActionHandler({
+        actorId: 'actor1',
+        action: 'roll-strike',
+        params: { strikeSlug: 'bow-composite', variantIndex: 2 },
+      }),
+    ).rejects.toThrow(/has no variant 2/);
+  });
+
+  it('rejects non-character actors', async () => {
+    setupFoundry({ actor: makeActor({ type: 'npc' }) });
+    await expect(
+      invokeActorActionHandler({
+        actorId: 'actor1',
+        action: 'roll-strike',
+        params: { strikeSlug: 'longsword', variantIndex: 0 },
+      }),
+    ).rejects.toThrow(/not a character/);
+  });
+
+  it('rejects missing strikeSlug and non-integer variantIndex', async () => {
+    setupFoundry({ actor: makeStrikeActor() });
+    await expect(
+      invokeActorActionHandler({ actorId: 'actor1', action: 'roll-strike', params: { variantIndex: 0 } }),
+    ).rejects.toThrow(/strikeSlug is required/);
+    await expect(
+      invokeActorActionHandler({
+        actorId: 'actor1',
+        action: 'roll-strike',
+        params: { strikeSlug: 'longsword', variantIndex: 1.5 },
+      }),
+    ).rejects.toThrow(/variantIndex must be a non-negative integer/);
+  });
+
+  it('throws when the actor has no system.actions array', async () => {
+    setupFoundry({ actor: makeActor() });
+    await expect(
+      invokeActorActionHandler({
+        actorId: 'actor1',
+        action: 'roll-strike',
+        params: { strikeSlug: 'longsword', variantIndex: 0 },
+      }),
+    ).rejects.toThrow(/no system\.actions/);
+  });
+});
+
+describe('invokeActorActionHandler — roll-strike-damage', () => {
+  function makeStrikeActor(): MockActor {
+    return makeActor({
+      system: {
+        actions: [
+          {
+            slug: 'longsword',
+            damage: jest.fn().mockResolvedValue(undefined),
+            critical: jest.fn().mockResolvedValue(undefined),
+          },
+        ],
+      },
+    });
+  }
+
+  it('rolls normal damage when critical is false/omitted', async () => {
+    const actor = makeStrikeActor();
+    setupFoundry({ actor });
+
+    await invokeActorActionHandler({
+      actorId: 'actor1',
+      action: 'roll-strike-damage',
+      params: { strikeSlug: 'longsword' },
+    });
+
+    const strike = (actor.system as { actions: Array<{ damage: jest.Mock; critical: jest.Mock }> }).actions[0]!;
+    expect(strike.damage).toHaveBeenCalledWith({});
+    expect(strike.critical).not.toHaveBeenCalled();
+  });
+
+  it('rolls critical damage when critical is true', async () => {
+    const actor = makeStrikeActor();
+    setupFoundry({ actor });
+
+    await invokeActorActionHandler({
+      actorId: 'actor1',
+      action: 'roll-strike-damage',
+      params: { strikeSlug: 'longsword', critical: true },
+    });
+
+    const strike = (actor.system as { actions: Array<{ damage: jest.Mock; critical: jest.Mock }> }).actions[0]!;
+    expect(strike.critical).toHaveBeenCalledWith({});
+    expect(strike.damage).not.toHaveBeenCalled();
+  });
+
+  it('throws when the strike has no damage/critical function for the requested mode', async () => {
+    const bareActor = makeActor({
+      system: {
+        actions: [{ slug: 'longsword' }],
+      },
+    });
+    setupFoundry({ actor: bareActor });
+
+    await expect(
+      invokeActorActionHandler({
+        actorId: 'actor1',
+        action: 'roll-strike-damage',
+        params: { strikeSlug: 'longsword' },
+      }),
+    ).rejects.toThrow(/has no damage roll/);
+
+    delete (globalThis as unknown as Record<string, unknown>)['game'];
+    setupFoundry({ actor: bareActor });
+    await expect(
+      invokeActorActionHandler({
+        actorId: 'actor1',
+        action: 'roll-strike-damage',
+        params: { strikeSlug: 'longsword', critical: true },
+      }),
+    ).rejects.toThrow(/has no critical roll/);
+  });
+});
+
+describe('invokeActorActionHandler — post-item-to-chat', () => {
+  it('calls item.toMessage() and returns {ok, itemId, itemName}', async () => {
+    const item = makeItem({ id: 'item-xyz', name: 'Sword of Truth' });
+    const actor = makeActor();
+    actor.items.get.mockReturnValue(item);
+    setupFoundry({ actor });
+
+    const result = await invokeActorActionHandler({
+      actorId: 'actor1',
+      action: 'post-item-to-chat',
+      params: { itemId: 'item-xyz' },
+    });
+
+    expect(actor.items.get).toHaveBeenCalledWith('item-xyz');
+    expect(item.toMessage).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ ok: true, itemId: 'item-xyz', itemName: 'Sword of Truth' });
+  });
+
+  it('throws when the item is not on the actor', async () => {
+    const actor = makeActor();
+    actor.items.get.mockReturnValue(undefined);
+    setupFoundry({ actor });
+
+    await expect(
+      invokeActorActionHandler({
+        actorId: 'actor1',
+        action: 'post-item-to-chat',
+        params: { itemId: 'ghost' },
+      }),
+    ).rejects.toThrow(/item ghost not found/);
+  });
+
+  it('requires itemId', async () => {
+    setupFoundry({ actor: makeActor() });
+    await expect(
+      invokeActorActionHandler({ actorId: 'actor1', action: 'post-item-to-chat', params: {} }),
+    ).rejects.toThrow(/params\.itemId is required/);
   });
 });

--- a/apps/player-portal/mock/api-middleware.ts
+++ b/apps/player-portal/mock/api-middleware.ts
@@ -10,6 +10,15 @@
 //   PATCH /api/mcp/actors/:id            → merges the body's `flags` into
 //                                          the in-memory flag store and
 //                                          returns an ActorRef-shaped ack
+//   POST /api/mcp/actors/:id/actions/:action
+//                                        → no-op stub that acks `{ok: true}`;
+//                                          lets the SPA exercise action
+//                                          buttons without a live bridge
+//   GET  /api/mcp/compendium/document    → synthetic document built from
+//                                          the requested UUID's tail
+//                                          segment, so formula / feat /
+//                                          item detail panes render
+//                                          populated state
 //   POST /api/mcp/uploads                → decodes the base64 body into an
 //                                          in-memory buffer keyed by its
 //                                          relative path; later asset-
@@ -126,6 +135,56 @@ export function mockApi(fixturesDir: string): Plugin {
                 img: actor.img,
                 folder: null,
               });
+            })
+            .catch((err: unknown) => {
+              sendJson(res, 400, { error: err instanceof Error ? err.message : 'invalid body' });
+            });
+          return;
+        }
+
+        // Synthetic compendium document resolver. Derives a human name
+        // from the UUID's tail ("Compendium.pf2e.equipment-srd.Item.bomb-lesser"
+        // → "Bomb Lesser"), so formula / feat / item detail panes have
+        // *something* to show in mock mode. The real resolver runs on
+        // the live bridge in non-mock dev and in production.
+        const compendiumDocMatch = /^\/api\/mcp\/compendium\/document(?:\?.*)?$/.exec(url);
+        if (method === 'GET' && compendiumDocMatch) {
+          const uuid = new URLSearchParams(url.split('?')[1] ?? '').get('uuid') ?? '';
+          if (uuid.length === 0) {
+            sendJson(res, 400, { error: 'uuid query parameter is required' });
+            return;
+          }
+          const tail = uuid.split('.').pop() ?? uuid;
+          const name = tail
+            .split('-')
+            .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+            .join(' ');
+          sendJson(res, 200, {
+            document: {
+              id: tail,
+              uuid,
+              name,
+              type: 'consumable',
+              img: `icons/mock/${tail}.svg`,
+              system: {
+                level: { value: 1 },
+                traits: { value: ['mock', 'alchemical'], rarity: 'common' },
+                price: { value: { gp: 3 } },
+                description: { value: `<p>Mock description for <strong>${name}</strong>.</p>` },
+              },
+            },
+          });
+          return;
+        }
+
+        // Generic outbound-action passthrough. The live bridge dispatches
+        // per action; the mock just acks so the SPA's optimistic path
+        // works without a backend.
+        const actionMatch = /^\/api\/mcp\/actors\/([^/?]+)\/actions\/([^/?]+)(?:\?.*)?$/.exec(url);
+        if (method === 'POST' && actionMatch) {
+          readJsonBody(req)
+            .then(() => {
+              sendJson(res, 200, { ok: true });
             })
             .catch((err: unknown) => {
               sendJson(res, 400, { error: err instanceof Error ? err.message : 'invalid body' });

--- a/apps/player-portal/src/api/client.ts
+++ b/apps/player-portal/src/api/client.ts
@@ -60,18 +60,6 @@ export interface LongRestResponse {
   messageCount: number;
 }
 
-export type ActorType = 'character' | 'npc' | 'hazard' | 'loot' | 'party' | 'vehicle' | 'familiar';
-
-export interface RunActorScriptOptions {
-  actorId: string;
-  /** If set, throws before running `body` when the actor's type doesn't match. */
-  requireType?: ActorType;
-  /** JS body that runs inside an async IIFE with `actor` in scope. Must
-   *  `return` a JSON-serializable value — Foundry Documents need
-   *  `.toObject(false)` first. */
-  body: string;
-}
-
 async function request<T>(path: string, opts: RequestOptions = {}): Promise<T> {
   const method = opts.method ?? 'GET';
   const init: RequestInit = {
@@ -184,84 +172,35 @@ export const api = {
     request<{ ok: boolean }>(`/prompts/${bridgeId}/resolve`, { method: 'POST', body: { value } }),
   uploadAsset: (body: UploadAssetBody): Promise<UploadAssetResult> =>
     request<UploadAssetResult>('/uploads', { method: 'POST', body }),
-  // Runs `body` inside an async IIFE in the Foundry page with an `actor`
-  // local pre-resolved from the given id. Fails with a clear message if the
-  // actor doesn't exist or doesn't match `requireType`. `body` must
-  // explicitly `return` — JS has no implicit last-expression return. Hits
-  // /api/eval, so the server must have ALLOW_EVAL=1 for this to work at
-  // all; promote a call site to a typed command when the eval gate
-  // becomes a problem.
-  runActorScript: <T = unknown>(opts: RunActorScriptOptions): Promise<T> => {
-    const typeCheck =
-      opts.requireType !== undefined
-        ? `if (actor.type !== ${JSON.stringify(opts.requireType)}) throw new Error('Actor is not a ' + ${JSON.stringify(opts.requireType)});`
-        : '';
-    const script = `
-      const actor = game.actors.get(${JSON.stringify(opts.actorId)});
-      if (!actor) throw new Error('Actor not found: ' + ${JSON.stringify(opts.actorId)});
-      ${typeCheck}
-      ${opts.body}
-    `;
-    return request<T>('/eval', { method: 'POST', body: { script } });
-  },
+  // Crafts a formula via the pf2e `Craft` activity. pf2e resolves the
+  // item UUID internally, so the SPA passes the formula's compendium
+  // UUID + quantity; the action fires a Crafting skill check chat
+  // card and, on success, creates the item in the actor's inventory.
+  // Actor state refresh comes via the `actors` event channel.
+  craft: (id: string, itemUuid: string, quantity = 1): Promise<{ ok: boolean }> =>
+    api.invokeActorAction<{ ok: boolean }>(id, 'craft', { itemUuid, quantity }),
+  // pf2e Rest for the Night — daily prep, HP heal, spell slot reset,
+  // resource refresh. `messageCount` echoes how many chat messages
+  // the activity produced so the SPA can display "N recovery
+  // results" if it wants to.
   longRest: (id: string): Promise<LongRestResponse> =>
-    api.runActorScript<LongRestResponse>({
-      actorId: id,
-      requireType: 'character',
-      body: `
-        const messages = await game.pf2e.actions.restForTheNight({ actors: [actor], skipDialog: true });
-        return { ok: true, messageCount: messages.length };
-      `,
-    }),
-  // Rolls a single MAP variant of a Strike. variantIndex 0/1/2 maps to
-  // first attack / second (MAP) / third (MAP2). The PF2e `StrikeData`
-  // lives at `actor.system.actions[i]` and each variant exposes its
-  // own `roll()` that bakes in the MAP penalty.
+    api.invokeActorAction<LongRestResponse>(id, 'rest-for-the-night'),
+  // Rolls a single MAP variant of a Strike. `variantIndex` 0/1/2 maps
+  // to first attack / second (−5 MAP) / third (−10 MAP). pf2e's
+  // `StrikeData.variants[i].roll()` bakes in the MAP penalty.
   rollStrike: (id: string, strikeSlug: string, variantIndex: number): Promise<{ ok: boolean }> =>
-    api.runActorScript<{ ok: boolean }>({
-      actorId: id,
-      requireType: 'character',
-      body: `
-        const strike = actor.system.actions.find(s => s.slug === ${JSON.stringify(strikeSlug)});
-        if (!strike) throw new Error('Strike not found: ' + ${JSON.stringify(strikeSlug)});
-        const variant = strike.variants?.[${variantIndex.toString()}];
-        if (!variant) throw new Error('Strike variant ${variantIndex.toString()} not available');
-        await variant.roll({});
-        return { ok: true };
-      `,
-    }),
+    api.invokeActorAction<{ ok: boolean }>(id, 'roll-strike', { strikeSlug, variantIndex }),
+  // Rolls regular or critical damage for a Strike, based on the attack
+  // outcome the SPA reads from the chat card.
   rollStrikeDamage: (id: string, strikeSlug: string, critical: boolean): Promise<{ ok: boolean }> =>
-    api.runActorScript<{ ok: boolean }>({
-      actorId: id,
-      requireType: 'character',
-      body: `
-        const strike = actor.system.actions.find(s => s.slug === ${JSON.stringify(strikeSlug)});
-        if (!strike) throw new Error('Strike not found: ' + ${JSON.stringify(strikeSlug)});
-        if (${critical.toString()}) {
-          if (typeof strike.critical !== 'function') throw new Error('Strike has no critical roll');
-          await strike.critical({});
-        } else {
-          if (typeof strike.damage !== 'function') throw new Error('Strike has no damage roll');
-          await strike.damage({});
-        }
-        return { ok: true };
-      `,
-    }),
-  // Posts an item's action card to chat — the same behaviour as the
-  // pf2e sheet's "send to chat" button on an action/reaction/free
+    api.invokeActorAction<{ ok: boolean }>(id, 'roll-strike-damage', { strikeSlug, critical }),
+  // Posts an owned item's action card to chat — mirrors the pf2e
+  // sheet's "send to chat" button on an action / reaction / free
   // action. Consumable charge consumption is left to whoever clicks
-  // the roll buttons inside the posted card.
-  useItem: (id: string, itemId: string): Promise<{ ok: boolean }> =>
-    api.runActorScript<{ ok: boolean }>({
-      actorId: id,
-      requireType: 'character',
-      body: `
-        const item = actor.items.get(${JSON.stringify(itemId)});
-        if (!item) throw new Error('Item not found: ' + ${JSON.stringify(itemId)});
-        await item.toMessage();
-        return { ok: true };
-      `,
-    }),
+  // the roll buttons inside the posted card. Distinct from the typed
+  // `use-item` command, which runs the full activation pipeline.
+  useItem: (id: string, itemId: string): Promise<{ ok: boolean; itemId: string; itemName: string }> =>
+    api.invokeActorAction<{ ok: boolean; itemId: string; itemName: string }>(id, 'post-item-to-chat', { itemId }),
   listCompendiumSources: (
     opts: {
       documentType?: string;

--- a/apps/player-portal/src/components/tabs/Crafting.tsx
+++ b/apps/player-portal/src/components/tabs/Crafting.tsx
@@ -7,9 +7,11 @@ import type {
   CraftingFormulaEntry,
   PreparedFormulaData,
 } from '../../api/types';
+import { useActorAction } from '../../lib/useActorAction';
 import { SectionHeader } from '../common/SectionHeader';
 
 interface Props {
+  actorId: string;
   crafting: CraftingField;
 }
 
@@ -27,7 +29,7 @@ type Resolution =
 // code changes. Daily-prep mutations (prep/expend slots) aren't part of
 // this read-only phase; see the standalone-play-surface plan for the
 // outbound-actions step.
-export function Crafting({ crafting }: Props): React.ReactElement {
+export function Crafting({ actorId, crafting }: Props): React.ReactElement {
   const formulas = crafting.formulas;
   const entries = useMemo(
     // Sort by label for deterministic rendering — Object.values order
@@ -47,7 +49,12 @@ export function Crafting({ crafting }: Props): React.ReactElement {
         ) : (
           <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
             {formulas.map((formula) => (
-              <FormulaCard key={formula.uuid} formula={formula} resolution={resolutions.get(formula.uuid)} />
+              <FormulaCard
+                key={formula.uuid}
+                actorId={actorId}
+                formula={formula}
+                resolution={resolutions.get(formula.uuid)}
+              />
             ))}
           </ul>
         )}
@@ -68,9 +75,11 @@ export function Crafting({ crafting }: Props): React.ReactElement {
 }
 
 function FormulaCard({
+  actorId,
   formula,
   resolution,
 }: {
+  actorId: string;
   formula: CraftingFormulaEntry;
   resolution: Resolution | undefined;
 }): React.ReactElement {
@@ -78,6 +87,16 @@ function FormulaCard({
   const name = state.kind === 'ok' ? state.document.name : null;
   const img = state.kind === 'ok' ? state.document.img : null;
   const level = state.kind === 'ok' ? readLevel(state.document) : null;
+
+  // Use the shared state-machine hook so the button cycles idle →
+  // pending → idle (or error) without reinventing the wheel. The
+  // action is safe to fire even while the formula is still resolving
+  // — the bridge handler accepts raw compendium UUIDs.
+  const craft = useActorAction({
+    run: () => api.craft(actorId, formula.uuid, 1),
+  });
+  const pending = craft.state === 'pending';
+  const craftError = typeof craft.state === 'object' ? craft.state.error : null;
 
   return (
     <li
@@ -100,14 +119,30 @@ function FormulaCard({
         {state.kind === 'ok' && name !== null && (
           <span className="block truncate text-sm font-medium text-pf-text">{name}</span>
         )}
+        {craftError !== null && <span className="mt-1 block truncate text-[10px] text-red-700">{craftError}</span>}
       </div>
-      <div className="flex flex-shrink-0 flex-col items-end gap-0.5">
-        {level !== null && (
-          <span className="font-mono text-[10px] uppercase tracking-widest text-pf-alt-dark">Lv {level}</span>
-        )}
-        {formula.batch !== undefined && formula.batch > 1 && (
-          <span className="font-mono text-[10px] uppercase tracking-widest text-pf-alt-dark">×{formula.batch}</span>
-        )}
+      <div className="flex flex-shrink-0 flex-col items-end gap-1">
+        <div className="flex items-center gap-1.5">
+          {level !== null && (
+            <span className="font-mono text-[10px] uppercase tracking-widest text-pf-alt-dark">Lv {level}</span>
+          )}
+          {formula.batch !== undefined && formula.batch > 1 && (
+            <span className="font-mono text-[10px] uppercase tracking-widest text-pf-alt-dark">
+              ×{formula.batch}
+            </span>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            void craft.trigger();
+          }}
+          disabled={pending}
+          className="rounded border border-pf-primary bg-pf-primary/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest text-pf-primary hover:bg-pf-primary/20 disabled:cursor-not-allowed disabled:opacity-50"
+          data-craft-uuid={formula.uuid}
+        >
+          {pending ? 'Crafting…' : 'Craft'}
+        </button>
       </div>
     </li>
   );

--- a/apps/player-portal/src/routes/CharacterSheet.tsx
+++ b/apps/player-portal/src/routes/CharacterSheet.tsx
@@ -182,7 +182,7 @@ function CharacterSheetInner({ actorId, onBack, preferences }: InnerProps): Reac
           {activeTab === 'inventory' && (
             <Inventory items={state.actor.items} actorId={actorId} onActorChanged={reloadActor} />
           )}
-          {activeTab === 'crafting' && <Crafting crafting={state.actor.system.crafting} />}
+          {activeTab === 'crafting' && <Crafting actorId={actorId} crafting={state.actor.system.crafting} />}
           {activeTab === 'feats' && <Feats items={state.actor.items} />}
           {activeTab === 'proficiencies' && <Proficiencies system={state.actor.system} />}
           {activeTab === 'progression' && (


### PR DESCRIPTION
## Summary

Replaces [#46](https://github.com/AlexDickerson/foundry-toolkit/pull/46), which GitHub marked MERGED but whose commits never reached `main` — #46 was stacked on `consolidate-registry-pure` (PR #44's branch), and when #44 squash-merged and auto-deleted that branch, #46's merge target vanished. This PR rebases the same commit onto current `main`; the diff is identical to what #46 was meant to land.

## What this restores on main

Removes every `/api/eval` dependency from the player-portal play-surface and adds the Craft button, routing five new actions through the `invoke-actor-action` registry from #44:

| Action slug | Foundry call |
|---|---|
| `craft` | `game.pf2e.actions.craft({uuid, actors, quantity})` |
| `rest-for-the-night` | `game.pf2e.actions.restForTheNight({actors, skipDialog: true})` |
| `roll-strike` | `actor.system.actions[slug].variants[i].roll({})` |
| `roll-strike-damage` | `strike.damage({})` or `.critical({})` |
| `post-item-to-chat` | `actor.items.get(id).toMessage()` |

SPA: `api.longRest / rollStrike / rollStrikeDamage / useItem` keep their call signatures, now delegate to `api.invokeActorAction`. New `api.craft(id, uuid, quantity?)`. `runActorScript` + eval-only helpers removed (no other callers). Crafting tab renders a per-formula Craft button with the shared `useActorAction` hook.

Mock middleware gains `GET /api/mcp/compendium/document?uuid=…` (synthetic doc) and `POST /api/mcp/actors/:id/actions/:action` (ack stub) so detail panes + action buttons exercise under `dev:mock` without a live bridge.

21 new Jest cases across the five action handlers; bridge suite 684 → 705.

## Why the redo was needed

Stacked PRs (`--base feature-branch`) are fragile with auto-squash + auto-delete: when the parent squash-merges, the child's base vanishes and GitHub may show the child as MERGED even though its commits aren't on `main`. Fix going forward: open follow-ups against `main` after the parent lands, even if it means a tiny manual rebase.

## Test plan
- [x] Identical diff to #46 (just rebased from `consolidate-registry-pure` HEAD onto `main`'s post-#44 HEAD — no conflicts)
- [ ] CI re-runs on the rebased commit; expecting the same green as #46 had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)