### PR TITLE
Cleanup pass 1: docs + foundry-mcp un-bundling + CI/knip coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,9 @@ jobs:
           npm run test --workspace apps/dm-tool
           npm run test --workspace apps/player-portal
           npm run test --workspace apps/foundry-api-bridge
+          npm run test --workspace apps/foundry-mcp
           npm run test --workspace packages/shared
+          npm run test --workspace packages/pf2e-rules
 
   electronegativity:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ coverage/
 
 # Build outputs
 out/
+/dist/
 apps/dm-tool/out/
 apps/dm-tool/dist/
 apps/player-portal/dist/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Monorepo consolidating four Foundry VTT companion tools. npm-workspaces, no Turb
 - TypeScript 6, shared strict config in `tsconfig.base.json` (ES2022, Bundler moduleResolution, `noUnusedLocals` / `noUnusedParameters` on).
 - ESLint 10 flat config (`eslint.config.js`), `typescript-eslint`, `eslint-config-prettier`.
 - Prettier 3 (`.prettierrc`): 120-col, `trailingComma: all`, `singleQuote: true`, `semi: true`.
-- `@electron/rebuild` at root for `better-sqlite3` postinstall.
+- `@electron/rebuild` at root; `apps/dm-tool` owns the `better-sqlite3` rebuild via its own `postinstall`.
 
 ## Workspaces
 
@@ -25,7 +25,7 @@ Every workspace has its own `CLAUDE.md` covering app-specific details.
 
 ## Commands (root)
 
-- `npm install` — installs all workspaces; `postinstall` rebuilds `better-sqlite3` for Electron's ABI.
+- `npm install` — installs all workspaces; `apps/dm-tool`'s own `postinstall` rebuilds `better-sqlite3` against Electron's ABI. Other workspaces don't pay that cost.
 - `npm run rebuild-sqlite` — manual escape hatch if the native module ever gets out of sync.
 - `npm run dev:dm-tool` / `dev:mcp` / `dev:player-portal` / `dev:player-portal:mock` / `dev:api-bridge` — each targets one workspace.
 - `npm run typecheck` / `test` / `build` / `format` / `format:check` — fan out via `--workspaces --if-present`.
@@ -33,7 +33,11 @@ Every workspace has its own `CLAUDE.md` covering app-specific details.
 
 ## Root ESLint scope
 
-`eslint.config.js` explicitly ignores `apps/player-portal`, `apps/foundry-mcp`, `apps/foundry-api-bridge`, plus all `dist/`, `out/`, `server-dist/`, `tagger/`, `resources/`, and `.claude/`. The root ESLint pass therefore only covers **`apps/dm-tool` + `packages/*`**. The three excluded apps lint via their own workspace scripts.
+`eslint.config.js` explicitly ignores `apps/player-portal`, `apps/foundry-mcp`, `apps/foundry-api-bridge`, plus all `dist/`, `out/`, `server-dist/`, `tagger/`, `resources/`, and `.claude/`. The root ESLint pass therefore only covers **`apps/dm-tool` + `packages/*` + `tools/*`**. The three excluded apps lint via their own workspace scripts.
+
+`packages/*` deliberately do not declare their own `lint` scripts — they rely entirely on the root ESLint pass. Adding workspace-local lint scripts would re-lint the same files in CI.
+
+`knip.json` has explicit per-workspace entries for every workspace, including `packages/*`. Running `npm run knip` covers the full tree.
 
 If monorepo CI ever flags lint in ported/vendored code (pf2e SCSS in player-portal, forked Foundry module), scope CI — don't edit the source files.
 
