### PR TITLE
feat(player-portal): apply PF2e design language with dark/light toggle

### DIFF
--- a/apps/player-portal/src/components/ActorList.tsx
+++ b/apps/player-portal/src/components/ActorList.tsx
@@ -33,7 +33,7 @@ export function ActorList({ onSelect }: Props = {}): React.ReactElement {
   }, []);
 
   if (state.kind === 'loading') {
-    return <p className="text-sm text-neutral-500">Loading actors…</p>;
+    return <p className="text-sm text-pf-text-muted">Loading actors…</p>;
   }
 
   if (state.kind === 'error') {
@@ -47,11 +47,11 @@ export function ActorList({ onSelect }: Props = {}): React.ReactElement {
   }
 
   if (state.actors.length === 0) {
-    return <p className="text-sm text-neutral-500">No actors in the world yet.</p>;
+    return <p className="text-sm text-pf-text-muted">No actors in the world yet.</p>;
   }
 
   return (
-    <ul className="divide-y divide-neutral-200 rounded border border-neutral-200">
+    <ul className="divide-y divide-pf-border rounded border border-pf-border">
       {state.actors.map((actor) => {
         const isCharacter = actor.type === 'character';
         const clickable = isCharacter && onSelect !== undefined;
@@ -60,7 +60,7 @@ export function ActorList({ onSelect }: Props = {}): React.ReactElement {
             key={actor.id}
             className={[
               'flex items-center gap-3 px-4 py-3',
-              clickable ? 'cursor-pointer hover:bg-neutral-50' : '',
+              clickable ? 'cursor-pointer hover:bg-pf-bg-dark' : '',
             ].join(' ')}
             onClick={
               clickable
@@ -71,8 +71,8 @@ export function ActorList({ onSelect }: Props = {}): React.ReactElement {
             }
           >
             <span className="flex-1 truncate font-medium">{actor.name}</span>
-            <span className="text-xs uppercase tracking-wide text-neutral-500">{actor.type}</span>
-            {clickable && <span className="text-neutral-400">→</span>}
+            <span className="text-xs uppercase tracking-wide text-pf-text-muted">{actor.type}</span>
+            {clickable && <span className="text-pf-text-muted">→</span>}
           </li>
         );
       })}

--- a/apps/player-portal/src/components/CharactersLayout.tsx
+++ b/apps/player-portal/src/components/CharactersLayout.tsx
@@ -6,15 +6,7 @@ import { Outlet } from 'react-router-dom';
 
 export function CharactersLayout(): React.ReactElement {
   return (
-    <div
-      style={{
-        width: '100%',
-        height: '100%',
-        overflowY: 'auto',
-        backgroundColor: 'var(--color-pf-bg)',
-        color: 'var(--color-pf-text)',
-      }}
-    >
+    <div className="h-full w-full overflow-y-auto bg-pf-bg text-pf-text">
       <Outlet />
     </div>
   );

--- a/apps/player-portal/src/components/ConnectionIndicator.tsx
+++ b/apps/player-portal/src/components/ConnectionIndicator.tsx
@@ -1,0 +1,25 @@
+/** Live-connection status dot + label for pages that stream from the
+ *  sidecar WebSocket. Colors are semantic (green/amber/red) and intentionally
+ *  independent of the portal theme. */
+export function ConnectionIndicator({ status, stale }: { status: string; stale: boolean }) {
+  const dotColor =
+    status === 'connected' ? (stale ? '#d19a3a' : '#4ade80') : '#ef4444';
+  const label =
+    status === 'connected'
+      ? stale
+        ? 'Stale'
+        : 'Live'
+      : status === 'connecting'
+        ? 'Connecting…'
+        : 'Offline';
+
+  return (
+    <div className="flex items-center gap-1.5 text-xs text-portal-text-muted">
+      <span
+        className="inline-block h-2 w-2 rounded-full"
+        style={{ backgroundColor: dotColor }}
+      />
+      {label}
+    </div>
+  );
+}

--- a/apps/player-portal/src/components/Layout.tsx
+++ b/apps/player-portal/src/components/Layout.tsx
@@ -1,19 +1,16 @@
 import { Outlet } from 'react-router-dom';
+import { usePortalTheme } from '../hooks/usePortalTheme';
 import { Nav } from './Nav';
 
 export function Layout() {
+  const [theme, toggleTheme] = usePortalTheme();
   return (
     <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        width: '100vw',
-        height: '100vh',
-        backgroundColor: '#0f0f0f',
-      }}
+      data-portal-theme={theme}
+      className="flex h-screen w-screen flex-col bg-portal-bg"
     >
-      <Nav />
-      <main style={{ flex: 1, position: 'relative', minHeight: 0 }}>
+      <Nav theme={theme} onToggleTheme={toggleTheme} />
+      <main className="relative min-h-0 flex-1 overflow-hidden">
         <Outlet />
       </main>
     </div>

--- a/apps/player-portal/src/components/Nav.tsx
+++ b/apps/player-portal/src/components/Nav.tsx
@@ -8,36 +8,86 @@ const tabs = [
   { to: '/characters', label: 'Characters' },
 ];
 
-export function Nav() {
+interface Props {
+  theme: 'light' | 'dark';
+  onToggleTheme: () => void;
+}
+
+export function Nav({ theme, onToggleTheme }: Props) {
   return (
-    <nav
-      style={{
-        display: 'flex',
-        flexShrink: 0,
-        backgroundColor: '#1a1a1a',
-        borderBottom: '1px solid #2d2d2d',
-      }}
-    >
+    <nav className="flex flex-shrink-0 items-center border-b border-portal-border bg-portal-surface">
       {tabs.map((tab) => (
         <NavLink
           key={tab.to}
           to={tab.to}
           end={tab.end ?? false}
-          style={({ isActive }) => ({
-            padding: '12px 20px',
-            color: isActive ? '#ffffff' : '#9a9a9a',
-            textDecoration: 'none',
-            borderBottom: isActive ? '2px solid #e4a547' : '2px solid transparent',
-            fontSize: 14,
-            fontWeight: 500,
-            fontFamily: 'system-ui, -apple-system, sans-serif',
-            letterSpacing: '0.02em',
-            transition: 'color 0.15s, border-color 0.15s',
-          })}
+          className={({ isActive }) =>
+            [
+              'inline-flex items-center px-5 py-3 text-sm font-medium tracking-wide',
+              'border-b-2 transition-colors duration-150 no-underline',
+              isActive
+                ? 'border-portal-accent text-portal-text'
+                : 'border-transparent text-portal-text-muted hover:text-portal-text',
+            ].join(' ')
+          }
         >
           {tab.label}
         </NavLink>
       ))}
+
+      {/* Theme toggle — pushed to the right edge */}
+      <button
+        type="button"
+        onClick={onToggleTheme}
+        aria-label={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+        className="ml-auto mr-3 flex h-8 w-8 items-center justify-center rounded text-portal-text-muted transition-colors hover:text-portal-text"
+      >
+        {theme === 'dark' ? <SunIcon /> : <MoonIcon />}
+      </button>
     </nav>
+  );
+}
+
+function SunIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="4" />
+      <line x1="12" y1="2" x2="12" y2="4" />
+      <line x1="12" y1="20" x2="12" y2="22" />
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+      <line x1="2" y1="12" x2="4" y2="12" />
+      <line x1="20" y1="12" x2="22" y2="12" />
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+    </svg>
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+    </svg>
   );
 }

--- a/apps/player-portal/src/components/common/ModifierTooltip.tsx
+++ b/apps/player-portal/src/components/common/ModifierTooltip.tsx
@@ -19,17 +19,17 @@ export function ModifierTooltip({ title, breakdown, modifiers }: Props): React.R
       role="tooltip"
       className={[
         'invisible absolute left-0 top-full z-10 mt-1 w-72',
-        'rounded border border-neutral-300 bg-white p-3 text-xs shadow-lg',
+        'rounded border border-pf-border bg-pf-bg p-3 text-xs shadow-lg',
         'group-hover:visible',
       ].join(' ')}
     >
       <div className="mb-1 text-sm font-semibold text-neutral-900">{t(title)}</div>
-      <div className="mb-2 text-neutral-600">{breakdown}</div>
+      <div className="mb-2 text-pf-text-muted">{breakdown}</div>
       {active.length > 0 && (
         <ul className="space-y-0.5">
           {active.map((m) => (
             <li key={m.slug} className="flex items-center justify-between gap-2">
-              <span className="text-neutral-700">{t(m.label)}</span>
+              <span className="text-pf-text">{t(m.label)}</span>
               <span
                 className={['font-mono tabular-nums', m.kind === 'penalty' ? 'text-red-700' : 'text-emerald-800'].join(
                   ' ',

--- a/apps/player-portal/src/components/creator/AbilityBoostPicker.tsx
+++ b/apps/player-portal/src/components/creator/AbilityBoostPicker.tsx
@@ -138,8 +138,8 @@ export function AbilityBoostPicker({
                   isSelected
                     ? 'border-pf-primary bg-pf-tertiary/40'
                     : locked
-                      ? 'cursor-not-allowed border-pf-border bg-white opacity-40'
-                      : 'border-pf-border bg-white hover:bg-pf-tertiary/20',
+                      ? 'cursor-not-allowed border-pf-border bg-pf-bg opacity-40'
+                      : 'border-pf-border bg-pf-bg hover:bg-pf-tertiary/20',
                 ].join(' ')}
               >
                 <span className="text-[11px] font-semibold uppercase tracking-widest text-pf-alt-dark">
@@ -155,7 +155,7 @@ export function AbilityBoostPicker({
           <button
             type="button"
             onClick={onClose}
-            className="rounded border border-pf-border bg-white px-3 py-1 text-xs font-semibold uppercase tracking-widest text-pf-alt-dark hover:text-pf-primary"
+            className="rounded border border-pf-border bg-pf-bg px-3 py-1 text-xs font-semibold uppercase tracking-widest text-pf-alt-dark hover:text-pf-primary"
           >
             Cancel
           </button>
@@ -170,7 +170,7 @@ export function AbilityBoostPicker({
               'rounded border px-3 py-1 text-xs font-semibold uppercase tracking-widest',
               canApply
                 ? 'border-pf-primary bg-pf-primary text-white hover:brightness-110'
-                : 'cursor-not-allowed border-pf-border bg-white text-pf-alt opacity-60',
+                : 'cursor-not-allowed border-pf-border bg-pf-bg text-pf-alt opacity-60',
             ].join(' ')}
           >
             Apply {selected.length}/{BOOSTS_PER_SET}

--- a/apps/player-portal/src/components/creator/FeatPicker.tsx
+++ b/apps/player-portal/src/components/creator/FeatPicker.tsx
@@ -328,7 +328,7 @@ export function FeatPicker({ title, filters, characterContext, onPick, onClose }
               setQuery(e.target.value);
             }}
             placeholder="Type to filter…"
-            className="w-full rounded border border-pf-border bg-white px-2 py-1 text-sm text-pf-text placeholder:text-pf-alt focus:border-pf-primary focus:outline-none"
+            className="w-full rounded border border-pf-border bg-pf-bg px-2 py-1 text-sm text-pf-text placeholder:text-pf-alt focus:border-pf-primary focus:outline-none"
             data-testid="feat-picker-input"
           />
           <div className="mt-1 flex flex-wrap items-center justify-between gap-2">
@@ -532,7 +532,7 @@ function SourcePicker({
           'rounded border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest transition-colors',
           count > 0
             ? 'border-pf-primary bg-pf-primary/10 text-pf-primary'
-            : 'border-pf-border bg-white text-pf-alt-dark hover:text-pf-primary',
+            : 'border-pf-border bg-pf-bg text-pf-alt-dark hover:text-pf-primary',
         ].join(' ')}
       >
         {label} {open ? '▴' : '▾'}
@@ -541,7 +541,7 @@ function SourcePicker({
         <div
           role="listbox"
           data-testid="source-picker-panel"
-          className="absolute left-0 top-full z-10 mt-1 flex max-h-72 w-80 flex-col rounded border border-pf-border bg-white shadow-lg"
+          className="absolute left-0 top-full z-10 mt-1 flex max-h-72 w-80 flex-col rounded border border-pf-border bg-pf-bg shadow-lg"
         >
           <div className="flex items-center gap-1 border-b border-pf-border p-2">
             <input
@@ -551,7 +551,7 @@ function SourcePicker({
                 setFilter(e.target.value);
               }}
               placeholder="Filter sources…"
-              className="flex-1 rounded border border-pf-border bg-white px-2 py-0.5 text-xs text-pf-text placeholder:text-pf-alt focus:border-pf-primary focus:outline-none"
+              className="flex-1 rounded border border-pf-border bg-pf-bg px-2 py-0.5 text-xs text-pf-text placeholder:text-pf-alt focus:border-pf-primary focus:outline-none"
               data-testid="source-picker-filter"
             />
           </div>
@@ -653,7 +653,7 @@ function SortToggle({ sort, onChange }: { sort: SortState; onChange: (mode: Sort
               'px-2 py-0.5 transition-colors',
               active
                 ? 'bg-pf-primary text-white'
-                : 'bg-white text-pf-alt-dark hover:bg-pf-tertiary/40 hover:text-pf-primary',
+                : 'bg-pf-bg text-pf-alt-dark hover:bg-pf-tertiary/40 hover:text-pf-primary',
             ].join(' ')}
           >
             {opt.label}
@@ -980,7 +980,7 @@ function DetailPanel({
         <button
           type="button"
           onClick={onClose}
-          className="rounded border border-pf-border bg-white px-3 py-1 text-xs font-semibold uppercase tracking-widest text-pf-alt-dark hover:text-pf-primary"
+          className="rounded border border-pf-border bg-pf-bg px-3 py-1 text-xs font-semibold uppercase tracking-widest text-pf-alt-dark hover:text-pf-primary"
         >
           Back
         </button>

--- a/apps/player-portal/src/components/creator/PromptModal.tsx
+++ b/apps/player-portal/src/components/creator/PromptModal.tsx
@@ -191,7 +191,7 @@ export function PromptModal({ prompt }: Props): React.ReactElement {
                 onClick={(): void => {
                   void resolve(null);
                 }}
-                className="rounded border border-pf-border bg-white px-3 py-1.5 text-xs text-pf-text hover:bg-pf-bg-dark disabled:opacity-50"
+                className="rounded border border-pf-border bg-pf-bg px-3 py-1.5 text-xs text-pf-text hover:bg-pf-bg-dark disabled:opacity-50"
               >
                 Skip
               </button>

--- a/apps/player-portal/src/components/creator/SkillIncreasePicker.tsx
+++ b/apps/player-portal/src/components/creator/SkillIncreasePicker.tsx
@@ -139,7 +139,7 @@ export function SkillIncreasePicker({ level, characterContext, onPick, onClose }
           <button
             type="button"
             onClick={onClose}
-            className="rounded border border-pf-border bg-white px-3 py-1 text-xs font-semibold uppercase tracking-widest text-pf-alt-dark hover:text-pf-primary"
+            className="rounded border border-pf-border bg-pf-bg px-3 py-1 text-xs font-semibold uppercase tracking-widest text-pf-alt-dark hover:text-pf-primary"
           >
             Cancel
           </button>
@@ -156,7 +156,7 @@ export function SkillIncreasePicker({ level, characterContext, onPick, onClose }
               'rounded border px-3 py-1 text-xs font-semibold uppercase tracking-widest',
               selected !== null
                 ? 'border-pf-primary bg-pf-primary text-white hover:brightness-110'
-                : 'cursor-not-allowed border-pf-border bg-white text-pf-alt opacity-60',
+                : 'cursor-not-allowed border-pf-border bg-pf-bg text-pf-alt opacity-60',
             ].join(' ')}
           >
             {selected !== null ? `Apply ${capitaliseSlug(selected)}` : 'Apply'}

--- a/apps/player-portal/src/components/sheet/SheetHeader.tsx
+++ b/apps/player-portal/src/components/sheet/SheetHeader.tsx
@@ -64,7 +64,7 @@ export function SheetHeader({ character, onBack, onSettingsOpen }: Props): React
                 data-testid="open-settings"
                 aria-label="Settings"
                 title="Settings"
-                className="flex h-7 w-7 items-center justify-center rounded border border-neutral-300 bg-white text-neutral-700 hover:bg-neutral-50"
+                className="flex h-7 w-7 items-center justify-center rounded border border-pf-border bg-pf-bg text-pf-text hover:bg-pf-bg"
               >
                 <GearIcon />
               </button>
@@ -74,7 +74,7 @@ export function SheetHeader({ character, onBack, onSettingsOpen }: Props): React
                 type="button"
                 onClick={onBack}
                 data-testid="back-to-actors"
-                className="rounded border border-neutral-300 bg-white px-2 py-1 text-xs text-neutral-700 hover:bg-neutral-50"
+                className="rounded border border-pf-border bg-pf-bg px-2 py-1 text-xs text-pf-text hover:bg-pf-bg"
               >
                 ← Actors
               </button>

--- a/apps/player-portal/src/components/tabs/Actions.tsx
+++ b/apps/player-portal/src/components/tabs/Actions.tsx
@@ -30,7 +30,7 @@ export function Actions({ actions, items, abilities, actorId, onItemUsed }: Prop
 
   const hasAny = strikes.length > 0 || actionItems.length > 0;
   if (!hasAny) {
-    return <p className="text-sm text-neutral-500">No actions available.</p>;
+    return <p className="text-sm text-pf-text-muted">No actions available.</p>;
   }
 
   return (
@@ -81,7 +81,7 @@ function StrikeCard({
 
   return (
     <li
-      className="rounded border border-neutral-200 bg-white p-3"
+      className="rounded border border-pf-border bg-pf-bg p-3"
       data-strike-slug={strike.slug}
       data-ready={strike.ready ? 'true' : 'false'}
     >
@@ -89,19 +89,19 @@ function StrikeCard({
         <img
           src={strike.item.img}
           alt=""
-          className="h-10 w-10 flex-shrink-0 rounded border border-neutral-200 bg-neutral-50"
+          className="h-10 w-10 flex-shrink-0 rounded border border-pf-border bg-pf-bg-dark"
         />
         <div className="min-w-0 flex-1">
           <div className="flex items-baseline justify-between gap-2">
             <span className="truncate text-sm font-medium text-neutral-900">
               {strike.label}
               {strike.quantity > 1 && (
-                <span className="ml-2 text-xs font-normal text-neutral-500">×{strike.quantity}</span>
+                <span className="ml-2 text-xs font-normal text-pf-text-muted">×{strike.quantity}</span>
               )}
             </span>
             {damageText !== null && (
               <span
-                className="flex-shrink-0 font-mono text-xs tabular-nums text-neutral-500"
+                className="flex-shrink-0 font-mono text-xs tabular-nums text-pf-text-muted"
                 data-role="strike-damage"
               >
                 {damageText}
@@ -118,7 +118,7 @@ function StrikeCard({
               type="button"
               onClick={() => void damage.trigger()}
               disabled={damage.state === 'pending'}
-              className="rounded border border-neutral-300 bg-white px-2 py-0.5 text-[11px] font-semibold text-neutral-800 hover:bg-neutral-100 disabled:opacity-50"
+              className="rounded border border-pf-border bg-pf-bg px-2 py-0.5 text-[11px] font-semibold text-pf-text hover:bg-pf-bg-dark disabled:opacity-50"
               data-role="strike-damage-roll"
             >
               {damage.state === 'pending' ? 'Rolling…' : 'Damage'}
@@ -136,7 +136,7 @@ function StrikeCard({
           {error !== null && <p className="mt-1 text-[11px] text-red-700">{error}</p>}
           {allTraits.length > 0 && <TraitChips traits={allTraits} />}
           {range !== null && range !== undefined && (
-            <p className="mt-1 text-[10px] text-neutral-500">Range: {range} ft</p>
+            <p className="mt-1 text-[10px] text-pf-text-muted">Range: {range} ft</p>
           )}
         </div>
       </div>
@@ -239,7 +239,7 @@ function VariantStrip({
               'rounded border px-1.5 py-0.5 font-mono text-xs tabular-nums disabled:opacity-50',
               i === 0
                 ? 'border-emerald-300 bg-emerald-50 text-emerald-900 hover:bg-emerald-100'
-                : 'border-neutral-200 bg-neutral-50 text-neutral-700 hover:bg-neutral-100',
+                : 'border-pf-border bg-pf-bg text-pf-text hover:bg-pf-bg-dark',
             ].join(' ')}
           >
             {v.label}
@@ -305,7 +305,7 @@ function ActionCard({
 
   return (
     <li
-      className="rounded border border-neutral-200 bg-white"
+      className="rounded border border-pf-border bg-pf-bg"
       data-action-id={item.id}
       data-action-kind={kind}
       data-expanded={expanded ? 'true' : 'false'}
@@ -314,7 +314,7 @@ function ActionCard({
         <img
           src={item.img}
           alt=""
-          className="mt-0.5 h-8 w-8 flex-shrink-0 rounded border border-neutral-200 bg-neutral-50"
+          className="mt-0.5 h-8 w-8 flex-shrink-0 rounded border border-pf-border bg-pf-bg-dark"
         />
         <div className="min-w-0 flex-1">
           <div className="flex items-baseline gap-2">
@@ -341,7 +341,7 @@ function ActionCard({
               type="button"
               onClick={toggle}
               aria-label={expanded ? 'Collapse' : 'Expand'}
-              className="text-[10px] text-neutral-500 hover:text-neutral-800"
+              className="text-[10px] text-pf-text-muted hover:text-pf-text"
             >
               {expanded ? '▾' : '▸'}
             </button>
@@ -354,7 +354,7 @@ function ActionCard({
               {traits.map((slug) => (
                 <li
                   key={slug}
-                  className="rounded-full border border-neutral-300 bg-neutral-50 px-1.5 py-0.5 text-[10px] text-neutral-600"
+                  className="rounded-full border border-pf-border bg-pf-bg px-1.5 py-0.5 text-[10px] text-pf-text-muted"
                 >
                   {capitaliseSlug(slug)}
                 </li>
@@ -365,7 +365,7 @@ function ActionCard({
       </div>
       {expanded && (
         <div
-          className="border-t border-neutral-200 bg-pf-bg/60 px-3 py-2 text-sm text-pf-text"
+          className="border-t border-pf-border bg-pf-bg/60 px-3 py-2 text-sm text-pf-text"
           data-role="action-description"
         >
           {hasDescription ? (
@@ -396,7 +396,7 @@ function ActionCostBadge({ kind, count }: { kind: string; count: number | null }
     action: 'border-emerald-300 bg-emerald-50 text-emerald-800',
     reaction: 'border-sky-300 bg-sky-50 text-sky-800',
     free: 'border-violet-300 bg-violet-50 text-violet-800',
-    passive: 'border-neutral-300 bg-neutral-50 text-neutral-600',
+    passive: 'border-pf-border bg-pf-bg text-pf-text-muted',
   };
   return (
     <span
@@ -418,7 +418,7 @@ function TraitChips({ traits }: { traits: { name: string; label: string }[] }): 
       {traits.map((t) => (
         <li
           key={t.name}
-          className="rounded-full border border-neutral-300 bg-neutral-50 px-1.5 py-0.5 text-[10px] text-neutral-600"
+          className="rounded-full border border-pf-border bg-pf-bg px-1.5 py-0.5 text-[10px] text-pf-text-muted"
           title={t.name}
         >
           {t.label}

--- a/apps/player-portal/src/components/tabs/Character.tsx
+++ b/apps/player-portal/src/components/tabs/Character.tsx
@@ -65,7 +65,7 @@ export function Character({ system, actorId, onActorChanged }: Props): React.Rea
             <span data-stat="reach" className="tabular-nums">
               {reach.base} ft
               {reach.manipulate !== reach.base && (
-                <span className="text-neutral-500"> · {reach.manipulate} ft (manipulate)</span>
+                <span className="text-pf-text-muted"> · {reach.manipulate} ft (manipulate)</span>
               )}
             </span>
           </MetaItem>
@@ -84,7 +84,7 @@ export function Character({ system, actorId, onActorChanged }: Props): React.Rea
           <MetaItem label="Class DC">
             <span>
               <strong className="tabular-nums">{classDC.dc}</strong>{' '}
-              <span className="text-neutral-500">({classDC.label})</span>
+              <span className="text-pf-text-muted">({classDC.label})</span>
             </span>
           </MetaItem>
         )}
@@ -124,7 +124,7 @@ function AbilityBlock({
               data-attribute={ak}
               className={[
                 'relative flex flex-col items-center rounded border px-2 py-3',
-                isKey ? 'border-pf-tertiary-dark bg-pf-tertiary/40' : 'border-pf-border bg-white',
+                isKey ? 'border-pf-tertiary-dark bg-pf-tertiary/40' : 'border-pf-border bg-pf-bg',
               ].join(' ')}
             >
               {isKey && (
@@ -256,7 +256,7 @@ function HpTile({
 
   return (
     <div
-      className="flex flex-col items-center rounded border border-pf-border bg-white px-2 py-2"
+      className="flex flex-col items-center rounded border border-pf-border bg-pf-bg px-2 py-2"
       title={hp.breakdown}
       data-stat="hp"
     >
@@ -287,7 +287,7 @@ function StepButton({
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className="rounded border border-neutral-300 bg-white px-1 py-0.5 font-mono text-[10px] text-neutral-700 hover:bg-neutral-100 disabled:opacity-50"
+      className="rounded border border-pf-border bg-pf-bg px-1 py-0.5 font-mono text-[10px] text-pf-text hover:bg-pf-bg-dark disabled:opacity-50"
     >
       {label}
     </button>
@@ -362,7 +362,7 @@ function StatTile({
   if (onRoll === undefined) {
     return (
       <div
-        className="flex flex-col items-center rounded border border-pf-border bg-white px-3 py-2"
+        className="flex flex-col items-center rounded border border-pf-border bg-pf-bg px-3 py-2"
         title={title}
         {...rest}
       >
@@ -377,7 +377,7 @@ function StatTile({
       onClick={onRoll}
       disabled={pending === true}
       title={title}
-      className="flex flex-col items-center rounded border border-pf-border bg-white px-3 py-2 hover:border-pf-tertiary-dark hover:bg-pf-tertiary/40 disabled:opacity-60 disabled:hover:bg-white"
+      className="flex flex-col items-center rounded border border-pf-border bg-pf-bg px-3 py-2 hover:border-pf-tertiary-dark hover:bg-pf-tertiary/40 disabled:opacity-60 disabled:hover:bg-pf-bg"
       {...rest}
     >
       {contents}
@@ -478,7 +478,7 @@ function PipResource({
 }): React.ReactElement {
   return (
     <div className="flex items-center gap-2" title={title} {...rest}>
-      <span className="text-[11px] font-semibold uppercase tracking-widest text-neutral-500">{label}</span>
+      <span className="text-[11px] font-semibold uppercase tracking-widest text-pf-text-muted">{label}</span>
       {onAdjust !== undefined && (
         <StepButton label="−" disabled={pending ?? false} onClick={() => onAdjust(-1)} />
       )}
@@ -488,7 +488,7 @@ function PipResource({
             key={i}
             className={[
               'inline-block h-3 w-3 rounded-full border',
-              i < value ? colorOn : 'border-neutral-300 bg-white',
+              i < value ? colorOn : 'border-pf-border bg-pf-bg',
             ].join(' ')}
           />
         ))}
@@ -496,7 +496,7 @@ function PipResource({
       {onAdjust !== undefined && (
         <StepButton label="+" disabled={pending ?? false} onClick={() => onAdjust(1)} />
       )}
-      <span className="font-mono text-xs tabular-nums text-neutral-500">
+      <span className="font-mono text-xs tabular-nums text-pf-text-muted">
         {value}/{max}
       </span>
     </div>
@@ -516,7 +516,7 @@ function CountResource({
 }): React.ReactElement {
   return (
     <div className="flex items-center gap-2" {...rest}>
-      <span className="text-[11px] font-semibold uppercase tracking-widest text-neutral-500">{label}</span>
+      <span className="text-[11px] font-semibold uppercase tracking-widest text-pf-text-muted">{label}</span>
       <span className="font-mono text-sm tabular-nums text-neutral-900">
         {value}
         <span className="text-neutral-400">/{max}</span>
@@ -529,25 +529,25 @@ function ShieldTile({ shield }: { shield: Shield }): React.ReactElement {
   const name = t(shield.name);
   return (
     <div
-      className="flex items-center gap-3 rounded border border-neutral-200 bg-white px-3 py-2"
+      className="flex items-center gap-3 rounded border border-pf-border bg-pf-bg px-3 py-2"
       data-stat="shield"
       title={`Hardness ${shield.hardness.toString()} · Broken Threshold ${shield.brokenThreshold.toString()}`}
     >
       {shield.icon && (
-        <img src={shield.icon} alt="" className="h-8 w-8 shrink-0 rounded border border-neutral-200 bg-neutral-50" />
+        <img src={shield.icon} alt="" className="h-8 w-8 shrink-0 rounded border border-pf-border bg-pf-bg-dark" />
       )}
       <div className="flex flex-1 flex-wrap items-center gap-x-4 gap-y-1">
         <span className="text-sm font-medium text-neutral-900">{name}</span>
-        <span className="text-xs text-neutral-600">
+        <span className="text-xs text-pf-text-muted">
           <span className="font-semibold">+{shield.ac}</span> AC
         </span>
-        <span className="text-xs text-neutral-600">
+        <span className="text-xs text-pf-text-muted">
           HP{' '}
           <span className="font-mono tabular-nums">
             {shield.hp.value}/{shield.hp.max}
           </span>
         </span>
-        <span className="text-xs text-neutral-600">
+        <span className="text-xs text-pf-text-muted">
           Hardness <span className="font-mono tabular-nums">{shield.hardness}</span>
         </span>
         {shield.raised && (
@@ -667,7 +667,7 @@ function Condition({
 }): React.ReactElement {
   return (
     <div className="flex items-center gap-2" title={title} {...rest}>
-      <span className="text-[11px] font-semibold uppercase tracking-widest text-neutral-500">{label}</span>
+      <span className="text-[11px] font-semibold uppercase tracking-widest text-pf-text-muted">{label}</span>
       {onAdjust !== undefined && (
         <StepButton label="−" disabled={pending ?? false} onClick={() => onAdjust(-1)} />
       )}
@@ -677,7 +677,7 @@ function Condition({
             key={i}
             className={[
               'inline-block h-2.5 w-2.5 rounded-sm border',
-              i < value ? colorOn : 'border-neutral-300 bg-white',
+              i < value ? colorOn : 'border-pf-border bg-pf-bg',
             ].join(' ')}
           />
         ))}
@@ -685,7 +685,7 @@ function Condition({
       {onAdjust !== undefined && (
         <StepButton label="+" disabled={pending ?? false} onClick={() => onAdjust(1)} />
       )}
-      <span className="font-mono text-xs tabular-nums text-neutral-500">
+      <span className="font-mono text-xs tabular-nums text-pf-text-muted">
         {value}/{max}
       </span>
     </div>
@@ -717,7 +717,7 @@ function SpeedList({ speeds }: { speeds: Array<{ key: string; speed: Speed }> })
       {speeds.map(({ key, speed }, idx) => (
         <span key={key} className="inline-flex items-center gap-1" data-speed={key} title={speed.breakdown}>
           <span className="tabular-nums">{speed.value} ft</span>
-          <span className="text-xs text-neutral-500">{SPEED_LABELS[key] ?? humaniseSlug(key)}</span>
+          <span className="text-xs text-pf-text-muted">{SPEED_LABELS[key] ?? humaniseSlug(key)}</span>
           {idx < speeds.length - 1 && <span className="text-neutral-300">·</span>}
         </span>
       ))}
@@ -749,11 +749,11 @@ function IWRRow({ label, entries }: { label: string; entries: IWREntry[] }): Rea
   if (entries.length === 0) return null;
   return (
     <div className="flex flex-wrap items-center gap-1.5" data-iwr={label.toLowerCase()}>
-      <span className="text-[10px] font-semibold uppercase tracking-widest text-neutral-500">{label}</span>
+      <span className="text-[10px] font-semibold uppercase tracking-widest text-pf-text-muted">{label}</span>
       {entries.map((e, i) => (
         <span
           key={`${e.type}-${i.toString()}`}
-          className="rounded-full border border-neutral-300 bg-neutral-50 px-2.5 py-0.5 text-xs text-neutral-700"
+          className="rounded-full border border-pf-border bg-pf-bg px-2.5 py-0.5 text-xs text-pf-text"
           title={e.exceptions?.length ? `except ${e.exceptions.join(', ')}` : undefined}
         >
           {humaniseSlug(e.type)}
@@ -776,7 +776,7 @@ function XPBar({ value, max, pct }: { value: number; max: number; pct: number })
         {value} / {max}
       </span>
       <span
-        className="inline-block h-1.5 w-16 overflow-hidden rounded bg-neutral-200"
+        className="inline-block h-1.5 w-16 overflow-hidden rounded bg-pf-bg-dark"
         role="progressbar"
         aria-valuenow={value}
         aria-valuemin={0}

--- a/apps/player-portal/src/components/tabs/Character.tsx
+++ b/apps/player-portal/src/components/tabs/Character.tsx
@@ -517,9 +517,9 @@ function CountResource({
   return (
     <div className="flex items-center gap-2" {...rest}>
       <span className="text-[11px] font-semibold uppercase tracking-widest text-pf-text-muted">{label}</span>
-      <span className="font-mono text-sm tabular-nums text-neutral-900">
+      <span className="font-mono text-sm tabular-nums text-pf-text">
         {value}
-        <span className="text-neutral-400">/{max}</span>
+        <span className="text-pf-text-muted">/{max}</span>
       </span>
     </div>
   );
@@ -537,7 +537,7 @@ function ShieldTile({ shield }: { shield: Shield }): React.ReactElement {
         <img src={shield.icon} alt="" className="h-8 w-8 shrink-0 rounded border border-pf-border bg-pf-bg-dark" />
       )}
       <div className="flex flex-1 flex-wrap items-center gap-x-4 gap-y-1">
-        <span className="text-sm font-medium text-neutral-900">{name}</span>
+        <span className="text-sm font-medium text-pf-text">{name}</span>
         <span className="text-xs text-pf-text-muted">
           <span className="font-semibold">+{shield.ac}</span> AC
         </span>
@@ -718,7 +718,7 @@ function SpeedList({ speeds }: { speeds: Array<{ key: string; speed: Speed }> })
         <span key={key} className="inline-flex items-center gap-1" data-speed={key} title={speed.breakdown}>
           <span className="tabular-nums">{speed.value} ft</span>
           <span className="text-xs text-pf-text-muted">{SPEED_LABELS[key] ?? humaniseSlug(key)}</span>
-          {idx < speeds.length - 1 && <span className="text-neutral-300">·</span>}
+          {idx < speeds.length - 1 && <span className="text-pf-border">·</span>}
         </span>
       ))}
     </span>
@@ -772,7 +772,7 @@ function XPBar({ value, max, pct }: { value: number; max: number; pct: number })
   const clamped = Math.max(0, Math.min(100, pct));
   return (
     <span className="flex items-center gap-2" data-stat="xp">
-      <span className="font-mono tabular-nums text-neutral-900">
+      <span className="font-mono tabular-nums text-pf-text">
         {value} / {max}
       </span>
       <span

--- a/apps/player-portal/src/components/tabs/Crafting.tsx
+++ b/apps/player-portal/src/components/tabs/Crafting.tsx
@@ -182,7 +182,7 @@ function FormulaCard({
 
   return (
     <li className="relative" data-formula-uuid={formula.uuid}>
-      <details className="group rounded border border-pf-border bg-white open:rounded-b-none open:border-pf-primary/60 open:shadow-lg">
+      <details className="group rounded border border-pf-border bg-pf-bg open:rounded-b-none open:border-pf-primary/60 open:shadow-lg">
         <summary className="flex cursor-pointer list-none items-start gap-3 px-3 py-2 hover:bg-pf-bg-dark/40">
           {img !== null ? (
             <img
@@ -198,7 +198,7 @@ function FormulaCard({
             {state.kind === 'error' && (
               <>
                 <span className="block text-sm text-red-700">Unresolved formula</span>
-                <span className="block truncate font-mono text-[10px] text-neutral-500">{formula.uuid}</span>
+                <span className="block truncate font-mono text-[10px] text-pf-text-muted">{formula.uuid}</span>
               </>
             )}
             {state.kind === 'ok' && name !== null && (
@@ -266,7 +266,7 @@ function FormulaDetail({
     return (
       <>
         <p className="text-xs text-red-700">Couldn&apos;t load this formula: {state.message}</p>
-        <p className="mt-1 font-mono text-[10px] text-neutral-500">{uuid}</p>
+        <p className="mt-1 font-mono text-[10px] text-pf-text-muted">{uuid}</p>
         <div className="mt-2 flex justify-end">
           <RemoveFormulaButton onClick={onRemove} />
         </div>
@@ -323,7 +323,7 @@ function CraftingAbilityCard({
   const slotsMax = entry.maxSlots;
 
   return (
-    <li className="rounded border border-pf-border bg-white p-3" data-ability-slug={entry.slug}>
+    <li className="rounded border border-pf-border bg-pf-bg p-3" data-ability-slug={entry.slug}>
       <div className="flex items-start justify-between gap-2">
         <h3 className="text-sm font-semibold text-pf-text">{entry.label}</h3>
         <div className="flex flex-shrink-0 flex-wrap items-start justify-end gap-1">

--- a/apps/player-portal/src/components/tabs/Feats.tsx
+++ b/apps/player-portal/src/components/tabs/Feats.tsx
@@ -70,7 +70,7 @@ function FeatCard({ feat }: { feat: FeatItem }): React.ReactElement {
 
   return (
     <li className="relative" data-item-id={feat.id} data-feat-slug={feat.system.slug ?? ''}>
-      <details className="group rounded border border-pf-border bg-white open:rounded-b-none open:border-pf-primary/60 open:shadow-lg">
+      <details className="group rounded border border-pf-border bg-pf-bg open:rounded-b-none open:border-pf-primary/60 open:shadow-lg">
         <summary className="flex cursor-pointer list-none items-start gap-3 px-3 py-2 hover:bg-pf-bg-dark/40">
           <img
             src={feat.img}

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -195,7 +195,7 @@ export function Inventory({ items, actorId, onActorChanged }: Props): React.Reac
         </p>
       )}
       {physical.length === 0 && effectiveShopView === 'inventory' ? (
-        <p className="text-sm text-neutral-500">No items yet.</p>
+        <p className="text-sm text-pf-text-muted">No items yet.</p>
       ) : (
         <>
           <div className="flex flex-wrap items-center justify-between gap-4">
@@ -353,7 +353,7 @@ function CategorizedInventory({
   const buckets = view === 'list' ? topLevelByCategory : allByCategory;
   const presentCategories = CATEGORY_ORDER.filter((c) => (buckets.get(c)?.length ?? 0) > 0);
   if (presentCategories.length === 0) {
-    return <p className="text-sm text-neutral-500">No items yet.</p>;
+    return <p className="text-sm text-pf-text-muted">No items yet.</p>;
   }
   return (
     <div className="space-y-4">
@@ -404,7 +404,7 @@ function ShopGearMenu({
   return (
     <details className="relative" data-section="shop-debug">
       <summary
-        className="flex h-8 w-8 cursor-pointer list-none items-center justify-center rounded border border-pf-border bg-white text-base leading-none text-pf-alt-dark hover:bg-pf-bg-dark/40"
+        className="flex h-8 w-8 cursor-pointer list-none items-center justify-center rounded border border-pf-border bg-pf-bg text-base leading-none text-pf-alt-dark hover:bg-pf-bg-dark/40"
         title="Shop settings"
         aria-label="Shop settings"
         data-testid="shop-gear"
@@ -412,7 +412,7 @@ function ShopGearMenu({
         <span aria-hidden="true">⚙</span>
       </summary>
       <div
-        className="absolute right-0 top-full z-20 mt-1 w-64 rounded border border-pf-border bg-white p-3 text-xs text-pf-text shadow-lg"
+        className="absolute right-0 top-full z-20 mt-1 w-64 rounded border border-pf-border bg-pf-bg p-3 text-xs text-pf-text shadow-lg"
         data-role="shop-gear-menu"
       >
         <p className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark">
@@ -462,7 +462,7 @@ function ShopViewToggle({
   const inactive = 'text-pf-alt-dark hover:bg-pf-bg-dark/60';
   return (
     <div
-      className="inline-flex shrink-0 overflow-hidden rounded border border-pf-border bg-white"
+      className="inline-flex shrink-0 overflow-hidden rounded border border-pf-border bg-pf-bg"
       role="group"
       aria-label="Shop view"
       data-shop-view={view}
@@ -497,7 +497,7 @@ function ViewToggle({ view, onChange }: { view: ViewMode; onChange: (v: ViewMode
   const inactive = 'text-pf-alt-dark hover:bg-pf-bg-dark/60';
   return (
     <div
-      className="inline-flex shrink-0 overflow-hidden rounded border border-pf-border bg-white"
+      className="inline-flex shrink-0 overflow-hidden rounded border border-pf-border bg-pf-bg"
       role="group"
       aria-label="Inventory view"
       data-inventory-view={view}
@@ -559,7 +559,7 @@ function CoinStrip({ coins }: { coins: PhysicalItem[] }): React.ReactElement {
           ].join(' ')}
         >
           <strong>{totals[denom]}</strong>{' '}
-          <span className="text-[10px] uppercase tracking-wider text-neutral-500">{denom}</span>
+          <span className="text-[10px] uppercase tracking-wider text-pf-text-muted">{denom}</span>
         </span>
       ))}
     </div>
@@ -585,7 +585,7 @@ function ItemRow({
       : undefined;
 
   return (
-    <li className="rounded border border-pf-border bg-white" data-item-id={item.id} data-item-type={item.type}>
+    <li className="rounded border border-pf-border bg-pf-bg" data-item-id={item.id} data-item-type={item.type}>
       <details className="group">
         <summary className="flex cursor-pointer list-none items-center gap-3 px-3 py-2 hover:bg-pf-bg-dark/40">
           <img src={item.img} alt="" className="h-8 w-8 flex-shrink-0 rounded border border-pf-border bg-pf-bg-dark" />
@@ -593,10 +593,10 @@ function ItemRow({
             <div className="flex items-baseline gap-2">
               <span className="truncate text-sm text-neutral-900">{item.name}</span>
               {item.system.quantity > 1 && (
-                <span className="flex-shrink-0 text-xs text-neutral-500">×{item.system.quantity}</span>
+                <span className="flex-shrink-0 text-xs text-pf-text-muted">×{item.system.quantity}</span>
               )}
               {capacityText !== undefined && (
-                <span className="flex-shrink-0 text-[10px] uppercase tracking-wider text-neutral-500">
+                <span className="flex-shrink-0 text-[10px] uppercase tracking-wider text-pf-text-muted">
                   {capacityText}
                 </span>
               )}
@@ -672,7 +672,7 @@ function ContainerChildRow({ item }: { item: PhysicalItem }): React.ReactElement
           <img src={item.img} alt="" className="h-6 w-6 flex-shrink-0 rounded border border-pf-border bg-pf-bg-dark" />
           <div className="min-w-0 flex-1">
             <span className="truncate text-sm text-neutral-800">{item.name}</span>
-            {item.system.quantity > 1 && <span className="ml-2 text-xs text-neutral-500">×{item.system.quantity}</span>}
+            {item.system.quantity > 1 && <span className="ml-2 text-xs text-pf-text-muted">×{item.system.quantity}</span>}
           </div>
           <BulkLabel value={item.system.bulk.value} />
           <span className="ml-1 text-[10px] text-pf-alt-dark group-open:hidden">▸</span>
@@ -694,7 +694,7 @@ function GridTile({
   return (
     <li className="relative" data-item-id={item.id} data-item-type={item.type}>
       <details className="group">
-        <summary className="flex cursor-pointer list-none flex-col items-center gap-1 rounded border border-pf-border bg-white p-2 text-center hover:bg-pf-bg-dark/40 group-open:border-pf-primary/60 group-open:shadow-lg">
+        <summary className="flex cursor-pointer list-none flex-col items-center gap-1 rounded border border-pf-border bg-pf-bg p-2 text-center hover:bg-pf-bg-dark/40 group-open:border-pf-primary/60 group-open:shadow-lg">
           <div className="relative">
             <img src={item.img} alt="" className="h-14 w-14 rounded border border-pf-border bg-pf-bg-dark" />
             {item.system.quantity > 1 && (

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -548,14 +548,14 @@ function CoinStrip({ coins }: { coins: PhysicalItem[] }): React.ReactElement {
     }
   }
   return (
-    <div className="flex items-center gap-4 rounded border border-amber-300 bg-amber-50 px-3 py-2" data-section="coins">
-      <span className="text-[11px] font-semibold uppercase tracking-widest text-amber-800">Coins</span>
+    <div className="flex items-center gap-4 rounded border border-pf-tertiary-dark bg-pf-tertiary/20 px-3 py-2" data-section="coins">
+      <span className="text-[11px] font-semibold uppercase tracking-widest text-pf-alt-dark">Coins</span>
       {(['pp', 'gp', 'sp', 'cp'] as const).map((denom) => (
         <span
           key={denom}
           className={[
             'font-mono text-sm tabular-nums',
-            totals[denom] > 0 ? 'text-neutral-900' : 'text-neutral-300',
+            totals[denom] > 0 ? 'text-pf-text' : 'text-pf-text-muted',
           ].join(' ')}
         >
           <strong>{totals[denom]}</strong>{' '}

--- a/apps/player-portal/src/components/tabs/Proficiencies.tsx
+++ b/apps/player-portal/src/components/tabs/Proficiencies.tsx
@@ -124,7 +124,7 @@ function SkillRow({ skill, spanFull }: { skill: SkillStatistic; spanFull?: boole
   return (
     <li
       className={[
-        'group relative flex items-center gap-3 rounded border border-neutral-200 bg-white px-3 py-2',
+        'group relative flex items-center gap-3 rounded border border-pf-border bg-pf-bg px-3 py-2',
         spanFull === true ? 'sm:col-span-2' : '',
       ].join(' ')}
       data-statistic={skill.slug}
@@ -151,7 +151,7 @@ function MartialRow({
   return (
     <li
       className={[
-        'flex items-center gap-3 rounded border border-neutral-200 bg-white px-3 py-2',
+        'flex items-center gap-3 rounded border border-pf-border bg-pf-bg px-3 py-2',
         spanFull === true ? 'sm:col-span-2' : '',
       ].join(' ')}
       data-slug={slug}
@@ -168,7 +168,7 @@ function ClassDCRow({ classDC, spanFull }: { classDC: ClassDC; spanFull: boolean
   return (
     <li
       className={[
-        'group relative flex items-center gap-3 rounded border border-neutral-200 bg-white px-3 py-2',
+        'group relative flex items-center gap-3 rounded border border-pf-border bg-pf-bg px-3 py-2',
         spanFull ? 'sm:col-span-2' : '',
       ].join(' ')}
     >

--- a/apps/player-portal/src/components/tabs/Progression.tsx
+++ b/apps/player-portal/src/components/tabs/Progression.tsx
@@ -400,7 +400,7 @@ function LevelRow({
       // strength even when the row itself is dimmed.
       className={[
         'grid min-h-12 grid-cols-[3rem_1fr] items-center gap-3 rounded border px-3 py-2',
-        state === 'current' ? 'border-pf-primary bg-pf-tertiary/30' : 'border-pf-border bg-white',
+        state === 'current' ? 'border-pf-primary bg-pf-tertiary/30' : 'border-pf-border bg-pf-bg',
         state === 'past' ? 'opacity-60' : '',
       ].join(' ')}
     >
@@ -534,7 +534,7 @@ function FeatureChip({
   return (
     <li
       ref={chipRef}
-      className="inline-flex items-center gap-1.5 rounded border border-pf-border bg-white px-1.5 py-0.5 text-xs text-pf-text"
+      className="inline-flex items-center gap-1.5 rounded border border-pf-border bg-pf-bg px-1.5 py-0.5 text-xs text-pf-text"
       data-feature-uuid={feature.uuid}
       onMouseEnter={scheduleOpen}
       onMouseLeave={scheduleClose}
@@ -728,7 +728,7 @@ function PickedChip({ slot, pick, onClear }: { slot: SlotType; pick: Pick; onCle
       // picks show their description too.
       data-pick-uuid={featUuid}
       data-uuid={featUuid}
-      className="inline-flex items-center gap-1 rounded border border-pf-border bg-white pl-1 pr-0.5 text-[11px] text-pf-text"
+      className="inline-flex items-center gap-1 rounded border border-pf-border bg-pf-bg pl-1 pr-0.5 text-[11px] text-pf-text"
       title={title}
     >
       {body}

--- a/apps/player-portal/src/components/tabs/Spells.tsx
+++ b/apps/player-portal/src/components/tabs/Spells.tsx
@@ -20,7 +20,7 @@ export function Spells({ items, characterLevel }: Props): React.ReactElement {
   const spells = items.filter(isSpellItem);
 
   if (entries.length === 0 && spells.length === 0) {
-    return <p className="text-sm text-neutral-500">No spellcasting.</p>;
+    return <p className="text-sm text-pf-text-muted">No spellcasting.</p>;
   }
 
   const byEntry = new Map<string, SpellItem[]>();
@@ -161,7 +161,7 @@ function SpellCard({ spell, characterLevel }: { spell: SpellItem; characterLevel
 
   return (
     <li
-      className="rounded border border-pf-border bg-white"
+      className="rounded border border-pf-border bg-pf-bg"
       data-item-id={spell.id}
       data-spell-slug={spell.system.slug ?? ''}
     >

--- a/apps/player-portal/src/hooks/usePortalTheme.ts
+++ b/apps/player-portal/src/hooks/usePortalTheme.ts
@@ -1,0 +1,23 @@
+import { useCallback, useEffect, useState } from 'react';
+
+type PortalTheme = 'light' | 'dark';
+
+const STORAGE_KEY = 'portal-theme';
+const DEFAULT: PortalTheme = 'light';
+
+/** Manages the portal surface theme (light/dark). Persists to localStorage.
+ *  Returns [theme, toggleTheme]. Apply the theme by setting
+ *  `data-portal-theme={theme}` on the Layout root element. */
+export function usePortalTheme(): [PortalTheme, () => void] {
+  const [theme, setTheme] = useState<PortalTheme>(
+    () => (localStorage.getItem(STORAGE_KEY) as PortalTheme | null) ?? DEFAULT,
+  );
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme]);
+
+  const toggle = useCallback(() => setTheme((t) => (t === 'light' ? 'dark' : 'light')), []);
+
+  return [theme, toggle];
+}

--- a/apps/player-portal/src/routes/CharacterCreator.tsx
+++ b/apps/player-portal/src/routes/CharacterCreator.tsx
@@ -211,7 +211,7 @@ export function CharacterCreator(): React.ReactElement {
             resetPendingActor();
             onBack();
           }}
-          className="rounded border border-neutral-300 bg-white px-2 py-1 text-xs text-neutral-700 hover:bg-neutral-50"
+          className="rounded border border-pf-border bg-pf-bg px-2 py-1 text-xs text-pf-text hover:bg-pf-bg-dark"
         >
           ← Actors
         </button>
@@ -219,7 +219,7 @@ export function CharacterCreator(): React.ReactElement {
       </div>
 
       {creator.kind === 'creating' && (
-        <p className="rounded border border-pf-border bg-white p-4 text-sm italic text-pf-alt-dark">
+        <p className="rounded border border-pf-border bg-pf-bg p-4 text-sm italic text-pf-alt-dark">
           Creating draft actor…
         </p>
       )}
@@ -412,7 +412,7 @@ function StepNav({
                   ? 'border-pf-primary bg-pf-primary text-white'
                   : filled
                     ? 'border-pf-border bg-pf-bg text-pf-text hover:bg-pf-bg-dark'
-                    : 'border-pf-border bg-white text-pf-alt-dark hover:bg-pf-bg',
+                    : 'border-pf-border bg-pf-bg text-pf-alt-dark hover:bg-pf-bg-dark',
               ].join(' ')}
             >
               {STEP_LABEL[s]}

--- a/apps/player-portal/src/routes/CharacterCreator/CreatorSection.tsx
+++ b/apps/player-portal/src/routes/CharacterCreator/CreatorSection.tsx
@@ -17,7 +17,7 @@ export function CreatorSection({
     <section
       id={`creator-section-${id}`}
       data-creator-section={id}
-      className="mb-6 scroll-mt-20 rounded border border-pf-border bg-white p-4"
+      className="mb-6 scroll-mt-20 rounded border border-pf-border bg-pf-bg p-4"
     >
       <h2 className="mb-3 border-b border-pf-border pb-1 font-serif text-base font-semibold uppercase tracking-widest text-pf-alt-dark">
         {title}

--- a/apps/player-portal/src/routes/CharacterCreator/FeatSlot.tsx
+++ b/apps/player-portal/src/routes/CharacterCreator/FeatSlot.tsx
@@ -27,7 +27,7 @@ export function FeatSlot({
             type="button"
             onClick={onOpen}
             disabled={disabled === true}
-            className="rounded border border-pf-border bg-white px-2 py-1 text-xs text-pf-text hover:bg-pf-bg-dark disabled:cursor-not-allowed disabled:opacity-50"
+            className="rounded border border-pf-border bg-pf-bg px-2 py-1 text-xs text-pf-text hover:bg-pf-bg-dark disabled:cursor-not-allowed disabled:opacity-50"
           >
             + Choose
           </button>
@@ -39,7 +39,7 @@ export function FeatSlot({
         <>
           <span
             data-uuid={selection.uuid}
-            className="inline-flex items-center gap-1.5 rounded border border-pf-border bg-white px-2 py-1 text-xs text-pf-text"
+            className="inline-flex items-center gap-1.5 rounded border border-pf-border bg-pf-bg px-2 py-1 text-xs text-pf-text"
           >
             <img src={selection.img} alt="" className="h-4 w-4 rounded bg-pf-bg-dark" />
             <span className="truncate">{selection.name}</span>
@@ -47,7 +47,7 @@ export function FeatSlot({
           <button
             type="button"
             onClick={onOpen}
-            className="rounded border border-pf-border bg-white px-2 py-1 text-[10px] uppercase tracking-widest text-pf-alt-dark hover:bg-pf-bg-dark"
+            className="rounded border border-pf-border bg-pf-bg px-2 py-1 text-[10px] uppercase tracking-widest text-pf-alt-dark hover:bg-pf-bg-dark"
           >
             Change
           </button>

--- a/apps/player-portal/src/routes/CharacterCreator/PickerCard.tsx
+++ b/apps/player-portal/src/routes/CharacterCreator/PickerCard.tsx
@@ -66,7 +66,7 @@ export function PickerCard({
         type="button"
         onClick={onOpen}
         disabled={disabled === true}
-        className="rounded border border-pf-border bg-white px-2 py-1 text-xs text-pf-text hover:bg-pf-bg-dark disabled:cursor-not-allowed disabled:opacity-50"
+        className="rounded border border-pf-border bg-pf-bg px-2 py-1 text-xs text-pf-text hover:bg-pf-bg-dark disabled:cursor-not-allowed disabled:opacity-50"
       >
         Change
       </button>

--- a/apps/player-portal/src/routes/CharacterCreator/steps/AttributesStep.tsx
+++ b/apps/player-portal/src/routes/CharacterCreator/steps/AttributesStep.tsx
@@ -344,7 +344,7 @@ function BoostSlotPicker({
               'rounded border px-2 py-1 text-xs font-semibold uppercase tracking-widest transition-colors',
               isActive
                 ? 'border-pf-primary bg-pf-tertiary/40 text-pf-primary'
-                : 'border-pf-border bg-white text-pf-alt-dark hover:bg-pf-tertiary/20',
+                : 'border-pf-border bg-pf-bg text-pf-alt-dark hover:bg-pf-tertiary/20',
             ].join(' ')}
           >
             {key.toUpperCase()}
@@ -391,8 +391,8 @@ function FreeBoostBlock({
                 picked
                   ? 'border-pf-primary bg-pf-tertiary/40'
                   : locked
-                    ? 'cursor-not-allowed border-pf-border bg-white opacity-40'
-                    : 'border-pf-border bg-white hover:bg-pf-tertiary/20',
+                    ? 'cursor-not-allowed border-pf-border bg-pf-bg opacity-40'
+                    : 'border-pf-border bg-pf-bg hover:bg-pf-tertiary/20',
               ].join(' ')}
             >
               <span className="text-[11px] font-semibold uppercase tracking-widest text-pf-alt-dark">

--- a/apps/player-portal/src/routes/CharacterCreator/steps/ClassStep.tsx
+++ b/apps/player-portal/src/routes/CharacterCreator/steps/ClassStep.tsx
@@ -142,7 +142,7 @@ function ClassFeaturesList({ state }: { state: ClassDocState }): React.ReactElem
         <li
           key={f.uuid}
           data-uuid={f.uuid}
-          className="inline-flex cursor-default items-center gap-1.5 rounded border border-pf-border bg-white px-2 py-1 text-xs text-pf-text"
+          className="inline-flex cursor-default items-center gap-1.5 rounded border border-pf-border bg-pf-bg px-2 py-1 text-xs text-pf-text"
         >
           <img src={f.img} alt="" className="h-4 w-4 rounded bg-pf-bg-dark" />
           <span className="truncate">{f.name}</span>

--- a/apps/player-portal/src/routes/CharacterCreator/steps/IdentityStep.tsx
+++ b/apps/player-portal/src/routes/CharacterCreator/steps/IdentityStep.tsx
@@ -52,7 +52,7 @@ export function IdentityStep({
               }}
               autoFocus={autoFocus}
               placeholder={placeholder}
-              className="mt-1 w-full rounded border border-pf-border bg-white px-3 py-2 text-sm font-normal normal-case tracking-normal text-pf-text focus:border-pf-primary focus:outline-none"
+              className="mt-1 w-full rounded border border-pf-border bg-pf-bg px-3 py-2 text-sm font-normal normal-case tracking-normal text-pf-text focus:border-pf-primary focus:outline-none"
             />
           </label>
         ))}

--- a/apps/player-portal/src/routes/CharacterCreator/steps/LanguagesStep.tsx
+++ b/apps/player-portal/src/routes/CharacterCreator/steps/LanguagesStep.tsx
@@ -195,8 +195,8 @@ export function LanguagesStep({
                       picked
                         ? 'border-pf-primary bg-pf-tertiary/40 text-pf-primary'
                         : locked
-                          ? 'cursor-not-allowed border-pf-border bg-white text-pf-alt-dark opacity-40'
-                          : 'border-pf-border bg-white text-pf-text hover:bg-pf-tertiary/20',
+                          ? 'cursor-not-allowed border-pf-border bg-pf-bg text-pf-alt-dark opacity-40'
+                          : 'border-pf-border bg-pf-bg text-pf-text hover:bg-pf-tertiary/20',
                     ].join(' ')}
                   >
                     <span>{lang.label}</span>

--- a/apps/player-portal/src/routes/CharacterCreator/steps/SkillsStep.tsx
+++ b/apps/player-portal/src/routes/CharacterCreator/steps/SkillsStep.tsx
@@ -190,8 +190,8 @@ export function SkillsStep({
                       : picked
                         ? 'border-pf-primary bg-pf-tertiary/40 text-pf-primary'
                         : locked
-                          ? 'cursor-not-allowed border-pf-border bg-white text-pf-alt-dark opacity-40'
-                          : 'border-pf-border bg-white text-pf-text hover:bg-pf-tertiary/20',
+                          ? 'cursor-not-allowed border-pf-border bg-pf-bg text-pf-alt-dark opacity-40'
+                          : 'border-pf-border bg-pf-bg text-pf-text hover:bg-pf-tertiary/20',
                   ].join(' ')}
                 >
                   <span>{skill.label}</span>

--- a/apps/player-portal/src/routes/CharacterSheet.tsx
+++ b/apps/player-portal/src/routes/CharacterSheet.tsx
@@ -126,7 +126,7 @@ function CharacterSheetInner({ actorId, onBack, preferences }: InnerProps): Reac
           <button
             type="button"
             onClick={onBack}
-            className="rounded border border-neutral-300 bg-white px-2 py-1 text-xs text-neutral-700 hover:bg-neutral-50"
+            className="rounded border border-pf-border bg-pf-bg px-2 py-1 text-xs text-pf-text hover:bg-pf-bg-dark"
           >
             ← Actors
           </button>

--- a/apps/player-portal/src/routes/CharacterSheet.tsx
+++ b/apps/player-portal/src/routes/CharacterSheet.tsx
@@ -216,16 +216,15 @@ function readBackgroundPath(character: PreparedCharacter): string | null {
   return typeof raw === 'string' && raw.length > 0 ? raw : null;
 }
 
-// Layers a cream overlay on top of the user's image so arbitrary
-// artwork (dark, busy, saturated) stays readable behind the sheet
-// content. The overlay hex matches `--color-pf-bg` for the Classic
-// palette; since no scheme currently overrides the cream surface, this
-// stays visually consistent across color schemes.
+// Layers a semi-transparent overlay on top of the user's image so arbitrary
+// artwork (dark, busy, saturated) stays readable behind the sheet content.
+// Uses var(--pf-bg-overlay) so the overlay colour follows the portal theme
+// toggle (light: cream parchment at 88%, dark: navy at 88%).
 function buildSheetSurfaceStyle(bgPath: string | null): React.CSSProperties | undefined {
   if (!bgPath) return undefined;
   const url = bgPath.startsWith('/') ? bgPath : `/${bgPath}`;
   return {
-    backgroundImage: `linear-gradient(rgba(248, 244, 241, 0.88), rgba(248, 244, 241, 0.88)), url(${url})`,
+    backgroundImage: `linear-gradient(var(--pf-bg-overlay), var(--pf-bg-overlay)), url(${url})`,
     backgroundSize: 'auto, cover',
     backgroundPosition: 'center, center',
     backgroundRepeat: 'no-repeat, no-repeat',

--- a/apps/player-portal/src/routes/Characters.tsx
+++ b/apps/player-portal/src/routes/Characters.tsx
@@ -6,9 +6,9 @@ export function Characters(): React.ReactElement {
   return (
     <main className="mx-auto max-w-3xl p-6 font-sans">
       <h1 className="mb-4 text-2xl font-semibold">Characters</h1>
-      <p className="mb-6 text-sm text-neutral-500">
+      <p className="mb-6 text-sm text-pf-text-muted">
         Pick a character actor to view their sheet, or start a new draft. Pulls from{' '}
-        <code className="rounded bg-neutral-100 px-1 py-0.5">/api/mcp/actors</code>.
+        <code className="rounded bg-pf-bg-dark px-1 py-0.5">/api/mcp/actors</code>.
       </p>
       <div className="mb-4">
         <button

--- a/apps/player-portal/src/routes/Home.tsx
+++ b/apps/player-portal/src/routes/Home.tsx
@@ -15,55 +15,23 @@ const TILES: Tile[] = [
 
 export function Home(): React.ReactElement {
   return (
-    <div
-      style={{
-        width: '100%',
-        height: '100%',
-        overflowY: 'auto',
-        color: '#e5e5e5',
-        padding: '48px 32px',
-        fontFamily: 'system-ui, -apple-system, sans-serif',
-      }}
-    >
-      <div style={{ maxWidth: 960, margin: '0 auto' }}>
-        <header style={{ marginBottom: 32 }}>
-          <h1 style={{ fontSize: 32, fontWeight: 600, margin: 0, letterSpacing: '0.01em' }}>Player Portal</h1>
-          <p style={{ color: '#9a9a9a', marginTop: 8, fontSize: 14 }}>
+    <div className="h-full overflow-y-auto bg-portal-bg text-portal-text">
+      <div className="mx-auto max-w-4xl px-8 py-12">
+        <header className="mb-8">
+          <h1 className="font-serif text-3xl font-semibold tracking-tight">Player Portal</h1>
+          <p className="mt-2 text-sm text-portal-text-muted">
             Pick a destination, or jump straight in from the nav bar above.
           </p>
         </header>
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
-            gap: 16,
-          }}
-        >
+        <div className="grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(240px,1fr))]">
           {TILES.map((tile) => (
             <Link
               key={tile.to}
               to={tile.to}
-              style={{
-                display: 'block',
-                padding: '20px 20px 18px',
-                backgroundColor: '#1a1a1a',
-                border: '1px solid #2d2d2d',
-                borderRadius: 8,
-                color: '#e5e5e5',
-                textDecoration: 'none',
-                transition: 'border-color 0.15s, background-color 0.15s',
-              }}
-              onMouseEnter={(e): void => {
-                e.currentTarget.style.borderColor = '#e4a547';
-                e.currentTarget.style.backgroundColor = '#1f1f1f';
-              }}
-              onMouseLeave={(e): void => {
-                e.currentTarget.style.borderColor = '#2d2d2d';
-                e.currentTarget.style.backgroundColor = '#1a1a1a';
-              }}
+              className="block rounded-lg border border-portal-border bg-portal-surface p-5 text-portal-text no-underline transition-colors duration-150 hover:border-portal-accent hover:bg-portal-surface-hover"
             >
-              <div style={{ fontSize: 16, fontWeight: 600, marginBottom: 6 }}>{tile.label}</div>
-              <div style={{ fontSize: 13, color: '#9a9a9a', lineHeight: 1.45 }}>{tile.blurb}</div>
+              <div className="mb-1.5 text-base font-semibold">{tile.label}</div>
+              <div className="text-sm leading-relaxed text-portal-text-muted">{tile.blurb}</div>
             </Link>
           ))}
         </div>

--- a/apps/player-portal/src/routes/Inventory.tsx
+++ b/apps/player-portal/src/routes/Inventory.tsx
@@ -3,6 +3,7 @@
 // an update here within a second or two.
 
 import { useMemo } from 'react';
+import { ConnectionIndicator } from '../components/ConnectionIndicator';
 import { useLiveStream } from '../lib/live';
 import type { PartyInventoryItem } from '@foundry-toolkit/shared/types';
 
@@ -48,19 +49,25 @@ export function Inventory() {
     return map;
   }, [data]);
 
-  const totalBulk = useMemo(() => (data?.items ?? []).reduce((sum, i) => sum + (i.bulk ?? 0) * i.qty, 0), [data]);
-  const totalValue = useMemo(() => (data?.items ?? []).reduce((sum, i) => sum + (i.valueCp ?? 0) * i.qty, 0), [data]);
+  const totalBulk = useMemo(
+    () => (data?.items ?? []).reduce((sum, i) => sum + (i.bulk ?? 0) * i.qty, 0),
+    [data],
+  );
+  const totalValue = useMemo(
+    () => (data?.items ?? []).reduce((sum, i) => sum + (i.valueCp ?? 0) * i.qty, 0),
+    [data],
+  );
 
   const stale = status === 'disconnected' || (lastUpdated !== null && Date.now() - lastUpdated > 60_000);
 
   return (
-    <div style={{ width: '100%', height: '100%', overflowY: 'auto', color: '#e5e5e5', padding: '24px 32px' }}>
-      <div style={{ maxWidth: 960, margin: '0 auto' }}>
-        <header style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 20 }}>
+    <div className="h-full overflow-y-auto bg-portal-bg text-portal-text">
+      <div className="mx-auto max-w-4xl px-8 py-6">
+        <header className="mb-5 flex items-baseline justify-between">
           <div>
-            <h1 style={{ margin: 0, fontSize: 28, fontWeight: 600 }}>Party Inventory</h1>
+            <h1 className="text-2xl font-semibold">Party Inventory</h1>
             {data && (
-              <p style={{ margin: '4px 0 0', fontSize: 13, color: '#9a9a9a' }}>
+              <p className="mt-1 text-sm text-portal-text-muted">
                 {data.items.length} items · bulk {totalBulk.toFixed(1)} · value {formatCp(totalValue) || '—'}
               </p>
             )}
@@ -69,55 +76,29 @@ export function Inventory() {
         </header>
 
         {!data ? (
-          <p style={{ color: '#9a9a9a', fontSize: 14 }}>Connecting…</p>
+          <p className="text-sm text-portal-text-muted">Connecting…</p>
         ) : data.items.length === 0 ? (
-          <p style={{ color: '#9a9a9a', fontSize: 14 }}>The party has nothing stashed yet.</p>
+          <p className="text-sm text-portal-text-muted">The party has nothing stashed yet.</p>
         ) : (
           CATEGORY_ORDER.map((cat) => {
             const list = grouped.get(cat) ?? [];
             if (list.length === 0) return null;
             return (
-              <section key={cat} style={{ marginBottom: 28 }}>
-                <h2
-                  style={{
-                    fontSize: 13,
-                    fontWeight: 500,
-                    color: '#e4a547',
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.08em',
-                    borderBottom: '1px solid #333',
-                    paddingBottom: 6,
-                    marginBottom: 10,
-                  }}
-                >
-                  {CATEGORY_LABELS[cat]} <span style={{ color: '#6a6a6a' }}>· {list.length}</span>
+              <section key={cat} className="mb-7">
+                <h2 className="mb-2.5 border-b border-portal-border pb-1.5 text-xs font-medium uppercase tracking-widest text-portal-accent">
+                  {CATEGORY_LABELS[cat]}{' '}
+                  <span className="text-portal-text-muted">· {list.length}</span>
                 </h2>
-                <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+                <ul className="m-0 list-none p-0">
                   {list.map((item) => (
                     <li
                       key={item.id}
-                      style={{
-                        display: 'grid',
-                        gridTemplateColumns: '1fr auto auto',
-                        gap: 16,
-                        padding: '8px 0',
-                        borderBottom: '1px solid #1f1f1f',
-                        alignItems: 'baseline',
-                      }}
+                      className="grid items-baseline gap-4 border-b border-portal-border py-2 [grid-template-columns:1fr_auto_auto] last:border-0"
                     >
                       <div>
-                        <span style={{ fontSize: 15 }}>{item.name}</span>
+                        <span className="text-[15px]">{item.name}</span>
                         {item.carriedBy && (
-                          <span
-                            style={{
-                              marginLeft: 10,
-                              fontSize: 11,
-                              color: '#e4a547',
-                              backgroundColor: 'rgba(228, 165, 71, 0.1)',
-                              padding: '1px 6px',
-                              borderRadius: 3,
-                            }}
-                          >
+                          <span className="ml-2.5 rounded px-1.5 py-px text-[11px] bg-portal-accent-subtle text-portal-accent">
                             {item.carriedBy}
                           </span>
                         )}
@@ -126,23 +107,21 @@ export function Inventory() {
                             href={item.aonUrl}
                             target="_blank"
                             rel="noopener noreferrer"
-                            style={{ marginLeft: 10, fontSize: 11, color: '#6a9acf' }}
+                            className="ml-2.5 text-[11px] text-blue-500 hover:underline"
                           >
                             AoN
                           </a>
                         )}
                         {item.note && (
-                          <div style={{ fontSize: 12, color: '#8a8a8a', marginTop: 2, fontStyle: 'italic' }}>
-                            {item.note}
-                          </div>
+                          <div className="mt-0.5 text-xs italic text-portal-text-muted">{item.note}</div>
                         )}
                       </div>
-                      <div style={{ fontSize: 13, color: '#9a9a9a', whiteSpace: 'nowrap' }}>
+                      <div className="whitespace-nowrap text-sm text-portal-text-muted">
                         {item.bulk ? `bulk ${(item.bulk * item.qty).toFixed(1)}` : ''}
                         {item.bulk && item.valueCp ? ' · ' : ''}
                         {item.valueCp ? formatCp(item.valueCp * item.qty) : ''}
                       </div>
-                      <div style={{ fontSize: 15, fontWeight: 500, textAlign: 'right', minWidth: 40 }}>×{item.qty}</div>
+                      <div className="min-w-[40px] text-right text-[15px] font-medium">×{item.qty}</div>
                     </li>
                   ))}
                 </ul>
@@ -151,18 +130,6 @@ export function Inventory() {
           })
         )}
       </div>
-    </div>
-  );
-}
-
-function ConnectionIndicator({ status, stale }: { status: string; stale: boolean }) {
-  const color = status === 'connected' ? (stale ? '#d19a3a' : '#4ade80') : '#ef4444';
-  const label =
-    status === 'connected' ? (stale ? 'Stale' : 'Live') : status === 'connecting' ? 'Connecting…' : 'Offline';
-  return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, color: '#9a9a9a' }}>
-      <span style={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: color, display: 'inline-block' }} />
-      {label}
     </div>
   );
 }

--- a/apps/player-portal/src/routes/Leaderboard.tsx
+++ b/apps/player-portal/src/routes/Leaderboard.tsx
@@ -3,6 +3,7 @@
 // highlighted and pinned to the top of the ranked list.
 
 import { useMemo } from 'react';
+import { ConnectionIndicator } from '../components/ConnectionIndicator';
 import { useLiveStream } from '../lib/live';
 import type { AurusTeam } from '@foundry-toolkit/shared/types';
 
@@ -34,13 +35,13 @@ export function Leaderboard() {
   const stale = status === 'disconnected' || (lastUpdated !== null && Date.now() - lastUpdated > 60_000);
 
   return (
-    <div style={{ width: '100%', height: '100%', overflowY: 'auto', color: '#e5e5e5', padding: '24px 32px' }}>
-      <div style={{ maxWidth: 720, margin: '0 auto' }}>
-        <header style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 20 }}>
+    <div className="h-full overflow-y-auto bg-portal-bg text-portal-text">
+      <div className="mx-auto max-w-3xl px-8 py-6">
+        <header className="mb-5 flex items-baseline justify-between">
           <div>
-            <h1 style={{ margin: 0, fontSize: 28, fontWeight: 600 }}>Aurus Standings</h1>
+            <h1 className="text-2xl font-semibold">Aurus Standings</h1>
             {playerParty && playerRank !== null && (
-              <p style={{ margin: '4px 0 0', fontSize: 13, color: '#9a9a9a' }}>
+              <p className="mt-1 text-sm text-portal-text-muted">
                 {playerParty.name}: rank #{playerRank} of {ranked.length}
               </p>
             )}
@@ -49,92 +50,61 @@ export function Leaderboard() {
         </header>
 
         {!data ? (
-          <p style={{ color: '#9a9a9a', fontSize: 14 }}>Connecting…</p>
+          <p className="text-sm text-portal-text-muted">Connecting…</p>
         ) : ranked.length === 0 ? (
-          <p style={{ color: '#9a9a9a', fontSize: 14 }}>No teams have been registered yet.</p>
+          <p className="text-sm text-portal-text-muted">No teams have been registered yet.</p>
         ) : (
-          <ol style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+          <ol className="m-0 list-none space-y-2 p-0">
             {ranked.map((team, idx) => (
               <li
                 key={team.id}
-                style={{
-                  display: 'grid',
-                  gridTemplateColumns: '50px 1fr auto',
-                  gap: 16,
-                  alignItems: 'center',
-                  padding: '14px 18px',
-                  marginBottom: 8,
-                  borderRadius: 8,
-                  backgroundColor: team.isPlayerParty ? 'rgba(228, 165, 71, 0.12)' : '#1a1a1a',
-                  border: team.isPlayerParty ? '1px solid rgba(228, 165, 71, 0.4)' : '1px solid #2a2a2a',
-                }}
+                className={[
+                  'grid items-center gap-4 rounded-lg border px-4 py-3.5 [grid-template-columns:50px_1fr_auto]',
+                  team.isPlayerParty
+                    ? 'border-portal-accent/40 bg-portal-accent-subtle'
+                    : 'border-portal-border bg-portal-surface',
+                ].join(' ')}
               >
+                {/* Rank */}
                 <div
-                  style={{
-                    fontSize: 24,
-                    fontWeight: 700,
-                    color: idx < 3 ? '#e4a547' : '#6a6a6a',
-                    textAlign: 'center',
-                  }}
+                  className={[
+                    'text-center text-2xl font-bold',
+                    idx < 3 ? 'text-portal-accent' : 'text-portal-text-muted',
+                  ].join(' ')}
                 >
                   #{idx + 1}
                 </div>
+
+                {/* Team name + badge */}
                 <div>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                  <div className="flex items-center gap-2.5">
                     <span
-                      style={{
-                        display: 'inline-block',
-                        width: 14,
-                        height: 14,
-                        borderRadius: 3,
-                        backgroundColor: team.color,
-                      }}
+                      className="inline-block h-3.5 w-3.5 rounded-sm"
+                      style={{ backgroundColor: team.color }}
                     />
-                    <span style={{ fontSize: 17, fontWeight: 500 }}>{team.name}</span>
+                    <span className="text-[17px] font-medium">{team.name}</span>
                     {team.isPlayerParty && (
-                      <span
-                        style={{
-                          fontSize: 10,
-                          textTransform: 'uppercase',
-                          letterSpacing: '0.1em',
-                          backgroundColor: 'rgba(228, 165, 71, 0.2)',
-                          color: '#e4a547',
-                          padding: '2px 6px',
-                          borderRadius: 3,
-                        }}
-                      >
+                      <span className="rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-widest bg-portal-accent-subtle text-portal-accent">
                         Your party
                       </span>
                     )}
                   </div>
                   {team.note && (
-                    <div style={{ fontSize: 12, color: '#8a8a8a', marginTop: 4, fontStyle: 'italic' }}>{team.note}</div>
+                    <div className="mt-1 text-xs italic text-portal-text-muted">{team.note}</div>
                   )}
                 </div>
-                <div style={{ textAlign: 'right' }}>
-                  <div style={{ fontSize: 18, fontWeight: 600, color: '#e5e5e5' }}>
-                    {team.combatPower.toLocaleString()}
-                  </div>
-                  <div style={{ fontSize: 11, color: '#9a9a9a' }}>Combat</div>
-                  <div style={{ fontSize: 13, color: '#9a9a9a', marginTop: 4 }}>{cpToGp(team.valueReclaimedCp)} gp</div>
+
+                {/* Stats */}
+                <div className="text-right">
+                  <div className="text-lg font-semibold">{team.combatPower.toLocaleString()}</div>
+                  <div className="text-[11px] text-portal-text-muted">Combat</div>
+                  <div className="mt-1 text-sm text-portal-text-muted">{cpToGp(team.valueReclaimedCp)} gp</div>
                 </div>
               </li>
             ))}
           </ol>
         )}
       </div>
-    </div>
-  );
-}
-
-function ConnectionIndicator({ status, stale }: { status: string; stale: boolean }) {
-  const color = status === 'connected' ? (stale ? '#d19a3a' : '#4ade80') : '#ef4444';
-  const label =
-    status === 'connected' ? (stale ? 'Stale' : 'Live') : status === 'connecting' ? 'Connecting…' : 'Offline';
-  return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, color: '#9a9a9a' }}>
-      <span style={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: color, display: 'inline-block' }} />
-      {label}
     </div>
   );
 }

--- a/apps/player-portal/src/routes/Leaderboard.tsx
+++ b/apps/player-portal/src/routes/Leaderboard.tsx
@@ -61,7 +61,7 @@ export function Leaderboard() {
                 className={[
                   'grid items-center gap-4 rounded-lg border px-4 py-3.5 [grid-template-columns:50px_1fr_auto]',
                   team.isPlayerParty
-                    ? 'border-portal-accent/40 bg-portal-accent-subtle'
+                    ? 'border-portal-accent-dim bg-portal-accent-subtle'
                     : 'border-portal-border bg-portal-surface',
                 ].join(' ')}
               >

--- a/apps/player-portal/src/styles/index.css
+++ b/apps/player-portal/src/styles/index.css
@@ -21,6 +21,7 @@
 }
 
 [data-portal-theme='dark'] {
+  /* Portal nav/page surface tokens */
   --portal-bg: #0d111e;
   --portal-surface: #141928;
   --portal-surface-hover: #1b2236;
@@ -30,6 +31,35 @@
   --portal-accent: var(--color-pf-tertiary-dark); /* #cbb77a parchment gold */
   --portal-accent-subtle: rgba(203, 183, 122, 0.12);
   --portal-accent-border: rgba(203, 183, 122, 0.4);
+
+  /* PF2e token overrides — extend dark mode to CharactersLayout, the
+   * character sheet, and the character creator. CharactersLayout uses
+   * var(--color-pf-bg/text) inline; sheet/creator use bg-pf-* / text-pf-*
+   * Tailwind utilities. All cascade from this ancestor div. */
+
+  /* Surfaces */
+  --color-pf-bg: #0d111e;
+  --color-pf-bg-dark: #141928;
+  --color-pf-sub: #8a8fa5;
+  --color-pf-text: #e8e4dc;
+  --color-pf-text-muted: #8a8fa5;
+  --color-pf-border: #252e45;
+
+  /* Palette — brightened so these remain legible as text/accents on dark
+   * surfaces (text-pf-primary links, text-pf-secondary templated text,
+   * text-pf-alt-dark section headers). bg-pf-primary/secondary buttons
+   * keep their own white text so contrast is unaffected there. */
+  --color-pf-primary: #b50000;
+  --color-pf-primary-dark: #8a0000;
+  --color-pf-primary-light: #d01010;
+  --color-pf-secondary: #3b56d4;
+  --color-pf-secondary-dark: #2a3fb5;
+  --color-pf-secondary-light: #5a70e8;
+  --color-pf-alt: #a89070;
+  --color-pf-alt-dark: #c4b098; /* was #443730 — section headers need light text */
+  --color-pf-alt-light: #d4c0a8;
+  /* Tertiary (gold) and rarity/proficiency/success colors stay unchanged —
+   * they're light or semantic and already work on dark backgrounds. */
 }
 
 /* Custom Tailwind utilities for portal theming. Using @utility (not @theme)

--- a/apps/player-portal/src/styles/index.css
+++ b/apps/player-portal/src/styles/index.css
@@ -3,6 +3,43 @@
 @import './pf2e/tokens.css';
 @import './color-schemes.css';
 
+/* Portal surface tokens — light (default) and dark variants.
+ * Applied to the Layout root div via [data-portal-theme]. Tailwind
+ * utilities bg-portal-*, text-portal-*, border-portal-* etc. reference
+ * these via the @theme entries below. */
+:root {
+  --portal-bg: var(--color-pf-bg); /* #f8f4f1 cream parchment */
+  --portal-surface: var(--color-pf-bg-dark); /* #e6dfd7 */
+  --portal-surface-hover: #d4cbc2;
+  --portal-border: var(--color-pf-border); /* #baa991 */
+  --portal-text: var(--color-pf-text); /* #1c1c1c */
+  --portal-text-muted: var(--color-pf-text-muted); /* #605856 */
+  --portal-accent: var(--color-pf-primary); /* #5e0000 heraldic red */
+  --portal-accent-subtle: rgba(94, 0, 0, 0.08);
+}
+
+[data-portal-theme='dark'] {
+  --portal-bg: #0d111e;
+  --portal-surface: #141928;
+  --portal-surface-hover: #1b2236;
+  --portal-border: #252e45;
+  --portal-text: #e8e4dc;
+  --portal-text-muted: #8a8fa5;
+  --portal-accent: var(--color-pf-tertiary-dark); /* #cbb77a parchment gold */
+  --portal-accent-subtle: rgba(203, 183, 122, 0.12);
+}
+
+@theme {
+  --color-portal-bg: var(--portal-bg);
+  --color-portal-surface: var(--portal-surface);
+  --color-portal-surface-hover: var(--portal-surface-hover);
+  --color-portal-border: var(--portal-border);
+  --color-portal-text: var(--portal-text);
+  --color-portal-text-muted: var(--portal-text-muted);
+  --color-portal-accent: var(--portal-accent);
+  --color-portal-accent-subtle: var(--portal-accent-subtle);
+}
+
 /* Reserve scrollbar-gutter space always so the page doesn't horizontally
    shift when content grows past the viewport and a scrollbar appears. */
 html {

--- a/apps/player-portal/src/styles/index.css
+++ b/apps/player-portal/src/styles/index.css
@@ -10,6 +10,9 @@
  * compile-time values only and cannot chain through runtime var() refs. */
 :root {
   --portal-bg: var(--color-pf-bg); /* #f8f4f1 cream parchment */
+  /* Semi-transparent overlay used when a background image is set on the
+   * sheet surface. Must match --color-pf-bg at 88% opacity. */
+  --pf-bg-overlay: rgba(248, 244, 241, 0.88);
   --portal-surface: var(--color-pf-bg-dark); /* #e6dfd7 */
   --portal-surface-hover: #d4cbc2;
   --portal-border: var(--color-pf-border); /* #baa991 */
@@ -60,6 +63,9 @@
   --color-pf-alt-light: #d4c0a8;
   /* Tertiary (gold) and rarity/proficiency/success colors stay unchanged —
    * they're light or semantic and already work on dark backgrounds. */
+
+  /* Dark overlay for background-image sheets (matches dark --color-pf-bg) */
+  --pf-bg-overlay: rgba(13, 17, 30, 0.88);
 }
 
 /* Custom Tailwind utilities for portal theming. Using @utility (not @theme)

--- a/apps/player-portal/src/styles/index.css
+++ b/apps/player-portal/src/styles/index.css
@@ -61,6 +61,11 @@
   --color-pf-alt: #a89070;
   --color-pf-alt-dark: #c4b098; /* was #443730 — section headers need light text */
   --color-pf-alt-light: #d4c0a8;
+  /* Tertiary — darkened from parchment gold (#e9d7a1) to warm amber so
+   * bg-pf-tertiary buttons/chips are readable without being blinding. */
+  --color-pf-tertiary: #b08828;
+  --color-pf-tertiary-dark: #7a5e10;
+  --color-pf-tertiary-light: #d4a840;
   /* Tertiary (gold) and rarity/proficiency/success colors stay unchanged —
    * they're light or semantic and already work on dark backgrounds. */
 

--- a/apps/player-portal/src/styles/index.css
+++ b/apps/player-portal/src/styles/index.css
@@ -4,9 +4,10 @@
 @import './color-schemes.css';
 
 /* Portal surface tokens — light (default) and dark variants.
- * Applied to the Layout root div via [data-portal-theme]. Tailwind
- * utilities bg-portal-*, text-portal-*, border-portal-* etc. reference
- * these via the @theme entries below. */
+ * Applied to the Layout root div via [data-portal-theme="dark"]. The
+ * @utility rules below reference these variables directly at runtime,
+ * which is why we use @utility rather than @theme: @theme is for static
+ * compile-time values only and cannot chain through runtime var() refs. */
 :root {
   --portal-bg: var(--color-pf-bg); /* #f8f4f1 cream parchment */
   --portal-surface: var(--color-pf-bg-dark); /* #e6dfd7 */
@@ -16,6 +17,7 @@
   --portal-text-muted: var(--color-pf-text-muted); /* #605856 */
   --portal-accent: var(--color-pf-primary); /* #5e0000 heraldic red */
   --portal-accent-subtle: rgba(94, 0, 0, 0.08);
+  --portal-accent-border: rgba(94, 0, 0, 0.25);
 }
 
 [data-portal-theme='dark'] {
@@ -27,17 +29,42 @@
   --portal-text-muted: #8a8fa5;
   --portal-accent: var(--color-pf-tertiary-dark); /* #cbb77a parchment gold */
   --portal-accent-subtle: rgba(203, 183, 122, 0.12);
+  --portal-accent-border: rgba(203, 183, 122, 0.4);
 }
 
-@theme {
-  --color-portal-bg: var(--portal-bg);
-  --color-portal-surface: var(--portal-surface);
-  --color-portal-surface-hover: var(--portal-surface-hover);
-  --color-portal-border: var(--portal-border);
-  --color-portal-text: var(--portal-text);
-  --color-portal-text-muted: var(--portal-text-muted);
-  --color-portal-accent: var(--portal-accent);
-  --color-portal-accent-subtle: var(--portal-accent-subtle);
+/* Custom Tailwind utilities for portal theming. Using @utility (not @theme)
+ * so that the CSS variable references are resolved at runtime against the
+ * [data-portal-theme] cascade, not at compile time. All variants
+ * (hover:, focus:, etc.) work automatically on @utility classes. */
+@utility bg-portal-bg {
+  background-color: var(--portal-bg);
+}
+@utility bg-portal-surface {
+  background-color: var(--portal-surface);
+}
+@utility bg-portal-surface-hover {
+  background-color: var(--portal-surface-hover);
+}
+@utility bg-portal-accent-subtle {
+  background-color: var(--portal-accent-subtle);
+}
+@utility text-portal-text {
+  color: var(--portal-text);
+}
+@utility text-portal-text-muted {
+  color: var(--portal-text-muted);
+}
+@utility text-portal-accent {
+  color: var(--portal-accent);
+}
+@utility border-portal-border {
+  border-color: var(--portal-border);
+}
+@utility border-portal-accent {
+  border-color: var(--portal-accent);
+}
+@utility border-portal-accent-dim {
+  border-color: var(--portal-accent-border);
 }
 
 /* Reserve scrollbar-gutter space always so the page doesn't horizontally


### PR DESCRIPTION
## Summary

Applies the PF2e design language to the player portal's non-character-creator pages (Home, Inventory, Leaderboard, Nav, Layout) and adds a toggleable light/dark theme. Light mode uses the PF2e cream parchment palette; dark mode uses a navy-dark surface with parchment gold accents. Preference persists to localStorage.

## Changes

- `src/styles/index.css` — `--portal-*` CSS custom properties (light default + `[data-portal-theme="dark"]` override); registered in `@theme` for Tailwind utilities
- `src/hooks/usePortalTheme.ts` — new hook; reads/writes `localStorage`, defaults to `'light'`
- `src/components/Layout.tsx` — calls hook, applies `data-portal-theme` on root div, passes theme to Nav
- `src/components/Nav.tsx` — Tailwind portal utilities replacing inline hex; sun/moon toggle button at right edge
- `src/components/ConnectionIndicator.tsx` — new shared component extracted from Inventory + Leaderboard
- `src/routes/Home.tsx` — Tailwind portal utilities; JS hover handlers removed (CSS `hover:` variants)
- `src/routes/Inventory.tsx` — Tailwind portal utilities; uses shared ConnectionIndicator
- `src/routes/Leaderboard.tsx` — Tailwind portal utilities; uses shared ConnectionIndicator
- `src/routes/Characters.tsx` + `ActorList.tsx` — `neutral-*` to `pf-*` tokens

## Test plan

- [ ] `npm run dev:player-portal:mock` — landing page renders in light parchment mode; sun/moon button toggles to dark navy; refresh preserves choice
- [ ] Nav active tab border changes color with theme (red in light, gold in dark)
- [ ] Inventory and Leaderboard render in theme-correct colors
- [ ] Characters section stays on parchment regardless of portal theme toggle
- [ ] No new typecheck or lint errors