### PR TITLE
Extract useRemoteData<T> + adopt in FeatPicker matches/sources

### DIFF
--- a/apps/player-portal/src/components/creator/FeatPicker.tsx
+++ b/apps/player-portal/src/components/creator/FeatPicker.tsx
@@ -67,49 +67,6 @@ export function FeatPicker({ title, filters, characterContext, onPick, onClose }
   // round trip.
   const prereqCacheRef = useRef<Map<string, string | null>>(new Map());
 
-  // Apply sort on top of whatever order the server returned. Client-side
-  // is fine because the server already caps results (limit 50 by default
-  // from the picker), so the sort runs over a tiny array. Entries missing
-  // a level always sink to the bottom of a Level sort (in either
-  // direction) and stay alpha-asc among themselves — "unknown" shouldn't
-  // leapfrog real data just because the user flipped direction.
-  //
-  // After sorting, optionally drop entries whose prereq evaluation came
-  // back `fails`. `unknown` (unparseable) stays through.
-  const visibleMatches = useMemo(() => {
-    if (matchesState.kind !== 'ready') return [];
-    const copy = [...matchesState.data];
-    const dirMul = sort.dir === 'desc' ? -1 : 1;
-    if (sort.mode === 'level') {
-      const leveled = copy.filter((m) => m.level !== undefined);
-      const unlevelled = copy.filter((m) => m.level === undefined);
-      leveled.sort((a, b) => {
-        const lvlCmp = ((a.level ?? 0) - (b.level ?? 0)) * dirMul;
-        if (lvlCmp !== 0) return lvlCmp;
-        // Keep intra-tier ordering alpha-asc regardless of direction,
-        // so scanning a level band reads left-to-right like a glossary.
-        return a.name.localeCompare(b.name);
-      });
-      unlevelled.sort((a, b) => a.name.localeCompare(b.name));
-      return hideUnmet
-        ? [...leveled, ...unlevelled].filter((m) => evaluations.get(m.uuid) !== 'fails')
-        : [...leveled, ...unlevelled];
-    }
-    copy.sort((a, b) => a.name.localeCompare(b.name) * dirMul);
-    return hideUnmet ? copy.filter((m) => evaluations.get(m.uuid) !== 'fails') : copy;
-  }, [matchesState, sort, hideUnmet, evaluations]);
-
-  const onSortClick = (mode: SortMode): void => {
-    setSort((prev) =>
-      prev.mode === mode
-        ? // Re-clicking the active option flips direction.
-          { mode, dir: prev.dir === 'asc' ? 'desc' : 'asc' }
-        : // Switching modes resets direction to ascending so users
-          // don't carry an expectation from the other axis.
-          { mode, dir: 'asc' },
-    );
-  };
-
   // Stable filter key for the search effect dep array. Source titles
   // are sorted for order-stability so toggling a checkbox refires the
   // search with the new scope. The caller's `packIds` doesn't change
@@ -214,6 +171,49 @@ export function FeatPicker({ title, filters, characterContext, onPick, onClose }
     },
     [filters.documentType, callerPackIdsKey, debouncedQuery, traitsKey, filters.maxLevel],
   );
