### PR TITLE
feat(shared): add Golarion globe auto-rotate

### DIFF
--- a/apps/player-portal/src/routes/Globe.tsx
+++ b/apps/player-portal/src/routes/Globe.tsx
@@ -15,6 +15,7 @@ import {
   ensureDefaultImage,
   ensureIconImage,
   pinsToGeoJson,
+  startAutoRotate,
 } from '@foundry-toolkit/shared/golarion-map';
 import { MissionBriefing } from '@foundry-toolkit/shared/MissionBriefing';
 import type { GlobePin, MissionData } from '@foundry-toolkit/shared/types';
@@ -80,6 +81,7 @@ export function Globe() {
 
     map.on('style.load', () => {
       map.setProjection({ type: 'globe' });
+      startAutoRotate(map, { startDelayMs: 500 });
     });
 
     map.addControl(new maplibregl.NavigationControl(), 'top-right');

--- a/packages/shared/src/golarion-map/auto-rotate.test.ts
+++ b/packages/shared/src/golarion-map/auto-rotate.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeLng } from './auto-rotate';
+
+// ---------------------------------------------------------------------------
+// normalizeLng — longitude wrapping
+// ---------------------------------------------------------------------------
+
+describe('normalizeLng', () => {
+  it('leaves values inside [-180, 180) unchanged', () => {
+    expect(normalizeLng(0)).toBe(0);
+    expect(normalizeLng(90)).toBe(90);
+    expect(normalizeLng(-90)).toBe(-90);
+    expect(normalizeLng(179.9)).toBeCloseTo(179.9);
+    expect(normalizeLng(-179.9)).toBeCloseTo(-179.9);
+  });
+
+  it('wraps 180 to -180 (anti-meridian)', () => {
+    expect(normalizeLng(180)).toBe(-180);
+  });
+
+  it('wraps values just above 180 to just below -180', () => {
+    expect(normalizeLng(181)).toBeCloseTo(-179);
+  });
+
+  it('wraps values just below -180 to just below 180', () => {
+    expect(normalizeLng(-181)).toBeCloseTo(179);
+  });
+
+  it('wraps 360 back to 0', () => {
+    expect(normalizeLng(360)).toBe(0);
+  });
+
+  it('wraps -360 back to 0', () => {
+    expect(normalizeLng(-360)).toBe(0);
+  });
+
+  it('wraps large positive values (multiple revolutions)', () => {
+    // 540 = 360 + 180 → -180
+    expect(normalizeLng(540)).toBe(-180);
+    // 720 = two full revolutions → 0
+    expect(normalizeLng(720)).toBe(0);
+    // 810 = 720 + 90 → 90
+    expect(normalizeLng(810)).toBeCloseTo(90);
+  });
+
+  it('wraps large negative values (multiple revolutions)', () => {
+    expect(normalizeLng(-540)).toBe(-180);
+    expect(normalizeLng(-720)).toBe(0);
+    expect(normalizeLng(-810)).toBeCloseTo(-90);
+  });
+
+  it('handles fractional degrees without losing precision', () => {
+    expect(normalizeLng(185.5)).toBeCloseTo(-174.5);
+    expect(normalizeLng(-185.5)).toBeCloseTo(174.5);
+  });
+});

--- a/packages/shared/src/golarion-map/auto-rotate.ts
+++ b/packages/shared/src/golarion-map/auto-rotate.ts
@@ -125,11 +125,16 @@ export function startAutoRotate(map: Map, options?: AutoRotateOptions): () => vo
     const dt = (timestamp - lastTimestamp) / 1000; // seconds
     lastTimestamp = timestamp;
 
-    const center = map.getCenter();
-    const sign = opts.direction === 'east' ? 1 : -1;
-    const newLng = normalizeLng(center.lng + opts.degreesPerSecond * dt * sign);
-
-    map.jumpTo({ center: [newLng, center.lat] });
+    // Skip the center update while MapLibre is running a zoom animation
+    // (e.g. scroll-to-zoom ease). jumpTo cancels ongoing animations, which
+    // makes scrolling feel sluggish without this guard. lastTimestamp is still
+    // advanced so there is no stutter when the zoom settles.
+    if (!map.isZooming()) {
+      const center = map.getCenter();
+      const sign = opts.direction === 'east' ? 1 : -1;
+      const newLng = normalizeLng(center.lng + opts.degreesPerSecond * dt * sign);
+      map.jumpTo({ center: [newLng, center.lat] });
+    }
 
     rafId = requestAnimationFrame(frame);
   }

