### PR TITLE
Extract shared HTTP primitives to @foundry-toolkit/shared/http

### DIFF
--- a/apps/dm-tool/electron/compendium/client.test.ts
+++ b/apps/dm-tool/electron/compendium/client.test.ts
@@ -103,7 +103,7 @@ describe('createCompendiumHttpClient', () => {
     const client = createCompendiumHttpClient('http://localhost:8765');
     fetchMock.mockResolvedValueOnce(jsonResponse({ error: 'Not found', suggestion: 'Check the uuid' }, 404));
     await expect(client.getCompendiumDocument('bad-uuid')).rejects.toMatchObject({
-      name: 'CompendiumRequestError',
+      name: 'ApiRequestError',
       status: 404,
       message: 'Not found',
       suggestion: 'Check the uuid',
@@ -114,7 +114,7 @@ describe('createCompendiumHttpClient', () => {
     const client = createCompendiumHttpClient('http://localhost:8765');
     fetchMock.mockResolvedValueOnce(new Response('<html>oops</html>', { status: 502 }));
     await expect(client.searchCompendium({ q: 'any' })).rejects.toMatchObject({
-      name: 'CompendiumRequestError',
+      name: 'ApiRequestError',
       status: 502,
       message: 'HTTP 502',
     });

--- a/apps/dm-tool/electron/compendium/client.ts
+++ b/apps/dm-tool/electron/compendium/client.ts
@@ -2,11 +2,15 @@
 // no caching, no fallbacks. The factory in ./index.ts composes this with
 // the SQLite cache layer from @foundry-toolkit/db/pf2e.
 //
-// Shapes mirror apps/character-creator/src/api/client.ts; only the
-// compendium subset dm-tool actually calls is ported.
+// The transport primitives (`ApiRequestError`, `requestJson`,
+// `buildCompendiumQuery`) live in `@foundry-toolkit/shared/http` so
+// player-portal can share them. We re-export under the historical local
+// names (`CompendiumRequestError`, `buildSearchQuery`) so existing
+// callsites + `instanceof` checks keep working.
+
+import { buildCompendiumQuery, requestJson } from '@foundry-toolkit/shared/http';
 
 import type {
-  ApiError,
   CompendiumDocument,
   CompendiumMatch,
   CompendiumPack,
@@ -14,50 +18,15 @@ import type {
   CompendiumSource,
 } from './types.js';
 
-export class CompendiumRequestError extends Error {
-  readonly status: number;
-  readonly suggestion: string | undefined;
-
-  constructor(status: number, error: string, suggestion?: string) {
-    super(error);
-    this.name = 'CompendiumRequestError';
-    this.status = status;
-    this.suggestion = suggestion;
-  }
-}
+export {
+  ApiRequestError as CompendiumRequestError,
+  buildCompendiumQuery as buildSearchQuery,
+} from '@foundry-toolkit/shared/http';
 
 /** Strip a trailing slash if present. The mcp config path normaliser
  *  already does this on save, but callers may pass a raw value. */
 function normaliseBase(url: string): string {
   return url.replace(/\/+$/, '');
-}
-
-async function requestJson<T>(url: string): Promise<T> {
-  const res = await fetch(url, { headers: { Accept: 'application/json' } });
-  if (!res.ok) {
-    let body: ApiError = { error: `HTTP ${res.status.toString()}` };
-    try {
-      body = (await res.json()) as ApiError;
-    } catch {
-      // Response wasn't JSON — fall through with the status-only error.
-    }
-    throw new CompendiumRequestError(res.status, body.error, body.suggestion);
-  }
-  return (await res.json()) as T;
-}
-
-export function buildSearchQuery(opts: CompendiumSearchOptions): string {
-  const params = new URLSearchParams();
-  if (opts.q !== undefined && opts.q.length > 0) params.set('q', opts.q);
-  if (opts.packIds !== undefined && opts.packIds.length > 0) params.set('packId', opts.packIds.join(','));
-  if (opts.documentType !== undefined) params.set('documentType', opts.documentType);
-  if (opts.traits !== undefined && opts.traits.length > 0) params.set('traits', opts.traits.join(','));
-  if (opts.anyTraits !== undefined && opts.anyTraits.length > 0) params.set('anyTraits', opts.anyTraits.join(','));
-  if (opts.sources !== undefined && opts.sources.length > 0) params.set('sources', opts.sources.join(','));
-  if (opts.ancestrySlug !== undefined && opts.ancestrySlug.length > 0) params.set('ancestrySlug', opts.ancestrySlug);
-  if (opts.maxLevel !== undefined) params.set('maxLevel', opts.maxLevel.toString());
-  if (opts.limit !== undefined) params.set('limit', opts.limit.toString());
-  return params.toString();
 }
 
 export interface CompendiumHttpClient {
@@ -80,7 +49,7 @@ export function createCompendiumHttpClient(baseUrl: string): CompendiumHttpClien
 
   return {
     searchCompendium(opts) {
-      return requestJson<{ matches: CompendiumMatch[] }>(`${base}/api/compendium/search?${buildSearchQuery(opts)}`);
+      return requestJson<{ matches: CompendiumMatch[] }>(`${base}/api/compendium/search?${buildCompendiumQuery(opts)}`);
     },
 
     getCompendiumDocument(uuid) {

--- a/apps/dm-tool/electron/compendium/index.test.ts
+++ b/apps/dm-tool/electron/compendium/index.test.ts
@@ -126,7 +126,7 @@ describe('createCompendiumApi', () => {
     });
 
     await expect(api.getCompendiumDocument('never-seen')).rejects.toMatchObject({
-      name: 'CompendiumRequestError',
+      name: 'ApiRequestError',
       status: 502,
     });
   });

--- a/apps/player-portal/src/api/client.ts
+++ b/apps/player-portal/src/api/client.ts
@@ -19,12 +19,12 @@ import type {
 // action.
 type ActorActionParams = Record<string, unknown>;
 import type { UploadAssetResult } from '@foundry-toolkit/shared/foundry-api';
+import { buildCompendiumQuery, requestJson } from '@foundry-toolkit/shared/http';
 
 import type {
   ActorItemRef,
   ActorRef,
   ActorSummary,
-  ApiError,
   CompendiumDocument,
   CompendiumMatch,
   CompendiumPack,
@@ -33,22 +33,14 @@ import type {
   PreparedActor,
 } from './types';
 
+// Re-export the shared error so existing `instanceof ApiRequestError`
+// callsites keep importing from this module.
+export { ApiRequestError } from '@foundry-toolkit/shared/http';
+
 // Dev: Vite proxies /api → :3000 (Fastify). Fastify then proxies /api/mcp →
 // foundry-mcp (:8765) and handles /api/live/* in-process. Prod: one Fastify
 // serves the built SPA + both namespaces same-origin.
 const BASE = '/api/mcp';
-
-export class ApiRequestError extends Error {
-  readonly status: number;
-  readonly suggestion: string | undefined;
-
-  constructor(status: number, error: string, suggestion?: string) {
-    super(error);
-    this.name = 'ApiRequestError';
-    this.status = status;
-    this.suggestion = suggestion;
-  }
-}
 
 interface RequestOptions {
   method?: 'GET' | 'POST' | 'PATCH' | 'DELETE';
@@ -60,41 +52,12 @@ export interface LongRestResponse {
   messageCount: number;
 }
 
-async function request<T>(path: string, opts: RequestOptions = {}): Promise<T> {
-  const method = opts.method ?? 'GET';
-  const init: RequestInit = {
-    method,
-    headers:
-      opts.body !== undefined
-        ? { Accept: 'application/json', 'Content-Type': 'application/json' }
-        : { Accept: 'application/json' },
-  };
-  if (opts.body !== undefined) init.body = JSON.stringify(opts.body);
-  const res = await fetch(`${BASE}${path}`, init);
-  if (!res.ok) {
-    let body: ApiError = { error: `HTTP ${res.status.toString()}` };
-    try {
-      body = (await res.json()) as ApiError;
-    } catch {
-      // Response wasn't JSON — fall through with the status-only error.
-    }
-    throw new ApiRequestError(res.status, body.error, body.suggestion);
+function request<T>(path: string, opts: RequestOptions = {}): Promise<T> {
+  const init: RequestInit = { method: opts.method ?? 'GET' };
+  if (opts.body !== undefined) {
+    init.body = JSON.stringify(opts.body);
   }
-  return (await res.json()) as T;
-}
-
-function buildCompendiumQuery(opts: CompendiumSearchOptions): string {
-  const params = new URLSearchParams();
-  if (opts.q !== undefined && opts.q.length > 0) params.set('q', opts.q);
-  if (opts.packIds !== undefined && opts.packIds.length > 0) params.set('packId', opts.packIds.join(','));
-  if (opts.documentType !== undefined) params.set('documentType', opts.documentType);
-  if (opts.traits !== undefined && opts.traits.length > 0) params.set('traits', opts.traits.join(','));
-  if (opts.anyTraits !== undefined && opts.anyTraits.length > 0) params.set('anyTraits', opts.anyTraits.join(','));
-  if (opts.sources !== undefined && opts.sources.length > 0) params.set('sources', opts.sources.join(','));
-  if (opts.ancestrySlug !== undefined && opts.ancestrySlug.length > 0) params.set('ancestrySlug', opts.ancestrySlug);
-  if (opts.maxLevel !== undefined) params.set('maxLevel', opts.maxLevel.toString());
-  if (opts.limit !== undefined) params.set('limit', opts.limit.toString());
-  return params.toString();
+  return requestJson<T>(`${BASE}${path}`, init);
 }
 
 export const api = {

--- a/packages/shared/CLAUDE.md
+++ b/packages/shared/CLAUDE.md
@@ -22,6 +22,7 @@ Subpath exports:
 - `.` / `./types` — `src/types.ts`
 - `./foundry-api` — `src/foundry-api.ts` (foundry-mcp `/api/*` wire contract: `CompendiumMatch`, `ActorRef`, `PreparedActor`, `ApiError`, etc.)
 - `./foundry-markup` — `src/foundry-markup.ts`
+- `./http` — `src/http.ts` (`ApiRequestError`, `requestJson<T>`, `buildCompendiumQuery` — runtime helpers for hitting the foundry-mcp REST surface)
 - `./map-stem` — `src/map-stem.ts`
 - `./MissionBriefing` — `src/MissionBriefing.tsx` (React component)
 - `./golarion-map` — `src/golarion-map/index.ts`

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,6 +11,7 @@
     "./env-auto": "./src/env-auto.ts",
     "./foundry-api": "./src/foundry-api.ts",
     "./foundry-markup": "./src/foundry-markup.ts",
+    "./http": "./src/http.ts",
     "./map-stem": "./src/map-stem.ts",
     "./MissionBriefing": "./src/MissionBriefing.tsx",
     "./golarion-map": "./src/golarion-map/index.ts",

--- a/packages/shared/src/http.ts
+++ b/packages/shared/src/http.ts
@@ -1,0 +1,81 @@
+// Shared HTTP primitives for the foundry-mcp REST surface (`/api/*`).
+//
+// Both consumers — `apps/dm-tool/electron/compendium/client.ts` (Electron
+// main process, talks directly to a configurable foundry-mcp base URL)
+// and `apps/player-portal/src/api/client.ts` (browser, talks via the
+// `/api/mcp/*` reverse proxy) — used to ship near-identical copies of:
+//
+//   - an `ApiRequestError` class that carries `{status, error, suggestion}`
+//   - a `requestJson<T>` fetch helper that unwraps the JSON envelope
+//   - a `buildCompendiumQuery` URL-search-params builder
+//
+// They live here so the wire contract has one source of truth. Consumers
+// re-export under their existing local names (e.g. dm-tool keeps the
+// `CompendiumRequestError` alias) so callsites don't have to churn.
+
+import type { ApiError, CompendiumSearchOptions } from './foundry-api.js';
+
+/** Error thrown by `requestJson` on non-ok responses. Carries the parsed
+ *  `error` message plus the optional `suggestion` the foundry-mcp REST
+ *  surface returns on 4xx/5xx envelopes. */
+export class ApiRequestError extends Error {
+  readonly status: number;
+  readonly suggestion: string | undefined;
+
+  constructor(status: number, error: string, suggestion?: string) {
+    super(error);
+    this.name = 'ApiRequestError';
+    this.status = status;
+    this.suggestion = suggestion;
+  }
+}
+
+/** Fetch + JSON unwrap with error-envelope handling. Throws
+ *  `ApiRequestError` on non-ok responses; threads through the parsed
+ *  `{error, suggestion}` payload when present, and falls back to a
+ *  status-only message when the response body isn't JSON.
+ *
+ *  Caller passes the full URL — base-URL handling stays in the
+ *  consumer. Sets `Accept: application/json` always; sets
+ *  `Content-Type: application/json` automatically when a body is
+ *  present and the caller hasn't already specified one. */
+export async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const headers = new Headers({ Accept: 'application/json' });
+  if (init?.headers) {
+    new Headers(init.headers).forEach((value, key) => {
+      headers.set(key, value);
+    });
+  }
+  if (init?.body !== undefined && !headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json');
+  }
+  const res = await fetch(url, { ...init, headers });
+  if (!res.ok) {
+    let body: ApiError = { error: `HTTP ${res.status.toString()}` };
+    try {
+      body = (await res.json()) as ApiError;
+    } catch {
+      // Response wasn't JSON — fall through with the status-only error.
+    }
+    throw new ApiRequestError(res.status, body.error, body.suggestion);
+  }
+  return (await res.json()) as T;
+}
+
+/** Build the query-string portion of a `/api/compendium/search` URL
+ *  (and friends — the same opts shape drives `/sources` too). Both
+ *  dm-tool and player-portal hit the same endpoint, so the param
+ *  construction stays here. */
+export function buildCompendiumQuery(opts: CompendiumSearchOptions): string {
+  const params = new URLSearchParams();
+  if (opts.q !== undefined && opts.q.length > 0) params.set('q', opts.q);
+  if (opts.packIds !== undefined && opts.packIds.length > 0) params.set('packId', opts.packIds.join(','));
+  if (opts.documentType !== undefined) params.set('documentType', opts.documentType);
+  if (opts.traits !== undefined && opts.traits.length > 0) params.set('traits', opts.traits.join(','));
+  if (opts.anyTraits !== undefined && opts.anyTraits.length > 0) params.set('anyTraits', opts.anyTraits.join(','));
+  if (opts.sources !== undefined && opts.sources.length > 0) params.set('sources', opts.sources.join(','));
+  if (opts.ancestrySlug !== undefined && opts.ancestrySlug.length > 0) params.set('ancestrySlug', opts.ancestrySlug);
+  if (opts.maxLevel !== undefined) params.set('maxLevel', opts.maxLevel.toString());
+  if (opts.limit !== undefined) params.set('limit', opts.limit.toString());
+  return params.toString();
+}


### PR DESCRIPTION
## Summary

`ApiRequestError`, `requestJson<T>`, and `buildCompendiumQuery` were near-identical copies in `apps/dm-tool/electron/compendium/client.ts` and `apps/player-portal/src/api/client.ts`. Move them to a new `packages/shared/src/http.ts` (exposed as the `./http` subpath of `@foundry-toolkit/shared`) so the wire contract has one source of truth.

- New file: `packages/shared/src/http.ts`
- New subpath: `@foundry-toolkit/shared/http`
- `apps/dm-tool/electron/compendium/client.ts` — drop the local class + helpers, re-export under the historical names (`CompendiumRequestError`, `buildSearchQuery`) so existing callsites and `instanceof` checks don't churn.
- `apps/player-portal/src/api/client.ts` — drop the local class + helpers, re-export `ApiRequestError` so the 9 callsites that import it from `'../../api/client'` don't churn.
- Three dm-tool test assertions that pinned `name: 'CompendiumRequestError'` are updated to `'ApiRequestError'` to match the unified class name.

No runtime behaviour change.

## Bucket C-b context

This is **C-b1** from the cleanup audit. **C-b2** (extract `useRemoteData<T>` hook + refactor `FeatPicker` / `ItemShopPicker` / `Crafting`) follows in its own PR after this one merges.

## Test plan

- [ ] CI green (lint / typecheck / format / knip / tests)
- [ ] Local: `npm run test --workspace apps/dm-tool` and `--workspace apps/player-portal` pass (already verified)
- [ ] Smoke: `npm run dev:player-portal` — FeatPicker still searches, ApiRequestError-driven error UI still displays
- [ ] Smoke: dm-tool compendium browsers still hit foundry-mcp via the typed client

🤖 Generated with [Claude Code](https://claude.com/claude-code)