+
+  // Apply sort on top of whatever order the server returned. Client-side
+  // is fine because the server already caps results (limit 50 by default
+  // from the picker), so the sort runs over a tiny array. Entries missing
+  // a level always sink to the bottom of a Level sort (in either
+  // direction) and stay alpha-asc among themselves — "unknown" shouldn't
+  // leapfrog real data just because the user flipped direction.
+  //
+  // After sorting, optionally drop entries whose prereq evaluation came
+  // back `fails`. `unknown` (unparseable) stays through.
+  const visibleMatches = useMemo(() => {
+    if (matchesState.kind !== 'ready') return [];
+    const copy = [...matchesState.data];
+    const dirMul = sort.dir === 'desc' ? -1 : 1;
+    if (sort.mode === 'level') {
+      const leveled = copy.filter((m) => m.level !== undefined);
+      const unlevelled = copy.filter((m) => m.level === undefined);
+      leveled.sort((a, b) => {
+        const lvlCmp = ((a.level ?? 0) - (b.level ?? 0)) * dirMul;
+        if (lvlCmp !== 0) return lvlCmp;
+        // Keep intra-tier ordering alpha-asc regardless of direction,
+        // so scanning a level band reads left-to-right like a glossary.
+        return a.name.localeCompare(b.name);
+      });
+      unlevelled.sort((a, b) => a.name.localeCompare(b.name));
+      return hideUnmet
+        ? [...leveled, ...unlevelled].filter((m) => evaluations.get(m.uuid) !== 'fails')
+        : [...leveled, ...unlevelled];
+    }
+    copy.sort((a, b) => a.name.localeCompare(b.name) * dirMul);
+    return hideUnmet ? copy.filter((m) => evaluations.get(m.uuid) !== 'fails') : copy;
+  }, [matchesState, sort, hideUnmet, evaluations]);
+
+  const onSortClick = (mode: SortMode): void => {
+    setSort((prev) =>
+      prev.mode === mode
+        ? // Re-clicking the active option flips direction.
+          { mode, dir: prev.dir === 'asc' ? 'desc' : 'asc' }
+        : // Switching modes resets direction to ascending so users
+          // don't carry an expectation from the other axis.
+          { mode, dir: 'asc' },
+    );
+  };
 
   useEffect(() => {
     inputRef.current?.focus();

--- a/apps/player-portal/src/components/creator/FeatPicker.tsx
+++ b/apps/player-portal/src/components/creator/FeatPicker.tsx
@@ -3,6 +3,7 @@ import { api, ApiRequestError } from '../../api/client';
 import type { CompendiumDocument, CompendiumMatch, CompendiumSearchOptions, CompendiumSource } from '../../api/types';
 import { enrichDescription } from '../../lib/foundry-enrichers';
 import { useDebounce } from '../../lib/useDebounce';
+import { type RemoteDataState, useRemoteData } from '../../lib/useRemoteData';
 import { useUuidHover } from '../../lib/useUuidHover';
 import { evaluateDocument } from '../../prereqs';
 import type { CharacterContext, Evaluation } from '../../prereqs';
@@ -34,16 +35,6 @@ interface Props {
   onClose: () => void;
 }
 
-type FetchState =
-  | { kind: 'loading' }
-  | { kind: 'ready'; matches: CompendiumMatch[] }
-  | { kind: 'error'; message: string };
-
-type SourcesState =
-  | { kind: 'loading' }
-  | { kind: 'ready'; sources: CompendiumSource[] }
-  | { kind: 'error'; message: string };
-
 type DetailState =
   | { kind: 'idle' }
   | { kind: 'loading'; uuid: string }
@@ -56,10 +47,8 @@ type DetailState =
 // skill / general feat slots.
 export function FeatPicker({ title, filters, characterContext, onPick, onClose }: Props): React.ReactElement {
   const [query, setQuery] = useState('');
-  const [state, setState] = useState<FetchState>({ kind: 'loading' });
   const [sort, setSort] = useState<SortState>({ mode: 'alpha', dir: 'asc' });
   const [selectedSources, setSelectedSources] = useState<string[]>([]);
-  const [sources, setSources] = useState<SourcesState>({ kind: 'loading' });
   const [detailTarget, setDetailTarget] = useState<CompendiumMatch | null>(null);
   const [detail, setDetail] = useState<DetailState>({ kind: 'idle' });
   const [evaluations, setEvaluations] = useState<Map<string, Evaluation>>(new Map());
@@ -88,8 +77,8 @@ export function FeatPicker({ title, filters, characterContext, onPick, onClose }
   // After sorting, optionally drop entries whose prereq evaluation came
   // back `fails`. `unknown` (unparseable) stays through.
   const visibleMatches = useMemo(() => {
-    if (state.kind !== 'ready') return [];
-    const copy = [...state.matches];
+    if (matchesState.kind !== 'ready') return [];
+    const copy = [...matchesState.data];
     const dirMul = sort.dir === 'desc' ? -1 : 1;
     if (sort.mode === 'level') {
       const leveled = copy.filter((m) => m.level !== undefined);
@@ -108,7 +97,7 @@ export function FeatPicker({ title, filters, characterContext, onPick, onClose }
     }
     copy.sort((a, b) => a.name.localeCompare(b.name) * dirMul);
     return hideUnmet ? copy.filter((m) => evaluations.get(m.uuid) !== 'fails') : copy;
-  }, [state, sort, hideUnmet, evaluations]);
+  }, [matchesState, sort, hideUnmet, evaluations]);
 
   const onSortClick = (mode: SortMode): void => {
     setSort((prev) =>
@@ -148,29 +137,26 @@ export function FeatPicker({ title, filters, characterContext, onPick, onClose }
     ],
   );
 
-  useEffect(() => {
-    let cancelled = false;
-    // Deliberately not flipping state back to 'loading' here — that
-    // would trigger an extra render (react-hooks/set-state-in-effect)
-    // and flash the empty-list state between keystrokes. Instead the
-    // previous `ready` matches stay visible until the next response
-    // lands, giving a calm "narrow-in-place" feel to the picker.
-    const opts: CompendiumSearchOptions = {
-      q: debouncedQuery,
-      limit: 50,
-    };
-    if (filters.packIds !== undefined && filters.packIds.length > 0) opts.packIds = filters.packIds;
-    if (selectedSources.length > 0) opts.sources = selectedSources;
-    if (filters.documentType !== undefined) opts.documentType = filters.documentType;
-    if (filters.traits !== undefined) opts.traits = filters.traits;
-    if (filters.anyTraits !== undefined) opts.anyTraits = filters.anyTraits;
-    if (filters.maxLevel !== undefined) opts.maxLevel = filters.maxLevel;
-    if (filters.ancestrySlug !== undefined) opts.ancestrySlug = filters.ancestrySlug;
-    api
-      .searchCompendium(opts)
-      .then((result) => {
-        if (cancelled) return;
-        setState({ kind: 'ready', matches: result.matches });
+  // Live match list. `useRemoteData` keeps the previous `ready` data
+  // visible across re-fetches so the list narrows in place without
+  // flashing an empty state between keystrokes.
+  const matchesState = useRemoteData<CompendiumMatch[]>(
+    async () => {
+      const opts: CompendiumSearchOptions = { q: debouncedQuery, limit: 50 };
+      if (filters.packIds !== undefined && filters.packIds.length > 0) opts.packIds = filters.packIds;
+      if (selectedSources.length > 0) opts.sources = selectedSources;
+      if (filters.documentType !== undefined) opts.documentType = filters.documentType;
+      if (filters.traits !== undefined) opts.traits = filters.traits;
+      if (filters.anyTraits !== undefined) opts.anyTraits = filters.anyTraits;
+      if (filters.maxLevel !== undefined) opts.maxLevel = filters.maxLevel;
+      if (filters.ancestrySlug !== undefined) opts.ancestrySlug = filters.ancestrySlug;
+      const result = await api.searchCompendium(opts);
+      return result.matches;
+    },
+    // filterKey captures every filter field used inside the fetcher.
+    [debouncedQuery, filterKey],
+    {
+      onSuccess: (matches, isCancelled) => {
         // Background prefetch the full document for each match so the
         // detail pane opens instantly on click. Each worker also
         // resolves that document's prereqs against the compendium and
@@ -180,12 +166,12 @@ export function FeatPicker({ title, filters, characterContext, onPick, onClose }
         // 50 results come back.
         const ctx = characterContext;
         void prefetchDocuments(
-          result.matches,
+          matches,
           docCacheRef.current,
           prereqCacheRef.current,
           ctx
             ? (uuid, doc) => {
-                if (cancelled) return;
+                if (isCancelled()) return;
                 const evaluation = evaluateDocument(doc, ctx);
                 setEvaluations((prev) => {
                   if (prev.get(uuid) === evaluation) return prev;
@@ -195,59 +181,39 @@ export function FeatPicker({ title, filters, characterContext, onPick, onClose }
                 });
               }
             : undefined,
-          () => cancelled,
+          isCancelled,
         );
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        const message = err instanceof ApiRequestError ? err.message : err instanceof Error ? err.message : String(err);
-        setState({ kind: 'error', message });
-      });
-    return (): void => {
-      cancelled = true;
-    };
-    // filterKey captures every filter field; exhaustive-deps is happy.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [debouncedQuery, filterKey]);
+      },
+    },
+  );
 
-  // Keep the source-book counts in lockstep with the current search
-  // filters (text query, traits, maxLevel). The source filter itself
-  // is NOT passed in — we want counts for every source regardless of
-  // which ones the user has ticked, so the dropdown reads as "how many
+  // Source-book counts stay in lockstep with the current search filters
+  // (text query, traits, maxLevel). The source filter itself is NOT
+  // passed in — we want counts for every source regardless of which
+  // ones the user has ticked, so the dropdown reads as "how many
   // matches each source would contribute" (classic multi-select facet
   // behaviour). Packs + documentType stay since those are caller-side
   // invariants.
   const traitsKey = (filters.traits ?? []).join('|');
-  useEffect(() => {
-    let cancelled = false;
-    const opts: {
-      documentType?: string;
-      packIds?: string[];
-      q?: string;
-      traits?: string[];
-      maxLevel?: number;
-    } = {};
-    if (filters.documentType !== undefined) opts.documentType = filters.documentType;
-    if (filters.packIds !== undefined && filters.packIds.length > 0) opts.packIds = filters.packIds;
-    if (debouncedQuery.length > 0) opts.q = debouncedQuery;
-    if (filters.traits !== undefined && filters.traits.length > 0) opts.traits = filters.traits;
-    if (filters.maxLevel !== undefined) opts.maxLevel = filters.maxLevel;
-    api
-      .listCompendiumSources(opts)
-      .then((result) => {
-        if (cancelled) return;
-        setSources({ kind: 'ready', sources: result.sources });
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        const message = err instanceof Error ? err.message : String(err);
-        setSources({ kind: 'error', message });
-      });
-    return (): void => {
-      cancelled = true;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filters.documentType, callerPackIdsKey, debouncedQuery, traitsKey, filters.maxLevel]);
+  const sourcesState = useRemoteData<CompendiumSource[]>(
+    async () => {
+      const opts: {
+        documentType?: string;
+        packIds?: string[];
+        q?: string;
+        traits?: string[];
+        maxLevel?: number;
+      } = {};
+      if (filters.documentType !== undefined) opts.documentType = filters.documentType;
+      if (filters.packIds !== undefined && filters.packIds.length > 0) opts.packIds = filters.packIds;
+      if (debouncedQuery.length > 0) opts.q = debouncedQuery;
+      if (filters.traits !== undefined && filters.traits.length > 0) opts.traits = filters.traits;
+      if (filters.maxLevel !== undefined) opts.maxLevel = filters.maxLevel;
+      const result = await api.listCompendiumSources(opts);
+      return result.sources;
+    },
+    [filters.documentType, callerPackIdsKey, debouncedQuery, traitsKey, filters.maxLevel],
+  );
 
   useEffect(() => {
     inputRef.current?.focus();
@@ -367,7 +333,7 @@ export function FeatPicker({ title, filters, characterContext, onPick, onClose }
           />
           <div className="mt-1 flex flex-wrap items-center justify-between gap-2">
             <div className="flex items-center gap-2">
-              <SourcePicker sources={sources} selected={selectedSources} onChange={setSelectedSources} />
+              <SourcePicker sources={sourcesState} selected={selectedSources} onChange={setSelectedSources} />
               <UnmetToggle hide={hideUnmet} onChange={setHideUnmet} />
               <FilterSummary filters={filters} />
             </div>
@@ -380,12 +346,14 @@ export function FeatPicker({ title, filters, characterContext, onPick, onClose }
             className={['overflow-y-auto', detailOpen ? 'w-80 shrink-0 border-r border-pf-border' : 'flex-1'].join(' ')}
             data-testid="feat-picker-results"
           >
-            {state.kind === 'loading' && <p className="p-4 text-sm italic text-pf-alt">Searching…</p>}
-            {state.kind === 'error' && <p className="p-4 text-sm text-pf-primary">Search failed: {state.message}</p>}
-            {state.kind === 'ready' && visibleMatches.length === 0 && (
+            {matchesState.kind === 'loading' && <p className="p-4 text-sm italic text-pf-alt">Searching…</p>}
+            {matchesState.kind === 'error' && (
+              <p className="p-4 text-sm text-pf-primary">Search failed: {matchesState.message}</p>
+            )}
+            {matchesState.kind === 'ready' && visibleMatches.length === 0 && (
               <p className="p-4 text-sm italic text-pf-alt">No matches. Loosen the filters or search term.</p>
             )}
-            {state.kind === 'ready' && visibleMatches.length > 0 && (
+            {matchesState.kind === 'ready' && visibleMatches.length > 0 && (
               <MatchList
                 matches={visibleMatches}
                 evaluations={evaluations}
@@ -498,7 +466,7 @@ function SourcePicker({
   selected,
   onChange,
 }: {
-  sources: SourcesState;
+  sources: RemoteDataState<CompendiumSource[]>;
   selected: string[];
   onChange: (next: string[]) => void;
 }): React.ReactElement {
@@ -527,8 +495,8 @@ function SourcePicker({
   const filtered = useMemo(() => {
     if (sources.kind !== 'ready') return [];
     const needle = filter.trim().toLowerCase();
-    if (!needle) return sources.sources;
-    return sources.sources.filter((s) => s.title.toLowerCase().includes(needle));
+    if (!needle) return sources.data;
+    return sources.data.filter((s) => s.title.toLowerCase().includes(needle));
   }, [sources, filter]);
 
   const toggle = (title: string): void => {

--- a/apps/player-portal/src/lib/useRemoteData.ts
+++ b/apps/player-portal/src/lib/useRemoteData.ts
@@ -1,0 +1,69 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * State of a single remote fetch driven by `useRemoteData`.
+ *
+ * Re-fetches (triggered by changing deps) intentionally do NOT reset to
+ * `'loading'` — the previous `'ready'` data stays visible until the next
+ * response lands. That avoids flashing an empty/loading state during
+ * incremental narrowing (e.g. typing into a search box).
+ */
+export type RemoteDataState<T> =
+  | { kind: 'loading' }
+  | { kind: 'ready'; data: T }
+  | { kind: 'error'; message: string };
+
+export interface UseRemoteDataOptions<T> {
+  /** Optional side effect run on each successful fetch, after the
+   *  hook's state has been set. Receives the resolved data plus an
+   *  `isCancelled` probe so any background work it kicks off
+   *  (e.g. document prefetches) can abort when the effect cleans up. */
+  onSuccess?: (data: T, isCancelled: () => boolean) => void;
+}
+
+/**
+ * Single-target async data hook. Calls `fetcher` on mount and whenever
+ * any entry in `deps` changes. Cancellation flips on cleanup, so any
+ * resolved-but-stale response is dropped before it can update state.
+ *
+ * The caller owns the deps array — the hook does not run an
+ * exhaustive-deps check on `fetcher` (otherwise callers would have to
+ * memoize an inline async closure on every render, which defeats the
+ * point).
+ */
+export function useRemoteData<T>(
+  fetcher: () => Promise<T>,
+  deps: ReadonlyArray<unknown>,
+  options?: UseRemoteDataOptions<T>,
+): RemoteDataState<T> {
+  // Track latest options so the hook always calls the most recent
+  // `onSuccess` without forcing the caller to memoize it.
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const [state, setState] = useState<RemoteDataState<T>>({ kind: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+    const isCancelled = (): boolean => cancelled;
+
+    fetcher()
+      .then((data) => {
+        if (cancelled) return;
+        setState({ kind: 'ready', data });
+        optionsRef.current?.onSuccess?.(data, isCancelled);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : String(err);
+        setState({ kind: 'error', message });
+      });
+
+    return (): void => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+
+  return state;
+}


### PR DESCRIPTION
## Summary

Add a generic single-target async data hook (`useRemoteData<T>`) to `apps/player-portal/src/lib/` and adopt it for the two clean-fit fetches in `FeatPicker` (matches list + source-book counts).

The hook deliberately keeps previous `ready` data visible across re-fetches (no flash to `loading` between keystrokes) — the same "narrow-in-place" UX FeatPicker was already opting into.

## Why scoped to FeatPicker only

Surveying the audit's three target callsites turned up real shape divergence:

- **FeatPicker `state` (matches) and `sources`** — clean fit. ✅ Migrated here.
- **FeatPicker `DetailState`** — 4-state machine (idle / loading-with-uuid / ready / error) with cache-hit short-circuit. Doesn't fit the single-target shape. Left ad-hoc.
- **Crafting `Resolution`** — held inside a per-uuid `Map<uuid, Resolution>` from a custom `useUuidResolutions` hook. Parallel-fetch reduce, not a single fetch. Different hook entirely.
- **ItemShopPicker** — three independent `useState`s for `matches` / `loading` / `error` rather than a discriminated union. Migrating has a larger blast radius than the audit suggested (~10-15 callsite changes for `loading` boolean → `state.kind === 'loading'`). Better as its own PR.

So this PR delivers the hook + the two safe migrations. `Crafting` and `ItemShopPicker` will get their own follow-up PRs (or stay as-is if the cost-benefit doesn't pan out — both work fine today).

## Diff shape

- `apps/player-portal/src/lib/useRemoteData.ts` — new (~50 LOC)
- `apps/player-portal/src/components/creator/FeatPicker.tsx` — net negative (~-30 LOC after dropping the two state machines + their useEffects)

## Test plan

- [ ] CI green (lint / typecheck / format / knip / tests)
- [ ] Local: `npm run test --workspace apps/player-portal` passes (verified — FeatPicker integration tests cover this surface)
- [ ] Smoke: open the character creator, add a feat slot — picker opens, matches stream in, sources count stays in lockstep with the search query, error / empty paths still render their banners

🤖 Generated with [Claude Code](https://claude.com/claude-code)