--- a/packages/shared/src/golarion-map/auto-rotate.ts
+++ b/packages/shared/src/golarion-map/auto-rotate.ts
@@ -1,9 +1,9 @@
 // Golarion globe auto-rotation helper.
 // Advances the map center longitude each animation frame so the globe
 // appears to spin slowly under a stationary viewer. Rotation stops
-// permanently on the first user interaction (drag, zoom, pitch, wheel,
-// click, touch) and can also be cancelled manually via the returned
-// teardown function.
+// permanently the first time the user manually drags the globe
+// (drag, rotate, or pitch gesture) and can also be cancelled via the
+// returned teardown function. Scroll/wheel zooms do not stop rotation.
 //
 // Use `jumpTo` (not `easeTo`) for per-frame nudges — it's cheaper and
 // avoids fighting its own animation queue.
@@ -73,10 +73,12 @@ export function startAutoRotate(map: Map, options?: AutoRotateOptions): () => vo
   let cancelled = false;
   let delayTimer: ReturnType<typeof setTimeout> | null = null;
 
-  const canvas = map.getCanvas();
-
   // ---- Interaction listeners -----------------------------------------------
 
+  // Only stop on manual drag gestures (left-click drag, right-click rotate,
+  // two-finger pitch). Scroll/wheel events zoom the map but should not
+  // interrupt the auto-rotation.
+  //
   // MapLibre *start events carry `originalEvent` only when the action was
   // user-initiated. Programmatic changes (e.g. our own jumpTo calls) do not
   // set originalEvent, so we ignore those to avoid self-cancelling.
@@ -86,21 +88,12 @@ export function startAutoRotate(map: Map, options?: AutoRotateOptions): () => vo
     }
   }
 
-  // DOM events on the canvas fire only on real user input — no filtering needed.
-  function onDomInteraction(): void {
-    cancel('interaction');
-  }
-
   // ---- Cancel / teardown --------------------------------------------------
 
   function removeListeners(): void {
     map.off('dragstart', onMapStart);
     map.off('rotatestart', onMapStart);
     map.off('pitchstart', onMapStart);
-    map.off('zoomstart', onMapStart);
-    canvas.removeEventListener('wheel', onDomInteraction);
-    canvas.removeEventListener('mousedown', onDomInteraction);
-    canvas.removeEventListener('touchstart', onDomInteraction);
   }
 
   function cancel(reason: 'interaction' | 'manual'): void {
@@ -146,15 +139,12 @@ export function startAutoRotate(map: Map, options?: AutoRotateOptions): () => vo
     rafId = requestAnimationFrame(frame);
   }
 
-  // Register interaction listeners immediately so any user touch before the
-  // delay elapses also cancels the pending start.
+  // Register drag listeners immediately so a drag before the delay elapses
+  // also cancels the pending start. Scroll/wheel is intentionally excluded —
+  // zooming should not interrupt auto-rotation.
   map.on('dragstart', onMapStart);
   map.on('rotatestart', onMapStart);
   map.on('pitchstart', onMapStart);
