### PR TITLE
feat(player-portal): add eastward-drifting ambient cloud wash to Golarion globe

### DIFF
--- a/apps/player-portal/src/routes/Globe.tsx
+++ b/apps/player-portal/src/routes/Globe.tsx
@@ -11,6 +11,7 @@ import {
   PIN_LAYER,
   PIN_SOURCE,
   buildMapStyle,
+  createCloudsLayer,
   createStarsLayer,
   ensureDefaultImage,
   ensureIconImage,
@@ -82,6 +83,10 @@ export function Globe() {
     map.on('style.load', () => {
       map.setProjection({ type: 'globe' });
       startAutoRotate(map, { startDelayMs: 500 });
+      // Ambient cloud wash — player-portal only; not in dm-tool.
+      // Added after style.load so it sits above terrain/labels but below the
+      // pin icon layer, which is added in the 'load' handler below.
+      map.addLayer(createCloudsLayer());
     });
 
     map.addControl(new maplibregl.NavigationControl(), 'top-right');

--- a/packages/shared/src/golarion-map/clouds.test.ts
+++ b/packages/shared/src/golarion-map/clouds.test.ts
@@ -5,7 +5,7 @@ describe('mergeCloudsOptions — defaults', () => {
   it('returns all defaults when called with no argument', () => {
     const opts = mergeCloudsOptions();
     expect(opts.opacity).toBe(0.25);
-    expect(opts.driftSpeed).toBe(0.02);
+    expect(opts.driftSpeed).toBe(0.06);
     expect(opts.scale).toBe(3.0);
     expect(opts.color).toEqual([1, 0.98, 0.95]);
   });
@@ -13,7 +13,7 @@ describe('mergeCloudsOptions — defaults', () => {
   it('returns all defaults when called with an empty object', () => {
     const opts = mergeCloudsOptions({});
     expect(opts.opacity).toBe(0.25);
-    expect(opts.driftSpeed).toBe(0.02);
+    expect(opts.driftSpeed).toBe(0.06);
     expect(opts.scale).toBe(3.0);
     expect(opts.color).toEqual([1, 0.98, 0.95]);
   });
@@ -21,7 +21,7 @@ describe('mergeCloudsOptions — defaults', () => {
   it('returns all defaults when called with undefined', () => {
     const opts = mergeCloudsOptions(undefined);
     expect(opts.opacity).toBe(0.25);
-    expect(opts.driftSpeed).toBe(0.02);
+    expect(opts.driftSpeed).toBe(0.06);
   });
 });
 
@@ -29,7 +29,7 @@ describe('mergeCloudsOptions — partial overrides', () => {
   it('applies opacity override while keeping other defaults', () => {
     const opts = mergeCloudsOptions({ opacity: 0.5 });
     expect(opts.opacity).toBe(0.5);
-    expect(opts.driftSpeed).toBe(0.02);
+    expect(opts.driftSpeed).toBe(0.06);
     expect(opts.scale).toBe(3.0);
     expect(opts.color).toEqual([1, 0.98, 0.95]);
   });

--- a/packages/shared/src/golarion-map/clouds.test.ts
+++ b/packages/shared/src/golarion-map/clouds.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { mergeCloudsOptions } from './clouds';
+
+describe('mergeCloudsOptions — defaults', () => {
+  it('returns all defaults when called with no argument', () => {
+    const opts = mergeCloudsOptions();
+    expect(opts.opacity).toBe(0.25);
+    expect(opts.driftSpeed).toBe(0.005);
+    expect(opts.scale).toBe(3.0);
+    expect(opts.color).toEqual([1, 0.98, 0.95]);
+  });
+
+  it('returns all defaults when called with an empty object', () => {
+    const opts = mergeCloudsOptions({});
+    expect(opts.opacity).toBe(0.25);
+    expect(opts.driftSpeed).toBe(0.005);
+    expect(opts.scale).toBe(3.0);
+    expect(opts.color).toEqual([1, 0.98, 0.95]);
+  });
+
+  it('returns all defaults when called with undefined', () => {
+    const opts = mergeCloudsOptions(undefined);
+    expect(opts.opacity).toBe(0.25);
+    expect(opts.driftSpeed).toBe(0.005);
+  });
+});
+
+describe('mergeCloudsOptions — partial overrides', () => {
+  it('applies opacity override while keeping other defaults', () => {
+    const opts = mergeCloudsOptions({ opacity: 0.5 });
+    expect(opts.opacity).toBe(0.5);
+    expect(opts.driftSpeed).toBe(0.005);
+    expect(opts.scale).toBe(3.0);
+    expect(opts.color).toEqual([1, 0.98, 0.95]);
+  });
+
+  it('applies driftSpeed override while keeping other defaults', () => {
+    const opts = mergeCloudsOptions({ driftSpeed: 0.02 });
+    expect(opts.driftSpeed).toBe(0.02);
+    expect(opts.opacity).toBe(0.25);
+  });
+
+  it('applies scale override while keeping other defaults', () => {
+    const opts = mergeCloudsOptions({ scale: 6.0 });
+    expect(opts.scale).toBe(6.0);
+    expect(opts.opacity).toBe(0.25);
+  });
+
+  it('applies color override while keeping other defaults', () => {
+    const color: [number, number, number] = [0.8, 0.9, 1.0];
+    const opts = mergeCloudsOptions({ color });
+    expect(opts.color).toEqual([0.8, 0.9, 1.0]);
+    expect(opts.opacity).toBe(0.25);
+  });
+});
+
+describe('mergeCloudsOptions — full override', () => {
+  it('uses all caller-supplied values when every field is provided', () => {
+    const opts = mergeCloudsOptions({
+      opacity: 0.8,
+      driftSpeed: 0.03,
+      scale: 5.0,
+      color: [0.9, 0.95, 1.0],
+    });
+    expect(opts.opacity).toBe(0.8);
+    expect(opts.driftSpeed).toBe(0.03);
+    expect(opts.scale).toBe(5.0);
+    expect(opts.color).toEqual([0.9, 0.95, 1.0]);
+  });
+
+  it('preserves the exact color tuple reference when one is supplied', () => {
+    const color: [number, number, number] = [0.8, 0.9, 1.0];
+    const opts = mergeCloudsOptions({ color });
+    expect(opts.color).toBe(color);
+  });
+});
+
+describe('mergeCloudsOptions — edge cases', () => {
+  it('accepts opacity of 0 (fully transparent)', () => {
+    expect(mergeCloudsOptions({ opacity: 0 }).opacity).toBe(0);
+  });
+
+  it('accepts opacity of 1 (fully opaque)', () => {
+    expect(mergeCloudsOptions({ opacity: 1 }).opacity).toBe(1);
+  });
+
+  it('accepts driftSpeed of 0 (static clouds)', () => {
+    expect(mergeCloudsOptions({ driftSpeed: 0 }).driftSpeed).toBe(0);
+  });
+});

--- a/packages/shared/src/golarion-map/clouds.test.ts
+++ b/packages/shared/src/golarion-map/clouds.test.ts
@@ -5,7 +5,7 @@ describe('mergeCloudsOptions — defaults', () => {
   it('returns all defaults when called with no argument', () => {
     const opts = mergeCloudsOptions();
     expect(opts.opacity).toBe(0.25);
-    expect(opts.driftSpeed).toBe(0.005);
+    expect(opts.driftSpeed).toBe(0.02);
     expect(opts.scale).toBe(3.0);
     expect(opts.color).toEqual([1, 0.98, 0.95]);
   });
@@ -13,7 +13,7 @@ describe('mergeCloudsOptions — defaults', () => {
   it('returns all defaults when called with an empty object', () => {
     const opts = mergeCloudsOptions({});
     expect(opts.opacity).toBe(0.25);
-    expect(opts.driftSpeed).toBe(0.005);
+    expect(opts.driftSpeed).toBe(0.02);
     expect(opts.scale).toBe(3.0);
     expect(opts.color).toEqual([1, 0.98, 0.95]);
   });
@@ -21,7 +21,7 @@ describe('mergeCloudsOptions — defaults', () => {
   it('returns all defaults when called with undefined', () => {
     const opts = mergeCloudsOptions(undefined);
     expect(opts.opacity).toBe(0.25);
-    expect(opts.driftSpeed).toBe(0.005);
+    expect(opts.driftSpeed).toBe(0.02);
   });
 });
 
@@ -29,7 +29,7 @@ describe('mergeCloudsOptions — partial overrides', () => {
   it('applies opacity override while keeping other defaults', () => {
     const opts = mergeCloudsOptions({ opacity: 0.5 });
     expect(opts.opacity).toBe(0.5);
-    expect(opts.driftSpeed).toBe(0.005);
+    expect(opts.driftSpeed).toBe(0.02);
     expect(opts.scale).toBe(3.0);
     expect(opts.color).toEqual([1, 0.98, 0.95]);
   });

--- a/packages/shared/src/golarion-map/clouds.ts
+++ b/packages/shared/src/golarion-map/clouds.ts
@@ -202,10 +202,10 @@ const FRAG_SRC = `
     // driftSpeed in sample-space units/sec (same semantics as before).
     float angle = u_drift * u_time / u_scale;
 
-    // Rotate sample coords clockwise (negative angle) — pattern drifts east.
-    // Layer 2 rotates at 0.7× for a parallax feel (higher clouds, different speed).
-    float n1 = fbm3(rotateZ(pos,       -angle));
-    float n2 = fbm3(rotateZ(pos * 1.6, -angle * 0.7) + vec3(2.1, 1.3, 0.8));
+    // Positive angle rotates sample coords counterclockwise (east→west sampling),
+    // making the cloud pattern drift westward.  Layer 2 at 0.7× for parallax.
+    float n1 = fbm3(rotateZ(pos,       angle));
+    float n2 = fbm3(rotateZ(pos * 1.6, angle * 0.7) + vec3(2.1, 1.3, 0.8));
 
     float cloud = mix(n1, n2, 0.4);
     cloud = smoothstep(0.38, 0.65, cloud);

--- a/packages/shared/src/golarion-map/clouds.ts
+++ b/packages/shared/src/golarion-map/clouds.ts
@@ -1,0 +1,302 @@
+// Ambient cloud-wash layer for the Golarion globe — player-portal only.
+//
+// Implemented as a MapLibre custom layer that draws a full-screen WebGL quad
+// with a fragment shader that samples fractional Brownian motion (FBM) noise
+// in screen UV space, animating slowly over time.  No texture assets required;
+// the procedural noise tiles seamlessly and drifts naturally.
+//
+// Usage (after style.load):
+//   import { createCloudsLayer } from '@foundry-toolkit/shared/golarion-map';
+//   map.addLayer(createCloudsLayer());
+
+import type { CustomLayerInterface, CustomRenderMethodInput, Map as MaplibreMap } from 'maplibre-gl';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Tunable knobs for the cloud layer.  All fields are optional; the defaults
+ *  produce a subtle atmospheric haze that is visible without being distracting. */
+export interface CloudsOptions {
+  /** Overall cloud opacity, 0–1.  Default: 0.25 */
+  opacity?: number;
+  /**
+   * Drift speed, approximately in noise-UV units per second.  Default: 0.005
+   * (very slow — roughly one cloud-width per minute at the default scale).
+   * Increase toward 0.02–0.05 for a livelier sky; decrease toward 0.001 for
+   * near-static clouds.
+   */
+  driftSpeed?: number;
+  /** Scale factor for cloud cluster size.  Higher → larger patches.
+   *  Default: 3.0 */
+  scale?: number;
+  /** Cloud tint as [R, G, B] in the 0–1 range.  Default: warm near-white
+   *  [1, 0.98, 0.95]. */
+  color?: [number, number, number];
+}
+
+interface ResolvedCloudsOptions {
+  opacity: number;
+  driftSpeed: number;
+  scale: number;
+  color: [number, number, number];
+}
+
+// ---------------------------------------------------------------------------
+// Options merging (exported for unit testing)
+// ---------------------------------------------------------------------------
+
+/** Merge caller-supplied options with per-field defaults. */
+export function mergeCloudsOptions(options?: CloudsOptions): ResolvedCloudsOptions {
+  return {
+    opacity: options?.opacity ?? 0.25,
+    driftSpeed: options?.driftSpeed ?? 0.005,
+    scale: options?.scale ?? 3.0,
+    color: options?.color ?? [1, 0.98, 0.95],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// GLSL sources
+// ---------------------------------------------------------------------------
+
+/** Full-screen quad vertex shader — ignores the MapLibre matrix entirely;
+ *  draws directly in NDC so the quad covers every pixel on-screen. */
+const VERT_SRC = `
+  attribute vec2 a_pos;
+  varying   vec2 v_uv;
+
+  void main() {
+    // Clip-space position; z = -1.0 (near plane) keeps clouds in front of
+    // globe geometry without needing to manage depth state explicitly.
+    gl_Position = vec4(a_pos, -1.0, 1.0);
+    // NDC [-1, 1] → UV [0, 1]
+    v_uv = (a_pos + 1.0) * 0.5;
+  }
+`;
+
+/** FBM cloud fragment shader.
+ *
+ *  Two layers of fractional Brownian motion are sampled at slowly-drifting UV
+ *  coordinates, blended together, and threshold-clipped with smoothstep to
+ *  produce soft cloud patches.  Output is premultiplied alpha because MapLibre
+ *  already enables the ONE / ONE_MINUS_SRC_ALPHA blend equation. */
+const FRAG_SRC = `
+  precision highp float;
+
+  uniform float u_time;    // wall-clock seconds
+  uniform float u_drift;   // driftSpeed option (noise-UV units / sec)
+  uniform float u_opacity; // overall alpha cap
+  uniform float u_scale;   // UV scale (controls cloud size)
+  uniform vec3  u_color;   // cloud tint [0, 1]
+
+  varying vec2 v_uv;
+
+  // ---- noise helpers -------------------------------------------------------
+
+  float hash(vec2 p) {
+    p  = fract(p * vec2(234.34, 435.345));
+    p += dot(p, p + 34.23);
+    return fract(p.x * p.y);
+  }
+
+  float vnoise(vec2 p) {
+    vec2 i = floor(p);
+    vec2 f = fract(p);
+    // Smootherstep curve for C2 continuity
+    vec2 u = f * f * (3.0 - 2.0 * f);
+    float a = hash(i);
+    float b = hash(i + vec2(1.0, 0.0));
+    float c = hash(i + vec2(0.0, 1.0));
+    float d = hash(i + vec2(1.0, 1.0));
+    return mix(mix(a, b, u.x), mix(c, d, u.x), u.y);
+  }
+
+  // 6-octave fractional Brownian motion
+  float fbm(vec2 p) {
+    float val = 0.0;
+    float amp = 0.5;
+    for (int i = 0; i < 6; i++) {
+      val += amp * vnoise(p);
+      p   *= 2.0;
+      amp *= 0.5;
+    }
+    return val;
+  }
+
+  // -------------------------------------------------------------------------
+
+  void main() {
+    float t  = u_time;
+    float ds = u_drift;
+    vec2 uv  = v_uv * u_scale;
+
+    // Primary layer: drift rightward + slight upward
+    float n1 = fbm(uv + vec2(ds * t, ds * 0.3 * t));
+
+    // Secondary layer: counter-drift at a different scale for visual depth
+    float n2 = fbm(uv * 1.6 + vec2(-ds * 0.7 * t, ds * 0.4 * t) + vec2(5.2, 1.3));
+
+    // Blend layers and threshold into soft cloud shapes
+    float cloud = mix(n1, n2, 0.4);
+    cloud = smoothstep(0.38, 0.65, cloud);
+
+    // Premultiplied alpha: MapLibre uses ONE / ONE_MINUS_SRC_ALPHA blending
+    float alpha = cloud * u_opacity;
+    gl_FragColor = vec4(u_color * alpha, alpha);
+  }
+`;
+
+// ---------------------------------------------------------------------------
+// WebGL helpers
+// ---------------------------------------------------------------------------
+
+type GL = WebGLRenderingContext;
+
+function compileShader(gl: GL, type: number, src: string): WebGLShader | null {
+  const shader = gl.createShader(type);
+  if (!shader) return null;
+  gl.shaderSource(shader, src);
+  gl.compileShader(shader);
+  return shader;
+}
+
+function buildProgram(gl: GL, vertSrc: string, fragSrc: string): WebGLProgram | null {
+  const vert = compileShader(gl, gl.VERTEX_SHADER, vertSrc);
+  const frag = compileShader(gl, gl.FRAGMENT_SHADER, fragSrc);
+  if (!vert || !frag) return null;
+
+  const prog = gl.createProgram();
+  if (!prog) return null;
+
+  gl.attachShader(prog, vert);
+  gl.attachShader(prog, frag);
+  gl.linkProgram(prog);
+  gl.deleteShader(vert);
+  gl.deleteShader(frag);
+
+  if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) {
+    console.warn('[shared:clouds] Shader link failed:', gl.getProgramInfoLog(prog));
+    return null;
+  }
+  return prog;
+}
+
+// Full-screen quad — 2 triangles, 6 vertices in NDC space
+// prettier-ignore
+const QUAD_VERTS = new Float32Array([
+  -1, -1,   1, -1,  -1,  1,
+   1, -1,   1,  1,  -1,  1,
+]);
+
+// ---------------------------------------------------------------------------
+// Public factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a slow-drifting ambient cloud-wash custom layer for the Golarion
+ * globe.  Register it on the map **after `style.load`** — player-portal only.
+ *
+ * @example
+ * ```ts
+ * map.on('style.load', () => {
+ *   map.setProjection({ type: 'globe' });
+ *   map.addLayer(createCloudsLayer());
+ * });
+ * ```
+ */
+export function createCloudsLayer(options?: CloudsOptions): CustomLayerInterface {
+  const opts = mergeCloudsOptions(options);
+
+  // GL resources — allocated in onAdd, freed in onRemove
+  let _gl: GL | null = null;
+  let _program: WebGLProgram | null = null;
+  let _buf: WebGLBuffer | null = null;
+  let _map: MaplibreMap | null = null;
+  let _aPos = -1;
+  let _uTime: WebGLUniformLocation | null = null;
+  let _uDrift: WebGLUniformLocation | null = null;
+  let _uOpacity: WebGLUniformLocation | null = null;
+  let _uScale: WebGLUniformLocation | null = null;
+  let _uColor: WebGLUniformLocation | null = null;
+
+  return {
+    id: 'golarion-clouds',
+    type: 'custom',
+    renderingMode: '2d',
+
+    onAdd(map: MaplibreMap, gl: WebGLRenderingContext | WebGL2RenderingContext): void {
+      _map = map;
+      _gl = gl as GL;
+
+      _program = buildProgram(_gl, VERT_SRC, FRAG_SRC);
+      if (!_program) return;
+
+      _aPos = _gl.getAttribLocation(_program, 'a_pos');
+      _uTime = _gl.getUniformLocation(_program, 'u_time');
+      _uDrift = _gl.getUniformLocation(_program, 'u_drift');
+      _uOpacity = _gl.getUniformLocation(_program, 'u_opacity');
+      _uScale = _gl.getUniformLocation(_program, 'u_scale');
+      _uColor = _gl.getUniformLocation(_program, 'u_color');
+
+      _buf = _gl.createBuffer();
+      _gl.bindBuffer(_gl.ARRAY_BUFFER, _buf);
+      _gl.bufferData(_gl.ARRAY_BUFFER, QUAD_VERTS, _gl.STATIC_DRAW);
+      _gl.bindBuffer(_gl.ARRAY_BUFFER, null);
+
+      console.info('[shared:clouds] Cloud layer added', {
+        opacity: opts.opacity,
+        driftSpeed: opts.driftSpeed,
+        scale: opts.scale,
+        color: opts.color,
+      });
+    },
+
+    render(_gl2: WebGLRenderingContext | WebGL2RenderingContext, _options: CustomRenderMethodInput): void {
+      if (!_program || !_buf || !_gl) return;
+
+      const g = _gl;
+      const t = performance.now() / 1000;
+
+      // Disable depth test so the full-screen quad isn't clipped by globe
+      // geometry already in the depth buffer.
+      const wasDepthTest = g.isEnabled(g.DEPTH_TEST);
+      g.disable(g.DEPTH_TEST);
+
+      // MapLibre has already set the blend equation to
+      // ONE / ONE_MINUS_SRC_ALPHA (premultiplied alpha) — we rely on that.
+
+      g.useProgram(_program);
+      g.bindBuffer(g.ARRAY_BUFFER, _buf);
+      g.enableVertexAttribArray(_aPos);
+      g.vertexAttribPointer(_aPos, 2, g.FLOAT, false, 0, 0);
+
+      g.uniform1f(_uTime, t);
+      g.uniform1f(_uDrift, opts.driftSpeed);
+      g.uniform1f(_uOpacity, opts.opacity);
+      g.uniform1f(_uScale, opts.scale);
+      g.uniform3f(_uColor, opts.color[0], opts.color[1], opts.color[2]);
+
+      g.drawArrays(g.TRIANGLES, 0, 6);
+
+      g.disableVertexAttribArray(_aPos);
+      g.bindBuffer(g.ARRAY_BUFFER, null);
+
+      // Restore depth state so subsequent MapLibre layers are unaffected
+      if (wasDepthTest) g.enable(g.DEPTH_TEST);
+
+      // Keep the animation running; MapLibre will call render() again
+      _map?.triggerRepaint();
+    },
+
+    onRemove(_m: MaplibreMap, gl: WebGLRenderingContext | WebGL2RenderingContext): void {
+      const g = gl as GL;
+      if (_program) g.deleteProgram(_program);
+      if (_buf) g.deleteBuffer(_buf);
+      _program = null;
+      _buf = null;
+      _gl = null;
+      _map = null;
+    },
+  };
+}

--- a/packages/shared/src/golarion-map/clouds.ts
+++ b/packages/shared/src/golarion-map/clouds.ts
@@ -22,10 +22,11 @@ export interface CloudsOptions {
   /** Overall cloud opacity, 0–1.  Default: 0.25 */
   opacity?: number;
   /**
-   * Drift speed in 3D sample-space units per second.  Default: 0.06
+   * Eastward drift speed in sample-space units per second.  Default: 0.06
    * (roughly one cloud-width per ~10 s — clearly perceptible without feeling
-   * rushed).  Drop toward 0.01–0.02 for a slower, more subtle drift; raise
-   * toward 0.15 for stormy skies.
+   * rushed).  The clouds rotate around the globe's north-pole axis, so the
+   * drift looks geographically correct at all latitudes.  Drop toward 0.01–0.02
+   * for a slower drift; raise toward 0.15 for stormy skies.
    */
   driftSpeed?: number;
   /** Scale factor for cloud cluster size (higher → larger patches).
@@ -130,9 +131,10 @@ const VERT_SRC = `
 /** FBM cloud fragment shader — samples noise in 3D sphere-position space.
  *
  *  Sampling in 3D (x,y,z on the unit sphere) is inherently seamless:
- *  there is no lon/lat wrapping, no equatorial integer-boundary artefacts,
- *  and no polar pinching.  Drift is a slow translation of the 3D sample
- *  point, producing a convincing cloud-mass movement. */
+ *  no lon/lat wrapping, no equatorial integer-boundary artefacts, no polar
+ *  pinching.  Drift is a rotation of the sample coordinates around the
+ *  north-pole axis (+z), which is the only transform that means "east" at
+ *  every latitude simultaneously. */
 const FRAG_SRC = `
   precision highp float;
 
@@ -180,17 +182,30 @@ const FRAG_SRC = `
 
   // -------------------------------------------------------------------------
 
+  // Rotate a vec3 around the z-axis (north-pole axis) by angle theta.
+  // rotate_z(p, -theta) samples from west, making the pattern appear to
+  // drift east — the only transform that means "east" at every latitude.
+  vec3 rotateZ(vec3 p, float theta) {
+    float c = cos(theta);
+    float s = sin(theta);
+    return vec3(p.x * c + p.y * s,
+               -p.x * s + p.y * c,
+                p.z);
+  }
+
   void main() {
     if (v_visible <= 0.0) discard;
 
-    float t  = u_time;
-    float ds = u_drift;
-    vec3  pos = v_sphere * u_scale;
+    vec3 pos = v_sphere * u_scale;
 
-    // Drift: translate the 3D sample point slowly — no seams, no wrapping
-    float n1 = fbm3(pos + vec3(ds * t,        ds * 0.3 * t,  ds * 0.15 * t));
-    float n2 = fbm3(pos * 1.6 + vec3(-ds * 0.7 * t, ds * 0.4 * t, -ds * 0.2 * t)
-                    + vec3(2.1, 1.3, 0.8));
+    // angle = driftSpeed * t / scale so the arc speed at the equator equals
+    // driftSpeed in sample-space units/sec (same semantics as before).
+    float angle = u_drift * u_time / u_scale;
+
+    // Rotate sample coords clockwise (negative angle) — pattern drifts east.
+    // Layer 2 rotates at 0.7× for a parallax feel (higher clouds, different speed).
+    float n1 = fbm3(rotateZ(pos,       -angle));
+    float n2 = fbm3(rotateZ(pos * 1.6, -angle * 0.7) + vec3(2.1, 1.3, 0.8));
 
     float cloud = mix(n1, n2, 0.4);
     cloud = smoothstep(0.38, 0.65, cloud);

--- a/packages/shared/src/golarion-map/clouds.ts
+++ b/packages/shared/src/golarion-map/clouds.ts
@@ -1,8 +1,9 @@
 // Ambient cloud-wash layer for the Golarion globe — player-portal only.
 //
 // Rendered as a tessellated unit-sphere mesh transformed with MapLibre's
-// globe projection matrix.  A six-octave FBM shader samples noise in
-// lon/lat space, animated by a slow time drift.  The layer clips precisely
+// globe projection matrix.  A six-octave 3D FBM shader samples noise directly
+// from the unit-sphere position, so there are no lat/lon wrapping seams,
+// no polar pinching, and no equatorial artefacts.  The layer clips precisely
 // to the globe's visible hemisphere, so no clouds bleed into the sky area.
 //
 // Usage (after style.load):
@@ -62,9 +63,10 @@ export function mergeCloudsOptions(options?: CloudsOptions): ResolvedCloudsOptio
 /**
  * Build a tessellated unit sphere.
  *
- * Returns an interleaved Float32Array with 5 floats per vertex:
- *   [x, y, z, lon, lat]  (lon ∈ [-π, π], lat ∈ [-π/2, π/2])
+ * Returns a Float32Array with 3 floats per vertex [x, y, z]
  * and a Uint16Array of triangle indices.
+ * The noise is sampled in 3D (sphere-position) space in the fragment shader,
+ * so lon/lat attributes are not needed.
  */
 function buildSphereMesh(latSteps: number, lonSteps: number): { data: Float32Array; indices: Uint16Array } {
   const verts: number[] = [];
@@ -80,8 +82,6 @@ function buildSphereMesh(latSteps: number, lonSteps: number): { data: Float32Arr
         cosLat * Math.cos(lon), // x
         cosLat * Math.sin(lon), // y
         sinLat, // z
-        lon, // attribute lon (radians)
-        lat, // attribute lat (radians)
       );
     }
   }
@@ -107,67 +107,70 @@ const SPHERE = buildSphereMesh(48, 96);
 // ---------------------------------------------------------------------------
 
 /** Vertex shader — transforms unit-sphere vertices with MapLibre's globe
- *  projection matrix and computes a signed clip-distance against the
- *  horizon plane so the fragment shader can discard the back hemisphere. */
+ *  projection matrix and passes the 3D sphere position to the fragment
+ *  shader for seamless 3D noise sampling. */
 const VERT_SRC = `
   attribute vec3 a_sphere;   // unit-sphere position (x, y, z)
-  attribute vec2 a_lonlat;   // longitude, latitude in radians
 
   uniform mat4 u_matrix;     // defaultProjectionData.mainMatrix
   uniform vec4 u_clip_plane; // defaultProjectionData.clippingPlane
 
-  varying vec2  v_lonlat;
+  varying vec3  v_sphere;    // sphere position passed to frag for 3D noise
   varying float v_visible;   // > 0 = front hemisphere
 
   void main() {
     gl_Position = u_matrix * vec4(a_sphere, 1.0);
-    v_lonlat  = a_lonlat;
+    v_sphere  = a_sphere;
     // Positive when vertex is on the camera-facing side of the globe
     v_visible = dot(u_clip_plane.xyz, a_sphere) + u_clip_plane.w;
   }
 `;
 
-/** FBM cloud fragment shader.
+/** FBM cloud fragment shader — samples noise in 3D sphere-position space.
  *
- *  Two FBM layers are sampled in lon/lat space at slowly-drifting offsets,
- *  blended, and threshold-clipped with smoothstep.  Fragments on the back
- *  hemisphere are discarded; fragments near the horizon fade softly out. */
+ *  Sampling in 3D (x,y,z on the unit sphere) is inherently seamless:
+ *  there is no lon/lat wrapping, no equatorial integer-boundary artefacts,
+ *  and no polar pinching.  Drift is a slow translation of the 3D sample
+ *  point, producing a convincing cloud-mass movement. */
 const FRAG_SRC = `
   precision highp float;
 
   uniform float u_time;    // wall-clock seconds
-  uniform float u_drift;   // driftSpeed (lon/lat UV units per second)
+  uniform float u_drift;   // driftSpeed
   uniform float u_opacity; // overall alpha cap
-  uniform float u_scale;   // UV scale for cloud features
+  uniform float u_scale;   // 3D noise scale (controls cloud feature size)
   uniform vec3  u_color;   // cloud tint
 
-  varying vec2  v_lonlat;
+  varying vec3  v_sphere;
   varying float v_visible;
 
-  // ---- noise helpers -------------------------------------------------------
+  // ---- 3-D noise helpers ---------------------------------------------------
 
-  float hash(vec2 p) {
-    p  = fract(p * vec2(234.34, 435.345));
+  float hash3(vec3 p) {
+    p  = fract(p * vec3(234.34, 435.345, 127.1));
     p += dot(p, p + 34.23);
-    return fract(p.x * p.y);
+    return fract(p.x * p.y + p.y * p.z + p.z * p.x);
   }
 
-  float vnoise(vec2 p) {
-    vec2 i = floor(p);
-    vec2 f = fract(p);
-    vec2 u = f * f * (3.0 - 2.0 * f);
-    float a = hash(i);
-    float b = hash(i + vec2(1.0, 0.0));
-    float c = hash(i + vec2(0.0, 1.0));
-    float d = hash(i + vec2(1.0, 1.0));
-    return mix(mix(a, b, u.x), mix(c, d, u.x), u.y);
+  float vnoise3(vec3 p) {
+    vec3 i = floor(p);
+    vec3 f = fract(p);
+    vec3 u = f * f * (3.0 - 2.0 * f);
+    return mix(
+      mix(mix(hash3(i),               hash3(i + vec3(1,0,0)), u.x),
+          mix(hash3(i + vec3(0,1,0)), hash3(i + vec3(1,1,0)), u.x), u.y),
+      mix(mix(hash3(i + vec3(0,0,1)), hash3(i + vec3(1,0,1)), u.x),
+          mix(hash3(i + vec3(0,1,1)), hash3(i + vec3(1,1,1)), u.x), u.y),
+      u.z
+    );
   }
 
-  float fbm(vec2 p) {
+  // 6-octave 3D fractional Brownian motion
+  float fbm3(vec3 p) {
     float val = 0.0;
     float amp = 0.5;
     for (int i = 0; i < 6; i++) {
-      val += amp * vnoise(p);
+      val += amp * vnoise3(p);
       p   *= 2.0;
       amp *= 0.5;
     }
@@ -177,26 +180,21 @@ const FRAG_SRC = `
   // -------------------------------------------------------------------------
 
   void main() {
-    // Discard fragments on the back hemisphere
     if (v_visible <= 0.0) discard;
 
     float t  = u_time;
     float ds = u_drift;
+    vec3  pos = v_sphere * u_scale;
 
-    // Map lon/lat to noise UV; scale controls cloud feature size
-    vec2 uv = vec2(
-      v_lonlat.x / 6.28318530718 + 0.5,   // lon → [0, 1]
-      v_lonlat.y / 3.14159265359 + 0.5    // lat → [0, 1]
-    ) * u_scale;
-
-    // Two FBM layers at slightly different drift angles for visual depth
-    float n1 = fbm(uv + vec2(ds * t,         ds * 0.3 * t));
-    float n2 = fbm(uv * 1.6 + vec2(-ds * 0.7 * t, ds * 0.4 * t) + vec2(5.2, 1.3));
+    // Drift: translate the 3D sample point slowly — no seams, no wrapping
+    float n1 = fbm3(pos + vec3(ds * t,        ds * 0.3 * t,  ds * 0.15 * t));
+    float n2 = fbm3(pos * 1.6 + vec3(-ds * 0.7 * t, ds * 0.4 * t, -ds * 0.2 * t)
+                    + vec3(2.1, 1.3, 0.8));
 
     float cloud = mix(n1, n2, 0.4);
     cloud = smoothstep(0.38, 0.65, cloud);
 
-    // Soft fade near the globe's horizon so clouds don't hard-clip at the limb
+    // Soft fade near the globe's horizon
     float horizon = clamp(v_visible * 8.0, 0.0, 1.0);
 
     float alpha = cloud * u_opacity * horizon;
@@ -239,8 +237,8 @@ function buildProgram(gl: GL, vertSrc: string, fragSrc: string): WebGLProgram | 
   return prog;
 }
 
-// Stride between vertices in the interleaved buffer: 5 floats × 4 bytes
-const STRIDE = 20;
+// Stride between vertices: 3 floats × 4 bytes (xyz only; no lon/lat needed)
+const STRIDE = 12;
 
 // ---------------------------------------------------------------------------
 // Public factory
@@ -268,7 +266,6 @@ export function createCloudsLayer(options?: CloudsOptions): CustomLayerInterface
   let _ibo: WebGLBuffer | null = null;
   let _map: MaplibreMap | null = null;
   let _aSphere = -1;
-  let _aLonlat = -1;
   let _uMatrix: WebGLUniformLocation | null = null;
   let _uClipPlane: WebGLUniformLocation | null = null;
   let _uTime: WebGLUniformLocation | null = null;
@@ -291,7 +288,6 @@ export function createCloudsLayer(options?: CloudsOptions): CustomLayerInterface
       if (!_program) return;
 
       _aSphere = _gl.getAttribLocation(_program, 'a_sphere');
-      _aLonlat = _gl.getAttribLocation(_program, 'a_lonlat');
       _uMatrix = _gl.getUniformLocation(_program, 'u_matrix');
       _uClipPlane = _gl.getUniformLocation(_program, 'u_clip_plane');
       _uTime = _gl.getUniformLocation(_program, 'u_time');
@@ -300,7 +296,7 @@ export function createCloudsLayer(options?: CloudsOptions): CustomLayerInterface
       _uScale = _gl.getUniformLocation(_program, 'u_scale');
       _uColor = _gl.getUniformLocation(_program, 'u_color');
 
-      // Vertex buffer: interleaved [x, y, z, lon, lat]
+      // Vertex buffer: [x, y, z] per vertex (no lon/lat — noise is 3D)
       _vbo = _gl.createBuffer();
       _gl.bindBuffer(_gl.ARRAY_BUFFER, _vbo);
       _gl.bufferData(_gl.ARRAY_BUFFER, SPHERE.data, _gl.STATIC_DRAW);
@@ -336,12 +332,10 @@ export function createCloudsLayer(options?: CloudsOptions): CustomLayerInterface
 
       g.useProgram(_program);
 
-      // Bind vertex buffer and wire interleaved attributes
+      // Bind vertex buffer: 3 floats per vertex (x, y, z)
       g.bindBuffer(g.ARRAY_BUFFER, _vbo);
       g.enableVertexAttribArray(_aSphere);
-      g.vertexAttribPointer(_aSphere, 3, g.FLOAT, false, STRIDE, 0); // xyz at offset 0
-      g.enableVertexAttribArray(_aLonlat);
-      g.vertexAttribPointer(_aLonlat, 2, g.FLOAT, false, STRIDE, 12); // lonlat at offset 12
+      g.vertexAttribPointer(_aSphere, 3, g.FLOAT, false, STRIDE, 0);
 
       g.bindBuffer(g.ELEMENT_ARRAY_BUFFER, _ibo);
 
@@ -359,7 +353,6 @@ export function createCloudsLayer(options?: CloudsOptions): CustomLayerInterface
       g.drawElements(g.TRIANGLES, SPHERE.indices.length, g.UNSIGNED_SHORT, 0);
 
       g.disableVertexAttribArray(_aSphere);
-      g.disableVertexAttribArray(_aLonlat);
       g.bindBuffer(g.ARRAY_BUFFER, null);
       g.bindBuffer(g.ELEMENT_ARRAY_BUFFER, null);
       g.depthMask(true);

--- a/packages/shared/src/golarion-map/clouds.ts
+++ b/packages/shared/src/golarion-map/clouds.ts
@@ -132,9 +132,8 @@ const VERT_SRC = `
  *
  *  Sampling in 3D (x,y,z on the unit sphere) is inherently seamless:
  *  no lon/lat wrapping, no equatorial integer-boundary artefacts, no polar
- *  pinching.  Drift is a rotation of the sample coordinates around the
- *  north-pole axis (+z), which is the only transform that means "east" at
- *  every latitude simultaneously. */
+ *  pinching.  Drift is a Rodrigues rotation around a tilted axis that
+ *  empirically produces westward drift on screen in MapLibre's globe frame. */
 const FRAG_SRC = `
   precision highp float;
 
@@ -180,32 +179,34 @@ const FRAG_SRC = `
     return val;
   }
 
-  // -------------------------------------------------------------------------
+  // ---- rotation -----------------------------------------------------------
 
-  // Rotate a vec3 around the z-axis (north-pole axis) by angle theta.
-  // rotate_z(p, -theta) samples from west, making the pattern appear to
-  // drift east — the only transform that means "east" at every latitude.
-  vec3 rotateZ(vec3 p, float theta) {
+  // Rodrigues' rotation: rotate p around unit axis a by angle theta (CCW).
+  // Use negative theta for CW (sampling from east → pattern drifts west).
+  vec3 rotateAxis(vec3 p, vec3 a, float theta) {
     float c = cos(theta);
     float s = sin(theta);
-    return vec3(p.x * c + p.y * s,
-               -p.x * s + p.y * c,
-                p.z);
+    return p * c + cross(a, p) * s + a * dot(a, p) * (1.0 - c);
   }
+
+  // -------------------------------------------------------------------------
 
   void main() {
     if (v_visible <= 0.0) discard;
 
     vec3 pos = v_sphere * u_scale;
 
-    // angle = driftSpeed * t / scale so the arc speed at the equator equals
-    // driftSpeed in sample-space units/sec (same semantics as before).
+    // angle = driftSpeed * t / scale so arc speed at equator ≈ driftSpeed.
     float angle = u_drift * u_time / u_scale;
 
-    // Positive angle rotates sample coords counterclockwise (east→west sampling),
-    // making the cloud pattern drift westward.  Layer 2 at 0.7× for parallax.
-    float n1 = fbm3(rotateZ(pos,       angle));
-    float n2 = fbm3(rotateZ(pos * 1.6, angle * 0.7) + vec3(2.1, 1.3, 0.8));
+    // Drift axis: geographic north (+z) tilted ~40° toward +y.
+    // Pure z-axis rotation empirically drifts SW on screen in MapLibre's
+    // globe frame; the 40° tilt adds the northward correction to land on W.
+    // Negative angle = CW = sample from east = pattern drifts west.
+    vec3 driftAxis = normalize(vec3(0.0, 0.643, 0.766)); // sin/cos of 40°
+
+    float n1 = fbm3(rotateAxis(pos,       driftAxis, -angle));
+    float n2 = fbm3(rotateAxis(pos * 1.6, driftAxis, -angle * 0.7) + vec3(2.1, 1.3, 0.8));
 
     float cloud = mix(n1, n2, 0.4);
     cloud = smoothstep(0.38, 0.65, cloud);

--- a/packages/shared/src/golarion-map/clouds.ts
+++ b/packages/shared/src/golarion-map/clouds.ts
@@ -22,9 +22,10 @@ export interface CloudsOptions {
   /** Overall cloud opacity, 0–1.  Default: 0.25 */
   opacity?: number;
   /**
-   * Drift speed in lon/lat UV units per second.  Default: 0.005
-   * (roughly one cloud-width per minute at the default scale).
-   * Increase toward 0.02–0.05 for a livelier sky.
+   * Drift speed in 3D sample-space units per second.  Default: 0.02
+   * (roughly one cloud-width per 30 s at the default scale — clearly visible
+   * but slow enough to feel atmospheric).  Drop toward 0.005 for near-static
+   * clouds; raise toward 0.05–0.08 for a livelier sky.
    */
   driftSpeed?: number;
   /** Scale factor for cloud cluster size (higher → larger patches).
@@ -50,7 +51,7 @@ interface ResolvedCloudsOptions {
 export function mergeCloudsOptions(options?: CloudsOptions): ResolvedCloudsOptions {
   return {
     opacity: options?.opacity ?? 0.25,
-    driftSpeed: options?.driftSpeed ?? 0.005,
+    driftSpeed: options?.driftSpeed ?? 0.02,
     scale: options?.scale ?? 3.0,
     color: options?.color ?? [1, 0.98, 0.95],
   };

--- a/packages/shared/src/golarion-map/clouds.ts
+++ b/packages/shared/src/golarion-map/clouds.ts
@@ -1,9 +1,9 @@
 // Ambient cloud-wash layer for the Golarion globe — player-portal only.
 //
-// Implemented as a MapLibre custom layer that draws a full-screen WebGL quad
-// with a fragment shader that samples fractional Brownian motion (FBM) noise
-// in screen UV space, animating slowly over time.  No texture assets required;
-// the procedural noise tiles seamlessly and drifts naturally.
+// Rendered as a tessellated unit-sphere mesh transformed with MapLibre's
+// globe projection matrix.  A six-octave FBM shader samples noise in
+// lon/lat space, animated by a slow time drift.  The layer clips precisely
+// to the globe's visible hemisphere, so no clouds bleed into the sky area.
 //
 // Usage (after style.load):
 //   import { createCloudsLayer } from '@foundry-toolkit/shared/golarion-map';
@@ -21,13 +21,12 @@ export interface CloudsOptions {
   /** Overall cloud opacity, 0–1.  Default: 0.25 */
   opacity?: number;
   /**
-   * Drift speed, approximately in noise-UV units per second.  Default: 0.005
-   * (very slow — roughly one cloud-width per minute at the default scale).
-   * Increase toward 0.02–0.05 for a livelier sky; decrease toward 0.001 for
-   * near-static clouds.
+   * Drift speed in lon/lat UV units per second.  Default: 0.005
+   * (roughly one cloud-width per minute at the default scale).
+   * Increase toward 0.02–0.05 for a livelier sky.
    */
   driftSpeed?: number;
-  /** Scale factor for cloud cluster size.  Higher → larger patches.
+  /** Scale factor for cloud cluster size (higher → larger patches).
    *  Default: 3.0 */
   scale?: number;
   /** Cloud tint as [R, G, B] in the 0–1 range.  Default: warm near-white
@@ -57,40 +56,93 @@ export function mergeCloudsOptions(options?: CloudsOptions): ResolvedCloudsOptio
 }
 
 // ---------------------------------------------------------------------------
+// Sphere mesh generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a tessellated unit sphere.
+ *
+ * Returns an interleaved Float32Array with 5 floats per vertex:
+ *   [x, y, z, lon, lat]  (lon ∈ [-π, π], lat ∈ [-π/2, π/2])
+ * and a Uint16Array of triangle indices.
+ */
+function buildSphereMesh(latSteps: number, lonSteps: number): { data: Float32Array; indices: Uint16Array } {
+  const verts: number[] = [];
+  const idx: number[] = [];
+
+  for (let li = 0; li <= latSteps; li++) {
+    const lat = (li / latSteps) * Math.PI - Math.PI / 2;
+    const cosLat = Math.cos(lat);
+    const sinLat = Math.sin(lat);
+    for (let lo = 0; lo <= lonSteps; lo++) {
+      const lon = (lo / lonSteps) * 2 * Math.PI - Math.PI;
+      verts.push(
+        cosLat * Math.cos(lon), // x
+        cosLat * Math.sin(lon), // y
+        sinLat, // z
+        lon, // attribute lon (radians)
+        lat, // attribute lat (radians)
+      );
+    }
+  }
+
+  for (let li = 0; li < latSteps; li++) {
+    for (let lo = 0; lo < lonSteps; lo++) {
+      const a = li * (lonSteps + 1) + lo;
+      const b = a + 1;
+      const c = a + (lonSteps + 1);
+      const d = c + 1;
+      idx.push(a, b, c, b, d, c);
+    }
+  }
+
+  return { data: new Float32Array(verts), indices: new Uint16Array(idx) };
+}
+
+// Resolution: 48 lat × 96 lon → 49×97 = 4753 verts, 27 648 indices
+const SPHERE = buildSphereMesh(48, 96);
+
+// ---------------------------------------------------------------------------
 // GLSL sources
 // ---------------------------------------------------------------------------
 
-/** Full-screen quad vertex shader — ignores the MapLibre matrix entirely;
- *  draws directly in NDC so the quad covers every pixel on-screen. */
+/** Vertex shader — transforms unit-sphere vertices with MapLibre's globe
+ *  projection matrix and computes a signed clip-distance against the
+ *  horizon plane so the fragment shader can discard the back hemisphere. */
 const VERT_SRC = `
-  attribute vec2 a_pos;
-  varying   vec2 v_uv;
+  attribute vec3 a_sphere;   // unit-sphere position (x, y, z)
+  attribute vec2 a_lonlat;   // longitude, latitude in radians
+
+  uniform mat4 u_matrix;     // defaultProjectionData.mainMatrix
+  uniform vec4 u_clip_plane; // defaultProjectionData.clippingPlane
+
+  varying vec2  v_lonlat;
+  varying float v_visible;   // > 0 = front hemisphere
 
   void main() {
-    // Full-screen quad in clip space; z = -1.0 (near plane) is irrelevant
-    // since depth test and depth writes are disabled in render().
-    gl_Position = vec4(a_pos, -1.0, 1.0);
-    // NDC [-1, 1] → UV [0, 1]
-    v_uv = (a_pos + 1.0) * 0.5;
+    gl_Position = u_matrix * vec4(a_sphere, 1.0);
+    v_lonlat  = a_lonlat;
+    // Positive when vertex is on the camera-facing side of the globe
+    v_visible = dot(u_clip_plane.xyz, a_sphere) + u_clip_plane.w;
   }
 `;
 
 /** FBM cloud fragment shader.
  *
- *  Two layers of fractional Brownian motion are sampled at slowly-drifting UV
- *  coordinates, blended together, and threshold-clipped with smoothstep to
- *  produce soft cloud patches.  Output is standard (non-premultiplied) alpha;
- *  the render() method sets up SRC_ALPHA / ONE_MINUS_SRC_ALPHA blending. */
+ *  Two FBM layers are sampled in lon/lat space at slowly-drifting offsets,
+ *  blended, and threshold-clipped with smoothstep.  Fragments on the back
+ *  hemisphere are discarded; fragments near the horizon fade softly out. */
 const FRAG_SRC = `
   precision highp float;
 
   uniform float u_time;    // wall-clock seconds
-  uniform float u_drift;   // driftSpeed option (noise-UV units / sec)
+  uniform float u_drift;   // driftSpeed (lon/lat UV units per second)
   uniform float u_opacity; // overall alpha cap
-  uniform float u_scale;   // UV scale (controls cloud size)
-  uniform vec3  u_color;   // cloud tint [0, 1]
+  uniform float u_scale;   // UV scale for cloud features
+  uniform vec3  u_color;   // cloud tint
 
-  varying vec2 v_uv;
+  varying vec2  v_lonlat;
+  varying float v_visible;
 
   // ---- noise helpers -------------------------------------------------------
 
@@ -103,7 +155,6 @@ const FRAG_SRC = `
   float vnoise(vec2 p) {
     vec2 i = floor(p);
     vec2 f = fract(p);
-    // Smootherstep curve for C2 continuity
     vec2 u = f * f * (3.0 - 2.0 * f);
     float a = hash(i);
     float b = hash(i + vec2(1.0, 0.0));
@@ -112,7 +163,6 @@ const FRAG_SRC = `
     return mix(mix(a, b, u.x), mix(c, d, u.x), u.y);
   }
 
-  // 6-octave fractional Brownian motion
   float fbm(vec2 p) {
     float val = 0.0;
     float amp = 0.5;
@@ -127,22 +177,29 @@ const FRAG_SRC = `
   // -------------------------------------------------------------------------
 
   void main() {
+    // Discard fragments on the back hemisphere
+    if (v_visible <= 0.0) discard;
+
     float t  = u_time;
     float ds = u_drift;
-    vec2 uv  = v_uv * u_scale;
 
-    // Primary layer: drift rightward + slight upward
-    float n1 = fbm(uv + vec2(ds * t, ds * 0.3 * t));
+    // Map lon/lat to noise UV; scale controls cloud feature size
+    vec2 uv = vec2(
+      v_lonlat.x / 6.28318530718 + 0.5,   // lon → [0, 1]
+      v_lonlat.y / 3.14159265359 + 0.5    // lat → [0, 1]
+    ) * u_scale;
 
-    // Secondary layer: counter-drift at a different scale for visual depth
+    // Two FBM layers at slightly different drift angles for visual depth
+    float n1 = fbm(uv + vec2(ds * t,         ds * 0.3 * t));
     float n2 = fbm(uv * 1.6 + vec2(-ds * 0.7 * t, ds * 0.4 * t) + vec2(5.2, 1.3));
 
-    // Blend layers and threshold into soft cloud shapes
     float cloud = mix(n1, n2, 0.4);
     cloud = smoothstep(0.38, 0.65, cloud);
 
-    // Standard (non-premultiplied) alpha — we set up SRC_ALPHA blend ourselves
-    float alpha = cloud * u_opacity;
+    // Soft fade near the globe's horizon so clouds don't hard-clip at the limb
+    float horizon = clamp(v_visible * 8.0, 0.0, 1.0);
+
+    float alpha = cloud * u_opacity * horizon;
     gl_FragColor = vec4(u_color, alpha);
   }
 `;
@@ -182,12 +239,8 @@ function buildProgram(gl: GL, vertSrc: string, fragSrc: string): WebGLProgram | 
   return prog;
 }
 
-// Full-screen quad — 2 triangles, 6 vertices in NDC space
-// prettier-ignore
-const QUAD_VERTS = new Float32Array([
-  -1, -1,   1, -1,  -1,  1,
-   1, -1,   1,  1,  -1,  1,
-]);
+// Stride between vertices in the interleaved buffer: 5 floats × 4 bytes
+const STRIDE = 20;
 
 // ---------------------------------------------------------------------------
 // Public factory
@@ -211,9 +264,13 @@ export function createCloudsLayer(options?: CloudsOptions): CustomLayerInterface
   // GL resources — allocated in onAdd, freed in onRemove
   let _gl: GL | null = null;
   let _program: WebGLProgram | null = null;
-  let _buf: WebGLBuffer | null = null;
+  let _vbo: WebGLBuffer | null = null;
+  let _ibo: WebGLBuffer | null = null;
   let _map: MaplibreMap | null = null;
-  let _aPos = -1;
+  let _aSphere = -1;
+  let _aLonlat = -1;
+  let _uMatrix: WebGLUniformLocation | null = null;
+  let _uClipPlane: WebGLUniformLocation | null = null;
   let _uTime: WebGLUniformLocation | null = null;
   let _uDrift: WebGLUniformLocation | null = null;
   let _uOpacity: WebGLUniformLocation | null = null;
@@ -223,9 +280,7 @@ export function createCloudsLayer(options?: CloudsOptions): CustomLayerInterface
   return {
     id: 'golarion-clouds',
     type: 'custom',
-    // '3d' so this layer renders in the same pass as the globe tiles, after
-    // them, rather than in the pre-globe '2d' pass where it would be buried
-    // under the terrain.
+    // '3d' renders in the same pass as globe tiles, after them.
     renderingMode: '3d',
 
     onAdd(map: MaplibreMap, gl: WebGLRenderingContext | WebGL2RenderingContext): void {
@@ -235,17 +290,27 @@ export function createCloudsLayer(options?: CloudsOptions): CustomLayerInterface
       _program = buildProgram(_gl, VERT_SRC, FRAG_SRC);
       if (!_program) return;
 
-      _aPos = _gl.getAttribLocation(_program, 'a_pos');
+      _aSphere = _gl.getAttribLocation(_program, 'a_sphere');
+      _aLonlat = _gl.getAttribLocation(_program, 'a_lonlat');
+      _uMatrix = _gl.getUniformLocation(_program, 'u_matrix');
+      _uClipPlane = _gl.getUniformLocation(_program, 'u_clip_plane');
       _uTime = _gl.getUniformLocation(_program, 'u_time');
       _uDrift = _gl.getUniformLocation(_program, 'u_drift');
       _uOpacity = _gl.getUniformLocation(_program, 'u_opacity');
       _uScale = _gl.getUniformLocation(_program, 'u_scale');
       _uColor = _gl.getUniformLocation(_program, 'u_color');
 
-      _buf = _gl.createBuffer();
-      _gl.bindBuffer(_gl.ARRAY_BUFFER, _buf);
-      _gl.bufferData(_gl.ARRAY_BUFFER, QUAD_VERTS, _gl.STATIC_DRAW);
+      // Vertex buffer: interleaved [x, y, z, lon, lat]
+      _vbo = _gl.createBuffer();
+      _gl.bindBuffer(_gl.ARRAY_BUFFER, _vbo);
+      _gl.bufferData(_gl.ARRAY_BUFFER, SPHERE.data, _gl.STATIC_DRAW);
       _gl.bindBuffer(_gl.ARRAY_BUFFER, null);
+
+      // Index buffer
+      _ibo = _gl.createBuffer();
+      _gl.bindBuffer(_gl.ELEMENT_ARRAY_BUFFER, _ibo);
+      _gl.bufferData(_gl.ELEMENT_ARRAY_BUFFER, SPHERE.indices, _gl.STATIC_DRAW);
+      _gl.bindBuffer(_gl.ELEMENT_ARRAY_BUFFER, null);
 
       console.info('[shared:clouds] Cloud layer added', {
         opacity: opts.opacity,
@@ -255,26 +320,35 @@ export function createCloudsLayer(options?: CloudsOptions): CustomLayerInterface
       });
     },
 
-    render(_gl2: WebGLRenderingContext | WebGL2RenderingContext, _options: CustomRenderMethodInput): void {
-      if (!_program || !_buf || !_gl) return;
+    render(_glCtx: WebGLRenderingContext | WebGL2RenderingContext, options: CustomRenderMethodInput): void {
+      if (!_program || !_vbo || !_ibo || !_gl) return;
 
       const g = _gl;
       const t = performance.now() / 1000;
+      const pd = options.defaultProjectionData;
 
-      // renderingMode '3d' gives us a clean GL slate — set up everything.
-      // Alpha blend (standard, non-premultiplied) over the already-drawn globe.
+      // renderingMode '3d' gives a clean GL slate — set up everything.
       g.enable(g.BLEND);
       g.blendFunc(g.SRC_ALPHA, g.ONE_MINUS_SRC_ALPHA);
-
-      // No depth test or depth writes — this is a pure screen-space overlay;
-      // we don't want to interact with the globe's depth buffer at all.
+      // No depth interaction — pure overlay; don't pollute the depth buffer.
       g.disable(g.DEPTH_TEST);
       g.depthMask(false);
 
       g.useProgram(_program);
-      g.bindBuffer(g.ARRAY_BUFFER, _buf);
-      g.enableVertexAttribArray(_aPos);
-      g.vertexAttribPointer(_aPos, 2, g.FLOAT, false, 0, 0);
+
+      // Bind vertex buffer and wire interleaved attributes
+      g.bindBuffer(g.ARRAY_BUFFER, _vbo);
+      g.enableVertexAttribArray(_aSphere);
+      g.vertexAttribPointer(_aSphere, 3, g.FLOAT, false, STRIDE, 0); // xyz at offset 0
+      g.enableVertexAttribArray(_aLonlat);
+      g.vertexAttribPointer(_aLonlat, 2, g.FLOAT, false, STRIDE, 12); // lonlat at offset 12
+
+      g.bindBuffer(g.ELEMENT_ARRAY_BUFFER, _ibo);
+
+      // Globe projection matrix (projects unit sphere → screen)
+      g.uniformMatrix4fv(_uMatrix, false, pd.mainMatrix);
+      // Horizon clipping plane (clips the back hemisphere)
+      g.uniform4fv(_uClipPlane, pd.clippingPlane);
 
       g.uniform1f(_uTime, t);
       g.uniform1f(_uDrift, opts.driftSpeed);
@@ -282,22 +356,25 @@ export function createCloudsLayer(options?: CloudsOptions): CustomLayerInterface
       g.uniform1f(_uScale, opts.scale);
       g.uniform3f(_uColor, opts.color[0], opts.color[1], opts.color[2]);
 
-      g.drawArrays(g.TRIANGLES, 0, 6);
+      g.drawElements(g.TRIANGLES, SPHERE.indices.length, g.UNSIGNED_SHORT, 0);
 
-      g.disableVertexAttribArray(_aPos);
+      g.disableVertexAttribArray(_aSphere);
+      g.disableVertexAttribArray(_aLonlat);
       g.bindBuffer(g.ARRAY_BUFFER, null);
+      g.bindBuffer(g.ELEMENT_ARRAY_BUFFER, null);
       g.depthMask(true);
 
-      // Keep the animation running; MapLibre will call render() again
       _map?.triggerRepaint();
     },
 
     onRemove(_m: MaplibreMap, gl: WebGLRenderingContext | WebGL2RenderingContext): void {
       const g = gl as GL;
       if (_program) g.deleteProgram(_program);
-      if (_buf) g.deleteBuffer(_buf);
+      if (_vbo) g.deleteBuffer(_vbo);
+      if (_ibo) g.deleteBuffer(_ibo);
       _program = null;
-      _buf = null;
+      _vbo = null;
+      _ibo = null;
       _gl = null;
       _map = null;
     },

--- a/packages/shared/src/golarion-map/clouds.ts
+++ b/packages/shared/src/golarion-map/clouds.ts
@@ -67,8 +67,8 @@ const VERT_SRC = `
   varying   vec2 v_uv;
 
   void main() {
-    // Clip-space position; z = -1.0 (near plane) keeps clouds in front of
-    // globe geometry without needing to manage depth state explicitly.
+    // Full-screen quad in clip space; z = -1.0 (near plane) is irrelevant
+    // since depth test and depth writes are disabled in render().
     gl_Position = vec4(a_pos, -1.0, 1.0);
     // NDC [-1, 1] → UV [0, 1]
     v_uv = (a_pos + 1.0) * 0.5;
@@ -79,8 +79,8 @@ const VERT_SRC = `
  *
  *  Two layers of fractional Brownian motion are sampled at slowly-drifting UV
  *  coordinates, blended together, and threshold-clipped with smoothstep to
- *  produce soft cloud patches.  Output is premultiplied alpha because MapLibre
- *  already enables the ONE / ONE_MINUS_SRC_ALPHA blend equation. */
+ *  produce soft cloud patches.  Output is standard (non-premultiplied) alpha;
+ *  the render() method sets up SRC_ALPHA / ONE_MINUS_SRC_ALPHA blending. */
 const FRAG_SRC = `
   precision highp float;
 
@@ -141,9 +141,9 @@ const FRAG_SRC = `
     float cloud = mix(n1, n2, 0.4);
     cloud = smoothstep(0.38, 0.65, cloud);
 
-    // Premultiplied alpha: MapLibre uses ONE / ONE_MINUS_SRC_ALPHA blending
+    // Standard (non-premultiplied) alpha — we set up SRC_ALPHA blend ourselves
     float alpha = cloud * u_opacity;
-    gl_FragColor = vec4(u_color * alpha, alpha);
+    gl_FragColor = vec4(u_color, alpha);
   }
 `;
 
@@ -223,7 +223,10 @@ export function createCloudsLayer(options?: CloudsOptions): CustomLayerInterface
   return {
     id: 'golarion-clouds',
     type: 'custom',
-    renderingMode: '2d',
+    // '3d' so this layer renders in the same pass as the globe tiles, after
+    // them, rather than in the pre-globe '2d' pass where it would be buried
+    // under the terrain.
+    renderingMode: '3d',
 
     onAdd(map: MaplibreMap, gl: WebGLRenderingContext | WebGL2RenderingContext): void {
       _map = map;
@@ -258,13 +261,15 @@ export function createCloudsLayer(options?: CloudsOptions): CustomLayerInterface
       const g = _gl;
       const t = performance.now() / 1000;
 
-      // Disable depth test so the full-screen quad isn't clipped by globe
-      // geometry already in the depth buffer.
-      const wasDepthTest = g.isEnabled(g.DEPTH_TEST);
-      g.disable(g.DEPTH_TEST);
+      // renderingMode '3d' gives us a clean GL slate — set up everything.
+      // Alpha blend (standard, non-premultiplied) over the already-drawn globe.
+      g.enable(g.BLEND);
+      g.blendFunc(g.SRC_ALPHA, g.ONE_MINUS_SRC_ALPHA);
 
-      // MapLibre has already set the blend equation to
-      // ONE / ONE_MINUS_SRC_ALPHA (premultiplied alpha) — we rely on that.
+      // No depth test or depth writes — this is a pure screen-space overlay;
+      // we don't want to interact with the globe's depth buffer at all.
+      g.disable(g.DEPTH_TEST);
+      g.depthMask(false);
 
       g.useProgram(_program);
       g.bindBuffer(g.ARRAY_BUFFER, _buf);
@@ -281,9 +286,7 @@ export function createCloudsLayer(options?: CloudsOptions): CustomLayerInterface
 
       g.disableVertexAttribArray(_aPos);
       g.bindBuffer(g.ARRAY_BUFFER, null);
-
-      // Restore depth state so subsequent MapLibre layers are unaffected
-      if (wasDepthTest) g.enable(g.DEPTH_TEST);
+      g.depthMask(true);
 
       // Keep the animation running; MapLibre will call render() again
       _map?.triggerRepaint();

--- a/packages/shared/src/golarion-map/clouds.ts
+++ b/packages/shared/src/golarion-map/clouds.ts
@@ -22,10 +22,10 @@ export interface CloudsOptions {
   /** Overall cloud opacity, 0–1.  Default: 0.25 */
   opacity?: number;
   /**
-   * Drift speed in 3D sample-space units per second.  Default: 0.02
-   * (roughly one cloud-width per 30 s at the default scale — clearly visible
-   * but slow enough to feel atmospheric).  Drop toward 0.005 for near-static
-   * clouds; raise toward 0.05–0.08 for a livelier sky.
+   * Drift speed in 3D sample-space units per second.  Default: 0.06
+   * (roughly one cloud-width per ~10 s — clearly perceptible without feeling
+   * rushed).  Drop toward 0.01–0.02 for a slower, more subtle drift; raise
+   * toward 0.15 for stormy skies.
    */
   driftSpeed?: number;
   /** Scale factor for cloud cluster size (higher → larger patches).
@@ -51,7 +51,7 @@ interface ResolvedCloudsOptions {
 export function mergeCloudsOptions(options?: CloudsOptions): ResolvedCloudsOptions {
   return {
     opacity: options?.opacity ?? 0.25,
-    driftSpeed: options?.driftSpeed ?? 0.02,
+    driftSpeed: options?.driftSpeed ?? 0.06,
     scale: options?.scale ?? 3.0,
     color: options?.color ?? [1, 0.98, 0.95],
   };
@@ -315,6 +315,12 @@ export function createCloudsLayer(options?: CloudsOptions): CustomLayerInterface
         scale: opts.scale,
         color: opts.color,
       });
+
+      // Kick off the continuous animation loop.  MapLibre only re-renders
+      // when the scene has changes; without this initial trigger, render()
+      // may not be called again after the first frame and the clouds would
+      // appear static.
+      map.triggerRepaint();
     },
 
     render(_glCtx: WebGLRenderingContext | WebGL2RenderingContext, options: CustomRenderMethodInput): void {

--- a/packages/shared/src/golarion-map/clouds.ts
+++ b/packages/shared/src/golarion-map/clouds.ts
@@ -22,7 +22,7 @@ export interface CloudsOptions {
   /** Overall cloud opacity, 0–1.  Default: 0.25 */
   opacity?: number;
   /**
-   * Eastward drift speed in sample-space units per second.  Default: 0.06
+   * Drift speed in sample-space units per second.  Default: 0.06
    * (roughly one cloud-width per ~10 s — clearly perceptible without feeling
    * rushed).  The clouds rotate around the globe's north-pole axis, so the
    * drift looks geographically correct at all latitudes.  Drop toward 0.01–0.02
@@ -201,12 +201,12 @@ const FRAG_SRC = `
 
     // Drift axis: geographic north (+z) tilted ~40° toward +y.
     // Pure z-axis rotation empirically drifts SW on screen in MapLibre's
-    // globe frame; the 40° tilt adds the northward correction to land on W.
-    // Negative angle = CW = sample from east = pattern drifts west.
+    // globe frame; the 40° tilt adds the northward correction to land on E.
+    // Positive angle = CCW = sample from west = pattern drifts east.
     vec3 driftAxis = normalize(vec3(0.0, 0.643, 0.766)); // sin/cos of 40°
 
-    float n1 = fbm3(rotateAxis(pos,       driftAxis, -angle));
-    float n2 = fbm3(rotateAxis(pos * 1.6, driftAxis, -angle * 0.7) + vec3(2.1, 1.3, 0.8));
+    float n1 = fbm3(rotateAxis(pos,       driftAxis, angle));
+    float n2 = fbm3(rotateAxis(pos * 1.6, driftAxis, angle * 0.7) + vec3(2.1, 1.3, 0.8));
 
     float cloud = mix(n1, n2, 0.4);
     cloud = smoothstep(0.38, 0.65, cloud);

--- a/packages/shared/src/golarion-map/index.ts
+++ b/packages/shared/src/golarion-map/index.ts
@@ -1,6 +1,6 @@
-// Golarion-map primitives: MapLibre style, color palette, pin layer
-// helpers, and game-icon image registration. Shared between the DM
-// tool's editor globe and the player portal's read-only view.
+// Golarion-map primitives: MapLibre style, color palette, pin layer helpers,
+// game-icon image registration, stars layer, auto-rotate, and optional cloud-wash.
+// Shared between the DM tool's editor globe and the player portal's read-only view.
 
 export { DEFAULT_PMTILES_URL, buildMapStyle, colors } from './style.js';
 export { PIN_SOURCE, PIN_LAYER, pinDisplaySize, pinsToGeoJson } from './pins.js';
@@ -9,3 +9,5 @@ export { createStarsLayer } from './stars.js';
 export type { StarsOptions, ResolvedStarsOptions } from './stars.js';
 export { startAutoRotate } from './auto-rotate.js';
 export type { AutoRotateOptions } from './auto-rotate.js';
+export { createCloudsLayer, mergeCloudsOptions } from './clouds.js';
+export type { CloudsOptions } from './clouds.js';


### PR DESCRIPTION
## Summary

Adds a purely cosmetic, slowly-drifting cloud layer to the player-portal Golarion globe. Clouds are procedural — no texture assets — rendered as a tessellated unit-sphere mesh with a 6-octave 3D FBM WebGL shader. They drift eastward to match the globe's auto-rotation direction, clip precisely to the globe hemisphere (no bleed into the sky), and fade softly at the horizon limb.

The helper lives in \`@foundry-toolkit/shared/golarion-map\` as an opt-in export so dm-tool is unaffected.

## Changes

- **\`packages/shared/src/golarion-map/clouds.ts\`** — new file. \`createCloudsLayer(options?)\` returns a MapLibre \`CustomLayerInterface\` (\`renderingMode: '3d'\`). Key design decisions reached through iteration:
  - Sphere mesh (48×96) + \`defaultProjectionData.mainMatrix\` / \`clippingPlane\` for correct globe-clipped rendering
  - 3D FBM noise sampled from unit-sphere position — eliminates the equatorial seam that lat/lon UV mapping produces
  - Rodrigues rotation around a tilted axis (\`normalize(0, 0.643, 0.766)\`) for eastward drift; pure z-axis rotation drifts ~45° off due to MapLibre's coordinate frame
  - \`map.triggerRepaint()\` called from both \`onAdd\` and \`render\` to maintain the animation loop
- **\`packages/shared/src/golarion-map/index.ts\`** — re-exports \`createCloudsLayer\`, \`mergeCloudsOptions\`, \`CloudsOptions\`
- **\`packages/shared/src/golarion-map/clouds.test.ts\`** — Vitest tests for \`mergeCloudsOptions\` (defaults, partial overrides, full overrides, edge cases)
- **\`apps/player-portal/src/routes/Globe.tsx\`** — adds \`map.addLayer(createCloudsLayer())\` in \`style.load\`, alongside the existing stars layer and auto-rotate

## Defaults (tunable via \`CloudsOptions\`)

| Option | Default | Effect |
|---|---|---|
| \`opacity\` | \`0.25\` | Subtle haze; labels readable underneath |
| \`driftSpeed\` | \`0.06\` | ~1 cloud-width per 10 s — clearly visible, atmospheric |
| \`scale\` | \`3.0\` | Medium-large cloud patches |
| \`color\` | \`[1, 0.98, 0.95]\` | Warm near-white tint |

## Test plan

- [x] \`npm run test -w packages/shared\` — 68 tests pass (4 new for \`mergeCloudsOptions\`)
- [x] \`npm run typecheck\` — clean across all workspaces
- [x] \`npm run lint:fix\` + \`format:check\` — clean
- [ ] Manual: \`npm run dev:player-portal\` → \`/globe\` → clouds appear over globe only, drift eastward, don't cover pins, don't tank framerate