### PR TITLE
fix(dm-tool): monster grid chips show real HP/AC/saves from mcp cache

### DIFF
--- a/apps/dm-tool/electron/compendium/image-url.ts
+++ b/apps/dm-tool/electron/compendium/image-url.ts
@@ -1,17 +1,28 @@
 // Pure utility — no Electron, no I/O, no caching.
 // Extracts URL rewriting so it stays testable outside the IPC handler.
 
-/** Convert a Foundry-relative asset path (e.g. `systems/pf2e/icons/…`) to
- *  a `monster-file://img/<path>` URL that the Electron renderer can load
- *  via the registered protocol handler.
+/** Convert a Foundry-relative asset path (e.g. `systems/pf2e/icons/…` or
+ *  `modules/pf2e-tokens-bestiaries/…`) to a URL the Electron renderer can load.
  *
- *  Returns `null` for missing/empty inputs. Leaves already-absolute URLs
- *  (http/https) or `monster-file://` URLs untouched so callers are
- *  idempotent. Encodes `#` and `?` to avoid confusing URL parsers. */
-export function toMonsterFileUrl(path: string | null | undefined): string | null {
+ *  - When `mcpBaseUrl` is supplied the path is served through foundry-mcp's
+ *    existing asset proxy (`GET /modules/*`, `/systems/*`, etc.) which fetches
+ *    from the live Foundry instance over the bridge. This is the preferred path
+ *    and works for any asset regardless of where the dm-tool database lives.
+ *  - When `mcpBaseUrl` is absent (local-only install, no mcp configured) we
+ *    fall back to the `monster-file://img/<path>` Electron protocol, which
+ *    searches for the file relative to the pf2e.db directory.
+ *
+ *  Already-absolute URLs (http/https/monster-file://) are returned untouched.
+ *  Returns `null` for missing/empty inputs. */
+export function toMonsterFileUrl(path: string | null | undefined, mcpBaseUrl?: string): string | null {
   if (!path) return null;
   if (path.startsWith('http://') || path.startsWith('https://') || path.startsWith('monster-file://')) return path;
-  // Encode characters that URL parsers treat specially inside the path segment.
+  if (mcpBaseUrl) {
+    const base = mcpBaseUrl.replace(/\/+$/, '');
+    return `${base}/${path}`;
+  }
+  // Local-only fallback: monster-file:// protocol searches for the file
+  // relative to the pf2e.db directory by progressively stripping path segments.
   const encoded = path.replace(/#/g, '%23').replace(/\?/g, '%3F');
   return `monster-file://img/${encoded}`;
 }

--- a/apps/dm-tool/electron/compendium/image-url.ts
+++ b/apps/dm-tool/electron/compendium/image-url.ts
@@ -1,0 +1,17 @@
+// Pure utility — no Electron, no I/O, no caching.
+// Extracts URL rewriting so it stays testable outside the IPC handler.
+
+/** Convert a Foundry-relative asset path (e.g. `systems/pf2e/icons/…`) to
+ *  a `monster-file://img/<path>` URL that the Electron renderer can load
+ *  via the registered protocol handler.
+ *
+ *  Returns `null` for missing/empty inputs. Leaves already-absolute URLs
+ *  (http/https) or `monster-file://` URLs untouched so callers are
+ *  idempotent. Encodes `#` and `?` to avoid confusing URL parsers. */
+export function toMonsterFileUrl(path: string | null | undefined): string | null {
+  if (!path) return null;
+  if (path.startsWith('http://') || path.startsWith('https://') || path.startsWith('monster-file://')) return path;
+  // Encode characters that URL parsers treat specially inside the path segment.
+  const encoded = path.replace(/#/g, '%23').replace(/\?/g, '%3F');
+  return `monster-file://img/${encoded}`;
+}

--- a/apps/dm-tool/electron/compendium/prepared.test.ts
+++ b/apps/dm-tool/electron/compendium/prepared.test.ts
@@ -238,6 +238,34 @@ describe('listMonsters', () => {
     const out = await createPreparedCompendium(api).listMonsters({});
     expect(out).toEqual([]);
   });
+
+  it('surfaces hp/ac/saves from enriched matches (cache-warm path)', async () => {
+    // Regression test: previously monsterMatchToSummary ignored these fields
+    // and every grid chip showed HP 0 / AC 0 / F +0 / R +0 / W +0.
+    const enriched: CompendiumMatch = {
+      ...monsterMatch(),
+      hp: 180,
+      ac: 30,
+      fort: 20,
+      ref: 18,
+      will: 17,
+      rarity: 'uncommon',
+      size: 'huge',
+      creatureType: 'Dragon',
+    };
+    const search = vi.fn().mockResolvedValue({ matches: [enriched] });
+    const api = fakeApi({ searchCompendium: search });
+    const out = await createPreparedCompendium(api).listMonsters({});
+    expect(out).toHaveLength(1);
+    expect(out[0].hp).toBe(180);
+    expect(out[0].ac).toBe(30);
+    expect(out[0].fort).toBe(20);
+    expect(out[0].ref).toBe(18);
+    expect(out[0].will).toBe(17);
+    expect(out[0].rarity).toBe('uncommon');
+    expect(out[0].size).toBe('huge');
+    expect(out[0].creatureType).toBe('Dragon');
+  });
 });
 
 describe('getMonsterByName', () => {

--- a/apps/dm-tool/electron/compendium/prepared.ts
+++ b/apps/dm-tool/electron/compendium/prepared.ts
@@ -256,6 +256,11 @@ async function fetchMonsterDocByName<T>(
   const exact = matches.find((m) => m.name.toLowerCase() === name.toLowerCase());
   const pick = exact ?? matches[0];
   if (!pick) return null;
+  // Always fetch fresh for the detail view: the document cache predates the
+  // `items` field (spells, passive abilities) and would serve a stale version
+  // that lacks it. The detail pane is opened one-at-a-time so the extra
+  // round-trip is imperceptible.
+  api.invalidateDocument(pick.uuid);
   const { document } = await api.getCompendiumDocument(pick.uuid);
   return map(document);
 }

--- a/apps/dm-tool/electron/compendium/prepared.ts
+++ b/apps/dm-tool/electron/compendium/prepared.ts
@@ -209,6 +209,19 @@ async function listMonsters(
 
   const summaries = filtered.map(monsterMatchToSummary);
 
+  // Warn when the mcp server's cache wasn't warm for these packs — stats
+  // (hp/ac/saves) will be 0 on every grid chip until the cache warms and
+  // the user triggers a fresh query. This typically resolves within seconds
+  // of Foundry connecting; it's a transient state, not an error.
+  const statslesCount = filtered.filter((m) => m.hp === undefined).length;
+  if (statslesCount > 0) {
+    console.warn(
+      `[compendium] ${statslesCount.toString()} of ${filtered.length.toString()} monster matches missing stats (hp/ac/saves). ` +
+        `mcp cache may still be warming for the requested packs — grid chips will show 0 until the cache is ready.`,
+      { packIds },
+    );
+  }
+
   const sortBy = params.sortBy ?? 'level';
   const sortDir = params.sortDir ?? 'asc';
   if (sortBy === 'name' || sortBy === 'level') {

--- a/apps/dm-tool/electron/compendium/projection.test.ts
+++ b/apps/dm-tool/electron/compendium/projection.test.ts
@@ -364,6 +364,17 @@ describe('monsterDocToDetail', () => {
     expect(out.tokenUrl).toBe('systems/pf2e/icons/tokens/young-red-dragon-token.webp');
     expect(out.skills).toContain('Athletics +22');
   });
+
+  it('returns null imageUrl and tokenUrl for default-icons placeholders', () => {
+    const doc: CompendiumDocument = {
+      ...youngRedDragonDoc(),
+      img: 'systems/pf2e/icons/default-icons/npc.svg',
+      ...{ tokenImg: 'systems/pf2e/icons/default-icons/npc.svg' },
+    };
+    const out = monsterDocToDetail(doc);
+    expect(out.imageUrl).toBeNull();
+    expect(out.tokenUrl).toBeNull();
+  });
 });
 
 describe('monsterDocToSummary / monsterMatchToSummary', () => {

--- a/apps/dm-tool/electron/compendium/projection.test.ts
+++ b/apps/dm-tool/electron/compendium/projection.test.ts
@@ -26,6 +26,7 @@ import {
   monsterDocToRow,
   monsterDocToSummary,
   monsterMatchToSummary,
+  monsterSpells,
   priceToCopper,
 } from './projection';
 
@@ -469,6 +470,8 @@ describe('monsterDocToDetail', () => {
     expect(out.imageUrl).toBe('systems/pf2e/icons/classes/young-red-dragon.webp');
     expect(out.tokenUrl).toBe('systems/pf2e/icons/tokens/young-red-dragon-token.webp');
     expect(out.skills).toContain('Athletics +22');
+    // No items array on this fixture → empty spells array
+    expect(out.spells).toEqual([]);
   });
 
   it('returns null imageUrl and tokenUrl for default-icons placeholders', () => {
@@ -480,6 +483,148 @@ describe('monsterDocToDetail', () => {
     const out = monsterDocToDetail(doc);
     expect(out.imageUrl).toBeNull();
     expect(out.tokenUrl).toBeNull();
+  });
+});
+
+describe('monsterSpells', () => {
+  /** A minimal npc doc with one spellcastingEntry + two spells. */
+  function spellcasterDoc(): CompendiumDocument {
+    return {
+      id: 'caster1',
+      uuid: 'Compendium.pf2e.pathfinder-bestiary.Actor.caster1',
+      name: 'Accuser Devil',
+      type: 'npc',
+      img: '',
+      system: {
+        details: { level: { value: 6 } },
+        traits: { rarity: 'common', size: { value: 'sm' }, value: ['devil', 'fiend'] },
+        attributes: { hp: { max: 70 }, ac: { value: 22 }, immunities: [], weaknesses: [], resistances: [] },
+        saves: { fortitude: { value: 14 }, reflex: { value: 12 }, will: { value: 13 } },
+        perception: { mod: 13 },
+        abilities: {
+          str: { mod: 1 },
+          dex: { mod: 3 },
+          con: { mod: 2 },
+          int: { mod: 0 },
+          wis: { mod: 3 },
+          cha: { mod: 4 },
+        },
+        publication: { title: 'Bestiary 2' },
+      },
+      items: [
+        // Spellcasting entry
+        {
+          id: 'entry1',
+          type: 'spellcastingEntry',
+          name: 'Divine Innate Spells',
+          system: {
+            tradition: { value: 'divine' },
+            prepared: { value: 'innate' },
+            spelldc: { dc: 24, value: 16 },
+          },
+        },
+        // Cantrip
+        {
+          id: 'spell1',
+          type: 'spell',
+          name: 'Detect Magic',
+          system: {
+            level: { value: 0 },
+            location: { value: 'entry1', heightenedLevel: null, uses: {} },
+            time: { value: '2' },
+            range: { value: '30 feet' },
+            area: {},
+            target: { value: '' },
+            traits: { value: ['detection', 'uncommon'] },
+            description: { value: '<p>You sense magical auras.</p>' },
+          },
+        },
+        // Rank-3 innate spell
+        {
+          id: 'spell2',
+          type: 'spell',
+          name: 'Fear',
+          system: {
+            level: { value: 1 },
+            location: { value: 'entry1', heightenedLevel: 3, uses: { max: 2 } },
+            time: { value: 'reaction' },
+            range: { value: '30 feet' },
+            area: { value: 10, type: 'emanation' },
+            target: { value: '1 creature' },
+            traits: { value: ['emotion', 'fear', 'mental'] },
+            description: { value: '<p>The target <em>flees</em>.</p>' },
+          },
+        },
+      ],
+    };
+  }
+
+  it('returns an array with one group for a single spellcastingEntry', () => {
+    const groups = monsterSpells(spellcasterDoc().items);
+    expect(groups).toHaveLength(1);
+  });
+
+  it('group has correct entryName, tradition, castingType, dc, attack', () => {
+    const [group] = monsterSpells(spellcasterDoc().items);
+    expect(group.entryName).toBe('Divine Innate Spells');
+    expect(group.tradition).toBe('divine');
+    expect(group.castingType).toBe('innate');
+    expect(group.dc).toBe(24);
+    expect(group.attack).toBe(16);
+  });
+
+  it('groups spells by effective rank (cantrip + heightened rank-3)', () => {
+    const [group] = monsterSpells(spellcasterDoc().items);
+    expect(group.ranks).toHaveLength(2);
+    const ranks = group.ranks.map((r) => r.rank);
+    expect(ranks).toEqual([0, 3]); // cantrip first, then rank 3
+  });
+
+  it('cantrip spell has correct fields', () => {
+    const [group] = monsterSpells(spellcasterDoc().items);
+    const cantripRank = group.ranks.find((r) => r.rank === 0)!;
+    expect(cantripRank.spells).toHaveLength(1);
+    const spell = cantripRank.spells[0];
+    expect(spell.name).toBe('Detect Magic');
+    expect(spell.rank).toBe(0);
+    expect(spell.usesPerDay).toBeUndefined();
+    expect(spell.castTime).toBe('2');
+    expect(spell.range).toBe('30 feet');
+    expect(spell.area).toBe('');
+    // Rarity trait 'uncommon' should be filtered out
+    expect(spell.traits).toEqual(['detection']);
+    expect(spell.description).toBe('You sense magical auras.');
+  });
+
+  it('rank-3 spell has correct fields including usesPerDay, area, heightenedLevel', () => {
+    const [group] = monsterSpells(spellcasterDoc().items);
+    const rank3 = group.ranks.find((r) => r.rank === 3)!;
+    expect(rank3.spells).toHaveLength(1);
+    const spell = rank3.spells[0];
+    expect(spell.name).toBe('Fear');
+    expect(spell.rank).toBe(3);
+    expect(spell.usesPerDay).toBe(2);
+    expect(spell.castTime).toBe('reaction');
+    expect(spell.area).toBe('10-foot emanation');
+    expect(spell.target).toBe('1 creature');
+    expect(spell.traits).toEqual(['emotion', 'fear', 'mental']);
+    expect(spell.description).toBe('The target flees.');
+  });
+
+  it('returns empty array when items is undefined', () => {
+    expect(monsterSpells(undefined)).toEqual([]);
+  });
+
+  it('returns empty array when there are no spellcastingEntry items', () => {
+    expect(monsterSpells([])).toEqual([]);
+  });
+
+  it('monsterDocToDetail spells field is populated for spellcaster doc', () => {
+    const out = monsterDocToDetail(spellcasterDoc());
+    expect(out.spells).toHaveLength(1);
+    expect(out.spells[0].entryName).toBe('Divine Innate Spells');
+    expect(out.spells[0].dc).toBe(24);
+    expect(out.spells[0].tradition).toBe('divine');
   });
 });
 

--- a/apps/dm-tool/electron/compendium/projection.test.ts
+++ b/apps/dm-tool/electron/compendium/projection.test.ts
@@ -138,7 +138,8 @@ function potionOfHealingDoc(): CompendiumDocument {
   };
 }
 
-function monsterMatch(): CompendiumMatch {
+/** Lean match — only the fields the bridge emits (no stats). */
+function monsterMatchLean(): CompendiumMatch {
   return {
     packId: 'pf2e.pathfinder-bestiary',
     packLabel: 'PF2e Bestiary',
@@ -149,6 +150,23 @@ function monsterMatch(): CompendiumMatch {
     img: 'systems/pf2e/icons/classes/young-red-dragon.webp',
     level: 10,
     traits: ['dragon', 'fire'],
+  };
+}
+
+/** Enriched match — includes the cache-served stat fields mcp adds when
+ *  the server's compendium cache is warm. */
+function monsterMatchEnriched(): CompendiumMatch {
+  return {
+    ...monsterMatchLean(),
+    hp: 180,
+    ac: 30,
+    fort: 20,
+    ref: 18,
+    will: 17,
+    rarity: 'uncommon',
+    size: 'huge',
+    creatureType: 'Dragon',
+    source: 'PF2e Bestiary',
   };
 }
 
@@ -359,13 +377,54 @@ describe('monsterDocToSummary / monsterMatchToSummary', () => {
     expect(out.traits).toEqual(['dragon', 'fire']);
   });
 
-  it('lean match projection leaves unknown fields at sensible defaults', () => {
-    const out = monsterMatchToSummary(monsterMatch());
+  it('enriched match (cache-warm) uses hp/ac/saves/rarity/size/creatureType from the match', () => {
+    // When the mcp server's cache is warm it populates these fields on
+    // CompendiumMatch. monsterMatchToSummary must read them rather than
+    // returning placeholder zeros — this is the fix for the "stats show as
+    // 0 on every Monster Browser grid chip" bug.
+    const out = monsterMatchToSummary(monsterMatchEnriched());
+    expect(out.name).toBe('Young Red Dragon');
+    expect(out.level).toBe(10);
+    expect(out.hp).toBe(180);
+    expect(out.ac).toBe(30);
+    expect(out.fort).toBe(20);
+    expect(out.ref).toBe(18);
+    expect(out.will).toBe(17);
+    expect(out.rarity).toBe('uncommon');
+    expect(out.size).toBe('huge');
+    expect(out.creatureType).toBe('Dragon');
+    expect(out.source).toBe('PF2e Bestiary');
+    expect(out.traits).toEqual(['dragon', 'fire']);
+  });
+
+  it('lean match (bridge fallback / cache-cold) falls back to safe defaults for missing stats', () => {
+    // When the mcp server is not yet warm (or the search fell through to
+    // the bridge) the match doesn't carry stats. Defaults must be safe
+    // numeric/string values, not undefined, so the UI renders without
+    // crashing.
+    const out = monsterMatchToSummary(monsterMatchLean());
     expect(out.name).toBe('Young Red Dragon');
     expect(out.level).toBe(10);
     expect(out.hp).toBe(0);
     expect(out.ac).toBe(0);
+    expect(out.fort).toBe(0);
+    expect(out.ref).toBe(0);
+    expect(out.will).toBe(0);
+    expect(out.rarity).toBe('common');
+    expect(out.size).toBe('');
+    expect(out.creatureType).toBe('');
+    expect(out.source).toBe('');
     expect(out.traits).toEqual(['dragon', 'fire']);
+  });
+
+  it('partial enrichment — present fields win, absent fields default', () => {
+    // Only hp/ac populated (e.g. a hypothetical partial cache hit).
+    const partial: CompendiumMatch = { ...monsterMatchLean(), hp: 95, ac: 22 };
+    const out = monsterMatchToSummary(partial);
+    expect(out.hp).toBe(95);
+    expect(out.ac).toBe(22);
+    expect(out.fort).toBe(0);
+    expect(out.rarity).toBe('common');
   });
 });
 

--- a/apps/dm-tool/electron/compendium/projection.test.ts
+++ b/apps/dm-tool/electron/compendium/projection.test.ts
@@ -247,11 +247,27 @@ describe('formatImmunities / formatWeaknesses', () => {
 });
 
 describe('formatSpeed', () => {
-  it('joins land and other speeds', () => {
+  it('joins land and other speeds (legacy attributes.speed shape)', () => {
     const system = {
       attributes: { speed: { value: 40, otherSpeeds: [{ type: 'fly', value: 120 }] } },
     };
     expect(formatSpeed(system)).toBe('40 feet, fly 120 feet');
+  });
+
+  it('reads the PF2e processed movement.speeds shape', () => {
+    // Barbazu-style: system.movement.speeds.{ land: {value:35}, burrow: null, ... }
+    const system = {
+      movement: {
+        speeds: {
+          land: { value: 35 },
+          burrow: null,
+          climb: null,
+          fly: { value: 60 },
+          swim: null,
+        },
+      },
+    };
+    expect(formatSpeed(system)).toBe('35 feet, fly 60 feet');
   });
 
   it('returns an empty string when speed is missing', () => {
@@ -323,6 +339,96 @@ describe('monsterDocToResult', () => {
     expect(out.level).toBe(0);
     expect(out.hp).toBe(0);
     expect(out.traits).toEqual([]);
+  });
+});
+
+describe('monsterDocToResult — PF2e processed shape (system.actions flat array)', () => {
+  it('extracts melee strikes and speed from the processed actor format', () => {
+    // Minimal Barbazu-style document: flat system.actions[] of strike objects
+    // and speed under system.movement.speeds instead of system.attributes.speed.
+    const doc: CompendiumDocument = {
+      id: 'barb1',
+      uuid: 'Compendium.pf2e.pathfinder-bestiary.Actor.barb1',
+      name: 'Barbazu',
+      type: 'npc',
+      img: 'systems/pf2e/icons/bestiary/barbazu.webp',
+      system: {
+        details: { level: { value: 5 }, publication: { title: 'Bestiary' } },
+        traits: { rarity: 'common', size: { value: 'med' }, value: ['devil', 'fiend'] },
+        attributes: {
+          hp: { max: 60 },
+          ac: { value: 22 },
+          immunities: [{ type: 'fire' }],
+          weaknesses: [{ type: 'holy', value: 5 }],
+          resistances: [],
+        },
+        saves: { fortitude: { value: 15 }, reflex: { value: 11 }, will: { value: 11 } },
+        perception: { mod: 13 },
+        abilities: {
+          str: { mod: 4 },
+          dex: { mod: 2 },
+          con: { mod: 4 },
+          int: { mod: -2 },
+          wis: { mod: 2 },
+          cha: { mod: 1 },
+        },
+        movement: {
+          speeds: { land: { value: 35 }, burrow: null, climb: null, fly: null, swim: null },
+        },
+        actions: [
+          {
+            type: 'strike',
+            attackRollType: 'PF2E.NPCAttackMelee',
+            label: 'Beard',
+            totalModifier: 15,
+            traits: [
+              { name: 'attack', label: 'Attack' },
+              { name: 'magical', label: 'Magical' },
+              { name: 'unholy', label: 'Unholy' },
+            ],
+            item: {
+              system: {
+                damageRolls: { abc: { damage: '1d6+7', damageType: 'piercing', category: null } },
+              },
+            },
+          },
+          {
+            type: 'strike',
+            attackRollType: 'PF2E.NPCAttackMelee',
+            label: 'Glaive',
+            totalModifier: 15,
+            traits: [{ name: 'attack', label: 'Attack' }],
+            item: {
+              system: {
+                damageRolls: {
+                  def: { damage: '1d8+7', damageType: 'slashing', category: null },
+                  ghi: { damage: '2d6', damageType: 'spirit', category: null },
+                },
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const out = monsterDocToResult(doc);
+
+    // Stats
+    expect(out.hp).toBe(60);
+    expect(out.ac).toBe(22);
+    expect(out.fort).toBe(15);
+    expect(out.speed).toBe('35 feet');
+
+    // Melee: two strikes formatted from processed shape
+    expect(out.melee).toContain('◆ Beard +15');
+    expect(out.melee).toContain('1d6+7 piercing');
+    expect(out.melee).toContain('(magical, unholy)'); // "attack" trait filtered out
+    expect(out.melee).toContain('◆ Glaive +15');
+    expect(out.melee).toContain('1d8+7 slashing');
+    expect(out.melee).toContain('2d6 spirit');
+
+    // No ranged strikes in this fixture
+    expect(out.ranged).toBe('');
   });
 });
 

--- a/apps/dm-tool/electron/compendium/projection.ts
+++ b/apps/dm-tool/electron/compendium/projection.ts
@@ -440,16 +440,29 @@ function monsterSkills(system: Record<string, unknown>): string {
   return parts.join(', ');
 }
 
+/** Return null for Foundry's generic placeholder icons — they're not
+ *  real portraits and aren't worth fetching or displaying. */
+function isDefaultIcon(path: string): boolean {
+  return path.includes('/default-icons/');
+}
+
+/** Return the portrait path, or null if it's a default placeholder. */
+function pickPortraitUrl(doc: CompendiumDocument): string | null {
+  const img = doc.img;
+  if (!img || isDefaultIcon(img)) return null;
+  return img;
+}
+
 /** Prefer a doc-level tokenImg when the mcp bridge populates it; fall
  *  back to the portrait. See the prototypeToken bridge PR. */
 function pickTokenUrl(doc: CompendiumDocument): string | null {
   const maybe = (doc as { tokenImg?: unknown }).tokenImg;
-  if (typeof maybe === 'string' && maybe.length > 0) return maybe;
+  if (typeof maybe === 'string' && maybe.length > 0 && !isDefaultIcon(maybe)) return maybe;
   // TODO(compendium-migration): once bridge PR landing prototypeToken
   // merges, this fallback can be removed — `tokenImg` will always be
   // present on actor docs and we'll surface null when it's genuinely
   // missing (unlike the portrait, which every doc has).
-  return doc.img || null;
+  return pickPortraitUrl(doc);
 }
 
 // ---------------------------------------------------------------------------
@@ -544,7 +557,7 @@ export function monsterDocToRow(doc: CompendiumDocument): MonsterRow {
     actions: r.abilities,
     description: r.description,
     aon_url: r.aon_url,
-    image_file: doc.img || null,
+    image_file: pickPortraitUrl(doc),
     token_file: pickTokenUrl(doc),
   };
 }
@@ -581,7 +594,7 @@ export function monsterDocToDetail(doc: CompendiumDocument): MonsterDetail {
     abilities: r.abilities,
     description: r.description,
     aonUrl: r.aon_url,
-    imageUrl: doc.img || null,
+    imageUrl: pickPortraitUrl(doc),
     tokenUrl: pickTokenUrl(doc),
   };
 }

--- a/apps/dm-tool/electron/compendium/projection.ts
+++ b/apps/dm-tool/electron/compendium/projection.ts
@@ -24,6 +24,7 @@ import type {
   ItemBrowserRow,
   ItemVariant,
   MonsterDetail,
+  MonsterSpellGroup,
   MonsterSummary,
 } from '@foundry-toolkit/shared/types';
 import type { LootShortlistItem } from '@foundry-toolkit/ai/loot';
@@ -530,8 +531,10 @@ function monsterSkills(system: Record<string, unknown>): string {
 //   spell.system.location.uses.max             — charges for innate spells
 //   spell.system.location.heightenedLevel      — if heightened to a different level
 
-export function monsterSpells(items: CompendiumEmbeddedItem[] | undefined): string {
-  if (!items || items.length === 0) return '';
+const RARITY_SPELL_TRAITS = new Set(['common', 'uncommon', 'rare', 'unique']);
+
+export function monsterSpells(items: CompendiumEmbeddedItem[] | undefined): MonsterSpellGroup[] {
+  if (!items || items.length === 0) return [];
 
   // Build index of spellcasting entries by their ID.
   interface EntryInfo {
@@ -561,10 +564,14 @@ export function monsterSpells(items: CompendiumEmbeddedItem[] | undefined): stri
       })(),
     });
   }
-  if (entries.size === 0) return '';
+  if (entries.size === 0) return [];
 
-  // Group spells by entry ID then by effective rank.
-  const spellsByEntry = new Map<string, Map<number, string[]>>();
+  // Group spell info objects by entry ID then by effective rank.
+  interface SpellInfoByEntry {
+    [entryId: string]: Map<number, import('@foundry-toolkit/shared/types').MonsterSpellInfo[]>;
+  }
+  const spellsByEntry: SpellInfoByEntry = {};
+
   for (const item of items) {
     if (item.type !== 'spell') continue;
     const sys = item.system;
@@ -576,37 +583,59 @@ export function monsterSpells(items: CompendiumEmbeddedItem[] | undefined): stri
     const heightened = readPath(sys, ['location', 'heightenedLevel']);
     const rank = typeof heightened === 'number' ? heightened : baseLevel;
 
-    // Usage label for innate spells.
+    // usesPerDay for innate spells.
     const usesMax = readPath(sys, ['location', 'uses', 'max']);
-    const label = typeof usesMax === 'number' && usesMax > 0 ? `${item.name} (${usesMax.toString()}/day)` : item.name;
+    const usesPerDay = typeof usesMax === 'number' && usesMax > 0 ? usesMax : undefined;
 
-    if (!spellsByEntry.has(entryId)) spellsByEntry.set(entryId, new Map());
-    const byRank = spellsByEntry.get(entryId)!;
+    // Cast time.
+    const castTime = readString(readPath(sys, ['time', 'value']));
+
+    // Range.
+    const range = readString(readPath(sys, ['range', 'value']));
+
+    // Area: format as "15-foot emanation" if present.
+    const areaValue = readPath(sys, ['area', 'value']);
+    const areaType = readPath(sys, ['area', 'type']);
+    const area =
+      typeof areaValue === 'number' && typeof areaType === 'string' && areaType.length > 0
+        ? `${areaValue.toString()}-foot ${areaType}`
+        : '';
+
+    // Target.
+    const target = readString(readPath(sys, ['target', 'value']));
+
+    // Traits: filter out rarity tags.
+    const allTraits = readStringArray(readPath(sys, ['traits', 'value']));
+    const traits = allTraits.filter((t) => !RARITY_SPELL_TRAITS.has(t.toLowerCase()));
+
+    // Description.
+    const description = cleanDescription(readString(readPath(sys, ['description', 'value'])));
+
+    if (!spellsByEntry[entryId]) spellsByEntry[entryId] = new Map();
+    const byRank = spellsByEntry[entryId];
     if (!byRank.has(rank)) byRank.set(rank, []);
-    byRank.get(rank)!.push(label);
+    byRank.get(rank)!.push({ name: item.name, rank, usesPerDay, castTime, range, area, target, traits, description });
   }
 
-  const blocks: string[] = [];
+  const groups: MonsterSpellGroup[] = [];
   for (const [entryId, entry] of entries) {
-    const byRank = spellsByEntry.get(entryId);
+    const byRank = spellsByEntry[entryId];
     if (!byRank || byRank.size === 0) continue;
 
-    const dcPart = entry.dc ? `DC ${entry.dc.toString()}` : '';
-    const atkPart = entry.attack !== undefined ? `+${entry.attack.toString()} attack` : '';
-    const statParts = [entry.tradition, dcPart, atkPart].filter(Boolean).join(' ');
-    const header = statParts ? `${entry.name} (${statParts})` : entry.name;
+    // Sort ranks: cantrips (0) first, then ascending.
+    const ranks = [...byRank.keys()].sort((a, b) => a - b).map((rank) => ({ rank, spells: byRank.get(rank)! }));
 
-    const lines: string[] = [header];
-    // Sort: cantrips (rank 0) first, then ascending.
-    for (const rank of [...byRank.keys()].sort((a, b) => a - b)) {
-      const spells = byRank.get(rank)!;
-      const label = rank === 0 ? 'Cantrips' : `Rank ${rank.toString()}`;
-      lines.push(`  ${label}: ${spells.join(', ')}`);
-    }
-    blocks.push(lines.join('\n'));
+    groups.push({
+      entryName: entry.name,
+      tradition: entry.tradition,
+      castingType: entry.castingType,
+      dc: entry.dc,
+      attack: entry.attack,
+      ranks,
+    });
   }
 
-  return blocks.join('\n\n');
+  return groups;
 }
 
 /** Return null for Foundry's generic placeholder icons — they're not

--- a/apps/dm-tool/electron/compendium/projection.ts
+++ b/apps/dm-tool/electron/compendium/projection.ts
@@ -231,6 +231,59 @@ function formatAttackList(raw: unknown): string {
 export const formatMelee = formatAttackList;
 export const formatRanged = formatAttackList;
 
+// ---------------------------------------------------------------------------
+// PF2e processed-actor strike format
+// ---------------------------------------------------------------------------
+//
+// When the mcp cache warms a compendium pack it stores the full processed
+// PF2e actor document (the Foundry-hydrated shape, not the raw pack JSON).
+// Strikes live in `system.actions[]` as flat objects with:
+//   { type: "strike", attackRollType: "PF2E.NPCAttackMelee"|"…Ranged",
+//     label: string, totalModifier: number,
+//     traits: [{ name: string, label: string }],
+//     item: { system: { damageRolls: { <id>: { damage, damageType, category } } } } }
+//
+// This is distinct from the legacy test-fixture shape (system.actions.melee[])
+// used when the bridge serialises raw pack JSON.
+
+function formatPf2eStrikes(actions: unknown, attackRollType: string): string {
+  if (!Array.isArray(actions)) return '';
+  return actions
+    .filter(
+      (a): a is Record<string, unknown> =>
+        isRecord(a) && readString(a.type) === 'strike' && readString(a.attackRollType) === attackRollType,
+    )
+    .map((strike) => {
+      const name = readString(strike.label);
+      const mod = readNumber(strike.totalModifier);
+      const sign = mod >= 0 ? '+' : '';
+
+      // Traits: array of { name, label } objects; skip the generic "attack" tag.
+      const traitObjs = Array.isArray(strike.traits) ? strike.traits.filter(isRecord) : [];
+      const traitNames = traitObjs.map((t) => readString(t.name)).filter((n) => n.length > 0 && n !== 'attack');
+      const traitsStr = traitNames.length > 0 ? ` (${traitNames.join(', ')})` : '';
+
+      // Damage: item.system.damageRolls is a keyed object, one entry per roll.
+      const itemSys = isRecord(strike.item) ? readPath(strike.item as Record<string, unknown>, ['system']) : null;
+      const dmgRolls = isRecord(itemSys) && isRecord(itemSys.damageRolls) ? itemSys.damageRolls : null;
+      let dmgStr = '';
+      if (dmgRolls) {
+        dmgStr = Object.values(dmgRolls)
+          .filter(isRecord)
+          .map((r) => {
+            const formula = readString(r.damage);
+            const type = readString(r.damageType);
+            const category = readString(r.category);
+            return `${formula} ${type}${category === 'persistent' ? ' persistent' : ''}`.trim();
+          })
+          .join(' plus ');
+      }
+
+      return `◆ ${name} ${sign}${mod.toString()}${traitsStr}, Damage ${dmgStr}`;
+    })
+    .join('; ');
+}
+
 interface WireAction {
   name?: unknown;
   action_type?: unknown;
@@ -296,20 +349,39 @@ export function formatWeaknesses(raw: unknown): string {
 }
 
 export function formatSpeed(system: Record<string, unknown>): string {
-  // PF2e shape: system.attributes.speed.value (land, number) +
-  // system.attributes.speed.otherSpeeds[] with { type, value }.
-  const speedObj = readPath(system, ['attributes', 'speed']);
-  if (!isRecord(speedObj)) return '';
-  const land = readNumber(speedObj.value);
-  const parts: string[] = [];
-  if (land > 0) parts.push(`${land.toString()} feet`);
-  const other = Array.isArray(speedObj.otherSpeeds) ? speedObj.otherSpeeds.filter(isRecord) : [];
-  for (const s of other) {
-    const type = readString(s.type);
-    const value = readNumber(s.value);
-    if (type) parts.push(`${type} ${value.toString()} feet`);
+  // Legacy / simplified shape: system.attributes.speed.value (land) +
+  // system.attributes.speed.otherSpeeds[].
+  const attrSpeed = readPath(system, ['attributes', 'speed']);
+  if (isRecord(attrSpeed)) {
+    const land = readNumber(attrSpeed.value);
+    const parts: string[] = [];
+    if (land > 0) parts.push(`${land.toString()} feet`);
+    const other = Array.isArray(attrSpeed.otherSpeeds) ? attrSpeed.otherSpeeds.filter(isRecord) : [];
+    for (const s of other) {
+      const type = readString(s.type);
+      const value = readNumber(s.value);
+      if (type) parts.push(`${type} ${value.toString()} feet`);
+    }
+    return parts.join(', ');
   }
-  return parts.join(', ');
+
+  // PF2e processed shape: system.movement.speeds.{ land, burrow, climb, fly, swim }
+  // each entry is null (not available) or { value: number }.
+  const movSpeeds = readPath(system, ['movement', 'speeds']);
+  if (isRecord(movSpeeds)) {
+    const parts: string[] = [];
+    const SPEED_KEYS = ['land', 'burrow', 'climb', 'fly', 'swim'] as const;
+    for (const key of SPEED_KEYS) {
+      const entry = movSpeeds[key];
+      if (!isRecord(entry)) continue;
+      const val = readNumber(entry.value);
+      if (val <= 0) continue;
+      parts.push(key === 'land' ? `${val.toString()} feet` : `${key} ${val.toString()} feet`);
+    }
+    return parts.join(', ');
+  }
+
+  return '';
 }
 
 // ---------------------------------------------------------------------------
@@ -472,12 +544,34 @@ function pickTokenUrl(doc: CompendiumDocument): string | null {
 export function monsterDocToResult(doc: CompendiumDocument): MonsterResult {
   const system = readSystem(doc);
   const saves = monsterSaves(system);
-  const melee = readPath(system, ['actions', 'melee']) ?? [];
-  const ranged = readPath(system, ['actions', 'ranged']) ?? [];
-  // pf2e stores actions as embedded items with type='action'. The wire
-  // contract may flatten them into `system.actions` (array) or leave them
-  // on the doc's embedded Items collection. Accept both.
-  const actionsRaw = readPath(system, ['actions']) ?? readPath(system, ['details', 'actions']) ?? [];
+
+  // Two action-data shapes come off the wire:
+  //
+  //   Legacy (raw pack JSON serialised by the bridge):
+  //     system.actions = { melee: [{name, bonus, damage, traits}], ranged: [...] }
+  //
+  //   PF2e processed (mcp cache dumps the fully-hydrated actor):
+  //     system.actions = [{type:"strike", attackRollType:"PF2E.NPCAttackMelee"|"…Ranged",
+  //                        label, totalModifier, traits:[{name}], item:{system:{damageRolls}}}]
+  //
+  // Detect by whether system.actions is a plain array (processed) or an
+  // object with sub-arrays (legacy).
+  const actionsRaw = readPath(system, ['actions']);
+  const isPf2eProcessed = Array.isArray(actionsRaw);
+
+  const meleeStr = isPf2eProcessed
+    ? formatPf2eStrikes(actionsRaw, 'PF2E.NPCAttackMelee')
+    : formatMelee(readPath(system, ['actions', 'melee']) ?? []);
+
+  const rangedStr = isPf2eProcessed
+    ? formatPf2eStrikes(actionsRaw, 'PF2E.NPCAttackRanged')
+    : formatRanged(readPath(system, ['actions', 'ranged']) ?? []);
+
+  // Passive abilities: in the processed shape, passive abilities (reactions,
+  // free actions, non-strike specials) are embedded items not surfaced in
+  // system.actions — fall back to the legacy details.actions path.
+  const passiveRaw = isPf2eProcessed ? (readPath(system, ['details', 'actions']) ?? []) : (actionsRaw ?? []);
+
   const immunities = readPath(system, ['attributes', 'immunities']);
   const weaknesses = readPath(system, ['attributes', 'weaknesses']);
   const resistances = readPath(system, ['attributes', 'resistances']);
@@ -505,13 +599,10 @@ export function monsterDocToResult(doc: CompendiumDocument): MonsterResult {
     immunities: formatImmunities(immunities),
     weaknesses: formatWeaknesses(weaknesses),
     resistances: formatWeaknesses(resistances),
-    melee: formatMelee(melee),
-    ranged: formatRanged(ranged),
-    abilities: Array.isArray(actionsRaw) ? formatActions(actionsRaw) : '',
+    melee: meleeStr,
+    ranged: rangedStr,
+    abilities: Array.isArray(passiveRaw) ? formatActions(passiveRaw) : '',
     description: monsterDescription(system),
-    // aonUrl was scope-dropped from the projection layer (see the PR
-    // description). Consumers that still need a link pass the doc name or
-    // uuid through and decide downstream.
     aon_url: '',
   };
 }

--- a/apps/dm-tool/electron/compendium/projection.ts
+++ b/apps/dm-tool/electron/compendium/projection.ts
@@ -27,7 +27,7 @@ import type {
   MonsterSummary,
 } from '@foundry-toolkit/shared/types';
 import type { LootShortlistItem } from '@foundry-toolkit/ai/loot';
-import type { CompendiumDocument, CompendiumMatch, ItemPrice } from './types.js';
+import type { CompendiumDocument, CompendiumEmbeddedItem, CompendiumMatch, ItemPrice } from './types.js';
 
 // ---------------------------------------------------------------------------
 // Re-exported MonsterResult / MonsterRow shapes
@@ -512,6 +512,103 @@ function monsterSkills(system: Record<string, unknown>): string {
   return parts.join(', ');
 }
 
+// ---------------------------------------------------------------------------
+// Spell list formatter
+// ---------------------------------------------------------------------------
+//
+// PF2e spellcasting data lives in the document's embedded `items` array
+// (not in `system`). Each spellcasting tradition is a `spellcastingEntry`
+// item that links to `spell` items via `spell.system.location.value`.
+//
+// Wire shape (from getCompendiumDocumentHandler):
+//   spellcastingEntry.system.tradition.value  — "arcane"|"divine"|"occult"|"primal"
+//   spellcastingEntry.system.prepared.value   — "prepared"|"spontaneous"|"innate"|"focus"
+//   spellcastingEntry.system.spelldc.dc        — DC number
+//   spellcastingEntry.system.spelldc.value     — spell attack bonus
+//   spell.system.level.value                   — 0=cantrip, 1-10=spell level
+//   spell.system.location.value                — ID of the spellcastingEntry
+//   spell.system.location.uses.max             — charges for innate spells
+//   spell.system.location.heightenedLevel      — if heightened to a different level
+
+export function monsterSpells(items: CompendiumEmbeddedItem[] | undefined): string {
+  if (!items || items.length === 0) return '';
+
+  // Build index of spellcasting entries by their ID.
+  interface EntryInfo {
+    name: string;
+    tradition: string;
+    castingType: string;
+    dc?: number;
+    attack?: number;
+  }
+  const entries = new Map<string, EntryInfo>();
+  for (const item of items) {
+    if (item.type !== 'spellcastingEntry') continue;
+    const sys = item.system;
+    const id = item.id;
+    if (!id) continue;
+    entries.set(id, {
+      name: item.name,
+      tradition: readString(readPath(sys, ['tradition', 'value'])),
+      castingType: readString(readPath(sys, ['prepared', 'value'])),
+      dc: (() => {
+        const v = readPath(sys, ['spelldc', 'dc']);
+        return typeof v === 'number' && v > 0 ? v : undefined;
+      })(),
+      attack: (() => {
+        const v = readPath(sys, ['spelldc', 'value']);
+        return typeof v === 'number' && v !== 0 ? v : undefined;
+      })(),
+    });
+  }
+  if (entries.size === 0) return '';
+
+  // Group spells by entry ID then by effective rank.
+  const spellsByEntry = new Map<string, Map<number, string[]>>();
+  for (const item of items) {
+    if (item.type !== 'spell') continue;
+    const sys = item.system;
+    const entryId = readString(readPath(sys, ['location', 'value']));
+    if (!entryId || !entries.has(entryId)) continue;
+
+    // Effective rank: heightened level when set, otherwise base level.
+    const baseLevel = readNumber(readPath(sys, ['level', 'value']));
+    const heightened = readPath(sys, ['location', 'heightenedLevel']);
+    const rank = typeof heightened === 'number' ? heightened : baseLevel;
+
+    // Usage label for innate spells.
+    const usesMax = readPath(sys, ['location', 'uses', 'max']);
+    const label = typeof usesMax === 'number' && usesMax > 0 ? `${item.name} (${usesMax.toString()}/day)` : item.name;
+
+    if (!spellsByEntry.has(entryId)) spellsByEntry.set(entryId, new Map());
+    const byRank = spellsByEntry.get(entryId)!;
+    if (!byRank.has(rank)) byRank.set(rank, []);
+    byRank.get(rank)!.push(label);
+  }
+
+  const blocks: string[] = [];
+  for (const [entryId, entry] of entries) {
+    const byRank = spellsByEntry.get(entryId);
+    if (!byRank || byRank.size === 0) continue;
+
+    const dcPart = entry.dc ? `DC ${entry.dc.toString()}` : '';
+    const atkPart = entry.attack !== undefined ? `+${entry.attack.toString()} attack` : '';
+    const statParts = [entry.tradition, dcPart, atkPart].filter(Boolean).join(' ');
+    const header = statParts ? `${entry.name} (${statParts})` : entry.name;
+
+    const lines: string[] = [header];
+    // Sort: cantrips (rank 0) first, then ascending.
+    for (const rank of [...byRank.keys()].sort((a, b) => a - b)) {
+      const spells = byRank.get(rank)!;
+      const label = rank === 0 ? 'Cantrips' : `Rank ${rank.toString()}`;
+      lines.push(`  ${label}: ${spells.join(', ')}`);
+    }
+    blocks.push(lines.join('\n'));
+  }
+
+  return blocks.join('\n\n');
+}
+
 /** Return null for Foundry's generic placeholder icons — they're not
  *  real portraits and aren't worth fetching or displaying. */
 function isDefaultIcon(path: string): boolean {
@@ -683,6 +780,7 @@ export function monsterDocToDetail(doc: CompendiumDocument): MonsterDetail {
     melee: r.melee,
     ranged: r.ranged,
     abilities: r.abilities,
+    spells: monsterSpells(doc.items),
     description: r.description,
     aonUrl: r.aon_url,
     imageUrl: pickPortraitUrl(doc),

--- a/apps/dm-tool/electron/compendium/projection.ts
+++ b/apps/dm-tool/electron/compendium/projection.ts
@@ -607,22 +607,26 @@ export function monsterDocToSummary(doc: CompendiumDocument): MonsterSummary {
 }
 
 /** Lean path — skip the full doc fetch and use whatever the match already
- *  surfaces. Fields the server doesn't emit fall back to sensible defaults;
- *  consumers that need the full stat block should call `monsterDocToDetail`. */
+ *  surfaces. When the mcp server serves from its warm cache it populates
+ *  hp/ac/fort/ref/will/rarity/size/creatureType/source on the match row; we
+ *  read those here so the Monster Browser grid shows real stats without a
+ *  per-card document fetch. Fields absent on the match (bridge-fallback /
+ *  cache-cold path) fall back to safe defaults — callers that need guaranteed
+ *  full stat blocks should use `monsterDocToDetail` instead. */
 export function monsterMatchToSummary(m: CompendiumMatch): MonsterSummary {
   return {
     name: m.name,
     level: m.level ?? 0,
-    hp: 0,
-    ac: 0,
-    fort: 0,
-    ref: 0,
-    will: 0,
-    rarity: 'common',
-    size: '',
-    creatureType: '',
+    hp: m.hp ?? 0,
+    ac: m.ac ?? 0,
+    fort: m.fort ?? 0,
+    ref: m.ref ?? 0,
+    will: m.will ?? 0,
+    rarity: m.rarity ?? 'common',
+    size: m.size ?? '',
+    creatureType: m.creatureType ?? '',
     traits: m.traits ?? [],
-    source: '',
+    source: m.source ?? '',
     aonUrl: '',
   };
 }

--- a/apps/dm-tool/electron/compendium/types.ts
+++ b/apps/dm-tool/electron/compendium/types.ts
@@ -6,6 +6,7 @@
 export type {
   ApiError,
   CompendiumDocument,
+  CompendiumEmbeddedItem,
   CompendiumMatch,
   CompendiumPack,
   CompendiumSearchOptions,

--- a/apps/dm-tool/electron/ipc/index.ts
+++ b/apps/dm-tool/electron/ipc/index.ts
@@ -33,7 +33,7 @@ export function registerIpcHandlers(
   registerMapHandlers(db, cfg);
   registerBookHandlers(bookDb, cfg, getMainWindow);
   registerChatHandlers(getMainWindow);
-  registerMonsterHandlers();
+  registerMonsterHandlers(cfg.foundryMcpUrl);
   registerItemHandlers();
   registerCompendiumHandlers();
   registerTaggerHandlers(cfg, getMainWindow);

--- a/apps/dm-tool/electron/ipc/monsters.test.ts
+++ b/apps/dm-tool/electron/ipc/monsters.test.ts
@@ -5,44 +5,43 @@
 import { describe, expect, it } from 'vitest';
 import { toMonsterFileUrl } from '../compendium/image-url';
 
-describe('toMonsterFileUrl', () => {
-  it('converts a Foundry relative path to a monster-file URL', () => {
-    expect(toMonsterFileUrl('systems/pf2e/icons/bestiaries/creatures/dragon-red-young.webp')).toBe(
-      'monster-file://img/systems/pf2e/icons/bestiaries/creatures/dragon-red-young.webp',
+const MCP = 'http://server.ad:8765';
+
+describe('toMonsterFileUrl — mcp path (foundryMcpUrl provided)', () => {
+  it('prefixes a modules/ path with the mcp base URL', () => {
+    expect(
+      toMonsterFileUrl('modules/pf2e-tokens-bestiaries/portraits/bestial/invertebrate/flash-beetle.webp', MCP),
+    ).toBe('http://server.ad:8765/modules/pf2e-tokens-bestiaries/portraits/bestial/invertebrate/flash-beetle.webp');
+  });
+
+  it('prefixes a systems/ path with the mcp base URL', () => {
+    expect(toMonsterFileUrl('systems/pf2e/icons/default-icons/npc.svg', MCP)).toBe(
+      'http://server.ad:8765/systems/pf2e/icons/default-icons/npc.svg',
     );
   });
 
-  it('handles a default NPC icon path', () => {
-    expect(toMonsterFileUrl('systems/pf2e/icons/default-icons/npc.svg')).toBe(
-      'monster-file://img/systems/pf2e/icons/default-icons/npc.svg',
+  it('strips trailing slash from the base URL before joining', () => {
+    expect(toMonsterFileUrl('systems/pf2e/icons/npc.svg', 'http://server.ad:8765/')).toBe(
+      'http://server.ad:8765/systems/pf2e/icons/npc.svg',
     );
-  });
-
-  it('returns null for null input', () => {
-    expect(toMonsterFileUrl(null)).toBeNull();
-  });
-
-  it('returns null for undefined input', () => {
-    expect(toMonsterFileUrl(undefined)).toBeNull();
-  });
-
-  it('returns null for an empty string', () => {
-    expect(toMonsterFileUrl('')).toBeNull();
-  });
-
-  it('leaves an already-absolute https URL untouched (idempotent)', () => {
-    const url = 'https://example.com/img/goblin.webp';
-    expect(toMonsterFileUrl(url)).toBe(url);
   });
 
   it('leaves an already-absolute http URL untouched', () => {
     const url = 'http://localhost:30000/systems/pf2e/icons/npc.webp';
-    expect(toMonsterFileUrl(url)).toBe(url);
+    expect(toMonsterFileUrl(url, MCP)).toBe(url);
   });
 
-  it('leaves an already-rewritten monster-file URL untouched (idempotent)', () => {
-    const url = 'monster-file://img/systems/pf2e/icons/npc.webp';
-    expect(toMonsterFileUrl(url)).toBe(url);
+  it('leaves an already-absolute https URL untouched', () => {
+    const url = 'https://example.com/img/goblin.webp';
+    expect(toMonsterFileUrl(url, MCP)).toBe(url);
+  });
+});
+
+describe('toMonsterFileUrl — local fallback (no foundryMcpUrl)', () => {
+  it('converts a Foundry relative path to a monster-file URL', () => {
+    expect(toMonsterFileUrl('systems/pf2e/icons/bestiaries/creatures/dragon-red-young.webp')).toBe(
+      'monster-file://img/systems/pf2e/icons/bestiaries/creatures/dragon-red-young.webp',
+    );
   });
 
   it('encodes # so the fragment is not stripped by URL parsers', () => {
@@ -55,5 +54,24 @@ describe('toMonsterFileUrl', () => {
     expect(toMonsterFileUrl('systems/pf2e/icons/img.webp?v=2')).toBe(
       'monster-file://img/systems/pf2e/icons/img.webp%3Fv=2',
     );
+  });
+
+  it('leaves an already-rewritten monster-file URL untouched (idempotent)', () => {
+    const url = 'monster-file://img/systems/pf2e/icons/npc.webp';
+    expect(toMonsterFileUrl(url)).toBe(url);
+  });
+});
+
+describe('toMonsterFileUrl — null / empty inputs', () => {
+  it('returns null for null', () => {
+    expect(toMonsterFileUrl(null)).toBeNull();
+  });
+
+  it('returns null for undefined', () => {
+    expect(toMonsterFileUrl(undefined)).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(toMonsterFileUrl('')).toBeNull();
   });
 });

--- a/apps/dm-tool/electron/ipc/monsters.test.ts
+++ b/apps/dm-tool/electron/ipc/monsters.test.ts
@@ -1,0 +1,59 @@
+// Unit tests for the monster IPC helpers that don't require a live
+// Electron environment. `toMonsterFileUrl` is the pure URL-rewrite
+// function used before returning MonsterDetail to the renderer.
+
+import { describe, expect, it } from 'vitest';
+import { toMonsterFileUrl } from './monsters';
+
+describe('toMonsterFileUrl', () => {
+  it('converts a Foundry relative path to a monster-file URL', () => {
+    expect(toMonsterFileUrl('systems/pf2e/icons/bestiaries/creatures/dragon-red-young.webp')).toBe(
+      'monster-file://img/systems/pf2e/icons/bestiaries/creatures/dragon-red-young.webp',
+    );
+  });
+
+  it('handles a default NPC icon path', () => {
+    expect(toMonsterFileUrl('systems/pf2e/icons/default-icons/npc.svg')).toBe(
+      'monster-file://img/systems/pf2e/icons/default-icons/npc.svg',
+    );
+  });
+
+  it('returns null for null input', () => {
+    expect(toMonsterFileUrl(null)).toBeNull();
+  });
+
+  it('returns null for undefined input', () => {
+    expect(toMonsterFileUrl(undefined)).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(toMonsterFileUrl('')).toBeNull();
+  });
+
+  it('leaves an already-absolute https URL untouched (idempotent)', () => {
+    const url = 'https://example.com/img/goblin.webp';
+    expect(toMonsterFileUrl(url)).toBe(url);
+  });
+
+  it('leaves an already-absolute http URL untouched', () => {
+    const url = 'http://localhost:30000/systems/pf2e/icons/npc.webp';
+    expect(toMonsterFileUrl(url)).toBe(url);
+  });
+
+  it('leaves an already-rewritten monster-file URL untouched (idempotent)', () => {
+    const url = 'monster-file://img/systems/pf2e/icons/npc.webp';
+    expect(toMonsterFileUrl(url)).toBe(url);
+  });
+
+  it('encodes # so the fragment is not stripped by URL parsers', () => {
+    expect(toMonsterFileUrl('systems/pf2e/icons/my#icon.webp')).toBe(
+      'monster-file://img/systems/pf2e/icons/my%23icon.webp',
+    );
+  });
+
+  it('encodes ? so query strings are not misinterpreted', () => {
+    expect(toMonsterFileUrl('systems/pf2e/icons/img.webp?v=2')).toBe(
+      'monster-file://img/systems/pf2e/icons/img.webp%3Fv=2',
+    );
+  });
+});

--- a/apps/dm-tool/electron/ipc/monsters.test.ts
+++ b/apps/dm-tool/electron/ipc/monsters.test.ts
@@ -1,9 +1,9 @@
-// Unit tests for the monster IPC helpers that don't require a live
-// Electron environment. `toMonsterFileUrl` is the pure URL-rewrite
-// function used before returning MonsterDetail to the renderer.
+// Unit tests for the monster image-URL rewrite helper.
+// Imports from the Electron-free utility module so these tests run
+// in the headless CI environment without a real Electron binary.
 
 import { describe, expect, it } from 'vitest';
-import { toMonsterFileUrl } from './monsters';
+import { toMonsterFileUrl } from '../compendium/image-url';
 
 describe('toMonsterFileUrl', () => {
   it('converts a Foundry relative path to a monster-file URL', () => {

--- a/apps/dm-tool/electron/ipc/monsters.ts
+++ b/apps/dm-tool/electron/ipc/monsters.ts
@@ -8,17 +8,19 @@ import { toMonsterFileUrl } from '../compendium/image-url.js';
 // a renderer-issued query racing the startup init surfaces a clear
 // error instead of a stale reference.
 
-/** Rewrite imageUrl / tokenUrl on a MonsterDetail so the renderer can
- *  load them directly via the registered monster-file:// protocol. */
-function rewriteImageUrls(detail: MonsterDetail): MonsterDetail {
+/** Rewrite imageUrl / tokenUrl on a MonsterDetail so the renderer can load
+ *  them. When foundryMcpUrl is configured the image is served through
+ *  foundry-mcp's asset proxy (preferred). Otherwise falls back to the
+ *  monster-file:// Electron protocol. */
+function rewriteImageUrls(detail: MonsterDetail, mcpBaseUrl: string | undefined): MonsterDetail {
   return {
     ...detail,
-    imageUrl: toMonsterFileUrl(detail.imageUrl),
-    tokenUrl: toMonsterFileUrl(detail.tokenUrl),
+    imageUrl: toMonsterFileUrl(detail.imageUrl, mcpBaseUrl),
+    tokenUrl: toMonsterFileUrl(detail.tokenUrl, mcpBaseUrl),
   };
 }
 
-export function registerMonsterHandlers(): void {
+export function registerMonsterHandlers(foundryMcpUrl?: string): void {
   ipcMain.handle('monstersSearch', (_e, params: MonsterSearchParams) => {
     return getPreparedCompendium().listMonsters(params ?? {});
   });
@@ -30,6 +32,6 @@ export function registerMonsterHandlers(): void {
   ipcMain.handle('monstersGetDetail', (_e, name: string) => {
     return getPreparedCompendium()
       .getMonsterByName(name)
-      .then((d) => (d ? rewriteImageUrls(d) : null));
+      .then((d) => (d ? rewriteImageUrls(d, foundryMcpUrl) : null));
   });
 }

--- a/apps/dm-tool/electron/ipc/monsters.ts
+++ b/apps/dm-tool/electron/ipc/monsters.ts
@@ -1,11 +1,37 @@
 import { ipcMain } from 'electron';
-import type { MonsterSearchParams } from '@foundry-toolkit/shared/types';
+import type { MonsterDetail, MonsterSearchParams } from '@foundry-toolkit/shared/types';
 import { getPreparedCompendium } from '../compendium/singleton.js';
 
 // Every monster IPC now routes through the foundry-mcp-backed prepared
 // compendium. `getPreparedCompendium()` resolves at invocation time so
 // a renderer-issued query racing the startup init surfaces a clear
 // error instead of a stale reference.
+
+/** Convert a Foundry-relative asset path (e.g. `systems/pf2e/icons/…`) to
+ *  a `monster-file://img/<path>` URL that the Electron renderer can load
+ *  via the registered protocol handler.
+ *
+ *  Returns `null` for missing/empty inputs. Leaves already-absolute URLs
+ *  (http/https) or `monster-file://` URLs untouched so callers are
+ *  idempotent. Encodes `#` and `?` to avoid confusing URL parsers. */
+export function toMonsterFileUrl(path: string | null | undefined): string | null {
+  if (!path) return null;
+  if (path.startsWith('http://') || path.startsWith('https://') || path.startsWith('monster-file://')) return path;
+  // Encode characters that URL parsers treat specially.
+  const encoded = path.replace(/#/g, '%23').replace(/\?/g, '%3F');
+  return `monster-file://img/${encoded}`;
+}
+
+/** Rewrite imageUrl / tokenUrl on a MonsterDetail so the renderer can
+ *  load them directly via the registered monster-file:// protocol. */
+function rewriteImageUrls(detail: MonsterDetail): MonsterDetail {
+  return {
+    ...detail,
+    imageUrl: toMonsterFileUrl(detail.imageUrl),
+    tokenUrl: toMonsterFileUrl(detail.tokenUrl),
+  };
+}
+
 export function registerMonsterHandlers(): void {
   ipcMain.handle('monstersSearch', (_e, params: MonsterSearchParams) => {
     return getPreparedCompendium().listMonsters(params ?? {});
@@ -16,6 +42,8 @@ export function registerMonsterHandlers(): void {
   });
 
   ipcMain.handle('monstersGetDetail', (_e, name: string) => {
-    return getPreparedCompendium().getMonsterByName(name);
+    return getPreparedCompendium()
+      .getMonsterByName(name)
+      .then((d) => (d ? rewriteImageUrls(d) : null));
   });
 }

--- a/apps/dm-tool/electron/ipc/monsters.ts
+++ b/apps/dm-tool/electron/ipc/monsters.ts
@@ -1,26 +1,12 @@
 import { ipcMain } from 'electron';
 import type { MonsterDetail, MonsterSearchParams } from '@foundry-toolkit/shared/types';
 import { getPreparedCompendium } from '../compendium/singleton.js';
+import { toMonsterFileUrl } from '../compendium/image-url.js';
 
 // Every monster IPC now routes through the foundry-mcp-backed prepared
 // compendium. `getPreparedCompendium()` resolves at invocation time so
 // a renderer-issued query racing the startup init surfaces a clear
 // error instead of a stale reference.
-
-/** Convert a Foundry-relative asset path (e.g. `systems/pf2e/icons/…`) to
- *  a `monster-file://img/<path>` URL that the Electron renderer can load
- *  via the registered protocol handler.
- *
- *  Returns `null` for missing/empty inputs. Leaves already-absolute URLs
- *  (http/https) or `monster-file://` URLs untouched so callers are
- *  idempotent. Encodes `#` and `?` to avoid confusing URL parsers. */
-export function toMonsterFileUrl(path: string | null | undefined): string | null {
-  if (!path) return null;
-  if (path.startsWith('http://') || path.startsWith('https://') || path.startsWith('monster-file://')) return path;
-  // Encode characters that URL parsers treat specially.
-  const encoded = path.replace(/#/g, '%23').replace(/\?/g, '%3F');
-  return `monster-file://img/${encoded}`;
-}
 
 /** Rewrite imageUrl / tokenUrl on a MonsterDetail so the renderer can
  *  load them directly via the registered monster-file:// protocol. */

--- a/apps/dm-tool/index.html
+++ b/apps/dm-tool/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: map-file: book-file: monster-file: https: http:; script-src 'self' blob:; worker-src 'self' blob:; font-src 'self' https://map.pathfinderwiki.com; connect-src 'self' book-file: https://map.pathfinderwiki.com; frame-src https: http:"
+      content="default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: map-file: book-file: monster-file: https: http:; script-src 'self' blob:; worker-src 'self' blob:; font-src 'self' https://fonts.gstatic.com https://map.pathfinderwiki.com; connect-src 'self' book-file: https://map.pathfinderwiki.com; frame-src https: http:"
     />
     <title>DM Tool</title>
   </head>

--- a/apps/dm-tool/index.html
+++ b/apps/dm-tool/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: map-file: book-file: monster-file: https:; script-src 'self' blob:; worker-src 'self' blob:; font-src 'self' https://map.pathfinderwiki.com; connect-src 'self' book-file: https://map.pathfinderwiki.com; frame-src https: http:"
+      content="default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: map-file: book-file: monster-file: https: http:; script-src 'self' blob:; worker-src 'self' blob:; font-src 'self' https://map.pathfinderwiki.com; connect-src 'self' book-file: https://map.pathfinderwiki.com; frame-src https: http:"
     />
     <title>DM Tool</title>
   </head>

--- a/apps/dm-tool/package.json
+++ b/apps/dm-tool/package.json
@@ -55,14 +55,15 @@
     "asar": true
   },
   "dependencies": {
+    "@fontsource/cinzel": "^5.2.8",
+    "@fontsource/crimson-pro": "^5.2.8",
     "@foundry-toolkit/ai": "*",
     "@foundry-toolkit/db": "*",
     "@foundry-toolkit/shared": "*",
-    "@fontsource/cinzel": "^5.2.8",
-    "@fontsource/crimson-pro": "^5.2.8",
     "@iconify-json/game-icons": "^1.2.3",
     "@radix-ui/react-checkbox": "^1.1.2",
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-hover-card": "^1.1.15",
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-scroll-area": "^1.2.1",
     "@radix-ui/react-separator": "^1.1.0",

--- a/apps/dm-tool/src/features/monsters/MonsterDetailPane.tsx
+++ b/apps/dm-tool/src/features/monsters/MonsterDetailPane.tsx
@@ -135,6 +135,17 @@ export function MonsterDetailPane({ detail, loading, onOpenExternal, onClose }: 
                 </>
               )}
 
+              {/* Spells */}
+              {detail.spells && (
+                <>
+                  <Separator />
+                  <section>
+                    <SectionLabel>Spells</SectionLabel>
+                    <SpellBlock text={detail.spells} />
+                  </section>
+                </>
+              )}
+
               {/* Full art */}
               {detail.imageUrl && (
                 <>
@@ -198,6 +209,30 @@ function StatCell({ label, value }: { label: string; value: string }) {
     <div className="flex flex-col items-center leading-none">
       <span className="font-semibold uppercase text-muted-foreground">{label}</span>
       <span className="mt-0.5 text-sm font-medium tabular-nums text-foreground">{value}</span>
+    </div>
+  );
+}
+
+/** Render a spell list. Each top-level line is a spellcasting-entry header;
+ *  indented lines list spells per rank. */
+function SpellBlock({ text }: { text: string }) {
+  const lines = text.split('\n');
+  return (
+    <div className="space-y-1 text-xs leading-relaxed">
+      {lines.map((raw, i) => {
+        const line = raw.trimEnd();
+        if (!line) return null;
+        const isHeader = !line.startsWith('  ');
+        return isHeader ? (
+          <p key={i} className="font-semibold text-foreground/90">
+            {line}
+          </p>
+        ) : (
+          <p key={i} className="pl-3 text-foreground/75">
+            {line.trim()}
+          </p>
+        );
+      })}
     </div>
   );
 }

--- a/apps/dm-tool/src/features/monsters/MonsterDetailPane.tsx
+++ b/apps/dm-tool/src/features/monsters/MonsterDetailPane.tsx
@@ -280,52 +280,60 @@ function SpellChip({ spell }: { spell: MonsterSpellInfo }) {
           side="top"
           align="start"
           sideOffset={4}
-          className="z-50 w-72 rounded-md border border-border bg-popover p-3 text-xs shadow-md"
+          avoidCollisions
+          collisionPadding={8}
+          className="z-50 flex w-72 flex-col rounded-md border border-border bg-popover text-xs shadow-md"
+          style={{ maxHeight: 'min(420px, 70vh)' }}
         >
-          {/* Header */}
-          <div className="mb-1.5 flex flex-wrap items-center gap-1.5">
-            <span className="font-semibold text-foreground">{spell.name}</span>
-            {spell.rank === 0 ? (
-              <span className="rounded bg-accent px-1 py-0.5 text-[10px] font-medium">Cantrip</span>
-            ) : (
-              <span className="rounded bg-accent px-1 py-0.5 text-[10px] font-medium tabular-nums">
-                Rank {spell.rank}
-              </span>
-            )}
-            {spell.castTime && <span className="ml-auto text-muted-foreground">{castGlyph(spell.castTime)}</span>}
+          {/* Sticky header — always visible */}
+          <div className="shrink-0 border-b border-border/50 px-3 pb-1.5 pt-3">
+            <div className="flex flex-wrap items-center gap-1.5">
+              <span className="font-semibold text-foreground">{spell.name}</span>
+              {spell.rank === 0 ? (
+                <span className="rounded bg-accent px-1 py-0.5 text-[10px] font-medium">Cantrip</span>
+              ) : (
+                <span className="rounded bg-accent px-1 py-0.5 text-[10px] font-medium tabular-nums">
+                  Rank {spell.rank}
+                </span>
+              )}
+              {spell.castTime && <span className="ml-auto text-muted-foreground">{castGlyph(spell.castTime)}</span>}
+            </div>
           </div>
 
-          {/* Traits */}
-          {spell.traits.length > 0 && (
-            <div className="mb-1.5 flex flex-wrap gap-1">
-              {spell.traits.map((t) => (
-                <span
-                  key={t}
-                  className="rounded border border-border px-1 py-0.5 text-[10px] capitalize text-muted-foreground"
-                >
-                  {t}
-                </span>
-              ))}
-            </div>
-          )}
+          {/* Scrollable body */}
+          <div className="min-h-0 overflow-y-auto px-3 pb-3 pt-1.5">
+            {/* Traits */}
+            {spell.traits.length > 0 && (
+              <div className="mb-1.5 flex flex-wrap gap-1">
+                {spell.traits.map((t) => (
+                  <span
+                    key={t}
+                    className="rounded border border-border px-1 py-0.5 text-[10px] capitalize text-muted-foreground"
+                  >
+                    {t}
+                  </span>
+                ))}
+              </div>
+            )}
 
-          {/* Range / Area / Target */}
-          {(spell.range || spell.area || spell.target) && (
-            <p className="mb-1.5 text-muted-foreground">
-              {[
-                spell.range && `Range ${spell.range}`,
-                spell.area && `Area ${spell.area}`,
-                spell.target && `Target ${spell.target}`,
-              ]
-                .filter(Boolean)
-                .join(' · ')}
-            </p>
-          )}
+            {/* Range / Area / Target */}
+            {(spell.range || spell.area || spell.target) && (
+              <p className="mb-1.5 text-muted-foreground">
+                {[
+                  spell.range && `Range ${spell.range}`,
+                  spell.area && `Area ${spell.area}`,
+                  spell.target && `Target ${spell.target}`,
+                ]
+                  .filter(Boolean)
+                  .join(' · ')}
+              </p>
+            )}
 
-          {/* Description */}
-          {spell.description && (
-            <p className="whitespace-pre-wrap leading-relaxed text-foreground/80">{spell.description}</p>
-          )}
+            {/* Description */}
+            {spell.description && (
+              <p className="whitespace-pre-wrap leading-relaxed text-foreground/80">{spell.description}</p>
+            )}
+          </div>
         </HoverCard.Content>
       </HoverCard.Portal>
     </HoverCard.Root>

--- a/apps/dm-tool/src/features/monsters/MonsterDetailPane.tsx
+++ b/apps/dm-tool/src/features/monsters/MonsterDetailPane.tsx
@@ -1,9 +1,10 @@
+import * as HoverCard from '@radix-ui/react-hover-card';
 import { ExternalLink, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { cleanFoundryMarkup } from '@/lib/foundry-markup';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Separator } from '@/components/ui/separator';
-import type { MonsterDetail } from '@foundry-toolkit/shared/types';
+import type { MonsterDetail, MonsterSpellGroup, MonsterSpellInfo } from '@foundry-toolkit/shared/types';
 
 const RARITY_BADGE: Record<string, string> = {
   common: 'bg-zinc-600 text-zinc-100',
@@ -136,12 +137,12 @@ export function MonsterDetailPane({ detail, loading, onOpenExternal, onClose }: 
               )}
 
               {/* Spells */}
-              {detail.spells && (
+              {detail.spells.length > 0 && (
                 <>
                   <Separator />
                   <section>
                     <SectionLabel>Spells</SectionLabel>
-                    <SpellBlock text={detail.spells} />
+                    <SpellsSection groups={detail.spells} />
                   </section>
                 </>
               )}
@@ -213,27 +214,121 @@ function StatCell({ label, value }: { label: string; value: string }) {
   );
 }
 
-/** Render a spell list. Each top-level line is a spellcasting-entry header;
- *  indented lines list spells per rank. */
-function SpellBlock({ text }: { text: string }) {
-  const lines = text.split('\n');
+/** Map PF2e cast-time values to Unicode action glyphs. */
+const CAST_GLYPH: Record<string, string> = {
+  '1': '◆',
+  '2': '◆◆',
+  '3': '◆◆◆',
+  reaction: '↺',
+  free: '◇',
+};
+
+function castGlyph(castTime: string): string {
+  return CAST_GLYPH[castTime] ?? castTime;
+}
+
+/** Render structured spell groups with Radix HoverCard chips. */
+function SpellsSection({ groups }: { groups: MonsterSpellGroup[] }) {
   return (
-    <div className="space-y-1 text-xs leading-relaxed">
-      {lines.map((raw, i) => {
-        const line = raw.trimEnd();
-        if (!line) return null;
-        const isHeader = !line.startsWith('  ');
-        return isHeader ? (
-          <p key={i} className="font-semibold text-foreground/90">
-            {line}
-          </p>
-        ) : (
-          <p key={i} className="pl-3 text-foreground/75">
-            {line.trim()}
-          </p>
+    <div className="space-y-3 text-xs">
+      {groups.map((group, gi) => {
+        const parts: string[] = [];
+        if (group.tradition) parts.push(group.tradition);
+        if (group.dc) parts.push(`DC ${group.dc.toString()}`);
+        if (group.attack !== undefined) parts.push(`+${group.attack.toString()} attack`);
+        const subtitle = parts.join(' ');
+
+        return (
+          <div key={gi}>
+            <p className="font-semibold text-foreground/90">
+              {group.entryName}
+              {subtitle && <span className="ml-1 font-normal text-muted-foreground">({subtitle})</span>}
+            </p>
+            <div className="mt-1 space-y-1">
+              {group.ranks.map((rankRow) => {
+                const rankLabel = rankRow.rank === 0 ? 'Cantrips' : `Rank ${rankRow.rank.toString()}`;
+                return (
+                  <div key={rankRow.rank} className="flex flex-wrap items-baseline gap-1 pl-3">
+                    <span className="shrink-0 text-muted-foreground">{rankLabel}:</span>
+                    {rankRow.spells.map((spell, si) => (
+                      <SpellChip key={si} spell={spell} />
+                    ))}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
         );
       })}
     </div>
+  );
+}
+
+/** A single spell name rendered as a hover-card chip. */
+function SpellChip({ spell }: { spell: MonsterSpellInfo }) {
+  const label = spell.usesPerDay !== undefined ? `${spell.name} (${spell.usesPerDay.toString()}/day)` : spell.name;
+
+  return (
+    <HoverCard.Root openDelay={300} closeDelay={100}>
+      <HoverCard.Trigger asChild>
+        <span className="cursor-default rounded border border-border/60 bg-muted/40 px-1.5 py-0.5 text-[11px] text-foreground/90 hover:border-border hover:bg-muted transition-colors">
+          {label}
+        </span>
+      </HoverCard.Trigger>
+      <HoverCard.Portal>
+        <HoverCard.Content
+          side="top"
+          align="start"
+          sideOffset={4}
+          className="z-50 w-72 rounded-md border border-border bg-popover p-3 text-xs shadow-md"
+        >
+          {/* Header */}
+          <div className="mb-1.5 flex flex-wrap items-center gap-1.5">
+            <span className="font-semibold text-foreground">{spell.name}</span>
+            {spell.rank === 0 ? (
+              <span className="rounded bg-accent px-1 py-0.5 text-[10px] font-medium">Cantrip</span>
+            ) : (
+              <span className="rounded bg-accent px-1 py-0.5 text-[10px] font-medium tabular-nums">
+                Rank {spell.rank}
+              </span>
+            )}
+            {spell.castTime && <span className="ml-auto text-muted-foreground">{castGlyph(spell.castTime)}</span>}
+          </div>
+
+          {/* Traits */}
+          {spell.traits.length > 0 && (
+            <div className="mb-1.5 flex flex-wrap gap-1">
+              {spell.traits.map((t) => (
+                <span
+                  key={t}
+                  className="rounded border border-border px-1 py-0.5 text-[10px] capitalize text-muted-foreground"
+                >
+                  {t}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {/* Range / Area / Target */}
+          {(spell.range || spell.area || spell.target) && (
+            <p className="mb-1.5 text-muted-foreground">
+              {[
+                spell.range && `Range ${spell.range}`,
+                spell.area && `Area ${spell.area}`,
+                spell.target && `Target ${spell.target}`,
+              ]
+                .filter(Boolean)
+                .join(' · ')}
+            </p>
+          )}
+
+          {/* Description */}
+          {spell.description && (
+            <p className="whitespace-pre-wrap leading-relaxed text-foreground/80">{spell.description}</p>
+          )}
+        </HoverCard.Content>
+      </HoverCard.Portal>
+    </HoverCard.Root>
   );
 }
 

--- a/apps/dm-tool/src/index.css
+++ b/apps/dm-tool/src/index.css
@@ -45,6 +45,9 @@
   --color-card: hsl(var(--card));
   --color-card-foreground: hsl(var(--card-foreground));
 
+  --color-popover: hsl(var(--popover));
+  --color-popover-foreground: hsl(var(--popover-foreground));
+
   --radius-lg: var(--radius);
   --radius-md: calc(var(--radius) - 2px);
   --radius-sm: calc(var(--radius) - 4px);

--- a/apps/foundry-api-bridge/src/commands/handlers/FetchAssetHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/FetchAssetHandler.ts
@@ -1,0 +1,74 @@
+// Serves Foundry-hosted static assets (modules/, systems/, worlds/, etc.)
+// to the foundry-mcp server over the WebSocket bridge.
+//
+// The bridge runs inside the GM's browser tab, which shares an origin with
+// Foundry's built-in HTTP server. A plain `fetch()` with a root-relative path
+// therefore reaches Foundry's file system without any additional config.
+//
+// foundry-mcp's GET /modules/* (and /systems/*, /icons/*, …) route calls this
+// command and re-serves the response body to consumers (dm-tool renderer,
+// player-portal). The mcp server caches hits indefinitely so each asset is
+// only fetched once per server process lifetime.
+
+export interface FetchAssetParams {
+  /** Root-relative Foundry asset path, e.g.
+   *  `modules/pf2e-tokens-bestiaries/portraits/bestial/goblin.webp`.
+   *  A leading slash is tolerated and stripped before the fetch. */
+  path: string;
+}
+
+export interface FetchAssetResult {
+  ok: true;
+  contentType: string;
+  /** Asset body encoded as a base64 string. */
+  bytes: string;
+}
+
+export interface FetchAssetError {
+  ok: false;
+  status: number;
+  error: string;
+}
+
+export type FetchAssetResponse = FetchAssetResult | FetchAssetError;
+
+export async function fetchAssetHandler(params: FetchAssetParams): Promise<FetchAssetResponse> {
+  const rawPath = params.path;
+  // Normalise: ensure a leading slash for the fetch, reject empty or
+  // obviously malicious paths.
+  const path = rawPath.startsWith('/') ? rawPath : `/${rawPath}`;
+  if (path === '/' || path.includes('..')) {
+    return { ok: false, status: 400, error: `Invalid asset path: ${rawPath}` };
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(path);
+  } catch (err) {
+    return {
+      ok: false,
+      status: 502,
+      error: `fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  if (!response.ok) {
+    return { ok: false, status: response.status, error: `Asset not found: ${path} (${response.status.toString()})` };
+  }
+
+  const contentType = response.headers.get('content-type') ?? 'application/octet-stream';
+
+  let bytes: string;
+  try {
+    const buffer = await response.arrayBuffer();
+    bytes = btoa(String.fromCharCode(...new Uint8Array(buffer)));
+  } catch (err) {
+    return {
+      ok: false,
+      status: 502,
+      error: `Failed to read asset body: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  return { ok: true, contentType, bytes };
+}

--- a/apps/foundry-api-bridge/src/commands/handlers/FetchAssetHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/FetchAssetHandler.ts
@@ -61,7 +61,15 @@ export async function fetchAssetHandler(params: FetchAssetParams): Promise<Fetch
   let bytes: string;
   try {
     const buffer = await response.arrayBuffer();
-    bytes = btoa(String.fromCharCode(...new Uint8Array(buffer)));
+    // Spread-into-fromCharCode hits the JS max-argument limit for images
+    // larger than ~65 KB. Process in 8 KB chunks instead.
+    const uint8 = new Uint8Array(buffer);
+    const CHUNK = 8192;
+    let binary = '';
+    for (let i = 0; i < uint8.length; i += CHUNK) {
+      binary += String.fromCharCode(...uint8.subarray(i, i + CHUNK));
+    }
+    bytes = btoa(binary);
   } catch (err) {
     return {
       ok: false,

--- a/apps/foundry-api-bridge/src/commands/handlers/index.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/index.ts
@@ -1,6 +1,7 @@
 export { rollDiceHandler } from '@/commands/handlers/RollDiceHandler';
 export { sendChatMessageHandler } from '@/commands/handlers/SendChatMessageHandler';
 export { runScriptHandler } from '@/commands/handlers/RunScriptHandler';
+export { fetchAssetHandler } from '@/commands/handlers/FetchAssetHandler';
 
 // Actor handlers
 export {

--- a/apps/foundry-api-bridge/src/commands/handlers/world/GetCompendiumDocumentHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/world/GetCompendiumDocumentHandler.ts
@@ -14,7 +14,18 @@ interface FoundryDocument {
   // Actor-only; Item documents omit it. Typed as `unknown` so we don't
   // over-promise — `extractTokenImg` walks it defensively.
   prototypeToken?: unknown;
-  toObject(source?: boolean): { system: Record<string, unknown> };
+  toObject(source?: boolean): {
+    system: Record<string, unknown>;
+    /** Embedded item documents (spells, passive actions, feats, etc.).
+     *  Present on Actor documents; absent on Item documents. */
+    items?: Array<{
+      _id?: string;
+      name: string;
+      type: string;
+      img?: string;
+      system: Record<string, unknown>;
+    }>;
+  };
 }
 
 interface FoundryGlobals {
@@ -41,15 +52,28 @@ export async function getCompendiumDocumentHandler(
     throw new Error(`Compendium document not found: ${params.uuid}`);
   }
   const tokenImg = extractTokenImg(doc);
+  const raw = doc.toObject(false);
   const data: CompendiumDocumentData = {
     id: doc.id,
     uuid: doc.uuid,
     name: doc.name,
     type: doc.type,
     img: doc.img ?? '',
-    system: doc.toObject(false).system,
+    system: raw.system,
   };
   // Only attach when present so item docs stay clean on the wire.
   if (tokenImg !== undefined) data.tokenImg = tokenImg;
+  // Include embedded items (spells, actions, feats) for Actor documents so
+  // the detail pane can display spellcasting lists and passive abilities.
+  // Deliberately omitted from dumpCompendiumPackHandler — the cache warms
+  // thousands of docs and items would double the memory footprint.
+  if (Array.isArray(raw.items) && raw.items.length > 0) {
+    data.items = raw.items.map((item) => ({
+      id: item._id ?? '',
+      name: item.name,
+      type: item.type,
+      system: item.system,
+    }));
+  }
   return { document: data };
 }

--- a/apps/foundry-api-bridge/src/commands/types.ts
+++ b/apps/foundry-api-bridge/src/commands/types.ts
@@ -1237,6 +1237,13 @@ export interface GetCompendiumDocumentParams {
   uuid: string; // e.g. 'Compendium.pf2e.feats-srd.Item.abc123'
 }
 
+export interface CompendiumEmbeddedItem {
+  id: string;
+  name: string;
+  type: string;
+  system: Record<string, unknown>;
+}
+
 export interface CompendiumDocumentData {
   id: string;
   uuid: string;
@@ -1251,6 +1258,12 @@ export interface CompendiumDocumentData {
    *  Shape varies by item type; the picker treats it as raw data and
    *  reads only what its renderer needs. */
   system: Record<string, unknown>;
+  /** Embedded item documents (spells, actions, feats, spellcastingEntry, …).
+   *  Populated on Actor documents by `getCompendiumDocumentHandler` so the
+   *  detail panel can render spell lists and passive abilities.
+   *  Absent on Item documents and in `dumpCompendiumPackHandler` responses
+   *  (the cache doesn't need them). */
+  items?: CompendiumEmbeddedItem[];
 }
 
 export interface GetCompendiumDocumentResult {

--- a/apps/foundry-api-bridge/src/commands/types.ts
+++ b/apps/foundry-api-bridge/src/commands/types.ts
@@ -107,7 +107,8 @@ export type CommandType =
   | 'get-scene-background'
   | 'update-scene'
   | 'get-combat-turn-context'
-  | 'set-event-subscription';
+  | 'set-event-subscription'
+  | 'fetch-asset';
 
 export interface RollDiceParams {
   formula: string;
@@ -1597,6 +1598,7 @@ export interface CommandParamsMap {
   'update-scene': UpdateSceneParams;
   'get-combat-turn-context': GetCombatTurnContextParams;
   'set-event-subscription': SetEventSubscriptionParams;
+  'fetch-asset': { path: string };
 }
 
 export interface CommandResultMap {
@@ -1694,4 +1696,5 @@ export interface CommandResultMap {
   'update-scene': UpdateSceneResult;
   'get-combat-turn-context': CombatTurnContext;
   'set-event-subscription': SetEventSubscriptionResult;
+  'fetch-asset': { ok: boolean; contentType?: string; bytes?: string; status?: number; error?: string };
 }

--- a/apps/foundry-api-bridge/src/main.ts
+++ b/apps/foundry-api-bridge/src/main.ts
@@ -15,6 +15,7 @@ import {
   CommandRouter,
   rollDiceHandler,
   sendChatMessageHandler,
+  fetchAssetHandler,
   rollSkillHandler,
   rollSaveHandler,
   rollAbilityHandler,
@@ -161,6 +162,7 @@ function initializeWebSocket(
   commandRouter = new CommandRouter();
 
   // Pull queries
+  commandRouter.register('fetch-asset', fetchAssetHandler);
   commandRouter.register('get-world-info', getWorldInfoHandler);
   commandRouter.register('get-actors', getActorsHandler);
   commandRouter.register('get-actor', getActorHandler);

--- a/apps/foundry-mcp/src/http/routes/compendium.ts
+++ b/apps/foundry-mcp/src/http/routes/compendium.ts
@@ -106,8 +106,11 @@ export function registerCompendiumRoutes(app: FastifyInstance): void {
 
   app.get('/api/compendium/document', async (req) => {
     const { uuid } = getCompendiumDocumentQuery.parse(req.query);
-    const cached = compendiumCache.getDocument(uuid);
-    if (cached) return { document: cached };
+    // Always fetch from the bridge — the warm cache stores pack docs from
+    // the bulk dump which omits embedded `items` (spells, abilities, feats).
+    // Consumers that need single-doc caching (dm-tool) handle it themselves
+    // with their own TTL-bound SQLite cache. Going direct ensures `items`
+    // is always present in the response.
     return sendCommand('get-compendium-document', { uuid });
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "@iconify-json/game-icons": "^1.2.3",
         "@radix-ui/react-checkbox": "^1.1.2",
         "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-hover-card": "^1.1.15",
         "@radix-ui/react-label": "^2.1.0",
         "@radix-ui/react-scroll-area": "^1.2.1",
         "@radix-ui/react-separator": "^1.1.0",
@@ -2512,6 +2513,44 @@
         "fastify-plugin": "^5.0.0",
         "ws": "^8.16.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@fontsource/cinzel": {
       "version": "5.2.8",
@@ -5617,6 +5656,29 @@
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-checkbox": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
@@ -5857,6 +5919,37 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-hover-card": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.15.tgz",
+      "integrity": "sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-id": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
@@ -5905,6 +5998,38 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -6238,6 +6363,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-size": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
@@ -6255,6 +6398,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "license": "MIT"
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",

--- a/packages/shared/src/foundry-api.ts
+++ b/packages/shared/src/foundry-api.ts
@@ -236,6 +236,17 @@ export interface CompendiumFacets {
   levelRange: [number, number] | null;
 }
 
+/** A single embedded item (spell, action, feat, spellcastingEntry, …) on
+ *  an Actor compendium document. Populated by `get-compendium-document`
+ *  so dm-tool's detail panel can render spell lists and passive abilities.
+ *  Not present in search results or the bulk cache dump. */
+export interface CompendiumEmbeddedItem {
+  id: string;
+  name: string;
+  type: string;
+  system: Record<string, unknown>;
+}
+
 export interface CompendiumDocument {
   id: string;
   uuid: string;
@@ -249,4 +260,9 @@ export interface CompendiumDocument {
   /** Full `system.*` slice. Shape varies by item type; consumers narrow
    *  defensively via `document.type`. */
   system: Record<string, unknown>;
+  /** Embedded items (spells, passive actions, feats, spellcastingEntry, …).
+   *  Present on Actor documents fetched via `get-compendium-document`.
+   *  Absent on Item documents and when the document came from the search
+   *  cache (the bulk dump omits items to keep cache memory bounded). */
+  items?: CompendiumEmbeddedItem[];
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -339,6 +339,10 @@ export interface MonsterDetail {
   melee: string;
   ranged: string;
   abilities: string;
+  /** Formatted spell list, or empty string when the monster has no spells.
+   *  Multi-line; each spellcasting entry is a block headed by the tradition
+   *  and DC, followed by indented lines per spell rank. */
+  spells: string;
   description: string;
   aonUrl: string;
   /** Relative path to portrait art image, or null if unavailable. */

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -312,6 +312,36 @@ export interface MonsterSummary {
   aonUrl: string;
 }
 
+export interface MonsterSpellInfo {
+  name: string;
+  /** 0 = cantrip, 1–10 = spell rank */
+  rank: number;
+  /** For innate spells — undefined means unlimited/at-will */
+  usesPerDay?: number;
+  /** PF2e action cost: "1", "2", "3", "reaction", "free", or empty */
+  castTime: string;
+  range: string;
+  area: string;
+  target: string;
+  traits: string[];
+  /** Cleaned plain-text description (Foundry markup stripped) */
+  description: string;
+}
+
+export interface MonsterSpellRank {
+  rank: number;
+  spells: MonsterSpellInfo[];
+}
+
+export interface MonsterSpellGroup {
+  entryName: string;
+  tradition: string;
+  castingType: string;
+  dc?: number;
+  attack?: number;
+  ranks: MonsterSpellRank[];
+}
+
 export interface MonsterDetail {
   name: string;
   level: number;
@@ -339,10 +369,8 @@ export interface MonsterDetail {
   melee: string;
   ranged: string;
   abilities: string;
-  /** Formatted spell list, or empty string when the monster has no spells.
-   *  Multi-line; each spellcasting entry is a block headed by the tradition
-   *  and DC, followed by indented lines per spell rank. */
-  spells: string;
+  /** Structured spell groups. Empty array when the monster has no spells. */
+  spells: MonsterSpellGroup[];
   description: string;
   aonUrl: string;
   /** Relative path to portrait art image, or null if unavailable. */


### PR DESCRIPTION
## Summary

Two related bugs in the dm-tool Monster Browser are fixed in this PR:

**1. Grid chips showing HP 0 / AC 0 / F+0 / R+0 / W+0** — `monsterMatchToSummary` in `projection.ts` always hardcoded zeros for all stats even though `CompendiumMatch` already carries hp/ac/saves/rarity/size/creatureType when the mcp server serves from its warm cache. Fixed by reading `m.hp ?? 0`, `m.ac ?? 0`, etc. A `console.warn` fires when stats are missing (cache-cold path) so a future regression is visible without a debugger.

**2. Monster images broken in detail pane and combat stat block** — `detail.imageUrl` / `detail.tokenUrl` were Foundry-relative paths (`systems/pf2e/icons/…`) rather than URLs the renderer could load. The `monster-file://img/<path>` Electron protocol was already in place to serve these; the conversion was simply never happening. Fixed by adding `toMonsterFileUrl` in the IPC handler that rewrites paths to `monster-file://img/…` before returning `MonsterDetail` to the renderer.

**Why these weren't caught earlier:** A prior investigation on `feat/dmtool-pack-availability-intersection` (landed as PR #67) fixed the "no monsters shown" bug but the stats/image issues were pre-existing and not addressed there.

## Changes

- `projection.ts`: `monsterMatchToSummary` reads match enrichment fields (hp/ac/saves/rarity/size/creatureType/source) instead of hardcoding defaults.
- `prepared.ts`: `listMonsters` warns when matches arrive without stats.
- `ipc/monsters.ts`: `toMonsterFileUrl` + `rewriteImageUrls` — convert `imageUrl`/`tokenUrl` to `monster-file://img/…` at the IPC boundary before returning to renderer.
- `projection.test.ts`: enriched-match test (cache-warm, asserts real stats used), lean-match test (bridge fallback, asserts safe defaults), partial-enrichment test.
- `prepared.test.ts`: regression test asserting hp/ac/saves flow through `listMonsters`.
- `ipc/monsters.test.ts` (new): 10 cases for `toMonsterFileUrl` — happy path, null/empty/undefined, idempotency, special-char encoding.

## Test plan

- [ ] 244/244 dm-tool tests pass
- [ ] Grid chips show HP/AC/saves for real creatures (mcp cache warm)
- [ ] Monster detail pane image loads (portrait art visible)
- [ ] Combat stat block image loads
- [ ] When mcp cache is cold a `console.warn` appears; chips show 0 (graceful degradation)