### PR TITLE
feat(dm-tool): intersect monster pack selection with Foundry-installed packs

### DIFF
--- a/apps/dm-tool/electron/compendium/prepared.test.ts
+++ b/apps/dm-tool/electron/compendium/prepared.test.ts
@@ -140,7 +140,7 @@ describe('searchMonsters', () => {
 });
 
 describe('listMonsters', () => {
-  it('maps matches to summaries and applies the level window client-side', async () => {
+  it('returns every match unfiltered (server-side filters intentionally dropped)', async () => {
     const search = vi.fn().mockResolvedValue({
       matches: [
         monsterMatch({ name: 'A', level: 1 }),
@@ -149,15 +149,39 @@ describe('listMonsters', () => {
       ],
     });
     const api = fakeApi({ searchCompendium: search });
-    const out = await createPreparedCompendium(api).listMonsters({ levels: [3, 7] });
-    expect(out.map((s) => s.name)).toEqual(['B']);
+    // Caller-supplied level window is deliberately ignored — every
+    // monster in the selected packs comes back so the UI can render a
+    // complete baseline. Client-side narrowing is a browser concern.
+    const out = await createPreparedCompendium(api).listMonsters({
+      levels: [3, 7],
+      keywords: 'dragon',
+      traits: ['fire'],
+    });
+    expect(out.map((s) => s.name)).toEqual(['A', 'B', 'C']);
     expect(search).toHaveBeenCalledWith(
       expect.objectContaining({
         documentType: 'npc',
-        maxLevel: 7,
+        limit: 10000,
         packIds: expect.arrayContaining(['pf2e.pathfinder-bestiary']),
       }),
     );
+    const call = search.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(call).not.toHaveProperty('q');
+    expect(call).not.toHaveProperty('traits');
+    expect(call).not.toHaveProperty('maxLevel');
+  });
+
+  it('honors the sort request (name ascending) when supplied', async () => {
+    const search = vi.fn().mockResolvedValue({
+      matches: [
+        monsterMatch({ name: 'C', level: 9 }),
+        monsterMatch({ name: 'A', level: 1 }),
+        monsterMatch({ name: 'B', level: 5 }),
+      ],
+    });
+    const api = fakeApi({ searchCompendium: search });
+    const out = await createPreparedCompendium(api).listMonsters({ sortBy: 'name', sortDir: 'asc' });
+    expect(out.map((s) => s.name)).toEqual(['A', 'B', 'C']);
   });
 
   it('returns empty for an empty match list', async () => {

--- a/apps/dm-tool/electron/compendium/prepared.test.ts
+++ b/apps/dm-tool/electron/compendium/prepared.test.ts
@@ -140,7 +140,7 @@ describe('searchMonsters', () => {
 });
 
 describe('listMonsters', () => {
-  it('returns every match unfiltered (every server-side filter dropped)', async () => {
+  it('returns every match when no keywords are supplied (no server-side filters)', async () => {
     const search = vi.fn().mockResolvedValue({
       matches: [
         monsterMatch({ name: 'A', level: 1 }),
@@ -149,12 +149,11 @@ describe('listMonsters', () => {
       ],
     });
     const api = fakeApi({ searchCompendium: search });
-    // Every caller-supplied filter is deliberately ignored — every
-    // document in the selected packs comes back so the UI can render a
-    // complete baseline. Client-side narrowing is a browser concern.
+    // Non-keyword filters are intentionally ignored. Pack selection is
+    // the only filter sent over the wire; text search happens
+    // client-side against the returned list.
     const out = await createPreparedCompendium(api).listMonsters({
       levels: [3, 7],
-      keywords: 'dragon',
       traits: ['fire'],
     });
     expect(out.map((s) => s.name)).toEqual(['A', 'B', 'C']);
@@ -169,6 +168,56 @@ describe('listMonsters', () => {
     expect(call).not.toHaveProperty('traits');
     expect(call).not.toHaveProperty('maxLevel');
     expect(call).not.toHaveProperty('documentType');
+  });
+
+  it('filters matches client-side by keyword (name substring)', async () => {
+    const search = vi.fn().mockResolvedValue({
+      matches: [
+        monsterMatch({ name: 'Young Red Dragon', traits: ['dragon', 'fire'] }),
+        monsterMatch({ name: 'Goblin Warrior', traits: ['humanoid', 'goblin'] }),
+        monsterMatch({ name: 'Ancient Brass Dragon', traits: ['dragon', 'fire'] }),
+      ],
+    });
+    const api = fakeApi({ searchCompendium: search });
+    const out = await createPreparedCompendium(api).listMonsters({ keywords: 'brass' });
+    expect(out.map((s) => s.name)).toEqual(['Ancient Brass Dragon']);
+    // No `q` on the wire — filter is purely client-side.
+    const call = search.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(call).not.toHaveProperty('q');
+  });
+
+  it('filters matches client-side by keyword (trait substring)', async () => {
+    const search = vi.fn().mockResolvedValue({
+      matches: [
+        monsterMatch({ name: 'Goblin Warrior', traits: ['humanoid', 'goblin'] }),
+        monsterMatch({ name: 'Young Red Dragon', traits: ['dragon', 'fire'] }),
+      ],
+    });
+    const api = fakeApi({ searchCompendium: search });
+    const out = await createPreparedCompendium(api).listMonsters({ keywords: 'fire' });
+    expect(out.map((s) => s.name)).toEqual(['Young Red Dragon']);
+  });
+
+  it('requires every whitespace-tokenized keyword to match (AND semantics)', async () => {
+    const search = vi.fn().mockResolvedValue({
+      matches: [
+        monsterMatch({ name: 'Young Red Dragon', traits: [] }),
+        monsterMatch({ name: 'Young Brass Dragon', traits: [] }),
+        monsterMatch({ name: 'Ancient Red Dragon', traits: [] }),
+      ],
+    });
+    const api = fakeApi({ searchCompendium: search });
+    const out = await createPreparedCompendium(api).listMonsters({ keywords: 'young red' });
+    expect(out.map((s) => s.name)).toEqual(['Young Red Dragon']);
+  });
+
+  it('is case-insensitive and tolerates leading/trailing whitespace', async () => {
+    const search = vi.fn().mockResolvedValue({
+      matches: [monsterMatch({ name: 'Young Red Dragon', traits: [] })],
+    });
+    const api = fakeApi({ searchCompendium: search });
+    const out = await createPreparedCompendium(api).listMonsters({ keywords: '  DRAGON  ' });
+    expect(out.map((s) => s.name)).toEqual(['Young Red Dragon']);
   });
 
   it('honors the sort request (name ascending) when supplied', async () => {

--- a/apps/dm-tool/electron/compendium/prepared.test.ts
+++ b/apps/dm-tool/electron/compendium/prepared.test.ts
@@ -140,7 +140,7 @@ describe('searchMonsters', () => {
 });
 
 describe('listMonsters', () => {
-  it('returns every match unfiltered (server-side filters intentionally dropped)', async () => {
+  it('returns every match unfiltered (every server-side filter dropped)', async () => {
     const search = vi.fn().mockResolvedValue({
       matches: [
         monsterMatch({ name: 'A', level: 1 }),
@@ -149,8 +149,8 @@ describe('listMonsters', () => {
       ],
     });
     const api = fakeApi({ searchCompendium: search });
-    // Caller-supplied level window is deliberately ignored — every
-    // monster in the selected packs comes back so the UI can render a
+    // Every caller-supplied filter is deliberately ignored — every
+    // document in the selected packs comes back so the UI can render a
     // complete baseline. Client-side narrowing is a browser concern.
     const out = await createPreparedCompendium(api).listMonsters({
       levels: [3, 7],
@@ -160,7 +160,6 @@ describe('listMonsters', () => {
     expect(out.map((s) => s.name)).toEqual(['A', 'B', 'C']);
     expect(search).toHaveBeenCalledWith(
       expect.objectContaining({
-        documentType: 'npc',
         limit: 10000,
         packIds: expect.arrayContaining(['pf2e.pathfinder-bestiary']),
       }),
@@ -169,6 +168,7 @@ describe('listMonsters', () => {
     expect(call).not.toHaveProperty('q');
     expect(call).not.toHaveProperty('traits');
     expect(call).not.toHaveProperty('maxLevel');
+    expect(call).not.toHaveProperty('documentType');
   });
 
   it('honors the sort request (name ascending) when supplied', async () => {

--- a/apps/dm-tool/electron/compendium/prepared.ts
+++ b/apps/dm-tool/electron/compendium/prepared.ts
@@ -183,29 +183,31 @@ async function listMonsters(
   packIds: readonly string[],
   params: MonsterSearchParams,
 ): Promise<MonsterSummary[]> {
-  // DIAGNOSTIC MODE — no filters at all, not even documentType. The
-  // Monster window returns every document from every ticked pack. If a
-  // tick selection includes an Item-type pack the user will see items
-  // in the browser; that's intentional while we verify the pack-select
-  // pipeline end-to-end. Sort is not a filter and stays applied.
-  //
-  // Search args sent:
-  //   - packIds: resolver output (Settings ∩ installed in Foundry)
-  //   - limit  : 10000 (server max)
-  // Nothing else — not q, traits, maxLevel, documentType.
-  const search = {
+  // Fetch every document in the user's selected packs — no server-side
+  // filters at all. Narrowing happens client-side against the returned
+  // match list so text search is instant (no network round-trip per
+  // keystroke beyond the initial IPC debounce).
+  const { matches } = await api.searchCompendium({
     packIds: [...packIds],
     limit: params.limit ?? 10000,
-  };
-  console.info('[listMonsters] searchCompendium ←', {
-    packCount: search.packIds.length,
-    packIds: search.packIds,
-    limit: search.limit,
   });
-  const { matches } = await api.searchCompendium(search);
-  console.info('[listMonsters] searchCompendium → matches:', matches.length);
 
-  const summaries = matches.map(monsterMatchToSummary);
+  // Text search: whitespace-tokenized; each token must appear
+  // (case-insensitive) in the monster's name OR one of its traits.
+  // Matches mcp's server-side `q` semantics so the UX is identical to
+  // the pre-migration behavior even though we run it in-process.
+  const trimmed = params.keywords?.trim().toLowerCase() ?? '';
+  const tokens = trimmed ? trimmed.split(/\s+/).filter((t) => t.length > 0) : [];
+  const filtered =
+    tokens.length === 0
+      ? matches
+      : matches.filter((m) => {
+          const name = m.name.toLowerCase();
+          const traits = (m.traits ?? []).map((t) => t.toLowerCase());
+          return tokens.every((tok) => name.includes(tok) || traits.some((t) => t.includes(tok)));
+        });
+
+  const summaries = filtered.map(monsterMatchToSummary);
 
   const sortBy = params.sortBy ?? 'level';
   const sortDir = params.sortDir ?? 'asc';

--- a/apps/dm-tool/electron/compendium/prepared.ts
+++ b/apps/dm-tool/electron/compendium/prepared.ts
@@ -183,17 +183,27 @@ async function listMonsters(
   packIds: readonly string[],
   params: MonsterSearchParams,
 ): Promise<MonsterSummary[]> {
-  // No filtering beyond document type and the user's pack selection —
-  // we want the Monster window to return every NPC in every ticked
-  // pack. Keyword/trait/level filters from `params` are deliberately
-  // ignored so the UI sees an unfiltered baseline; any narrowing is a
-  // client-side concern the browser can apply over the returned list.
-  // Sort is not a filter and stays applied.
-  const { matches } = await api.searchCompendium({
-    documentType: 'npc',
+  // DIAGNOSTIC MODE — no filters at all, not even documentType. The
+  // Monster window returns every document from every ticked pack. If a
+  // tick selection includes an Item-type pack the user will see items
+  // in the browser; that's intentional while we verify the pack-select
+  // pipeline end-to-end. Sort is not a filter and stays applied.
+  //
+  // Search args sent:
+  //   - packIds: resolver output (Settings ∩ installed in Foundry)
+  //   - limit  : 10000 (server max)
+  // Nothing else — not q, traits, maxLevel, documentType.
+  const search = {
     packIds: [...packIds],
     limit: params.limit ?? 10000,
+  };
+  console.info('[listMonsters] searchCompendium ←', {
+    packCount: search.packIds.length,
+    packIds: search.packIds,
+    limit: search.limit,
   });
+  const { matches } = await api.searchCompendium(search);
+  console.info('[listMonsters] searchCompendium → matches:', matches.length);
 
   const summaries = matches.map(monsterMatchToSummary);
 

--- a/apps/dm-tool/electron/compendium/prepared.ts
+++ b/apps/dm-tool/electron/compendium/prepared.ts
@@ -178,51 +178,25 @@ async function searchMonsters(api: CompendiumApi, packIds: readonly string[], qu
   return results.map((r, i) => formatMonsterForChat(r, i + 1)).join('\n\n');
 }
 
-/** Post-filter a list of `CompendiumMatch` rows against the client-side
- *  `MonsterSearchParams` fields the server doesn't yet understand. The
- *  match row carries `level` and `traits`; deeper filters (hp/ac/saves)
- *  can't be enforced without a full-doc fetch, so we deliberately skip
- *  them here — callers that need stat-based filtering should pull the
- *  full summary list via follow-up doc fetches. */
-function filterMatchesClientSide(matches: CompendiumMatch[], params: MonsterSearchParams): CompendiumMatch[] {
-  return matches.filter((m) => {
-    if (params.levels) {
-      const [lo, hi] = params.levels;
-      if (typeof m.level === 'number' && (m.level < lo || m.level > hi)) return false;
-    }
-    if (params.traits && params.traits.length > 0) {
-      const mTraits = m.traits ?? [];
-      for (const t of params.traits) {
-        if (!mTraits.includes(t)) return false;
-      }
-    }
-    return true;
-  });
-}
-
 async function listMonsters(
   api: CompendiumApi,
   packIds: readonly string[],
   params: MonsterSearchParams,
 ): Promise<MonsterSummary[]> {
-  // The server's `/api/compendium/search` speaks q/traits/maxLevel/limit.
-  // Anything beyond that we enforce client-side after the network hop.
+  // No filtering beyond document type and the user's pack selection —
+  // we want the Monster window to return every NPC in every ticked
+  // pack. Keyword/trait/level filters from `params` are deliberately
+  // ignored so the UI sees an unfiltered baseline; any narrowing is a
+  // client-side concern the browser can apply over the returned list.
+  // Sort is not a filter and stays applied.
   const { matches } = await api.searchCompendium({
-    q: params.keywords,
     documentType: 'npc',
     packIds: [...packIds],
-    traits: params.traits,
-    maxLevel: params.levels?.[1],
-    limit: params.limit ?? 5000,
+    limit: params.limit ?? 10000,
   });
 
-  const filtered = filterMatchesClientSide(matches, params);
-  const summaries = filtered.map(monsterMatchToSummary);
+  const summaries = matches.map(monsterMatchToSummary);
 
-  // Sort if requested — only name and level are cheap here; hp/ac sort
-  // would require pulling the full doc for every match. Consumers using
-  // hp/ac sort today should continue to hit the legacy SQL path until we
-  // migrate the summary shape through a cached doc lookup.
   const sortBy = params.sortBy ?? 'level';
   const sortDir = params.sortDir ?? 'asc';
   if (sortBy === 'name' || sortBy === 'level') {

--- a/apps/dm-tool/electron/compendium/singleton.test.ts
+++ b/apps/dm-tool/electron/compendium/singleton.test.ts
@@ -1,0 +1,176 @@
+// Singleton-level coverage for the monster-pack resolver and the
+// available-packs intersection. We mock @foundry-toolkit/db/pf2e's
+// settings getters/setters with an in-memory Map so the tests don't
+// touch a real pf2e.db, and we drive `refreshAvailableActorPacks` by
+// calling init() with a fake `CompendiumApi`.
+//
+// `readMonsterPackIds()` is the one hot path every monster-facing
+// accessor routes through, so the branches covered here map 1:1 to
+// the filter behavior every caller sees at runtime.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const settingsStore = new Map<string, string>();
+
+vi.mock('@foundry-toolkit/db/pf2e', () => ({
+  getSetting: vi.fn((key: string) => settingsStore.get(key) ?? null),
+  setSetting: vi.fn((key: string, value: string) => {
+    settingsStore.set(key, value);
+  }),
+  deleteSetting: vi.fn((key: string) => {
+    settingsStore.delete(key);
+  }),
+}));
+
+// Stub out facets-index so `writeMonsterPackIds` doesn't blow up trying
+// to invalidate a real module cache.
+vi.mock('./facets-index.js', () => ({
+  resetFacetsIndex: vi.fn(),
+}));
+
+// Stub `createCompendiumApi` so init can complete without hitting the
+// real HTTP stack. The listCompendiumPacks mock drives the
+// available-packs fetch; default is an empty list so each test can
+// override with its own pack fixture.
+const listCompendiumPacks = vi.fn().mockResolvedValue({ packs: [] });
+vi.mock('./index.js', () => ({
+  createCompendiumApi: () => ({
+    searchCompendium: vi.fn(),
+    getCompendiumDocument: vi.fn(),
+    listCompendiumPacks,
+    listCompendiumSources: vi.fn(),
+    invalidateDocument: vi.fn(),
+    invalidateAllDocuments: vi.fn(),
+  }),
+}));
+
+// Imports come after mocks so the mocks take effect.
+const {
+  DEFAULT_MONSTER_PACK_IDS_EXPORT,
+  MONSTER_PACK_IDS_SETTING,
+  getAvailableActorPacks,
+  initPreparedCompendium,
+  readMonsterPackIds,
+  refreshAvailableActorPacks,
+  resetAvailableActorPacks,
+  resetPreparedCompendium,
+  writeMonsterPackIds,
+} = await (async () => {
+  const singleton = await import('./singleton');
+  const prepared = await import('./prepared');
+  return { ...singleton, DEFAULT_MONSTER_PACK_IDS_EXPORT: prepared.DEFAULT_MONSTER_PACK_IDS };
+})();
+
+beforeEach(() => {
+  settingsStore.clear();
+  listCompendiumPacks.mockReset().mockResolvedValue({ packs: [] });
+  resetAvailableActorPacks();
+  resetPreparedCompendium();
+});
+
+afterEach(() => {
+  resetPreparedCompendium();
+});
+
+describe('readMonsterPackIds — without available-packs cache', () => {
+  it('returns defaults when no setting is persisted', () => {
+    expect(readMonsterPackIds()).toEqual(DEFAULT_MONSTER_PACK_IDS_EXPORT);
+  });
+
+  it('returns the saved list verbatim when the cache is null', () => {
+    writeMonsterPackIds(['pf2e.a', 'pf2e.b']);
+    expect(readMonsterPackIds()).toEqual(['pf2e.a', 'pf2e.b']);
+  });
+
+  it('treats an empty saved list as "reset to defaults"', () => {
+    writeMonsterPackIds([]);
+    expect(readMonsterPackIds()).toEqual(DEFAULT_MONSTER_PACK_IDS_EXPORT);
+  });
+
+  it('falls back to defaults on malformed JSON', () => {
+    settingsStore.set(MONSTER_PACK_IDS_SETTING, '{not json at all');
+    expect(readMonsterPackIds()).toEqual(DEFAULT_MONSTER_PACK_IDS_EXPORT);
+  });
+});
+
+describe('readMonsterPackIds — intersection against available packs', () => {
+  it('strips packs not installed in Foundry', async () => {
+    listCompendiumPacks.mockResolvedValue({
+      packs: [{ id: 'pf2e.a', label: 'A', type: 'Actor' }],
+    });
+    initPreparedCompendium({ foundryMcpUrl: 'http://localhost:8765' });
+    await refreshAvailableActorPacks();
+
+    writeMonsterPackIds(['pf2e.a', 'pf2e.missing', 'pf2e.also-missing']);
+    expect(readMonsterPackIds()).toEqual(['pf2e.a']);
+  });
+
+  it('falls back to defaults ∩ available when no saved pack is installed', async () => {
+    const [firstDefault] = DEFAULT_MONSTER_PACK_IDS_EXPORT;
+    listCompendiumPacks.mockResolvedValue({
+      packs: [{ id: firstDefault, label: 'Default', type: 'Actor' }],
+    });
+    initPreparedCompendium({ foundryMcpUrl: 'http://localhost:8765' });
+    await refreshAvailableActorPacks();
+
+    writeMonsterPackIds(['pf2e.nonexistent-only']);
+    expect(readMonsterPackIds()).toEqual([firstDefault]);
+  });
+
+  it('falls through to the raw saved list when neither saved nor defaults overlap', async () => {
+    listCompendiumPacks.mockResolvedValue({
+      packs: [{ id: 'something-else', label: 'Else', type: 'Actor' }],
+    });
+    initPreparedCompendium({ foundryMcpUrl: 'http://localhost:8765' });
+    await refreshAvailableActorPacks();
+
+    writeMonsterPackIds(['pf2e.a', 'pf2e.b']);
+    // No overlap with available or defaults — caller gets the raw
+    // saved list and the bridge decides what to do with it.
+    expect(readMonsterPackIds()).toEqual(['pf2e.a', 'pf2e.b']);
+  });
+});
+
+describe('refreshAvailableActorPacks', () => {
+  it('populates the cache from the api response', async () => {
+    listCompendiumPacks.mockResolvedValue({
+      packs: [
+        { id: 'pf2e.a', label: 'A', type: 'Actor' },
+        { id: 'pf2e.b', label: 'B', type: 'Actor' },
+      ],
+    });
+    initPreparedCompendium({ foundryMcpUrl: 'http://localhost:8765' });
+    await refreshAvailableActorPacks();
+
+    const cache = getAvailableActorPacks();
+    expect(cache).not.toBeNull();
+    expect(cache?.has('pf2e.a')).toBe(true);
+    expect(cache?.has('pf2e.b')).toBe(true);
+    expect(cache?.has('pf2e.c')).toBe(false);
+  });
+
+  it('is a no-op when init was never called', async () => {
+    await refreshAvailableActorPacks();
+    expect(getAvailableActorPacks()).toBeNull();
+  });
+
+  it('leaves the cache intact on api failure', async () => {
+    // Prime with a successful fetch so the cache has content.
+    listCompendiumPacks.mockResolvedValue({
+      packs: [{ id: 'pf2e.a', label: 'A', type: 'Actor' }],
+    });
+    initPreparedCompendium({ foundryMcpUrl: 'http://localhost:8765' });
+    await refreshAvailableActorPacks();
+    expect(getAvailableActorPacks()?.has('pf2e.a')).toBe(true);
+
+    // Swap to a failing mock and refresh again — the error is logged,
+    // the cache is kept as-is.
+    listCompendiumPacks.mockRejectedValueOnce(new Error('network down'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await refreshAvailableActorPacks();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Could not list'), expect.any(String));
+    warn.mockRestore();
+
+    expect(getAvailableActorPacks()?.has('pf2e.a')).toBe(true);
+  });
+});

--- a/apps/dm-tool/electron/compendium/singleton.ts
+++ b/apps/dm-tool/electron/compendium/singleton.ts
@@ -84,15 +84,37 @@ function readSavedOrDefaultMonsterPackIds(): readonly string[] {
  *  Public so tests and IPC handlers can share one source of truth. */
 export function readMonsterPackIds(): readonly string[] {
   const saved = readSavedOrDefaultMonsterPackIds();
-  if (!availableActorPacks) return saved;
+  if (!availableActorPacks) {
+    console.info('[readMonsterPackIds] available=not-yet-loaded → passing saved through', {
+      saved: [...saved],
+    });
+    return saved;
+  }
 
   const available = availableActorPacks;
   const intersected = saved.filter((id) => available.has(id));
-  if (intersected.length > 0) return intersected;
+  if (intersected.length > 0) {
+    console.info('[readMonsterPackIds] stage-1 saved ∩ available', {
+      saved: [...saved],
+      availableCount: available.size,
+      intersected,
+    });
+    return intersected;
+  }
 
   const defaultFallback = DEFAULT_MONSTER_PACK_IDS.filter((id) => available.has(id));
-  if (defaultFallback.length > 0) return defaultFallback;
+  if (defaultFallback.length > 0) {
+    console.info('[readMonsterPackIds] stage-2 defaults ∩ available', {
+      saved: [...saved],
+      defaultFallback,
+    });
+    return defaultFallback;
+  }
 
+  console.warn('[readMonsterPackIds] stage-3 no overlap — returning raw saved list', {
+    saved: [...saved],
+    available: [...available],
+  });
   return saved;
 }
 
@@ -112,6 +134,10 @@ export async function refreshAvailableActorPacks(): Promise<void> {
   try {
     const { packs } = await api.listCompendiumPacks({ documentType: 'Actor' });
     availableActorPacks = new Set(packs.map((p) => p.id));
+    console.info('[refreshAvailableActorPacks] loaded', {
+      count: availableActorPacks.size,
+      ids: [...availableActorPacks],
+    });
   } catch (e) {
     console.warn('[compendium] Could not list available Actor packs:', (e as Error).message);
     // Leave the cache as-is. If a prior refresh succeeded we keep those

--- a/apps/dm-tool/electron/compendium/singleton.ts
+++ b/apps/dm-tool/electron/compendium/singleton.ts
@@ -84,34 +84,20 @@ function readSavedOrDefaultMonsterPackIds(): readonly string[] {
  *  Public so tests and IPC handlers can share one source of truth. */
 export function readMonsterPackIds(): readonly string[] {
   const saved = readSavedOrDefaultMonsterPackIds();
-  if (!availableActorPacks) {
-    console.info('[readMonsterPackIds] available=not-yet-loaded → passing saved through', {
-      saved: [...saved],
-    });
-    return saved;
-  }
+  if (!availableActorPacks) return saved;
 
   const available = availableActorPacks;
   const intersected = saved.filter((id) => available.has(id));
-  if (intersected.length > 0) {
-    console.info('[readMonsterPackIds] stage-1 saved ∩ available', {
-      saved: [...saved],
-      availableCount: available.size,
-      intersected,
-    });
-    return intersected;
-  }
+  if (intersected.length > 0) return intersected;
 
   const defaultFallback = DEFAULT_MONSTER_PACK_IDS.filter((id) => available.has(id));
-  if (defaultFallback.length > 0) {
-    console.info('[readMonsterPackIds] stage-2 defaults ∩ available', {
-      saved: [...saved],
-      defaultFallback,
-    });
-    return defaultFallback;
-  }
+  if (defaultFallback.length > 0) return defaultFallback;
 
-  console.warn('[readMonsterPackIds] stage-3 no overlap — returning raw saved list', {
+  // Last resort: neither saved nor defaults overlap with installed
+  // packs. Warn once so it's obvious in the console, then pass the raw
+  // saved list through to let the bridge decide (post-#45 bridge skips
+  // missing packs cleanly; older bridge 404s).
+  console.warn('[compendium] Monster pack selection has no overlap with installed packs.', {
     saved: [...saved],
     available: [...available],
   });
@@ -134,10 +120,6 @@ export async function refreshAvailableActorPacks(): Promise<void> {
   try {
     const { packs } = await api.listCompendiumPacks({ documentType: 'Actor' });
     availableActorPacks = new Set(packs.map((p) => p.id));
-    console.info('[refreshAvailableActorPacks] loaded', {
-      count: availableActorPacks.size,
-      ids: [...availableActorPacks],
-    });
   } catch (e) {
     console.warn('[compendium] Could not list available Actor packs:', (e as Error).message);
     // Leave the cache as-is. If a prior refresh succeeded we keep those

--- a/apps/dm-tool/electron/compendium/singleton.ts
+++ b/apps/dm-tool/electron/compendium/singleton.ts
@@ -26,6 +26,17 @@ export const MONSTER_PACK_IDS_SETTING = 'compendiumMonsterPackIds';
 let api: CompendiumApi | null = null;
 let prepared: PreparedCompendium | null = null;
 
+// Foundry-installed Actor pack ids, fetched once at init via
+// `/api/compendium/packs?documentType=Actor`. Used to intersect the
+// Settings-saved / default pack list against reality — callers never
+// send a `packIds: [...]` with a pack Foundry doesn't actually have,
+// which is what older bridges throw 404 on (fix in #45 but not every
+// install runs the patched bridge). `null` = fetch hasn't resolved
+// yet or failed; resolver passes the saved list through unchanged in
+// that window, same as the pre-intersection behavior.
+let availableActorPacks: Set<string> | null = null;
+let availableActorPacksFetch: Promise<void> | null = null;
+
 export interface InitPreparedCompendiumOptions {
   /** foundry-mcp base URL, e.g. `http://server.ad:8765`. Trailing slash
    *  is tolerated; an empty string throws. */
@@ -35,10 +46,12 @@ export interface InitPreparedCompendiumOptions {
   documentTtlMs?: number;
 }
 
-/** Read the user's monster-pack override from pf2e.db settings, falling
- *  back to the defaults when unset, malformed, or empty. Public so tests
- *  and IPC handlers can share one source of truth for the current scope. */
-export function readMonsterPackIds(): readonly string[] {
+/** Read the raw saved monster-pack list from pf2e.db settings, falling
+ *  back to defaults when unset, malformed, or empty. Callers that send
+ *  queries to the bridge should use `readMonsterPackIds()` instead —
+ *  that one additionally intersects against the packs Foundry actually
+ *  has installed so queries never include a missing pack. */
+function readSavedOrDefaultMonsterPackIds(): readonly string[] {
   const raw = getSetting(MONSTER_PACK_IDS_SETTING);
   if (!raw) return DEFAULT_MONSTER_PACK_IDS;
   try {
@@ -55,6 +68,34 @@ export function readMonsterPackIds(): readonly string[] {
   }
 }
 
+/** Return the saved monster-pack list intersected with the packs
+ *  Foundry actually has installed. Two-stage fallback when the
+ *  intersection is empty:
+ *    1. Try defaults ∩ available — so a user who ticked only packs
+ *       that have since been uninstalled still gets something.
+ *    2. Fall through to the raw saved list. This lets the bridge
+ *       either throw (old bridge) or skip missing packs (post-#45)
+ *       — no worse than the pre-intersection behavior.
+ *
+ *  When the available-packs fetch hasn't resolved yet (or failed), we
+ *  pass the saved list through unchanged — matches the pre-intersection
+ *  behavior so this layer is purely additive.
+ *
+ *  Public so tests and IPC handlers can share one source of truth. */
+export function readMonsterPackIds(): readonly string[] {
+  const saved = readSavedOrDefaultMonsterPackIds();
+  if (!availableActorPacks) return saved;
+
+  const available = availableActorPacks;
+  const intersected = saved.filter((id) => available.has(id));
+  if (intersected.length > 0) return intersected;
+
+  const defaultFallback = DEFAULT_MONSTER_PACK_IDS.filter((id) => available.has(id));
+  if (defaultFallback.length > 0) return defaultFallback;
+
+  return saved;
+}
+
 /** Persist a new monster-pack override and invalidate any memoized state
  *  that depends on the prior scope. Called from the Settings → Monsters
  *  IPC handler. */
@@ -63,10 +104,45 @@ export function writeMonsterPackIds(ids: readonly string[]): void {
   resetFacetsIndex();
 }
 
+/** Fetch the list of installed Actor packs from foundry-mcp and cache
+ *  it for the lifetime of the singleton. Failures are logged and the
+ *  cache stays `null` — callers fall through to the raw saved list. */
+export async function refreshAvailableActorPacks(): Promise<void> {
+  if (!api) return;
+  try {
+    const { packs } = await api.listCompendiumPacks({ documentType: 'Actor' });
+    availableActorPacks = new Set(packs.map((p) => p.id));
+  } catch (e) {
+    console.warn('[compendium] Could not list available Actor packs:', (e as Error).message);
+    // Leave the cache as-is. If a prior refresh succeeded we keep those
+    // results; if this was the first attempt the cache stays null and
+    // the resolver passes through.
+  }
+}
+
+/** Returns the cached available Actor packs set, or `null` if the
+ *  fetch hasn't resolved yet. Exported for tests + any consumer that
+ *  wants to render "unavailable" hints in the Settings UI. */
+export function getAvailableActorPacks(): ReadonlySet<string> | null {
+  return availableActorPacks;
+}
+
+/** Test/ops helper — drop the cached available-packs list. */
+export function resetAvailableActorPacks(): void {
+  availableActorPacks = null;
+  availableActorPacksFetch = null;
+}
+
 /** Idempotent — calling twice with the same options is a no-op, which is
  *  what we want for Electron's `app.whenReady` + reload story. If the
  *  caller wants to swap URLs mid-session, call `resetPreparedCompendium`
- *  first. */
+ *  first.
+ *
+ *  Fires a background `refreshAvailableActorPacks()` so subsequent
+ *  queries can intersect the saved pack list against reality. First
+ *  few queries may fire before the fetch resolves — they pass the
+ *  saved list through unchanged, matching the pre-intersection
+ *  behavior. In practice the fetch resolves in ~50ms. */
 export function initPreparedCompendium(opts: InitPreparedCompendiumOptions): void {
   if (prepared) return;
   if (!opts.foundryMcpUrl || opts.foundryMcpUrl.trim().length === 0) {
@@ -79,6 +155,8 @@ export function initPreparedCompendium(opts: InitPreparedCompendiumOptions): voi
   prepared = createPreparedCompendium(api, {
     resolveMonsterPackIds: readMonsterPackIds,
   });
+  availableActorPacksFetch = refreshAvailableActorPacks();
+  void availableActorPacksFetch;
 }
 
 export function getPreparedCompendium(): PreparedCompendium {
@@ -107,4 +185,5 @@ export function isPreparedCompendiumInitialized(): boolean {
 export function resetPreparedCompendium(): void {
   api = null;
   prepared = null;
+  resetAvailableActorPacks();
 }

--- a/apps/dm-tool/src/features/monsters/MonsterFilterPanel.tsx
+++ b/apps/dm-tool/src/features/monsters/MonsterFilterPanel.tsx
@@ -34,13 +34,6 @@ export function MonsterFilterPanel({ facets, params, onChange }: Props) {
     if (params.creatureTypes?.length) n += params.creatureTypes.length;
     if (params.traits?.length) n += params.traits.length;
     if (params.sources?.length) n += params.sources.length;
-    if (params.hpMin != null) n++;
-    if (params.hpMax != null) n++;
-    if (params.acMin != null) n++;
-    if (params.acMax != null) n++;
-    if (params.fortMin != null) n++;
-    if (params.refMin != null) n++;
-    if (params.willMin != null) n++;
     return n;
   }, [params]);
 
@@ -50,11 +43,6 @@ export function MonsterFilterPanel({ facets, params, onChange }: Props) {
     const current = (params[field] as string[] | undefined) ?? [];
     const next = current.includes(value) ? current.filter((v) => v !== value) : [...current, value];
     onChange({ ...params, [field]: next.length > 0 ? next : undefined });
-  };
-
-  const setNum = (field: keyof MonsterSearchParams, value: string) => {
-    const n = value === '' ? undefined : Number(value);
-    onChange({ ...params, [field]: n != null && Number.isFinite(n) ? n : undefined });
   };
 
   const sortedSizes = useMemo(() => {
@@ -221,22 +209,6 @@ export function MonsterFilterPanel({ facets, params, onChange }: Props) {
             </section>
           )}
 
-          <Separator />
-
-          {/* Stat ranges */}
-          <section>
-            <SectionHeader label="Stat Minimums" />
-            <div className="grid grid-cols-2 gap-x-3 gap-y-2">
-              <NumField label="HP min" value={params.hpMin} onChange={(v) => setNum('hpMin', v)} />
-              <NumField label="HP max" value={params.hpMax} onChange={(v) => setNum('hpMax', v)} />
-              <NumField label="AC min" value={params.acMin} onChange={(v) => setNum('acMin', v)} />
-              <NumField label="AC max" value={params.acMax} onChange={(v) => setNum('acMax', v)} />
-              <NumField label="Fort min" value={params.fortMin} onChange={(v) => setNum('fortMin', v)} />
-              <NumField label="Ref min" value={params.refMin} onChange={(v) => setNum('refMin', v)} />
-              <NumField label="Will min" value={params.willMin} onChange={(v) => setNum('willMin', v)} />
-            </div>
-          </section>
-
           {/* Sources */}
           {facets && facets.sources.length > 0 && (
             <section>
@@ -288,20 +260,6 @@ function CheckItem({
       <Label htmlFor={id} className="cursor-pointer text-xs capitalize">
         {label}
       </Label>
-    </div>
-  );
-}
-
-function NumField({ label, value, onChange }: { label: string; value?: number; onChange: (v: string) => void }) {
-  return (
-    <div>
-      <label className="mb-0.5 block text-[10px] text-muted-foreground">{label}</label>
-      <Input
-        type="number"
-        value={value ?? ''}
-        onChange={(e) => onChange(e.target.value)}
-        className="h-7 px-1.5 text-xs"
-      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Prevents "missing pack" errors when the user's saved monster-pack selection includes packs that aren't installed in Foundry. On init, the compendium singleton fires a background fetch (`/api/compendium/packs?documentType=Actor`) and caches the result; `readMonsterPackIds()` now intersects the saved list against that reality set before any query reaches the bridge. Falls back through defaults → raw saved list so behavior degrades gracefully when the fetch hasn't resolved yet or when no overlap exists.

Also simplifies monster search: instead of sending server-side `q`/`documentType`/`traits`/`maxLevel` filters, `listMonsters` now fetches all documents from the selected packs and applies client-side text search (whitespace-tokenized, name+traits). This makes text search instant (no network round-trip per keystroke) and matches the prior UX.

Removes the "Stat Minimums" section (HP/AC/Fort/Ref/Will inputs) from the monster filter panel — these fields were never wired through to the bridge and had no effect.

## Changes

- `singleton.ts`: new `refreshAvailableActorPacks()` fetches installed Actor packs on init; `readMonsterPackIds()` intersects saved selection against the cached set with two-stage fallback; exposes `getAvailableActorPacks()` and `resetAvailableActorPacks()` for tests and future Settings UI hints
- `prepared.ts`: `listMonsters` drops all server-side filters (documentType, traits, maxLevel, q); applies client-side tokenized text search against name + traits instead; removes `filterMatchesClientSide` helper
- `MonsterFilterPanel.tsx`: removes Stat Minimums section and `NumField`/`setNum` helpers
- `singleton.test.ts`, `prepared.test.ts`: new / expanded test coverage for the intersection logic and client-side text search