-  map.on('zoomstart', onMapStart);
-  canvas.addEventListener('wheel', onDomInteraction, { passive: true });
-  canvas.addEventListener('mousedown', onDomInteraction);
-  canvas.addEventListener('touchstart', onDomInteraction, { passive: true });
 
   if (opts.startDelayMs > 0) {
     delayTimer = setTimeout(startLoop, opts.startDelayMs);

--- a/packages/shared/src/golarion-map/auto-rotate.ts
+++ b/packages/shared/src/golarion-map/auto-rotate.ts
@@ -1,0 +1,166 @@
+// Golarion globe auto-rotation helper.
+// Advances the map center longitude each animation frame so the globe
+// appears to spin slowly under a stationary viewer. Rotation stops
+// permanently on the first user interaction (drag, zoom, pitch, wheel,
+// click, touch) and can also be cancelled manually via the returned
+// teardown function.
+//
+// Use `jumpTo` (not `easeTo`) for per-frame nudges — it's cheaper and
+// avoids fighting its own animation queue.
+
+import type { Map } from 'maplibre-gl';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface AutoRotateOptions {
+  /** Degrees to advance per second. Default 6 (one full revolution per ~60 s). */
+  degreesPerSecond?: number;
+  /**
+   * Rotation direction.
+   * - `'east'` (default, earth-like): positive longitude delta.
+   * - `'west'`: negative longitude delta.
+   */
+  direction?: 'east' | 'west';
+  /**
+   * Delay in milliseconds before the rAF loop starts.
+   * Useful to let the page settle after load. Default 0.
+   */
+  startDelayMs?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for unit tests)
+// ---------------------------------------------------------------------------
+
+const DEFAULTS: Required<AutoRotateOptions> = {
+  degreesPerSecond: 6,
+  direction: 'east',
+  startDelayMs: 0,
+};
+
+/**
+ * Normalise a longitude value to the half-open range [-180, 180).
+ * Handles values that have drifted far outside the range over many frames.
+ */
+export function normalizeLng(lng: number): number {
+  return ((((lng + 180) % 360) + 360) % 360) - 180;
+}
+
+// ---------------------------------------------------------------------------
+// startAutoRotate
+// ---------------------------------------------------------------------------
+
+/**
+ * Start slowly auto-rotating the globe by incrementing the map center
+ * longitude on every animation frame.
+ *
+ * @returns A teardown function. Call it to cancel rotation manually.
+ *          Rotation also self-cancels on the first user interaction.
+ */
+export function startAutoRotate(map: Map, options?: AutoRotateOptions): () => void {
+  const opts: Required<AutoRotateOptions> = { ...DEFAULTS, ...options };
+
+  console.info('[shared:auto-rotate] startAutoRotate invoked', {
+    degreesPerSecond: opts.degreesPerSecond,
+    direction: opts.direction,
+    startDelayMs: opts.startDelayMs,
+  });
+
+  let rafId: number | null = null;
+  let lastTimestamp: number | null = null;
+  let cancelled = false;
+  let delayTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const canvas = map.getCanvas();
+
+  // ---- Interaction listeners -----------------------------------------------
+
+  // MapLibre *start events carry `originalEvent` only when the action was
+  // user-initiated. Programmatic changes (e.g. our own jumpTo calls) do not
+  // set originalEvent, so we ignore those to avoid self-cancelling.
+  function onMapStart(e: { originalEvent?: Event }): void {
+    if (e.originalEvent) {
+      cancel('interaction');
+    }
+  }
+
+  // DOM events on the canvas fire only on real user input — no filtering needed.
+  function onDomInteraction(): void {
+    cancel('interaction');
+  }
+
+  // ---- Cancel / teardown --------------------------------------------------
+
+  function removeListeners(): void {
+    map.off('dragstart', onMapStart);
+    map.off('rotatestart', onMapStart);
+    map.off('pitchstart', onMapStart);
+    map.off('zoomstart', onMapStart);
+    canvas.removeEventListener('wheel', onDomInteraction);
+    canvas.removeEventListener('mousedown', onDomInteraction);
+    canvas.removeEventListener('touchstart', onDomInteraction);
+  }
+
+  function cancel(reason: 'interaction' | 'manual'): void {
+    if (cancelled) return;
+    cancelled = true;
+
+    if (delayTimer !== null) {
+      clearTimeout(delayTimer);
+      delayTimer = null;
+    }
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+
+    removeListeners();
+    console.info(`[shared:auto-rotate] rotation stopped (${reason})`);
+  }
+
+  // ---- rAF loop -----------------------------------------------------------
+
+  function frame(timestamp: number): void {
+    if (cancelled) return;
+
+    if (lastTimestamp === null) {
+      lastTimestamp = timestamp;
+    }
+
+    const dt = (timestamp - lastTimestamp) / 1000; // seconds
+    lastTimestamp = timestamp;
+
+    const center = map.getCenter();
+    const sign = opts.direction === 'east' ? 1 : -1;
+    const newLng = normalizeLng(center.lng + opts.degreesPerSecond * dt * sign);
+
+    map.jumpTo({ center: [newLng, center.lat] });
+
+    rafId = requestAnimationFrame(frame);
+  }
+
+  function startLoop(): void {
+    if (cancelled) return;
+    rafId = requestAnimationFrame(frame);
+  }
+
+  // Register interaction listeners immediately so any user touch before the
+  // delay elapses also cancels the pending start.
+  map.on('dragstart', onMapStart);
+  map.on('rotatestart', onMapStart);
+  map.on('pitchstart', onMapStart);
+  map.on('zoomstart', onMapStart);
+  canvas.addEventListener('wheel', onDomInteraction, { passive: true });
+  canvas.addEventListener('mousedown', onDomInteraction);
+  canvas.addEventListener('touchstart', onDomInteraction, { passive: true });
+
+  if (opts.startDelayMs > 0) {
+    delayTimer = setTimeout(startLoop, opts.startDelayMs);
+  } else {
+    startLoop();
+  }
+
+  return () => cancel('manual');
+}

--- a/packages/shared/src/golarion-map/auto-rotate.ts
+++ b/packages/shared/src/golarion-map/auto-rotate.ts
@@ -73,12 +73,6 @@ export function startAutoRotate(map: Map, options?: AutoRotateOptions): () => vo
   let cancelled = false;
   let delayTimer: ReturnType<typeof setTimeout> | null = null;
 
-  // virtualLng advances every frame regardless of whether a zoom animation is
-  // in progress. We only apply it to the map when !isZooming(), so zoom easing
-  // runs undisturbed. When zoom settles the globe snaps to virtualLng — at
-  // 6°/s and a 300ms ease that's <2°, imperceptible at this rotation speed.
-  let virtualLng = map.getCenter().lng;
-
   // ---- Interaction listeners -----------------------------------------------
 
   // Only stop on manual drag gestures (left-click drag, right-click rotate,
@@ -131,15 +125,15 @@ export function startAutoRotate(map: Map, options?: AutoRotateOptions): () => vo
     const dt = (timestamp - lastTimestamp) / 1000; // seconds
     lastTimestamp = timestamp;
 
-    // Always advance virtualLng so the rotation clock never stops.
-    const sign = opts.direction === 'east' ? 1 : -1;
-    virtualLng = normalizeLng(virtualLng + opts.degreesPerSecond * dt * sign);
-
     // Skip jumpTo while MapLibre is running a zoom ease — jumpTo cancels
-    // in-progress animations. When isZooming() clears the globe applies
-    // virtualLng directly, catching up the accumulated delta in one frame.
+    // in-progress animations, making scroll-to-zoom feel sluggish.
+    // lastTimestamp still advances so there is no stutter when zoom settles
+    // and the globe resumes from exactly where it paused.
     if (!map.isZooming()) {
-      map.jumpTo({ center: [virtualLng, map.getCenter().lat] });
+      const center = map.getCenter();
+      const sign = opts.direction === 'east' ? 1 : -1;
+      const newLng = normalizeLng(center.lng + opts.degreesPerSecond * dt * sign);
+      map.jumpTo({ center: [newLng, center.lat] });
     }
 
     rafId = requestAnimationFrame(frame);

--- a/packages/shared/src/golarion-map/auto-rotate.ts
+++ b/packages/shared/src/golarion-map/auto-rotate.ts
@@ -73,6 +73,12 @@ export function startAutoRotate(map: Map, options?: AutoRotateOptions): () => vo
   let cancelled = false;
   let delayTimer: ReturnType<typeof setTimeout> | null = null;
 
+  // virtualLng advances every frame regardless of whether a zoom animation is
+  // in progress. We only apply it to the map when !isZooming(), so zoom easing
+  // runs undisturbed. When zoom settles the globe snaps to virtualLng — at
+  // 6°/s and a 300ms ease that's <2°, imperceptible at this rotation speed.
+  let virtualLng = map.getCenter().lng;
+
   // ---- Interaction listeners -----------------------------------------------
 
   // Only stop on manual drag gestures (left-click drag, right-click rotate,
@@ -125,15 +131,15 @@ export function startAutoRotate(map: Map, options?: AutoRotateOptions): () => vo
     const dt = (timestamp - lastTimestamp) / 1000; // seconds
     lastTimestamp = timestamp;
 
-    // Skip the center update while MapLibre is running a zoom animation
-    // (e.g. scroll-to-zoom ease). jumpTo cancels ongoing animations, which
-    // makes scrolling feel sluggish without this guard. lastTimestamp is still
-    // advanced so there is no stutter when the zoom settles.
+    // Always advance virtualLng so the rotation clock never stops.
+    const sign = opts.direction === 'east' ? 1 : -1;
+    virtualLng = normalizeLng(virtualLng + opts.degreesPerSecond * dt * sign);
+
+    // Skip jumpTo while MapLibre is running a zoom ease — jumpTo cancels
+    // in-progress animations. When isZooming() clears the globe applies
+    // virtualLng directly, catching up the accumulated delta in one frame.
     if (!map.isZooming()) {
-      const center = map.getCenter();
-      const sign = opts.direction === 'east' ? 1 : -1;
-      const newLng = normalizeLng(center.lng + opts.degreesPerSecond * dt * sign);
-      map.jumpTo({ center: [newLng, center.lat] });
+      map.jumpTo({ center: [virtualLng, map.getCenter().lat] });
     }
 
     rafId = requestAnimationFrame(frame);

--- a/packages/shared/src/golarion-map/index.ts
+++ b/packages/shared/src/golarion-map/index.ts
@@ -7,3 +7,5 @@ export { PIN_SOURCE, PIN_LAYER, pinDisplaySize, pinsToGeoJson } from './pins.js'
 export { ensureDefaultImage, ensureIconImage, getIconBody, iconKey, iconSvgHtml, resolvePinIcon } from './icons.js';
 export { createStarsLayer } from './stars.js';
 export type { StarsOptions, ResolvedStarsOptions } from './stars.js';
+export { startAutoRotate } from './auto-rotate.js';
+export type { AutoRotateOptions } from './auto-rotate.js';


### PR DESCRIPTION
## Summary
The Golarion globe in the player portal now slowly spins eastward when the page loads. Rotation uses `requestAnimationFrame` + `jumpTo` to advance center longitude at **6 degrees/s** (~1 full revolution per minute). Rotation stops permanently the first time the user **manually drags** the globe (left-click drag, right-click rotate, two-finger pitch). Scroll/wheel zooming does not stop rotation.

During a scroll-zoom gesture, rotation briefly pauses while MapLibre runs its zoom ease (~300ms), then resumes from the exact same position — no snap or stutter. This is a hard limitation of MapLibre's single-animation camera model: any `jumpTo` call cancels in-flight easing, so the two cannot run concurrently. Taking over scroll zoom entirely to work around it would sacrifice native easing, pinch-zoom, and zoom-toward-cursor behaviour — not worth it for an ambient effect.

## Changes
- `packages/shared/src/golarion-map/auto-rotate.ts` — new `startAutoRotate(map, options?)` helper; exports `AutoRotateOptions` type and `normalizeLng` pure function
- `packages/shared/src/golarion-map/index.ts` — re-exports the new helper and type
- `apps/player-portal/src/routes/Globe.tsx` — calls `startAutoRotate(map, { startDelayMs: 500 })` inside `style.load`
- `packages/shared/src/golarion-map/auto-rotate.test.ts` — Vitest tests for `normalizeLng`

## Options (all optional)
| Option | Default | Notes |
|---|---|---|
| `degreesPerSecond` | `6` | ~1 rev/min |
| `direction` | `'east'` | `'west'` reverses delta sign |
| `startDelayMs` | `0` | `500` used in Globe.tsx |

## Test plan
- [ ] `npm run test -w packages/shared` — all 65 tests pass
- [ ] `npm run typecheck` — clean across all workspaces
- [ ] `npm run dev:player-portal` → `/globe` → globe rotates eastward; scroll to zoom — rotation pauses during ease then resumes cleanly; drag the globe — rotation stops permanently