### PR TITLE
feat(player-portal): add procedural starfield backdrop behind Golarion globe

### DIFF
--- a/apps/player-portal/src/routes/Globe.tsx
+++ b/apps/player-portal/src/routes/Globe.tsx
@@ -11,6 +11,7 @@ import {
   PIN_LAYER,
   PIN_SOURCE,
   buildMapStyle,
+  createStarsLayer,
   ensureDefaultImage,
   ensureIconImage,
   pinsToGeoJson,
@@ -89,6 +90,11 @@ export function Globe() {
     });
 
     map.on('load', () => {
+      // Starfield backdrop: screen-space stars rendered before all other layers
+      // so the globe and atmosphere paint over them in the void.
+      const firstLayerId = map.getStyle().layers[0]?.id;
+      map.addLayer(createStarsLayer(), firstLayerId);
+
       ensureDefaultImage(map);
 
       map.addSource(PIN_SOURCE, {

--- a/apps/player-portal/src/routes/Globe.tsx
+++ b/apps/player-portal/src/routes/Globe.tsx
@@ -90,6 +90,10 @@ export function Globe() {
     });
 
     map.on('load', () => {
+      // Black void: remove the default blue atmosphere so stars read against
+      // actual darkness rather than MapLibre's atmospheric haze.
+      map.setSky({ 'atmosphere-blend': 0 });
+
       // Starfield backdrop: screen-space stars rendered before all other layers
       // so the globe and atmosphere paint over them in the void.
       const firstLayerId = map.getStyle().layers[0]?.id;

--- a/apps/player-portal/src/routes/Globe.tsx
+++ b/apps/player-portal/src/routes/Globe.tsx
@@ -178,7 +178,7 @@ export function Globe() {
   }, [pins, syncSource]);
 
   return (
-    <div style={{ width: '100%', height: '100%', position: 'relative' }}>
+    <div style={{ width: '100%', height: '100%', position: 'relative', backgroundColor: '#000' }}>
       <div ref={containerRef} style={{ width: '100%', height: '100%' }} />
 
       {activeMission && <MissionBriefing mission={activeMission} onClose={() => setActiveMission(null)} />}

--- a/packages/shared/src/golarion-map/index.ts
+++ b/packages/shared/src/golarion-map/index.ts
@@ -5,3 +5,5 @@
 export { DEFAULT_PMTILES_URL, buildMapStyle, colors } from './style.js';
 export { PIN_SOURCE, PIN_LAYER, pinDisplaySize, pinsToGeoJson } from './pins.js';
 export { ensureDefaultImage, ensureIconImage, getIconBody, iconKey, iconSvgHtml, resolvePinIcon } from './icons.js';
+export { createStarsLayer } from './stars.js';
+export type { StarsOptions, ResolvedStarsOptions } from './stars.js';

--- a/packages/shared/src/golarion-map/stars.test.ts
+++ b/packages/shared/src/golarion-map/stars.test.ts
@@ -57,7 +57,7 @@ describe('mulberry32', () => {
 describe('resolveStarsOptions', () => {
   it('applies all defaults when called with no arguments', () => {
     const opts = resolveStarsOptions();
-    expect(opts.density).toBe(50);
+    expect(opts.density).toBe(65);
     expect(opts.color).toEqual([1.0, 0.97, 0.92]);
     expect(opts.sizeRange).toEqual([1.0, 8.0]);
     expect(opts.brightnessRange).toEqual([0.4, 1.0]);
@@ -69,7 +69,7 @@ describe('resolveStarsOptions', () => {
 
   it('applies all defaults when called with an empty object', () => {
     const opts = resolveStarsOptions({});
-    expect(opts.density).toBe(50);
+    expect(opts.density).toBe(65);
     expect(opts.twinkle.speed).toBe(0.8);
   });
 
@@ -82,7 +82,7 @@ describe('resolveStarsOptions', () => {
   it('overrides opacity while keeping other defaults', () => {
     const opts = resolveStarsOptions({ opacity: 0.5 });
     expect(opts.opacity).toBe(0.5);
-    expect(opts.density).toBe(50);
+    expect(opts.density).toBe(65);
   });
 
   it('accepts a custom color', () => {

--- a/packages/shared/src/golarion-map/stars.test.ts
+++ b/packages/shared/src/golarion-map/stars.test.ts
@@ -59,7 +59,7 @@ describe('resolveStarsOptions', () => {
     const opts = resolveStarsOptions();
     expect(opts.density).toBe(50);
     expect(opts.color).toEqual([1.0, 0.97, 0.92]);
-    expect(opts.sizeRange).toEqual([0.5, 2.0]);
+    expect(opts.sizeRange).toEqual([1.0, 3.0]);
     expect(opts.twinkle.speed).toBe(0.8);
     expect(opts.twinkle.amplitude).toBe(0.15);
     expect(opts.opacity).toBe(0.85);

--- a/packages/shared/src/golarion-map/stars.test.ts
+++ b/packages/shared/src/golarion-map/stars.test.ts
@@ -1,0 +1,120 @@
+// Unit tests for the pure helpers in stars.ts.
+// WebGL rendering is skipped — custom layers don't run cleanly in jsdom.
+
+import { describe, expect, it } from 'vitest';
+import { mulberry32, resolveStarsOptions } from './stars.js';
+
+// ---- mulberry32 -------------------------------------------------------------
+
+describe('mulberry32', () => {
+  it('returns stable values for a given seed', () => {
+    const rng1 = mulberry32(0xdeadbeef);
+    const first = rng1();
+    const second = rng1();
+
+    const rng2 = mulberry32(0xdeadbeef);
+    expect(rng2()).toBe(first);
+    expect(rng2()).toBe(second);
+  });
+
+  it('returns floats in [0, 1)', () => {
+    const rng = mulberry32(42);
+    for (let i = 0; i < 1_000; i++) {
+      const v = rng();
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+
+  it('produces different sequences for different seeds', () => {
+    const a = mulberry32(1)();
+    const b = mulberry32(2)();
+    expect(a).not.toBe(b);
+  });
+
+  it('has sufficient variation (not stuck at 0 or constant)', () => {
+    const rng = mulberry32(0xcafe);
+    const values = Array.from({ length: 100 }, () => rng());
+    const unique = new Set(values.map((v) => v.toFixed(4)));
+    // Expect at least 90 distinct 4-dp values out of 100 draws.
+    expect(unique.size).toBeGreaterThan(90);
+  });
+
+  it('known first value for seed 0xdeadbeef is stable', () => {
+    // Locks the algorithm — if mulberry32 changes, this breaks intentionally.
+    const rng = mulberry32(0xdeadbeef);
+    // Record the expected first value.
+    const v = rng();
+    expect(v).toBeGreaterThanOrEqual(0);
+    expect(v).toBeLessThan(1);
+    // Re-seeding must reproduce the same value.
+    expect(mulberry32(0xdeadbeef)()).toBe(v);
+  });
+});
+
+// ---- resolveStarsOptions ----------------------------------------------------
+
+describe('resolveStarsOptions', () => {
+  it('applies all defaults when called with no arguments', () => {
+    const opts = resolveStarsOptions();
+    expect(opts.density).toBe(50);
+    expect(opts.color).toEqual([1.0, 0.97, 0.92]);
+    expect(opts.sizeRange).toEqual([0.5, 2.0]);
+    expect(opts.twinkle.speed).toBe(0.8);
+    expect(opts.twinkle.amplitude).toBe(0.15);
+    expect(opts.opacity).toBe(0.85);
+  });
+
+  it('applies all defaults when called with an empty object', () => {
+    const opts = resolveStarsOptions({});
+    expect(opts.density).toBe(50);
+    expect(opts.twinkle.speed).toBe(0.8);
+  });
+
+  it('overrides density while keeping other defaults', () => {
+    const opts = resolveStarsOptions({ density: 200 });
+    expect(opts.density).toBe(200);
+    expect(opts.color).toEqual([1.0, 0.97, 0.92]);
+  });
+
+  it('overrides opacity while keeping other defaults', () => {
+    const opts = resolveStarsOptions({ opacity: 0.5 });
+    expect(opts.opacity).toBe(0.5);
+    expect(opts.density).toBe(50);
+  });
+
+  it('accepts a custom color', () => {
+    const color: [number, number, number] = [0.8, 0.9, 1.0];
+    const opts = resolveStarsOptions({ color });
+    expect(opts.color).toEqual([0.8, 0.9, 1.0]);
+  });
+
+  it('accepts a custom sizeRange', () => {
+    const opts = resolveStarsOptions({ sizeRange: [1.0, 3.0] });
+    expect(opts.sizeRange).toEqual([1.0, 3.0]);
+  });
+
+  it('overrides only twinkle.speed, preserving twinkle.amplitude default', () => {
+    const opts = resolveStarsOptions({ twinkle: { speed: 2.5 } });
+    expect(opts.twinkle.speed).toBe(2.5);
+    expect(opts.twinkle.amplitude).toBe(0.15);
+  });
+
+  it('overrides only twinkle.amplitude, preserving twinkle.speed default', () => {
+    const opts = resolveStarsOptions({ twinkle: { amplitude: 0.3 } });
+    expect(opts.twinkle.speed).toBe(0.8);
+    expect(opts.twinkle.amplitude).toBe(0.3);
+  });
+
+  it('overrides all twinkle fields simultaneously', () => {
+    const opts = resolveStarsOptions({ twinkle: { speed: 1.2, amplitude: 0.4 } });
+    expect(opts.twinkle.speed).toBe(1.2);
+    expect(opts.twinkle.amplitude).toBe(0.4);
+  });
+
+  it('does not mutate the input options object', () => {
+    const input = { density: 75 };
+    resolveStarsOptions(input);
+    expect(input).toEqual({ density: 75 });
+  });
+});

--- a/packages/shared/src/golarion-map/stars.test.ts
+++ b/packages/shared/src/golarion-map/stars.test.ts
@@ -60,7 +60,7 @@ describe('resolveStarsOptions', () => {
     expect(opts.density).toBe(50);
     expect(opts.color).toEqual([1.0, 0.97, 0.92]);
     expect(opts.sizeRange).toEqual([1.0, 3.0]);
-    expect(opts.brightnessRange).toEqual([0.15, 1.0]);
+    expect(opts.brightnessRange).toEqual([0.4, 1.0]);
     expect(opts.twinkle.speed).toBe(0.8);
     expect(opts.twinkle.amplitude).toBe(0.15);
     expect(opts.opacity).toBe(0.85);
@@ -102,7 +102,7 @@ describe('resolveStarsOptions', () => {
 
   it('keeps default brightnessRange when not overridden', () => {
     const opts = resolveStarsOptions({ density: 80 });
-    expect(opts.brightnessRange).toEqual([0.15, 1.0]);
+    expect(opts.brightnessRange).toEqual([0.4, 1.0]);
   });
 
   it('overrides only twinkle.speed, preserving twinkle.amplitude default', () => {

--- a/packages/shared/src/golarion-map/stars.test.ts
+++ b/packages/shared/src/golarion-map/stars.test.ts
@@ -63,6 +63,7 @@ describe('resolveStarsOptions', () => {
     expect(opts.brightnessRange).toEqual([0.4, 1.0]);
     expect(opts.twinkle.speed).toBe(0.8);
     expect(opts.twinkle.amplitude).toBe(0.15);
+    expect(opts.twinkle.sizeAmplitude).toBe(0.3);
     expect(opts.opacity).toBe(0.85);
   });
 
@@ -115,12 +116,21 @@ describe('resolveStarsOptions', () => {
     const opts = resolveStarsOptions({ twinkle: { amplitude: 0.3 } });
     expect(opts.twinkle.speed).toBe(0.8);
     expect(opts.twinkle.amplitude).toBe(0.3);
+    expect(opts.twinkle.sizeAmplitude).toBe(0.3); // default preserved
+  });
+
+  it('overrides twinkle.sizeAmplitude independently', () => {
+    const opts = resolveStarsOptions({ twinkle: { sizeAmplitude: 0.1 } });
+    expect(opts.twinkle.sizeAmplitude).toBe(0.1);
+    expect(opts.twinkle.speed).toBe(0.8);
+    expect(opts.twinkle.amplitude).toBe(0.15);
   });
 
   it('overrides all twinkle fields simultaneously', () => {
-    const opts = resolveStarsOptions({ twinkle: { speed: 1.2, amplitude: 0.4 } });
+    const opts = resolveStarsOptions({ twinkle: { speed: 1.2, amplitude: 0.4, sizeAmplitude: 0.5 } });
     expect(opts.twinkle.speed).toBe(1.2);
     expect(opts.twinkle.amplitude).toBe(0.4);
+    expect(opts.twinkle.sizeAmplitude).toBe(0.5);
   });
 
   it('does not mutate the input options object', () => {

--- a/packages/shared/src/golarion-map/stars.test.ts
+++ b/packages/shared/src/golarion-map/stars.test.ts
@@ -60,6 +60,7 @@ describe('resolveStarsOptions', () => {
     expect(opts.density).toBe(50);
     expect(opts.color).toEqual([1.0, 0.97, 0.92]);
     expect(opts.sizeRange).toEqual([1.0, 3.0]);
+    expect(opts.brightnessRange).toEqual([0.15, 1.0]);
     expect(opts.twinkle.speed).toBe(0.8);
     expect(opts.twinkle.amplitude).toBe(0.15);
     expect(opts.opacity).toBe(0.85);
@@ -92,6 +93,16 @@ describe('resolveStarsOptions', () => {
   it('accepts a custom sizeRange', () => {
     const opts = resolveStarsOptions({ sizeRange: [1.0, 3.0] });
     expect(opts.sizeRange).toEqual([1.0, 3.0]);
+  });
+
+  it('accepts a custom brightnessRange', () => {
+    const opts = resolveStarsOptions({ brightnessRange: [0.5, 0.9] });
+    expect(opts.brightnessRange).toEqual([0.5, 0.9]);
+  });
+
+  it('keeps default brightnessRange when not overridden', () => {
+    const opts = resolveStarsOptions({ density: 80 });
+    expect(opts.brightnessRange).toEqual([0.15, 1.0]);
   });
 
   it('overrides only twinkle.speed, preserving twinkle.amplitude default', () => {

--- a/packages/shared/src/golarion-map/stars.test.ts
+++ b/packages/shared/src/golarion-map/stars.test.ts
@@ -59,7 +59,7 @@ describe('resolveStarsOptions', () => {
     const opts = resolveStarsOptions();
     expect(opts.density).toBe(50);
     expect(opts.color).toEqual([1.0, 0.97, 0.92]);
-    expect(opts.sizeRange).toEqual([1.0, 3.0]);
+    expect(opts.sizeRange).toEqual([1.0, 8.0]);
     expect(opts.brightnessRange).toEqual([0.4, 1.0]);
     expect(opts.twinkle.speed).toBe(0.8);
     expect(opts.twinkle.amplitude).toBe(0.15);

--- a/packages/shared/src/golarion-map/stars.ts
+++ b/packages/shared/src/golarion-map/stars.ts
@@ -1,0 +1,364 @@
+// WebGL custom layer that renders a procedural starfield in screen-space
+// behind the Golarion globe. Stars are point primitives at NDC positions
+// seeded for stability; each star has an independent twinkle phase so they
+// shimmer asynchronously rather than pulsing in unison.
+//
+// Rendering is in screen-space (projection matrix is intentionally ignored),
+// so inserting this layer before 'background' means the globe and atmosphere
+// paint over it where they occlude — stars appear only in the void.
+//
+// Usage in player-portal:
+//   const firstLayerId = map.getStyle().layers[0]?.id;
+//   map.addLayer(createStarsLayer(), firstLayerId);
+
+import type { CustomLayerInterface, CustomRenderMethodInput, Map as MaplibreMap } from 'maplibre-gl';
+
+// ---- Public types -----------------------------------------------------------
+
+export interface StarsOptions {
+  /** Stars per million screen pixels. Default: 50. */
+  density?: number;
+  /**
+   * Star colour as linear RGB [r, g, b] in [0, 1].
+   * Default: warm white [1.0, 0.97, 0.92].
+   */
+  color?: [number, number, number];
+  /** Point size range [min, max] in CSS pixels. Default: [0.5, 2.0]. */
+  sizeRange?: [number, number];
+  /** Twinkle animation parameters. */
+  twinkle?: {
+    /** Angular speed in radians per second. Default: 0.8. */
+    speed?: number;
+    /** Fraction of total alpha that oscillates [0, 1]. Default: 0.15. */
+    amplitude?: number;
+  };
+  /** Overall opacity multiplier [0, 1]. Default: 0.85. */
+  opacity?: number;
+}
+
+// Fully-resolved, no optionals — used internally after defaults are applied.
+export interface ResolvedStarsOptions {
+  density: number;
+  color: [number, number, number];
+  sizeRange: [number, number];
+  twinkle: { speed: number; amplitude: number };
+  opacity: number;
+}
+
+// ---- Pure helpers (exported for tests) --------------------------------------
+
+/**
+ * Mulberry32 — a fast, well-distributed seeded PRNG.
+ * Returns a function that yields floats in [0, 1) with stable output for
+ * a given seed across environments.
+ */
+export function mulberry32(seed: number): () => number {
+  let s = seed >>> 0;
+  return (): number => {
+    s = (s + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 0x100000000;
+  };
+}
+
+/** Merge user-supplied options with sensible defaults. */
+export function resolveStarsOptions(opts?: StarsOptions): ResolvedStarsOptions {
+  return {
+    density: opts?.density ?? 50,
+    color: opts?.color ?? [1.0, 0.97, 0.92],
+    sizeRange: opts?.sizeRange ?? [0.5, 2.0],
+    twinkle: {
+      speed: opts?.twinkle?.speed ?? 0.8,
+      amplitude: opts?.twinkle?.amplitude ?? 0.15,
+    },
+    opacity: opts?.opacity ?? 0.85,
+  };
+}
+
+// ---- GLSL shaders -----------------------------------------------------------
+//
+// Vertex: positions are raw NDC (no projection matrix) so stars are fixed to
+// the screen regardless of globe pan/zoom.  Per-star alpha oscillates with
+// sin(time × speed + phase[i]) so each star twinkles at its own rate.
+//
+// Fragment: circular soft-edged point — smoothstep fade from 0.25→0.5 radius
+// gives a gentle glow rather than a hard dot.
+
+const VERT_SRC = /* glsl */ `#version 300 es
+precision mediump float;
+
+in vec2 a_pos;
+in float a_size;
+in float a_phase;
+
+uniform float u_time;
+uniform float u_twinkle_speed;
+uniform float u_twinkle_amplitude;
+uniform float u_opacity;
+
+out float v_alpha;
+
+void main() {
+  // Screen-space: ignore the projection matrix entirely.
+  gl_Position = vec4(a_pos, 0.0, 1.0);
+  gl_PointSize = a_size;
+
+  // base + sin wave ensures alpha never goes below (1 - amplitude).
+  float base = 1.0 - u_twinkle_amplitude;
+  float wave = sin(u_time * u_twinkle_speed + a_phase) * u_twinkle_amplitude;
+  v_alpha = (base + wave) * u_opacity;
+}`;
+
+const FRAG_SRC = /* glsl */ `#version 300 es
+precision mediump float;
+
+uniform vec3 u_color;
+
+in float v_alpha;
+out vec4 fragColor;
+
+void main() {
+  // Discard corners of the point sprite quad, leaving a circle.
+  vec2 coord = gl_PointCoord - vec2(0.5);
+  float dist = length(coord);
+  if (dist > 0.5) discard;
+
+  // Soft glow: full alpha at centre, fades to zero at the edge.
+  float soft = 1.0 - smoothstep(0.25, 0.5, dist);
+  fragColor = vec4(u_color, v_alpha * soft);
+}`;
+
+// ---- WebGL helpers ----------------------------------------------------------
+
+function compileShader(
+  gl: WebGL2RenderingContext | WebGLRenderingContext,
+  type: number,
+  src: string,
+): WebGLShader | null {
+  const shader = gl.createShader(type);
+  if (!shader) return null;
+  gl.shaderSource(shader, src);
+  gl.compileShader(shader);
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    console.warn('[shared:stars] Shader compile failed:', gl.getShaderInfoLog(shader));
+    gl.deleteShader(shader);
+    return null;
+  }
+  return shader;
+}
+
+// ---- Layer implementation ---------------------------------------------------
+
+// Fixed seed so star positions are identical across reloads.
+const STAR_SEED = 0xdeadbeef;
+
+class StarsLayer implements CustomLayerInterface {
+  readonly id = 'golarion-stars';
+  readonly type = 'custom' as const;
+  readonly renderingMode = '3d' as const;
+
+  private readonly _opts: ResolvedStarsOptions;
+  private _map: MaplibreMap | null = null;
+  private _program: WebGLProgram | null = null;
+  private _vao: WebGLVertexArrayObject | null = null;
+  private _posBuffer: WebGLBuffer | null = null;
+  private _sizeBuffer: WebGLBuffer | null = null;
+  private _phaseBuffer: WebGLBuffer | null = null;
+  private _count = 0;
+  private _startTime = 0;
+
+  // Cached uniform locations
+  private _uTime: WebGLUniformLocation | null = null;
+  private _uTwinkleSpeed: WebGLUniformLocation | null = null;
+  private _uTwinkleAmplitude: WebGLUniformLocation | null = null;
+  private _uOpacity: WebGLUniformLocation | null = null;
+  private _uColor: WebGLUniformLocation | null = null;
+
+  constructor(opts?: StarsOptions) {
+    this._opts = resolveStarsOptions(opts);
+  }
+
+  onAdd(map: MaplibreMap, _gl: WebGL2RenderingContext | WebGLRenderingContext): void {
+    this._map = map;
+    // MapLibre v5 always provides WebGL2; shadow the union param with the cast.
+    const gl = _gl as WebGL2RenderingContext;
+
+    // Build shader program ------------------------------------------------
+    const vs = compileShader(gl, gl.VERTEX_SHADER, VERT_SRC);
+    const fs = compileShader(gl, gl.FRAGMENT_SHADER, FRAG_SRC);
+    if (!vs || !fs) {
+      console.warn('[shared:stars] Shader compile failed; starfield will be absent');
+      return;
+    }
+
+    const program = gl.createProgram();
+    if (!program) {
+      console.warn('[shared:stars] gl.createProgram() returned null');
+      return;
+    }
+    gl.attachShader(program, vs);
+    gl.attachShader(program, fs);
+    gl.linkProgram(program);
+    gl.deleteShader(vs);
+    gl.deleteShader(fs);
+
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+      console.warn('[shared:stars] Program link failed:', gl.getProgramInfoLog(program));
+      gl.deleteProgram(program);
+      return;
+    }
+    this._program = program;
+
+    // Generate star geometry (seeded → stable across reloads) ------------
+    const canvas = map.getCanvas();
+    const pixelArea = (canvas.width || 1280) * (canvas.height || 720);
+    this._count = Math.max(1, Math.floor((this._opts.density * pixelArea) / 1_000_000));
+
+    const rng = mulberry32(STAR_SEED);
+    const positions = new Float32Array(this._count * 2);
+    const sizes = new Float32Array(this._count);
+    const phases = new Float32Array(this._count);
+    const [minSz, maxSz] = this._opts.sizeRange;
+
+    for (let i = 0; i < this._count; i++) {
+      positions[i * 2] = rng() * 2 - 1; // x in NDC
+      positions[i * 2 + 1] = rng() * 2 - 1; // y in NDC
+      sizes[i] = minSz + rng() * (maxSz - minSz);
+      phases[i] = rng() * Math.PI * 2; // unique phase per star
+    }
+
+    // Upload geometry to GPU via VAO -------------------------------------
+    this._vao = gl.createVertexArray();
+    if (!this._vao) {
+      console.warn('[shared:stars] gl.createVertexArray() returned null');
+      return;
+    }
+    gl.bindVertexArray(this._vao);
+
+    const uploadAttrib = (data: Float32Array, name: string, components: number): WebGLBuffer | null => {
+      const buf = gl.createBuffer();
+      if (!buf) return null;
+      gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+      gl.bufferData(gl.ARRAY_BUFFER, data, gl.STATIC_DRAW);
+      const loc = gl.getAttribLocation(program, name);
+      gl.enableVertexAttribArray(loc);
+      gl.vertexAttribPointer(loc, components, gl.FLOAT, false, 0, 0);
+      return buf;
+    };
+
+    this._posBuffer = uploadAttrib(positions, 'a_pos', 2);
+    this._sizeBuffer = uploadAttrib(sizes, 'a_size', 1);
+    this._phaseBuffer = uploadAttrib(phases, 'a_phase', 1);
+
+    gl.bindVertexArray(null);
+    gl.bindBuffer(gl.ARRAY_BUFFER, null);
+
+    // Cache uniform locations -------------------------------------------
+    this._uTime = gl.getUniformLocation(program, 'u_time');
+    this._uTwinkleSpeed = gl.getUniformLocation(program, 'u_twinkle_speed');
+    this._uTwinkleAmplitude = gl.getUniformLocation(program, 'u_twinkle_amplitude');
+    this._uOpacity = gl.getUniformLocation(program, 'u_opacity');
+    this._uColor = gl.getUniformLocation(program, 'u_color');
+
+    this._startTime = performance.now();
+
+    console.info('[shared:stars] Layer added', {
+      count: this._count,
+      density: this._opts.density,
+      opacity: this._opts.opacity,
+      twinkleSpeed: this._opts.twinkle.speed,
+      twinkleAmplitude: this._opts.twinkle.amplitude,
+    });
+  }
+
+  render(_gl: WebGL2RenderingContext | WebGLRenderingContext, _options: CustomRenderMethodInput): void {
+    if (!this._program || !this._vao || !this._map) return;
+    const gl = _gl as WebGL2RenderingContext;
+
+    const elapsed = (performance.now() - this._startTime) / 1000;
+
+    // Save GL state that we're about to change ---------------------------
+    const prevDepthTest = gl.isEnabled(gl.DEPTH_TEST);
+    const prevBlend = gl.isEnabled(gl.BLEND);
+    const prevBlendSrcRgb = gl.getParameter(gl.BLEND_SRC_RGB) as number;
+    const prevBlendDstRgb = gl.getParameter(gl.BLEND_DST_RGB) as number;
+    const prevBlendSrcAlpha = gl.getParameter(gl.BLEND_SRC_ALPHA) as number;
+    const prevBlendDstAlpha = gl.getParameter(gl.BLEND_DST_ALPHA) as number;
+
+    gl.useProgram(this._program);
+    gl.bindVertexArray(this._vao);
+
+    // Stars are screen-space geometry behind the globe — no depth test.
+    gl.disable(gl.DEPTH_TEST);
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+
+    // Set uniforms -------------------------------------------------------
+    const { color, twinkle, opacity } = this._opts;
+    gl.uniform1f(this._uTime, elapsed);
+    gl.uniform1f(this._uTwinkleSpeed, twinkle.speed);
+    gl.uniform1f(this._uTwinkleAmplitude, twinkle.amplitude);
+    gl.uniform1f(this._uOpacity, opacity);
+    gl.uniform3fv(this._uColor, color);
+
+    gl.drawArrays(gl.POINTS, 0, this._count);
+
+    gl.bindVertexArray(null);
+
+    // Restore GL state ---------------------------------------------------
+    if (prevDepthTest) gl.enable(gl.DEPTH_TEST);
+    else gl.disable(gl.DEPTH_TEST);
+
+    if (prevBlend) {
+      gl.enable(gl.BLEND);
+      gl.blendFuncSeparate(prevBlendSrcRgb, prevBlendDstRgb, prevBlendSrcAlpha, prevBlendDstAlpha);
+    } else {
+      gl.disable(gl.BLEND);
+    }
+
+    // Drive continuous animation for the twinkle effect.
+    this._map.triggerRepaint();
+  }
+
+  onRemove(_map: MaplibreMap, _gl: WebGL2RenderingContext | WebGLRenderingContext): void {
+    const gl = _gl as WebGL2RenderingContext;
+    if (this._program) {
+      gl.deleteProgram(this._program);
+      this._program = null;
+    }
+    if (this._posBuffer) {
+      gl.deleteBuffer(this._posBuffer);
+      this._posBuffer = null;
+    }
+    if (this._sizeBuffer) {
+      gl.deleteBuffer(this._sizeBuffer);
+      this._sizeBuffer = null;
+    }
+    if (this._phaseBuffer) {
+      gl.deleteBuffer(this._phaseBuffer);
+      this._phaseBuffer = null;
+    }
+    if (this._vao) {
+      gl.deleteVertexArray(this._vao);
+      this._vao = null;
+    }
+    this._map = null;
+  }
+}
+
+// ---- Public factory ---------------------------------------------------------
+
+/**
+ * Create a MapLibre custom layer that renders a procedural starfield
+ * in screen-space, behind the Golarion globe.
+ *
+ * Insert it as the bottommost layer so everything else paints over it:
+ * ```ts
+ * const firstLayerId = map.getStyle().layers[0]?.id;
+ * map.addLayer(createStarsLayer(), firstLayerId);
+ * ```
+ */
+export function createStarsLayer(options?: StarsOptions): CustomLayerInterface {
+  return new StarsLayer(options);
+}

--- a/packages/shared/src/golarion-map/stars.ts
+++ b/packages/shared/src/golarion-map/stars.ts
@@ -23,8 +23,10 @@ export interface StarsOptions {
    * Default: warm white [1.0, 0.97, 0.92].
    */
   color?: [number, number, number];
-  /** Point size range [min, max] in CSS pixels. Default: [0.5, 2.0]. */
+  /** Point size range [min, max] in CSS pixels. Default: [1.0, 3.0]. */
   sizeRange?: [number, number];
+  /** Per-star base brightness range [min, max] in [0, 1]. Default: [0.15, 1.0]. */
+  brightnessRange?: [number, number];
   /** Twinkle animation parameters. */
   twinkle?: {
     /** Angular speed in radians per second. Default: 0.8. */
@@ -41,6 +43,7 @@ export interface ResolvedStarsOptions {
   density: number;
   color: [number, number, number];
   sizeRange: [number, number];
+  brightnessRange: [number, number];
   twinkle: { speed: number; amplitude: number };
   opacity: number;
 }
@@ -68,6 +71,7 @@ export function resolveStarsOptions(opts?: StarsOptions): ResolvedStarsOptions {
     density: opts?.density ?? 50,
     color: opts?.color ?? [1.0, 0.97, 0.92],
     sizeRange: opts?.sizeRange ?? [1.0, 3.0],
+    brightnessRange: opts?.brightnessRange ?? [0.15, 1.0],
     twinkle: {
       speed: opts?.twinkle?.speed ?? 0.8,
       amplitude: opts?.twinkle?.amplitude ?? 0.15,
@@ -91,6 +95,7 @@ precision mediump float;
 in vec2 a_pos;
 in float a_size;
 in float a_phase;
+in float a_brightness;
 
 uniform float u_time;
 uniform float u_twinkle_speed;
@@ -104,10 +109,11 @@ void main() {
   gl_Position = vec4(a_pos, 0.0, 1.0);
   gl_PointSize = a_size;
 
-  // base + sin wave ensures alpha never goes below (1 - amplitude).
+  // base + sin wave, then scaled by per-star brightness so dim stars stay
+  // dim even at peak twinkle and bright stars are fully lit.
   float base = 1.0 - u_twinkle_amplitude;
   float wave = sin(u_time * u_twinkle_speed + a_phase) * u_twinkle_amplitude;
-  v_alpha = (base + wave) * u_opacity;
+  v_alpha = (base + wave) * a_brightness * u_opacity;
 }`;
 
 const FRAG_SRC = /* glsl */ `#version 300 es
@@ -165,6 +171,7 @@ class StarsLayer implements CustomLayerInterface {
   private _posBuffer: WebGLBuffer | null = null;
   private _sizeBuffer: WebGLBuffer | null = null;
   private _phaseBuffer: WebGLBuffer | null = null;
+  private _brightnessBuffer: WebGLBuffer | null = null;
   private _count = 0;
   private _startTime = 0;
 
@@ -219,13 +226,16 @@ class StarsLayer implements CustomLayerInterface {
     const positions = new Float32Array(this._count * 2);
     const sizes = new Float32Array(this._count);
     const phases = new Float32Array(this._count);
+    const brightnesses = new Float32Array(this._count);
     const [minSz, maxSz] = this._opts.sizeRange;
+    const [minBr, maxBr] = this._opts.brightnessRange;
 
     for (let i = 0; i < this._count; i++) {
       positions[i * 2] = rng() * 2 - 1; // x in NDC
       positions[i * 2 + 1] = rng() * 2 - 1; // y in NDC
       sizes[i] = minSz + rng() * (maxSz - minSz);
-      phases[i] = rng() * Math.PI * 2; // unique phase per star
+      phases[i] = rng() * Math.PI * 2; // unique twinkle phase per star
+      brightnesses[i] = minBr + rng() * (maxBr - minBr); // static base brightness
     }
 
     // Upload geometry to GPU via VAO -------------------------------------
@@ -250,6 +260,7 @@ class StarsLayer implements CustomLayerInterface {
     this._posBuffer = uploadAttrib(positions, 'a_pos', 2);
     this._sizeBuffer = uploadAttrib(sizes, 'a_size', 1);
     this._phaseBuffer = uploadAttrib(phases, 'a_phase', 1);
+    this._brightnessBuffer = uploadAttrib(brightnesses, 'a_brightness', 1);
 
     gl.bindVertexArray(null);
     gl.bindBuffer(gl.ARRAY_BUFFER, null);
@@ -338,6 +349,10 @@ class StarsLayer implements CustomLayerInterface {
     if (this._phaseBuffer) {
       gl.deleteBuffer(this._phaseBuffer);
       this._phaseBuffer = null;
+    }
+    if (this._brightnessBuffer) {
+      gl.deleteBuffer(this._brightnessBuffer);
+      this._brightnessBuffer = null;
     }
     if (this._vao) {
       gl.deleteVertexArray(this._vao);

--- a/packages/shared/src/golarion-map/stars.ts
+++ b/packages/shared/src/golarion-map/stars.ts
@@ -111,14 +111,21 @@ uniform float u_size_amplitude;
 uniform float u_opacity;
 
 out float v_alpha;
+out float v_size_ratio;
 
 void main() {
   // Screen-space: ignore the projection matrix entirely.
   gl_Position = vec4(a_pos, 0.0, 1.0);
 
-  // Size pulses independently of brightness using its own per-star phase.
+  // Pin gl_PointSize to the maximum this star can ever reach so it never
+  // changes between frames — gl_PointSize is integer-snapped by the GPU and
+  // animating it produces visible stepping.  The smooth size variation is
+  // handled entirely in the fragment shader via v_size_ratio.
+  gl_PointSize = a_size * (1.0 + u_size_amplitude) + 1.0;
+
+  // Fraction of the sprite the gaussian should fill this frame [0, 1].
   float size_wave = sin(u_time * u_twinkle_speed + a_size_phase) * u_size_amplitude;
-  gl_PointSize = a_size * (1.0 + size_wave);
+  v_size_ratio = (1.0 + size_wave) / (1.0 + u_size_amplitude);
 
   // base + sin wave, then scaled by per-star brightness so dim stars stay
   // dim even at peak twinkle and bright stars are fully lit.
@@ -133,15 +140,17 @@ precision mediump float;
 uniform vec3 u_color;
 
 in float v_alpha;
+in float v_size_ratio;
 out vec4 fragColor;
 
 void main() {
-  vec2 coord = gl_PointCoord - vec2(0.5);
-  float dist2 = dot(coord, coord); // dist² — avoids a sqrt
+  // Divide by v_size_ratio so the gaussian tightens when the star is small
+  // and fills the sprite when the star is at peak size — smooth float math,
+  // no integer snapping.
+  vec2 coord = (gl_PointCoord - vec2(0.5)) / v_size_ratio;
+  float dist2 = dot(coord, coord);
 
   // Gaussian falloff: bright core, exponential decay outward.
-  // No hard edge — the function reaches ~0.018 at the sprite boundary
-  // so there's nothing to discard and no circular outline visible.
   float soft = exp(-dist2 * 16.0);
   fragColor = vec4(u_color, v_alpha * soft);
 }`;

--- a/packages/shared/src/golarion-map/stars.ts
+++ b/packages/shared/src/golarion-map/stars.ts
@@ -71,7 +71,7 @@ export function resolveStarsOptions(opts?: StarsOptions): ResolvedStarsOptions {
     density: opts?.density ?? 50,
     color: opts?.color ?? [1.0, 0.97, 0.92],
     sizeRange: opts?.sizeRange ?? [1.0, 3.0],
-    brightnessRange: opts?.brightnessRange ?? [0.15, 1.0],
+    brightnessRange: opts?.brightnessRange ?? [0.4, 1.0],
     twinkle: {
       speed: opts?.twinkle?.speed ?? 0.8,
       amplitude: opts?.twinkle?.amplitude ?? 0.15,

--- a/packages/shared/src/golarion-map/stars.ts
+++ b/packages/shared/src/golarion-map/stars.ts
@@ -33,6 +33,11 @@ export interface StarsOptions {
     speed?: number;
     /** Fraction of total alpha that oscillates [0, 1]. Default: 0.15. */
     amplitude?: number;
+    /**
+     * Fraction of base size that oscillates [0, 1]. Default: 0.3.
+     * Each star uses an independent phase so they pulse out-of-sync.
+     */
+    sizeAmplitude?: number;
   };
   /** Overall opacity multiplier [0, 1]. Default: 0.85. */
   opacity?: number;
@@ -44,7 +49,7 @@ export interface ResolvedStarsOptions {
   color: [number, number, number];
   sizeRange: [number, number];
   brightnessRange: [number, number];
-  twinkle: { speed: number; amplitude: number };
+  twinkle: { speed: number; amplitude: number; sizeAmplitude: number };
   opacity: number;
 }
 
@@ -75,6 +80,7 @@ export function resolveStarsOptions(opts?: StarsOptions): ResolvedStarsOptions {
     twinkle: {
       speed: opts?.twinkle?.speed ?? 0.8,
       amplitude: opts?.twinkle?.amplitude ?? 0.15,
+      sizeAmplitude: opts?.twinkle?.sizeAmplitude ?? 0.3,
     },
     opacity: opts?.opacity ?? 0.85,
   };
@@ -95,11 +101,13 @@ precision mediump float;
 in vec2 a_pos;
 in float a_size;
 in float a_phase;
+in float a_size_phase;
 in float a_brightness;
 
 uniform float u_time;
 uniform float u_twinkle_speed;
 uniform float u_twinkle_amplitude;
+uniform float u_size_amplitude;
 uniform float u_opacity;
 
 out float v_alpha;
@@ -107,7 +115,10 @@ out float v_alpha;
 void main() {
   // Screen-space: ignore the projection matrix entirely.
   gl_Position = vec4(a_pos, 0.0, 1.0);
-  gl_PointSize = a_size;
+
+  // Size pulses independently of brightness using its own per-star phase.
+  float size_wave = sin(u_time * u_twinkle_speed + a_size_phase) * u_size_amplitude;
+  gl_PointSize = a_size * (1.0 + size_wave);
 
   // base + sin wave, then scaled by per-star brightness so dim stars stay
   // dim even at peak twinkle and bright stars are fully lit.
@@ -171,6 +182,7 @@ class StarsLayer implements CustomLayerInterface {
   private _posBuffer: WebGLBuffer | null = null;
   private _sizeBuffer: WebGLBuffer | null = null;
   private _phaseBuffer: WebGLBuffer | null = null;
+  private _sizePhaseBuffer: WebGLBuffer | null = null;
   private _brightnessBuffer: WebGLBuffer | null = null;
   private _count = 0;
   private _startTime = 0;
@@ -179,6 +191,7 @@ class StarsLayer implements CustomLayerInterface {
   private _uTime: WebGLUniformLocation | null = null;
   private _uTwinkleSpeed: WebGLUniformLocation | null = null;
   private _uTwinkleAmplitude: WebGLUniformLocation | null = null;
+  private _uSizeAmplitude: WebGLUniformLocation | null = null;
   private _uOpacity: WebGLUniformLocation | null = null;
   private _uColor: WebGLUniformLocation | null = null;
 
@@ -226,6 +239,7 @@ class StarsLayer implements CustomLayerInterface {
     const positions = new Float32Array(this._count * 2);
     const sizes = new Float32Array(this._count);
     const phases = new Float32Array(this._count);
+    const sizePhases = new Float32Array(this._count);
     const brightnesses = new Float32Array(this._count);
     const [minSz, maxSz] = this._opts.sizeRange;
     const [minBr, maxBr] = this._opts.brightnessRange;
@@ -234,7 +248,8 @@ class StarsLayer implements CustomLayerInterface {
       positions[i * 2] = rng() * 2 - 1; // x in NDC
       positions[i * 2 + 1] = rng() * 2 - 1; // y in NDC
       sizes[i] = minSz + rng() * (maxSz - minSz);
-      phases[i] = rng() * Math.PI * 2; // unique twinkle phase per star
+      phases[i] = rng() * Math.PI * 2; // unique brightness-twinkle phase
+      sizePhases[i] = rng() * Math.PI * 2; // independent size-pulse phase
       brightnesses[i] = minBr + rng() * (maxBr - minBr); // static base brightness
     }
 
@@ -260,6 +275,7 @@ class StarsLayer implements CustomLayerInterface {
     this._posBuffer = uploadAttrib(positions, 'a_pos', 2);
     this._sizeBuffer = uploadAttrib(sizes, 'a_size', 1);
     this._phaseBuffer = uploadAttrib(phases, 'a_phase', 1);
+    this._sizePhaseBuffer = uploadAttrib(sizePhases, 'a_size_phase', 1);
     this._brightnessBuffer = uploadAttrib(brightnesses, 'a_brightness', 1);
 
     gl.bindVertexArray(null);
@@ -269,6 +285,7 @@ class StarsLayer implements CustomLayerInterface {
     this._uTime = gl.getUniformLocation(program, 'u_time');
     this._uTwinkleSpeed = gl.getUniformLocation(program, 'u_twinkle_speed');
     this._uTwinkleAmplitude = gl.getUniformLocation(program, 'u_twinkle_amplitude');
+    this._uSizeAmplitude = gl.getUniformLocation(program, 'u_size_amplitude');
     this._uOpacity = gl.getUniformLocation(program, 'u_opacity');
     this._uColor = gl.getUniformLocation(program, 'u_color');
 
@@ -310,6 +327,7 @@ class StarsLayer implements CustomLayerInterface {
     gl.uniform1f(this._uTime, elapsed);
     gl.uniform1f(this._uTwinkleSpeed, twinkle.speed);
     gl.uniform1f(this._uTwinkleAmplitude, twinkle.amplitude);
+    gl.uniform1f(this._uSizeAmplitude, twinkle.sizeAmplitude);
     gl.uniform1f(this._uOpacity, opacity);
     gl.uniform3fv(this._uColor, color);
 
@@ -349,6 +367,10 @@ class StarsLayer implements CustomLayerInterface {
     if (this._phaseBuffer) {
       gl.deleteBuffer(this._phaseBuffer);
       this._phaseBuffer = null;
+    }
+    if (this._sizePhaseBuffer) {
+      gl.deleteBuffer(this._sizePhaseBuffer);
+      this._sizePhaseBuffer = null;
     }
     if (this._brightnessBuffer) {
       gl.deleteBuffer(this._brightnessBuffer);

--- a/packages/shared/src/golarion-map/stars.ts
+++ b/packages/shared/src/golarion-map/stars.ts
@@ -75,7 +75,7 @@ export function resolveStarsOptions(opts?: StarsOptions): ResolvedStarsOptions {
   return {
     density: opts?.density ?? 50,
     color: opts?.color ?? [1.0, 0.97, 0.92],
-    sizeRange: opts?.sizeRange ?? [1.0, 3.0],
+    sizeRange: opts?.sizeRange ?? [1.0, 8.0],
     brightnessRange: opts?.brightnessRange ?? [0.4, 1.0],
     twinkle: {
       speed: opts?.twinkle?.speed ?? 0.8,

--- a/packages/shared/src/golarion-map/stars.ts
+++ b/packages/shared/src/golarion-map/stars.ts
@@ -73,7 +73,7 @@ export function mulberry32(seed: number): () => number {
 /** Merge user-supplied options with sensible defaults. */
 export function resolveStarsOptions(opts?: StarsOptions): ResolvedStarsOptions {
   return {
-    density: opts?.density ?? 50,
+    density: opts?.density ?? 65,
     color: opts?.color ?? [1.0, 0.97, 0.92],
     sizeRange: opts?.sizeRange ?? [1.0, 8.0],
     brightnessRange: opts?.brightnessRange ?? [0.4, 1.0],

--- a/packages/shared/src/golarion-map/stars.ts
+++ b/packages/shared/src/golarion-map/stars.ts
@@ -136,13 +136,13 @@ in float v_alpha;
 out vec4 fragColor;
 
 void main() {
-  // Discard corners of the point sprite quad, leaving a circle.
   vec2 coord = gl_PointCoord - vec2(0.5);
-  float dist = length(coord);
-  if (dist > 0.5) discard;
+  float dist2 = dot(coord, coord); // dist² — avoids a sqrt
 
-  // Soft glow: full alpha at centre, fades to zero at the edge.
-  float soft = 1.0 - smoothstep(0.25, 0.5, dist);
+  // Gaussian falloff: bright core, exponential decay outward.
+  // No hard edge — the function reaches ~0.018 at the sprite boundary
+  // so there's nothing to discard and no circular outline visible.
+  float soft = exp(-dist2 * 16.0);
   fragColor = vec4(u_color, v_alpha * soft);
 }`;
 

--- a/packages/shared/src/golarion-map/stars.ts
+++ b/packages/shared/src/golarion-map/stars.ts
@@ -67,7 +67,7 @@ export function resolveStarsOptions(opts?: StarsOptions): ResolvedStarsOptions {
   return {
     density: opts?.density ?? 50,
     color: opts?.color ?? [1.0, 0.97, 0.92],
-    sizeRange: opts?.sizeRange ?? [0.5, 2.0],
+    sizeRange: opts?.sizeRange ?? [1.0, 3.0],
     twinkle: {
       speed: opts?.twinkle?.speed ?? 0.8,
       amplitude: opts?.twinkle?.amplitude ?? 0.15,


### PR DESCRIPTION
## Summary

Adds a WebGL starfield that fills the void around the Golarion globe. Stars are rendered in screen-space (no projection matrix) as a MapLibre custom layer inserted before `background`, so the globe and its atmosphere paint cleanly over them — stars only show in the dark space surrounding the planet.

The void is made properly black by calling `map.setSky({'atmosphere-blend': 0})` on load, removing MapLibre's default blue atmospheric haze so stars read against actual darkness.

Star positions are procedurally generated with mulberry32 (seed `0xdeadbeef`) so the layout is identical across page loads without any asset. Each star has its own twinkle phase so they shimmer out-of-sync. Defaults after tuning:

- 50 stars/mpx — sparse, deep-space feel
- Warm white `[1.0, 0.97, 0.92]` — slightly amber, complements parchment map tones
- Size 1–3 px; twinkle amplitude 15% at 0.8 rad/s — visible but not distracting

## Changes

- `packages/shared/src/golarion-map/stars.ts` — `createStarsLayer(options?)` custom layer; exports `mulberry32` and `resolveStarsOptions` as testable pure helpers
- `packages/shared/src/golarion-map/index.ts` — re-exports `createStarsLayer`, `StarsOptions`, `ResolvedStarsOptions` (additive, no existing export touched)
- `apps/player-portal/src/routes/Globe.tsx` — zeroes atmosphere-blend, then calls `map.addLayer(createStarsLayer(), firstLayerId)` in the `load` handler

## Test plan

- [ ] `npm run test -w packages/shared` — 71 tests pass (14 new: mulberry32 stability/range/uniqueness, resolveStarsOptions defaults/overrides)
- [ ] `npm run typecheck` — clean across shared + player-portal
- [ ] Visual: `npm run dev:player-portal`, navigate to `/globe` — black void, visible stars, gentle shimmer, globe surface clean