### PR TITLE
Restore centered max-width wrapper on character creator/sheet

### DIFF
--- a/apps/player-portal/src/routes/CharacterCreator.tsx
+++ b/apps/player-portal/src/routes/CharacterCreator.tsx
@@ -363,7 +363,7 @@ export function CharacterCreator(): React.ReactElement {
   const pickerFilters = openPicker !== null ? filtersForTarget(openPicker, draft) : undefined;
 
   return (
-    <div>
+    <main className="mx-auto max-w-3xl p-6 font-sans">
       <div className="mb-4 flex items-center gap-3">
         <button
           type="button"
@@ -537,7 +537,7 @@ export function CharacterCreator(): React.ReactElement {
       {/* Module-driven prompts (pf2e ChoiceSets) render on top of
           everything else so the wizard pauses until the user picks. */}
       {activePrompt !== null && <PromptModal prompt={activePrompt} />}
-    </div>
+    </main>
   );
 }
 

--- a/apps/player-portal/src/routes/CharacterSheet.tsx
+++ b/apps/player-portal/src/routes/CharacterSheet.tsx
@@ -119,7 +119,7 @@ function CharacterSheetInner({ actorId, onBack, preferences }: InnerProps): Reac
   });
 
   return (
-    <div>
+    <main className="mx-auto max-w-3xl p-6 font-sans">
       {state.kind === 'loading' && (
         <div className="mb-4 flex items-center justify-between">
           <p className="text-sm text-neutral-500">Loading character…</p>
@@ -207,7 +207,7 @@ function CharacterSheetInner({ actorId, onBack, preferences }: InnerProps): Reac
           }}
         />
       )}
-    </div>
+    </main>
   );
 }
 


### PR DESCRIPTION
## Summary

- The standalone character-creator's `App.tsx` wrapped every view in `<main className=\"mx-auto max-w-3xl p-6 font-sans\">`. When it was folded into player-portal in #41, that wrapper was dropped — only [Characters.tsx](apps/player-portal/src/routes/Characters.tsx:7) (the list route) got its own copy.
- [CharacterCreator.tsx](apps/player-portal/src/routes/CharacterCreator.tsx) and [CharacterSheet.tsx](apps/player-portal/src/routes/CharacterSheet.tsx) were left as bare `<div>`s, so their content spanned the full viewport width with no padding or sans-serif font.
- Swap those bare `<div>`s for `<main className=\"mx-auto max-w-3xl p-6 font-sans\">` to match `Characters` and the pre-merge behavior.

## Test plan

- [x] `npm run typecheck --workspace apps/player-portal` clean
- [x] `npm run format:check` clean
- [x] `npm run lint --workspace apps/player-portal` — 0 errors, 29 pre-existing warnings
- [x] Manual verification via `dev:mock` at 1280px viewport: `main.mx-auto` on `/characters/new` computes to `max-width: 768px`, `margin-left/right: 248.5px` (centered), `padding: 24px`, `font-family: Roboto` (sans-serif).
- [ ] Spot-check `/characters` list and `/characters/:actorId` in a live environment look unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)