@@ -48,5 +52,5 @@ If monorepo CI ever flags lint in ported/vendored code (pf2e SCSS in player-port
 
 - `tagger/` is a Python subtool with its own build system; `auto-wall-bin/` holds a prebuilt binary. Neither is an npm workspace. `apps/dm-tool`'s electron-builder config references `../../tagger/dist/map-tagger.exe` and `../../auto-wall-bin/Auto-Wall.exe` as `extraResources` — both must exist at packaging time.
 - `.env` at the monorepo root holds Foundry credentials, `OPENAI_API_KEY`, and `ALLOW_EVAL`. Never commit it.
-- Deployments (Fly.io for `foundry-mcp`, electron-builder for `dm-tool`, GHCR images for `foundry-api-bridge` and `player-portal`) and CI workflows were **deferred** during consolidation — per-app Dockerfile and fly.toml references still point at the pre-consolidation GHCR repos. Re-point when productionizing.
+- A minimal lint/typecheck/test/knip pipeline runs in `.github/workflows/ci.yml` plus a dependency-review check. Per-app deployment workflows (Docker publish, Fly deploy) from the pre-consolidation repos were **not** ported. Per-app Dockerfile and fly.toml references still point at the pre-consolidation GHCR repos. Re-point when productionizing.
 - The old SPA → MCP rebuild cascade is gone: the character creator now lives inside `player-portal`'s own Fastify server, which proxies `/api/mcp/*` → `foundry-mcp`. `foundry-mcp` no longer bundles an SPA.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # foundry-toolkit
 
-Monorepo consolidating the Foundry VTT companion tools. Previously five separate repos; collapsed into one npm-workspaces monorepo.
+Monorepo consolidating four Foundry VTT companion tools into one npm-workspaces project.
 
 ## Layout
 
@@ -18,6 +18,7 @@ foundry-toolkit/
 ├── packages/
 │   ├── ai/                   PF2e GM assistant agents (chat, hooks, loot, classifier)
 │   ├── db/                   Data layer (pf2e.db, BookDb, MapDb)
+│   ├── pf2e-rules/           Pure PF2e rules math (XP budgets, treasure tables)
 │   └── shared/               Types + shared UI
 ├── resources/                dm-tool Electron icons
 ├── tagger/                   Python map-indexing subtool (built separately)
@@ -28,10 +29,11 @@ foundry-toolkit/
 
 ## Scripts (root)
 
-- `npm install` — installs everything + rebuilds better-sqlite3 for Electron
+- `npm install` — installs everything + rebuilds better-sqlite3 for dm-tool's Electron ABI
 - `npm run typecheck` — type-check all workspaces
 - `npm run test` — run all workspace test suites
 - `npm run lint` — root ESLint + per-workspace lint scripts
+- `npm run knip` — dead-code/unused-deps scan across the workspaces listed in `knip.json`
 - `npm run build` — build all workspaces
 - `npm run dev:dm-tool` — launch dm-tool Electron dev
 - `npm run dev:mcp` — launch foundry-mcp server
@@ -42,10 +44,10 @@ foundry-toolkit/
 
 See each workspace's README / CLAUDE.md for app-specific details.
 
-## Deferred from consolidation
+## CI and deployment
 
-- **CI**: per-repo GitHub Actions workflows were not ported. Minimal CI TBD.
-- **Deployments**: Fly.io (foundry-mcp), electron-builder (dm-tool), GHCR images (api-bridge, player-portal) all still reference the old repos. Re-point when productionizing.
+- **CI**: a minimal lint/typecheck/test/knip pipeline runs in [.github/workflows/ci.yml](.github/workflows/ci.yml). Per-app workflows (Docker publish, Fly deploy) from the pre-consolidation repos were not ported.
+- **Deployments**: Fly.io (foundry-mcp), electron-builder (dm-tool), GHCR images (api-bridge, player-portal) all still reference the old per-repo identifiers. Re-point when productionizing.
 - **Branches**: feature branches stay in the source repos until explicitly carried over.
 
 ## License

--- a/apps/dm-tool/package.json
+++ b/apps/dm-tool/package.json
@@ -16,7 +16,8 @@
     "test:coverage": "vitest run --coverage",
     "package": "electron-vite build && electron-builder --win",
     "package:dir": "electron-vite build && electron-builder --win --dir",
-    "package:ci": "electron-vite build && electron-builder --win --publish never"
+    "package:ci": "electron-vite build && electron-builder --win --publish never",
+    "postinstall": "electron-rebuild -f -w better-sqlite3"
   },
   "build": {
     "appId": "com.alexdickerson.dm-tool",

--- a/apps/foundry-api-bridge/dist/module.json
+++ b/apps/foundry-api-bridge/dist/module.json
@@ -2,7 +2,7 @@
   "id": "foundry-api-bridge",
   "title": "Foundry API Bridge (Foundry MCP)",
   "description": "Self-hosted bridge that exposes Foundry VTT to a local MCP server over WebSocket. The GM-side module receives JSON commands (rolls, combat, scenes, journals, tokens, tables, etc.) and replies with results. No outbound traffic.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "authors": [
     {
       "name": "Alex Dickerson",

--- a/apps/foundry-api-bridge/src/main.ts
+++ b/apps/foundry-api-bridge/src/main.ts
@@ -110,7 +110,8 @@ import {
   type SetEventSubscriptionParams,
 } from '@/commands';
 
-const MODULE_VERSION = '7.7.0';
+// Keep in sync with `package.json#version` and `dist/module.json#version`.
+const MODULE_VERSION = '1.3.0';
 
 let wsClients: WebSocketClient[] = [];
 let commandRouter: CommandRouter | null = null;

--- a/apps/foundry-mcp/CLAUDE.md
+++ b/apps/foundry-mcp/CLAUDE.md
@@ -1,6 +1,6 @@
 # foundry-mcp
 
-Self-hosted MCP server that bridges Claude Code (or any MCP client) to a live Foundry VTT instance. Pairs with the [foundry-api-bridge](../foundry-api-bridge/) module running in the GM's browser tab, plus the [character-creator](../character-creator/) SPA for the REST-driven character creator UI.
+Self-hosted MCP server that bridges Claude Code (or any MCP client) to a live Foundry VTT instance. Pairs with the [foundry-api-bridge](../foundry-api-bridge/) module running in the GM's browser tab. Sibling [player-portal](../player-portal/) consumes the REST surface via its `/api/mcp/*` reverse proxy.
 
 Part of the foundry-toolkit monorepo at `apps/foundry-mcp` — see the root [CLAUDE.md](../../CLAUDE.md) for cross-workspace context.
 
@@ -31,14 +31,14 @@ Default ports:
 - `src/tools/` — MCP tool implementations
 - `src/bridge.ts` — WebSocket bridge to Foundry module
 - `src/events/` — Multi-channel SSE pool + subscription lifecycle (see Event Channels below)
-- `src/http/` — Fastify REST surface (consumed by foundry-character-creator)
+- `src/http/` — Fastify REST surface (consumed by player-portal via its `/api/mcp/*` proxy)
 - `src/config.ts`, `src/logger.ts`
 - `src/index.ts` — Entry point
 - `_http/` — REST Client `.http` files for interactive endpoint testing
 
 ## Event Channels
 
-SSE pub/sub for live Foundry events (rolls, chat, combat). External consumers — dm-tool, character-creator, Discord bots, stream overlays — subscribe to a named channel and receive events as they fire. `Hooks.on` registrations on the Foundry side are lazy: the module only listens while at least one subscriber is connected, so an idle server pushes nothing.
+SSE pub/sub for live Foundry events (rolls, chat, combat). External consumers — dm-tool, player-portal, Discord bots, stream overlays — subscribe to a named channel and receive events as they fire. `Hooks.on` registrations on the Foundry side are lazy: the module only listens while at least one subscriber is connected, so an idle server pushes nothing.
 
 ### Architecture
 
@@ -77,7 +77,7 @@ The `actors` channel pushes a flattened `{ actorId, changedPaths }` diff for eve
 
 ### Testing
 
-`test/channel-manager.test.ts` covers pool invariants: 0↔1 transitions, fan-out, dead-subscriber pruning, idempotent unsubscribe, independent channels, callback errors. Module-side integration lives in the bridge repo's Jest suite.
+`test/channel-manager.test.ts` covers pool invariants: 0↔1 transitions, fan-out, dead-subscriber pruning, idempotent unsubscribe, independent channels, callback errors. Module-side integration lives in `apps/foundry-api-bridge`'s Jest suite.
 
 ## Git Workflow
 
@@ -89,12 +89,10 @@ The `actors` channel pushes a flattened `{ actorId, changedPaths }` diff for eve
 
 ## Deployment
 
-Primary deploy target: **Fly.io**, from a Docker image published to GHCR.
+Primary deploy target: **Fly.io**, from a Docker image published to GHCR. The deploy workflows from the pre-consolidation `foundry-mcp` repo were not ported into the monorepo — re-point when productionizing.
 
-- `Dockerfile` — multi-stage build: compiles the server, pulls the prebuilt SPA bundle from `ghcr.io/alexdickerson/foundry-character-creator:latest`, and serves both from a single Node process on `$PORT` (defaults to 8080 in the container, 8765 for local dev).
+- `Dockerfile` — multi-stage build: compiles the server, runs as a single Node process on `$PORT` (defaults to 8080 in the container, 8765 for local dev). The SPA used to be bundled here; that's gone — `apps/player-portal` is a separate deployable that proxies `/api/mcp/*` here.
 - `fly.toml` — Fly Machines config. `min_machines_running=1` + `auto_stop_machines=false` because the Foundry module's outbound WebSocket to `/foundry` must stay connected.
-- `.github/workflows/docker.yml` — builds + smoke-tests the image on PRs, publishes `ghcr.io/alexdickerson/foundry-mcp:{latest,version,sha}` on merges to main.
-- `.github/workflows/fly-deploy.yml` — triggers on successful Docker workflow completion on main (or via `workflow_dispatch`) and runs `flyctl deploy --remote-only --image ghcr.io/.../foundry-mcp:latest`. Requires the `FLY_API_TOKEN` secret.
 
 First-time setup:
 
@@ -103,7 +101,7 @@ fly launch --no-deploy              # creates the app; adjust name in fly.toml i
 fly secrets set OPENAI_API_KEY=...  # required for edit_image
 ```
 
-The Foundry module points its WebSocket at `wss://<app>.fly.dev/foundry`; MCP clients hit `https://<app>.fly.dev/mcp`; the character-creator SPA loads at `https://<app>.fly.dev/`. All same-origin, one container, one port.
+The Foundry module points its WebSocket at `wss://<app>.fly.dev/foundry`; MCP clients hit `https://<app>.fly.dev/mcp`. The player-portal SPA is deployed separately and proxies `/api/mcp/*` here.
 
 **Alternative — systemd on a Foundry host** (the old setup, still supported since the server is plain `node dist/index.js`):
 
@@ -113,13 +111,11 @@ systemctl --user restart foundry-mcp   # restart
 journalctl --user -u foundry-mcp -f    # tail logs
 ```
 
-The Docker image for Foundry+module itself lives in [foundry-api-bridge](https://github.com/AlexDickerson/foundry-api-bridge); this repo's image only bundles the MCP server + SPA.
-
 ## Key Decisions
 
 - WebSocket bridge to Foundry lives at `/foundry`; the module opens the WS outbound from the GM browser.
-- REST `/api/*` exposes the same data the MCP tools see (actors, items, compendia, scenes, etc.) for the character-creator SPA.
+- REST `/api/*` exposes the same data the MCP tools see (actors, items, compendia, scenes, etc.). Currently consumed by `apps/player-portal` via its `/api/mcp/*` reverse proxy.
 - OpenAI SDK used specifically for GPT-image-1 map editing (not for chat).
-- Module and frontend live in sibling workspaces (`apps/foundry-api-bridge`, `apps/character-creator`); runtime contract between them stays WS (module) + REST (frontend). HTTP request/response schemas are shared via `@foundry-toolkit/shared/rpc` so server and SPA can't drift silently.
-- Server ships three ways: as a source zip (GitHub Releases, for systemd-on-Foundry-host), as a bare Node process, and as a Docker image on GHCR that bundles the character-creator SPA for single-container Fly.io deploys. The Foundry + module Docker image still lives in foundry-api-bridge; this repo's image is MCP server + SPA only.
-- The SPA bundle is pulled into the Dockerfile via `COPY --from=ghcr.io/alexdickerson/foundry-character-creator:latest` rather than bundled here — keeps the frontend on its own release cadence and avoids duplicate checkouts in CI.
+- Module and frontend live in sibling workspaces (`apps/foundry-api-bridge`, `apps/player-portal`); runtime contract between them stays WS (module) + REST (frontend). HTTP request/response schemas are shared via `@foundry-toolkit/shared/rpc` so server and frontend can't drift silently.
+- This repo's image is MCP server only. The character-creator SPA used to be co-bundled at build time via `COPY --from=ghcr.io/.../foundry-character-creator:latest`; that bundling went away when the SPA was absorbed into `apps/player-portal` and split out as its own deployable.
+- The Foundry + module Docker image still lives in foundry-api-bridge; this image only runs the MCP server.

--- a/apps/foundry-mcp/Dockerfile
+++ b/apps/foundry-mcp/Dockerfile
@@ -1,15 +1,8 @@
 # =============================================================================
-# foundry-mcp — unified server + SPA image
+# foundry-mcp — server image
 # Stage 1: compile TypeScript in a build image with dev deps.
-# Stage 2: slim runtime image that bundles the prebuilt SPA static assets
-#          (pulled from the sibling foundry-character-creator GHCR image).
+# Stage 2: slim runtime image with the compiled server + production deps only.
 # =============================================================================
-
-# SPA source image. Declared BEFORE the first FROM so it's in global scope
-# and usable in subsequent `FROM ${SPA_IMAGE}` lines. Overridable via
-# `--build-arg SPA_IMAGE=...` — see .github/workflows/docker.yml for the
-# CI fallback behaviour when the sibling image isn't reachable.
-ARG SPA_IMAGE=ghcr.io/alexdickerson/foundry-character-creator:latest
 
 # -- Build: compile TypeScript --
 FROM node:20-alpine AS build
@@ -29,14 +22,7 @@ RUN npm run build
 RUN npm prune --omit=dev
 
 
-# -- Static SPA assets --
-# Sibling repo publishes the built SPA as an image with index.html +
-# assets/ under /usr/share/nginx/html. We just need the files; we don't run
-# this image, we COPY --from it.
-FROM ${SPA_IMAGE} AS spa
-
-
-# -- Runtime: node 20 alpine with compiled JS + SPA + production node_modules --
+# -- Runtime: node 20 alpine with compiled JS + production node_modules --
 FROM node:20-alpine AS runtime
 
 WORKDIR /app
@@ -45,15 +31,11 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV PORT=8080
 ENV HOST=0.0.0.0
-ENV STATIC_ROOT=/app/public
 
 # Compiled server + production dependency tree.
 COPY --from=build /app/package.json ./package.json
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
-
-# SPA static bundle published by the sibling repo.
-COPY --from=spa /usr/share/nginx/html /app/public
 
 # wget is in busybox — used by the Docker HEALTHCHECK below.
 EXPOSE 8080

--- a/apps/foundry-mcp/README.md
+++ b/apps/foundry-mcp/README.md
@@ -7,13 +7,14 @@ Self-hosted MCP server that bridges Claude (or any MCP client) to a live Foundry
 ```
 MCP client ──HTTP──> foundry-mcp server ──WebSocket──> foundry-api-bridge (in GM browser)
                          (host:8765)                        (Foundry VTT v13+)
+                    ▲
                     │
-                    └──REST /api/*──> foundry-character-creator (React SPA)
+       /api/mcp/* proxy from sibling player-portal SPA
 ```
 
-- **This repo (`foundry-mcp`)** — Node.js MCP server using Streamable HTTP transport. Accepts MCP tool calls, translates them to Foundry commands, and relays them over a WebSocket to the GM's browser session. Also exposes a Fastify REST surface at `/api/*` for the character-creator UI, and handles asset uploads directly to the Foundry data directory.
-- **[foundry-api-bridge](https://github.com/AlexDickerson/foundry-api-bridge)** — Foundry VTT module that runs in the GM's browser tab. Receives commands via WebSocket, executes them against the Foundry API, returns results. Ships with its own Docker image that layers the module onto `felddy/foundryvtt`.
-- **[foundry-character-creator](https://github.com/AlexDickerson/foundry-character-creator)** — React SPA that consumes this server's `/api/*` endpoints for a Pathfinder 2e character creator/viewer.
+- **This repo (`foundry-mcp`)** — Node.js MCP server using Streamable HTTP transport. Accepts MCP tool calls, translates them to Foundry commands, and relays them over a WebSocket to the GM's browser session. Also exposes a Fastify REST surface at `/api/*` and handles asset uploads directly to the Foundry data directory.
+- **[foundry-api-bridge](../foundry-api-bridge/)** — Foundry VTT module that runs in the GM's browser tab. Receives commands via WebSocket, executes them against the Foundry API, returns results. Ships with its own Docker image that layers the module onto `felddy/foundryvtt`.
+- **[player-portal](../player-portal/)** — Sibling app that hosts the PF2e character creator/sheet SPA + live-sync server. Reverse-proxies `/api/mcp/*` here so the SPA can hit this server's REST surface same-origin.
 
 ## MCP Tools
 
@@ -50,22 +51,19 @@ MCP clients connect to `http://<host>:8765/mcp`. The Foundry module connects its
 
 ## Local development
 
-The server is runtime-independent. For a full local stack:
+The server is runtime-independent. For a full local stack (run from the monorepo root unless noted):
 
-1. Start the Foundry + module container from the [foundry-api-bridge](https://github.com/AlexDickerson/foundry-api-bridge) repo:
+1. Start the Foundry + module container from the sibling workspace:
    ```bash
-   cd ../foundry-api-bridge
+   cd apps/foundry-api-bridge
    ./local.sh up
    ```
-2. Run the server here (in this repo):
+2. Run the server:
    ```bash
-   npm install
-   npm run dev
+   npm run dev:mcp
    ```
 3. In Foundry, enable the foundry-api-bridge module and set the WebSocket URL to `ws://localhost:8765/foundry`.
-4. (Optional) Start the character-creator SPA from [foundry-character-creator](https://github.com/AlexDickerson/foundry-character-creator):
+4. (Optional) Run the player-portal SPA:
    ```bash
-   cd ../foundry-character-creator
-   npm install
-   npm run dev
+   npm run dev:player-portal
    ```

--- a/apps/foundry-mcp/package.json
+++ b/apps/foundry-mcp/package.json
@@ -9,7 +9,7 @@
     "start": "node --env-file-if-exists=.env dist/index.js",
     "lint": "eslint \"src/**/*.ts\"",
     "lint:fix": "eslint \"src/**/*.ts\" --fix",
-    "test": "tsx --test test/**/*.test.ts"
+    "test": "tsx --test test/*.test.ts"
   },
   "dependencies": {
     "@foundry-toolkit/shared": "*",

--- a/apps/foundry-mcp/package.json
+++ b/apps/foundry-mcp/package.json
@@ -12,7 +12,6 @@
     "test": "tsx --test test/**/*.test.ts"
   },
   "dependencies": {
-    "@fastify/static": "^9.1.2",
     "@foundry-toolkit/shared": "*",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "fastify": "^5.3.2",

--- a/apps/foundry-mcp/src/http/app.ts
+++ b/apps/foundry-mcp/src/http/app.ts
@@ -1,9 +1,5 @@
 import Fastify, { type FastifyInstance } from 'fastify';
-import fastifyStatic from '@fastify/static';
 import { ZodError } from 'zod/v4';
-import { resolve } from 'node:path';
-import { createReadStream } from 'node:fs';
-import { stat } from 'node:fs/promises';
 import { log } from '../logger.js';
 import { registerActorRoutes } from './routes/actors.js';
 import { registerAssetRoutes } from './routes/assets.js';
@@ -13,21 +9,16 @@ import { registerEventRoutes } from './routes/events.js';
 import { registerPromptRoutes } from './routes/prompts.js';
 import { registerUploadRoutes } from './routes/uploads.js';
 
-// Directory on disk containing the built character-creator SPA.
-// In the container image this is `/app/public`; for local dev (where the SPA
-// isn't bundled in) we fall back to `./public` — missing dir is fine, the
-// static plugin tolerates it and the SPA fallback simply won't fire.
-const STATIC_ROOT = process.env.STATIC_ROOT ?? resolve(process.cwd(), 'public');
-
 export async function buildHttpApp(): Promise<FastifyInstance> {
   // The parent http.Server routes `/api/*` and most other GETs into this
   // Fastify instance via `app.routing(req, res)` — see src/index.ts. The
   // parent has its own logger, so Fastify's is off to avoid double logs.
   const app = Fastify({ logger: false });
 
-  // Permissive CORS. Same-origin in the unified-container deploy, but kept
-  // for LAN-direct REST clients (the character-creator dev server, `_http/`
-  // scratchpads, etc.).
+  // Permissive CORS for LAN-direct REST clients (player-portal dev server,
+  // `_http/` scratchpads, etc.). In the deployed topology player-portal
+  // proxies `/api/mcp/*` here so the request is same-origin from its point
+  // of view.
   app.addHook('onRequest', async (req, reply) => {
     reply.header('Access-Control-Allow-Origin', '*');
     reply.header('Access-Control-Allow-Methods', 'GET, POST, PATCH, DELETE, OPTIONS');
@@ -77,11 +68,6 @@ export async function buildHttpApp(): Promise<FastifyInstance> {
     reply.code(500).send({ error: msg });
   });
 
-  // NOTE: route registration order matters. /api/* and /healthz are
-  // registered BEFORE @fastify/static so they take precedence over the
-  // static plugin's wildcard catch-all. The asset-proxy prefixes
-  // (/icons, /systems, /modules, /worlds, /ui) must also register
-  // before @fastify/static so they beat the SPA fallback.
   registerActorRoutes(app);
   registerAssetRoutes(app);
   registerCompendiumRoutes(app);
@@ -96,49 +82,14 @@ export async function buildHttpApp(): Promise<FastifyInstance> {
     reply.type('text/plain').send('ok');
   });
 
-  // Serve the character-creator SPA static bundle. In production this dir
-  // comes from `COPY --from=ghcr.io/.../foundry-character-creator` in the
-  // Dockerfile. `wildcard: false` prevents the plugin from handling
-  // arbitrary unmatched paths — we want SPA fallback (below) to catch those
-  // instead of returning the plugin's own 404.
-  await app.register(fastifyStatic, {
-    root: STATIC_ROOT,
-    prefix: '/',
-    wildcard: false,
-    decorateReply: false,
-  });
-
-  // Not-found handler. For API calls we stick to the JSON envelope; for
-  // other GETs we fall back to the SPA index (client-side routing). Any
-  // non-GET method on an unknown path is a 404 — POST/PUT/DELETE on
-  // unknown routes should not be rewritten to HTML.
+  // Plain JSON 404. This server is API-only after the SPA un-bundling
+  // (the SPA now lives in `apps/player-portal`), so there's no HTML
+  // fallback for unknown paths.
   app.setNotFoundHandler(async (req, reply) => {
-    const isApi = req.url.startsWith('/api/') || req.url === '/api';
-    const isGet = req.method === 'GET';
-
-    if (isApi || !isGet) {
-      reply.code(isApi ? 404 : 404).send({
-        error: `Route ${req.method} ${req.url} not found`,
-        suggestion: 'See available endpoints under /api/ — actors, compendium.',
-      });
-      return;
-    }
-
-    // SPA fallback — stream index.html. If the bundle isn't present (local
-    // dev without the SPA baked in) return a clear 404.
-    const indexPath = resolve(STATIC_ROOT, 'index.html');
-    try {
-      await stat(indexPath);
-    } catch {
-      reply.code(404).send({
-        error: 'SPA bundle not present',
-        suggestion:
-          'Either run with the production container image (which bundles the character-creator SPA at /app/public) or set STATIC_ROOT to a directory containing index.html.',
-      });
-      return;
-    }
-
-    reply.type('text/html').send(createReadStream(indexPath));
+    reply.code(404).send({
+      error: `Route ${req.method} ${req.url} not found`,
+      suggestion: 'See available endpoints under /api/ — actors, compendium, events, prompts, uploads.',
+    });
   });
 
   await app.ready();

--- a/apps/foundry-mcp/src/http/compendium-cache.ts
+++ b/apps/foundry-mcp/src/http/compendium-cache.ts
@@ -3,7 +3,7 @@
 // search and document-fetch requests can be served without a
 // round-trip to the Foundry bridge.
 //
-// Motivation: the shop-browsing UI in foundry-character-creator was
+// Motivation: the shop-browsing UI in player-portal was
 // firing one `get-compendium-document` per search result to read
 // prices, which explodes in cost for anything beyond a narrow search.
 // Caching the whole pack collapses that into a constant-time lookup.

--- a/apps/foundry-mcp/src/http/routes/uploads.ts
+++ b/apps/foundry-mcp/src/http/routes/uploads.ts
@@ -5,7 +5,7 @@ import { FOUNDRY_DATA_DIR } from '../../config.js';
 import { uploadAssetBody } from '../schemas.js';
 
 // POST /api/uploads — mirrors the `upload_asset` MCP tool but over HTTP
-// so the character-creator SPA can deposit user-selected files (sheet
+// so the player-portal SPA can deposit user-selected files (sheet
 // backgrounds, portraits, etc.) into the Foundry Data directory. Once
 // written, the file is reachable through the same /systems, /modules,
 // /worlds asset prefixes the rest of the UI already fetches through —

--- a/apps/foundry-mcp/src/http/schemas.ts
+++ b/apps/foundry-mcp/src/http/schemas.ts
@@ -1,5 +1,5 @@
 // Zod schemas for the `/api/*` HTTP surface live in
-// `@foundry-toolkit/shared/rpc` — shared with character-creator so both
+// `@foundry-toolkit/shared/rpc` — shared with player-portal so both
 // ends of the wire can speak the same contract. This file re-exports
 // them so the existing `'../schemas.js'` imports in `src/http/routes/*`
 // keep working.

--- a/apps/foundry-mcp/src/index.ts
+++ b/apps/foundry-mcp/src/index.ts
@@ -10,8 +10,8 @@ import { registerTools } from './tools/index.js';
 import { buildHttpApp } from './http/app.js';
 import { registerCompendiumCacheWarming } from './http/compendium-cache-singleton.js';
 
-// Fastify app — handles /api/*, /healthz, static SPA assets, and SPA
-// fallback for unmatched GETs. Routed from the parent http.Server below.
+// Fastify app — handles /api/* and /healthz. Routed from the parent
+// http.Server below.
 const httpApp = await buildHttpApp();
 
 // Subscribe the compendium cache to module-connect events. No-op when
@@ -51,15 +51,14 @@ async function createSession(): Promise<StreamableHTTPServerTransport> {
 
 // ---------------------------------------------------------------------------
 // HTTP Server — routes MCP traffic and Foundry WS upgrades. Everything else
-// falls through to the Fastify app (/api/*, /healthz, SPA assets, fallback).
+// falls through to the Fastify app (/api/*, /healthz).
 // ---------------------------------------------------------------------------
 
 const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
   // Strip query string for path-only matching.
   const path = (req.url ?? '').split('?')[0] ?? '';
 
-  // MCP Streamable HTTP endpoint. Previously `/` was also accepted as a
-  // convenience alias; dropped now so the SPA can live at the root path.
+  // MCP Streamable HTTP endpoint.
   if (path === '/mcp') {
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
     let transport: StreamableHTTPServerTransport;
@@ -86,15 +85,6 @@ const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse
     return;
   }
 
-  // Server logs (legacy).
-  if (path.startsWith('/logs')) {
-    const url = new URL(req.url ?? '/', `http://${req.headers.host}`);
-    const n = parseInt(url.searchParams.get('n') ?? '50', 10);
-    res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify(log.tail(n)));
-    return;
-  }
-
   // Rich health probe — keeps bridge/session state. `/healthz` (the
   // lightweight container probe) is handled inside the Fastify app.
   if (path === '/health') {
@@ -109,8 +99,7 @@ const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse
     return;
   }
 
-  // Everything else — /api/*, /healthz, static SPA assets, SPA fallback —
-  // goes through Fastify.
+  // Everything else — /api/* and /healthz — goes through Fastify.
   httpApp.routing(req, res);
 });
 
@@ -132,6 +121,4 @@ httpServer.listen(PORT, HOST, () => {
   log.info(`  REST API:     http://${HOST}:${PORT}/api/`);
   log.info(`  Foundry WS:   ws://${HOST}:${PORT}/foundry`);
   log.info(`  Health:       http://${HOST}:${PORT}/health (rich) and /healthz (probe)`);
-  log.info(`  Logs:         http://${HOST}:${PORT}/logs`);
-  log.info(`  SPA:          http://${HOST}:${PORT}/`);
 });

--- a/knip.json
+++ b/knip.json
@@ -19,6 +19,40 @@
     "apps/player-portal": {
       "ignoreDependencies": ["@eslint/js"]
     },
+    "packages/ai": {
+      "entry": [
+        "src/index.ts",
+        "src/chat/index.ts",
+        "src/classifier/index.ts",
+        "src/hooks/index.ts",
+        "src/loot/index.ts",
+        "harness/run.ts"
+      ],
+      "project": ["src/**/*.ts", "harness/**/*.ts"]
+    },
+    "packages/db": {
+      "entry": ["src/index.ts", "src/pf2e/index.ts", "src/books/index.ts", "src/maps/index.ts"],
+      "project": ["src/**/*.ts"]
+    },
+    "packages/pf2e-rules": {
+      "entry": ["src/index.ts", "src/encounter.ts", "src/treasure.ts", "src/**/*.test.ts"],
+      "project": ["src/**/*.ts"]
+    },
+    "packages/shared": {
+      "entry": [
+        "src/types.ts",
+        "src/env.ts",
+        "src/env-auto.ts",
+        "src/foundry-api.ts",
+        "src/foundry-markup.ts",
+        "src/map-stem.ts",
+        "src/MissionBriefing.tsx",
+        "src/golarion-map/index.ts",
+        "src/rpc/index.ts",
+        "src/**/*.test.ts"
+      ],
+      "project": ["src/**/*.{ts,tsx}"]
+    },
     "tools/launcher": {
       "entry": ["preload.cjs", "renderer/renderer.js"],
       "project": ["**/*.{cjs,js}"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "foundry-toolkit",
       "version": "0.1.0",
-      "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
         "apps/*",
@@ -60,6 +59,7 @@
     "apps/dm-tool": {
       "name": "@foundry-toolkit/dm-tool",
       "version": "1.5.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@fontsource/cinzel": "^5.2.8",
         "@fontsource/crimson-pro": "^5.2.8",
@@ -125,7 +125,6 @@
       "name": "@foundry-toolkit/mcp",
       "version": "1.3.0",
       "dependencies": {
-        "@fastify/static": "^9.1.2",
         "@foundry-toolkit/shared": "*",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "fastify": "^5.3.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "dev:api-bridge": "npm --workspace apps/foundry-api-bridge run dev",
     "launcher": "npm --workspace tools/launcher start",
     "rebuild-sqlite": "electron-rebuild -f -w better-sqlite3",
-    "postinstall": "electron-rebuild -f -w better-sqlite3",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },

--- a/packages/shared/CLAUDE.md
+++ b/packages/shared/CLAUDE.md
@@ -25,7 +25,7 @@ Subpath exports:
 - `./map-stem` — `src/map-stem.ts`
 - `./MissionBriefing` — `src/MissionBriefing.tsx` (React component)
 - `./golarion-map` — `src/golarion-map/index.ts`
-- `./rpc` — `src/rpc/index.ts` (Zod schemas + `z.infer<>` types for the `/api/*` request surface; re-used by both `apps/foundry-mcp` server and `apps/character-creator` client)
+- `./rpc` — `src/rpc/index.ts` (Zod schemas + `z.infer<>` types for the `/api/*` request surface; re-used by both `apps/foundry-mcp` server and `apps/player-portal` client)
 
 ## Key decisions / gotchas
 


### PR DESCRIPTION
## Summary

Buckets A + B from the cleanup audit. No behaviour change for end users.

**Stale docs (A1-A4):** Refresh `foundry-mcp/CLAUDE.md`, `foundry-mcp/README.md`, root `README.md`, root `CLAUDE.md`, and `packages/shared/CLAUDE.md` after PR #41 (character-creator merged into player-portal).

**foundry-mcp un-bundling (A8 / A9):** Drop the SPA-serving code path that became dead after PR #41 — `@fastify/static` dep, `STATIC_ROOT` env var, SPA fallback handler, the sibling-image SPA stage in the Dockerfile, and the legacy `/logs` HTTP endpoint that has no clients.

**Hygiene (A5 / A6):** Add `/dist/` to root `.gitignore`. Align foundry-api-bridge versions — `dist/module.json` 1.2.0 → 1.3.0; `src/main.ts` hardcoded `7.7.0` → `1.3.0`.

**CI / monorepo plumbing (B1 / B2 / B4):**
- Expand CI test matrix to include `apps/foundry-mcp` and `packages/pf2e-rules`.
- Extend `knip.json` to cover `packages/*` — previously only `apps/*` + `tools/launcher`.
- Move `better-sqlite3` electron-rebuild `postinstall` from root to `apps/dm-tool`. Devs of other workspaces no longer pay the rebuild cost on fresh installs.

## Deferred to follow-up issues

- #52 — Port foundry-api-bridge from Jest to Vitest
- #53 — Rename leftover `'character-creator'` namespaces in player-portal

## Skipped (rationale in root CLAUDE.md)

- B3 lint scripts in `packages/*` — root ESLint already covers them; adding per-workspace lint would duplicate work in CI.

## Test plan

- [ ] CI green (lint / typecheck / format / knip / tests)
- [ ] Local: `npm run dev:mcp` boots cleanly (no SPA-related errors, no `/logs` references)
- [ ] Local: `npm run dev:dm-tool` loads (better-sqlite3 ABI still aligned after postinstall move)
- [ ] dm-tool packaging path (`npm run package:ci`) still produces an NSIS installer

🤖 Generated with [Claude Code](https://claude.com/claude-code)