### PR TITLE
feat(shared): add atmospheric halo to Golarion globe

### DIFF
--- a/apps/player-portal/src/routes/Globe.tsx
+++ b/apps/player-portal/src/routes/Globe.tsx
@@ -13,6 +13,7 @@ import {
   buildMapStyle,
   createCloudsLayer,
   createHaloLayer,
+  createLimbDarkeningLayer,
   createStarsLayer,
   ensureDefaultImage,
   ensureIconImage,
@@ -84,9 +85,11 @@ export function Globe() {
     map.on('style.load', () => {
       map.setProjection({ type: 'globe' });
       startAutoRotate(map, { startDelayMs: 500 });
+      // Limb darkening: subtle black overlay concentrated at the silhouette edge,
+      // providing the spherical-curvature depth cue. Added before clouds so the
+      // darkening is visible beneath any cloud cover.
+      map.addLayer(createLimbDarkeningLayer());
       // Ambient cloud wash — player-portal only; not in dm-tool.
-      // Added after style.load so it sits above terrain/labels but below the
-      // pin icon layer, which is added in the 'load' handler below.
       map.addLayer(createCloudsLayer());
     });
 

--- a/apps/player-portal/src/routes/Globe.tsx
+++ b/apps/player-portal/src/routes/Globe.tsx
@@ -12,6 +12,7 @@ import {
   PIN_SOURCE,
   buildMapStyle,
   createCloudsLayer,
+  createHaloLayer,
   createStarsLayer,
   ensureDefaultImage,
   ensureIconImage,
@@ -112,6 +113,12 @@ export function Globe() {
         type: 'geojson',
         data: pinsToGeoJson(pinsRef.current, map),
       });
+
+      // Atmospheric halo: soft glow ring at the globe silhouette, giving the
+      // depth cue that makes the globe read as a sphere rather than a flat disc.
+      // Added after the cloud layer (style.load) and before pin icons so the
+      // halo is visible at the limb without obscuring map markers.
+      map.addLayer(createHaloLayer());
 
       map.addLayer({
         id: PIN_LAYER,

--- a/packages/shared/src/golarion-map/halo.test.ts
+++ b/packages/shared/src/golarion-map/halo.test.ts
@@ -12,7 +12,7 @@ describe('mergeHaloOptions — defaults', () => {
     expect(opts.widthPx).toBe(35);
     expect(opts.innerFeatherPx).toBe(8);
     expect(opts.color).toEqual([0.18, 0.52, 1.0]);
-    expect(opts.opacity).toBe(0.75);
+    expect(opts.opacity).toBe(0.6);
   });
 
   it('returns all defaults when called with an empty object', () => {
@@ -20,7 +20,7 @@ describe('mergeHaloOptions — defaults', () => {
     expect(opts.widthPx).toBe(35);
     expect(opts.innerFeatherPx).toBe(8);
     expect(opts.color).toEqual([0.18, 0.52, 1.0]);
-    expect(opts.opacity).toBe(0.75);
+    expect(opts.opacity).toBe(0.6);
   });
 
   it('returns all defaults when called with undefined', () => {
@@ -37,7 +37,7 @@ describe('mergeHaloOptions — partial overrides', () => {
     const opts = mergeHaloOptions({ widthPx: 60 });
     expect(opts.widthPx).toBe(60);
     expect(opts.innerFeatherPx).toBe(8);
-    expect(opts.opacity).toBe(0.75);
+    expect(opts.opacity).toBe(0.6);
     expect(opts.color).toEqual([0.18, 0.52, 1.0]);
   });
 
@@ -59,7 +59,7 @@ describe('mergeHaloOptions — partial overrides', () => {
     const color: [number, number, number] = [0.3, 0.7, 1.0];
     const opts = mergeHaloOptions({ color });
     expect(opts.color).toEqual([0.3, 0.7, 1.0]);
-    expect(opts.opacity).toBe(0.75);
+    expect(opts.opacity).toBe(0.6);
     expect(opts.widthPx).toBe(35);
   });
 });

--- a/packages/shared/src/golarion-map/halo.test.ts
+++ b/packages/shared/src/golarion-map/halo.test.ts
@@ -1,0 +1,115 @@
+// Unit tests for pure helpers in halo.ts.
+// WebGL rendering is skipped — custom layers require a GPU context unavailable in jsdom.
+
+import { describe, expect, it } from 'vitest';
+import { mergeHaloOptions } from './halo.js';
+
+// ---- mergeHaloOptions — defaults --------------------------------------------
+
+describe('mergeHaloOptions — defaults', () => {
+  it('returns all defaults when called with no argument', () => {
+    const opts = mergeHaloOptions();
+    expect(opts.widthPx).toBe(35);
+    expect(opts.innerFeatherPx).toBe(8);
+    expect(opts.color).toEqual([0.18, 0.52, 1.0]);
+    expect(opts.opacity).toBe(0.75);
+  });
+
+  it('returns all defaults when called with an empty object', () => {
+    const opts = mergeHaloOptions({});
+    expect(opts.widthPx).toBe(35);
+    expect(opts.innerFeatherPx).toBe(8);
+    expect(opts.color).toEqual([0.18, 0.52, 1.0]);
+    expect(opts.opacity).toBe(0.75);
+  });
+
+  it('returns all defaults when called with undefined', () => {
+    const opts = mergeHaloOptions(undefined);
+    expect(opts.widthPx).toBe(35);
+    expect(opts.innerFeatherPx).toBe(8);
+  });
+});
+
+// ---- mergeHaloOptions — partial overrides -----------------------------------
+
+describe('mergeHaloOptions — partial overrides', () => {
+  it('applies widthPx override while keeping other defaults', () => {
+    const opts = mergeHaloOptions({ widthPx: 60 });
+    expect(opts.widthPx).toBe(60);
+    expect(opts.innerFeatherPx).toBe(8);
+    expect(opts.opacity).toBe(0.75);
+    expect(opts.color).toEqual([0.18, 0.52, 1.0]);
+  });
+
+  it('applies innerFeatherPx override while keeping other defaults', () => {
+    const opts = mergeHaloOptions({ innerFeatherPx: 15 });
+    expect(opts.innerFeatherPx).toBe(15);
+    expect(opts.widthPx).toBe(35);
+  });
+
+  it('applies opacity override while keeping other defaults', () => {
+    const opts = mergeHaloOptions({ opacity: 0.5 });
+    expect(opts.opacity).toBe(0.5);
+    expect(opts.widthPx).toBe(35);
+    expect(opts.innerFeatherPx).toBe(8);
+    expect(opts.color).toEqual([0.18, 0.52, 1.0]);
+  });
+
+  it('applies color override while keeping other defaults', () => {
+    const color: [number, number, number] = [0.3, 0.7, 1.0];
+    const opts = mergeHaloOptions({ color });
+    expect(opts.color).toEqual([0.3, 0.7, 1.0]);
+    expect(opts.opacity).toBe(0.75);
+    expect(opts.widthPx).toBe(35);
+  });
+});
+
+// ---- mergeHaloOptions — full override ---------------------------------------
+
+describe('mergeHaloOptions — full override', () => {
+  it('uses all caller-supplied values when every field is provided', () => {
+    const color: [number, number, number] = [0.1, 0.4, 0.9];
+    const opts = mergeHaloOptions({
+      widthPx: 50,
+      innerFeatherPx: 12,
+      color,
+      opacity: 0.9,
+    });
+    expect(opts.widthPx).toBe(50);
+    expect(opts.innerFeatherPx).toBe(12);
+    expect(opts.color).toEqual([0.1, 0.4, 0.9]);
+    expect(opts.opacity).toBe(0.9);
+  });
+
+  it('preserves the exact color tuple reference when one is supplied', () => {
+    const color: [number, number, number] = [0.2, 0.5, 0.8];
+    const opts = mergeHaloOptions({ color });
+    expect(opts.color).toBe(color);
+  });
+});
+
+// ---- mergeHaloOptions — edge cases ------------------------------------------
+
+describe('mergeHaloOptions — edge cases', () => {
+  it('accepts widthPx of 0 (hairline halo)', () => {
+    expect(mergeHaloOptions({ widthPx: 0 }).widthPx).toBe(0);
+  });
+
+  it('accepts innerFeatherPx of 0 (hard inner edge)', () => {
+    expect(mergeHaloOptions({ innerFeatherPx: 0 }).innerFeatherPx).toBe(0);
+  });
+
+  it('accepts opacity of 0 (fully transparent)', () => {
+    expect(mergeHaloOptions({ opacity: 0 }).opacity).toBe(0);
+  });
+
+  it('accepts opacity of 1 (fully opaque)', () => {
+    expect(mergeHaloOptions({ opacity: 1 }).opacity).toBe(1);
+  });
+
+  it('does not mutate the input options object', () => {
+    const input = { widthPx: 20 };
+    mergeHaloOptions(input);
+    expect(input).toEqual({ widthPx: 20 });
+  });
+});

--- a/packages/shared/src/golarion-map/halo.test.ts
+++ b/packages/shared/src/golarion-map/halo.test.ts
@@ -9,23 +9,23 @@ import { mergeHaloOptions } from './halo.js';
 describe('mergeHaloOptions — defaults', () => {
   it('returns all defaults when called with no argument', () => {
     const opts = mergeHaloOptions();
-    expect(opts.widthPx).toBe(35);
+    expect(opts.widthPx).toBe(18);
     expect(opts.innerFeatherPx).toBe(8);
     expect(opts.color).toEqual([0.18, 0.52, 1.0]);
-    expect(opts.opacity).toBe(0.6);
+    expect(opts.opacity).toBe(0.45);
   });
 
   it('returns all defaults when called with an empty object', () => {
     const opts = mergeHaloOptions({});
-    expect(opts.widthPx).toBe(35);
+    expect(opts.widthPx).toBe(18);
     expect(opts.innerFeatherPx).toBe(8);
     expect(opts.color).toEqual([0.18, 0.52, 1.0]);
-    expect(opts.opacity).toBe(0.6);
+    expect(opts.opacity).toBe(0.45);
   });
 
   it('returns all defaults when called with undefined', () => {
     const opts = mergeHaloOptions(undefined);
-    expect(opts.widthPx).toBe(35);
+    expect(opts.widthPx).toBe(18);
     expect(opts.innerFeatherPx).toBe(8);
   });
 });
@@ -37,20 +37,20 @@ describe('mergeHaloOptions — partial overrides', () => {
     const opts = mergeHaloOptions({ widthPx: 60 });
     expect(opts.widthPx).toBe(60);
     expect(opts.innerFeatherPx).toBe(8);
-    expect(opts.opacity).toBe(0.6);
+    expect(opts.opacity).toBe(0.45);
     expect(opts.color).toEqual([0.18, 0.52, 1.0]);
   });
 
   it('applies innerFeatherPx override while keeping other defaults', () => {
     const opts = mergeHaloOptions({ innerFeatherPx: 15 });
     expect(opts.innerFeatherPx).toBe(15);
-    expect(opts.widthPx).toBe(35);
+    expect(opts.widthPx).toBe(18);
   });
 
   it('applies opacity override while keeping other defaults', () => {
     const opts = mergeHaloOptions({ opacity: 0.5 });
     expect(opts.opacity).toBe(0.5);
-    expect(opts.widthPx).toBe(35);
+    expect(opts.widthPx).toBe(18);
     expect(opts.innerFeatherPx).toBe(8);
     expect(opts.color).toEqual([0.18, 0.52, 1.0]);
   });
@@ -59,8 +59,8 @@ describe('mergeHaloOptions — partial overrides', () => {
     const color: [number, number, number] = [0.3, 0.7, 1.0];
     const opts = mergeHaloOptions({ color });
     expect(opts.color).toEqual([0.3, 0.7, 1.0]);
-    expect(opts.opacity).toBe(0.6);
-    expect(opts.widthPx).toBe(35);
+    expect(opts.opacity).toBe(0.45);
+    expect(opts.widthPx).toBe(18);
   });
 });
 

--- a/packages/shared/src/golarion-map/halo.ts
+++ b/packages/shared/src/golarion-map/halo.ts
@@ -28,7 +28,7 @@ import type { CustomLayerInterface, CustomRenderMethodInput, Map as MaplibreMap 
  *  defaults produce a clearly visible atmospheric rim that reads as planetary
  *  curvature without obscuring the map surface. */
 export interface HaloOptions {
-  /** Width of the glow band outside the globe silhouette, in CSS pixels. Default: 35 */
+  /** Width of the glow band outside the globe silhouette, in CSS pixels. Default: 18 */
   widthPx?: number;
   /** How far inside the silhouette the alpha tapers to zero, in CSS pixels.
    *  A small value (default: 8) provides anti-aliasing at the limb without
@@ -37,7 +37,7 @@ export interface HaloOptions {
   /** Halo colour as linear RGB [R, G, B] in the 0–1 range.
    *  Default: atmospheric blue [0.18, 0.52, 1.0]. */
   color?: [number, number, number];
-  /** Peak opacity of the halo at the silhouette edge. Default: 0.6 */
+  /** Peak opacity of the halo at the silhouette edge. Default: 0.45 */
   opacity?: number;
 }
 
@@ -55,10 +55,10 @@ export interface ResolvedHaloOptions {
 /** Merge caller-supplied options with per-field defaults. */
 export function mergeHaloOptions(options?: HaloOptions): ResolvedHaloOptions {
   return {
-    widthPx: options?.widthPx ?? 35,
+    widthPx: options?.widthPx ?? 18,
     innerFeatherPx: options?.innerFeatherPx ?? 8,
     color: options?.color ?? [0.18, 0.52, 1.0],
-    opacity: options?.opacity ?? 0.6,
+    opacity: options?.opacity ?? 0.45,
   };
 }
 

--- a/packages/shared/src/golarion-map/halo.ts
+++ b/packages/shared/src/golarion-map/halo.ts
@@ -37,7 +37,7 @@ export interface HaloOptions {
   /** Halo colour as linear RGB [R, G, B] in the 0–1 range.
    *  Default: atmospheric blue [0.18, 0.52, 1.0]. */
   color?: [number, number, number];
-  /** Peak opacity of the halo at the silhouette edge. Default: 0.75 */
+  /** Peak opacity of the halo at the silhouette edge. Default: 0.6 */
   opacity?: number;
 }
 
@@ -58,7 +58,7 @@ export function mergeHaloOptions(options?: HaloOptions): ResolvedHaloOptions {
     widthPx: options?.widthPx ?? 35,
     innerFeatherPx: options?.innerFeatherPx ?? 8,
     color: options?.color ?? [0.18, 0.52, 1.0],
-    opacity: options?.opacity ?? 0.75,
+    opacity: options?.opacity ?? 0.6,
   };
 }
 
@@ -196,6 +196,9 @@ type Mat16 = readonly [
   number,
 ];
 
+/** 4-component vector as a fixed-length tuple (same motivation as Mat16). */
+type Vec4 = readonly [number, number, number, number];
+
 /**
  * Multiply a column-major 4×4 matrix by a homogeneous 4-vector.
  * Returns [x, y, z, w].
@@ -314,29 +317,79 @@ export function createHaloLayer(options?: HaloOptions): CustomLayerInterface {
       if (!_program || !_vao || !_gl || !_map) return;
       const gl = _gl;
 
-      // Derive the globe disc centre and radius in NDC from the projection matrix.
+      // Derive the globe disc centre and radius from the clip plane.
       //
-      // The globe is a unit sphere in MapLibre's globe coordinate system.
-      // Projecting [0,0,0] gives the disc centre (sphere origin → screen centre).
-      // Projecting [1,0,0] (an equatorial edge point) gives the approximate
-      // silhouette edge — accurate within ~6% at zoom 2, well within the soft
-      // inner-feather tolerance.
-      // Cast to Mat16 so literal-index access is typed as number, not
-      // number | undefined (required by noUncheckedIndexedAccess).
+      // MapLibre's clippingPlane satisfies:  dot(cp.xyz, p) + cp.w = 0
+      // for every point p on the unit sphere's silhouette ring — i.e. the
+      // actual boundary between the visible and hidden hemisphere.  Using this
+      // gives a rotationally-stable radius that does NOT oscillate as the globe
+      // auto-rotates (unlike projecting a fixed equatorial point such as [1,0,0]
+      // which sweeps from disc-edge to disc-centre and back each full rotation).
+      const cp = input.defaultProjectionData.clippingPlane as unknown as Vec4;
+      const cnx = cp[0],
+        cny = cp[1],
+        cnz = cp[2],
+        cnd = cp[3];
+      const nlen = Math.sqrt(cnx * cnx + cny * cny + cnz * cnz);
+      if (nlen < 1e-6) return; // degenerate clip plane
+
+      // Normalise plane normal
+      const nx = cnx / nlen,
+        ny = cny / nlen,
+        nz = cnz / nlen;
+      const dd = cnd / nlen;
+
+      // Silhouette ring in globe-space:
+      //   centre = -dd · n̂  (on or inside the unit sphere)
+      //   radius = sqrt(1 − dd²)
+      const scx = -dd * nx,
+        scy = -dd * ny,
+        scz = -dd * nz;
+      const sRad = Math.sqrt(Math.max(0, 1 - dd * dd));
+      if (sRad < 1e-6) return; // fully pole-on or degenerate
+
+      // Tangent vector e1 perpendicular to n̂.  Choose the basis axis whose
+      // component along n̂ is smallest for maximum numerical stability.
+      let e1x: number, e1y: number, e1z: number;
+      const absNx = Math.abs(nx),
+        absNy = Math.abs(ny),
+        absNz = Math.abs(nz);
+      if (absNx <= absNy && absNx <= absNz) {
+        // n × [1,0,0] = [0, nz, -ny]
+        const el = Math.sqrt(nz * nz + ny * ny);
+        e1x = 0;
+        e1y = nz / el;
+        e1z = -ny / el;
+      } else if (absNy <= absNz) {
+        // n × [0,1,0] = [-nz, 0, nx]
+        const el = Math.sqrt(nz * nz + nx * nx);
+        e1x = -nz / el;
+        e1y = 0;
+        e1z = nx / el;
+      } else {
+        // n × [0,0,1] = [ny, -nx, 0]
+        const el = Math.sqrt(ny * ny + nx * nx);
+        e1x = ny / el;
+        e1y = -nx / el;
+        e1z = 0;
+      }
+
+      // Project two opposing silhouette points; their screen-space midpoint is
+      // the disc centre and half their distance is the disc radius.
       const m = input.defaultProjectionData.mainMatrix as unknown as Mat16;
-      const centerNDC = projectToNDC(m, 0, 0, 0);
-      const edgeNDC = projectToNDC(m, 1, 0, 0);
+      const sil1 = projectToNDC(m, scx + sRad * e1x, scy + sRad * e1y, scz + sRad * e1z);
+      const sil2 = projectToNDC(m, scx - sRad * e1x, scy - sRad * e1y, scz - sRad * e1z);
+
+      const centerNDC: [number, number] = [(sil1[0] + sil2[0]) / 2, (sil1[1] + sil2[1]) / 2];
 
       const w = gl.drawingBufferWidth;
       const h = gl.drawingBufferHeight;
 
-      // Compute radius in physical pixels (accounts for viewport aspect ratio)
-      const dxNDC = edgeNDC[0] - centerNDC[0];
-      const dyNDC = edgeNDC[1] - centerNDC[1];
+      const dxNDC = sil1[0] - centerNDC[0];
+      const dyNDC = sil1[1] - centerNDC[1];
       const radiusPx = Math.sqrt((dxNDC * (w / 2)) ** 2 + (dyNDC * (h / 2)) ** 2);
 
-      // Guard against degenerate matrices (e.g. during projection transitions
-      // where the globe might not yet be on screen or the matrix is singular).
+      // Guard against degenerate matrices (e.g. during projection transitions).
       if (!isFinite(radiusPx) || radiusPx < 1 || radiusPx > 20_000) return;
 
       // Scale CSS-pixel widths to physical pixels using the canvas DPR.

--- a/packages/shared/src/golarion-map/halo.ts
+++ b/packages/shared/src/golarion-map/halo.ts
@@ -1,0 +1,396 @@
+// Screen-space atmospheric halo for the Golarion globe — player-portal only.
+//
+// Renders a soft radial glow ring just outside the globe's projected silhouette,
+// providing the depth cue that makes the globe read as a sphere in space rather
+// than a flat disc on a background.
+//
+// The layer covers the full viewport with a quad (NDC space). The fragment shader
+// converts each pixel's distance from the globe disc centre into a smooth alpha
+// profile: fading in from just inside the silhouette, peaking at the silhouette
+// edge, then decaying outward over the configured band width.
+//
+// Globe silhouette radius and screen-centre are derived each frame from
+// MapLibre's globe projection matrix so the halo tracks zoom and pan correctly.
+//
+// Usage (after style.load, before pin layer):
+//   import { createHaloLayer } from '@foundry-toolkit/shared/golarion-map';
+//   map.on('load', () => {
+//     map.addLayer(createHaloLayer());  // add before pin icons
+//   });
+
+import type { CustomLayerInterface, CustomRenderMethodInput, Map as MaplibreMap } from 'maplibre-gl';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Tunable knobs for the atmospheric halo layer. All fields are optional; the
+ *  defaults produce a clearly visible atmospheric rim that reads as planetary
+ *  curvature without obscuring the map surface. */
+export interface HaloOptions {
+  /** Width of the glow band outside the globe silhouette, in CSS pixels. Default: 35 */
+  widthPx?: number;
+  /** How far inside the silhouette the alpha tapers to zero, in CSS pixels.
+   *  A small value (default: 8) provides anti-aliasing at the limb without
+   *  painting over the map surface. */
+  innerFeatherPx?: number;
+  /** Halo colour as linear RGB [R, G, B] in the 0–1 range.
+   *  Default: atmospheric blue [0.18, 0.52, 1.0]. */
+  color?: [number, number, number];
+  /** Peak opacity of the halo at the silhouette edge. Default: 0.75 */
+  opacity?: number;
+}
+
+export interface ResolvedHaloOptions {
+  widthPx: number;
+  innerFeatherPx: number;
+  color: [number, number, number];
+  opacity: number;
+}
+
+// ---------------------------------------------------------------------------
+// Options merging (exported for unit testing)
+// ---------------------------------------------------------------------------
+
+/** Merge caller-supplied options with per-field defaults. */
+export function mergeHaloOptions(options?: HaloOptions): ResolvedHaloOptions {
+  return {
+    widthPx: options?.widthPx ?? 35,
+    innerFeatherPx: options?.innerFeatherPx ?? 8,
+    color: options?.color ?? [0.18, 0.52, 1.0],
+    opacity: options?.opacity ?? 0.75,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Geometry — full-screen quad (2 triangles, 6 vertices in NDC)
+// ---------------------------------------------------------------------------
+
+const QUAD_VERTS = new Float32Array([-1, -1, 1, -1, -1, 1, 1, -1, 1, 1, -1, 1]);
+
+// ---------------------------------------------------------------------------
+// GLSL sources
+// ---------------------------------------------------------------------------
+
+/** Vertex shader — passes NDC positions straight through; no globe matrix needed. */
+const VERT_SRC = /* glsl */ `#version 300 es
+precision mediump float;
+
+in  vec2 a_pos;
+out vec2 v_ndc;
+
+void main() {
+  gl_Position = vec4(a_pos, 0.0, 1.0);
+  v_ndc = a_pos;
+}`;
+
+/**
+ * Fragment shader — renders a smooth glow ring at the globe silhouette.
+ *
+ * Distances are computed in physical-pixel space (accounting for the viewport
+ * dimensions) so the halo band width is invariant to viewport aspect ratio.
+ *
+ * Alpha profile (d = signed pixel distance from silhouette; positive = outside):
+ *   d < -innerFeather  → 0  (inside the globe — no bleed onto the surface)
+ *   d ∈ [-inner, 0]    → ramps 0 → 1  (soft inner edge / anti-alias)
+ *   d = 0              → peak = 1  (the silhouette itself)
+ *   d ∈ [0, width]     → decays 1 → 0  (the atmospheric glow band into space)
+ *   d > width          → 0  (void; stars show through)
+ */
+const FRAG_SRC = /* glsl */ `#version 300 es
+precision mediump float;
+
+uniform vec2  u_viewport;    // physical pixel dimensions [w, h]
+uniform vec2  u_center_ndc;  // globe disc centre in NDC
+uniform float u_radius_px;   // globe disc radius in physical pixels
+uniform float u_width_px;    // outer glow width in physical pixels
+uniform float u_inner_px;    // inner feather width in physical pixels
+uniform vec3  u_color;       // halo colour (linear RGB)
+uniform float u_opacity;     // peak opacity
+
+in  vec2 v_ndc;
+out vec4 fragColor;
+
+void main() {
+  // Convert NDC → physical-pixel offset from globe centre, preserving aspect ratio
+  vec2  p_px    = (v_ndc - u_center_ndc) * u_viewport * 0.5;
+  float dist_px = length(p_px);
+
+  // Signed distance from the silhouette: positive = outside, negative = inside
+  float d = dist_px - u_radius_px;
+
+  // Outer decay: 1 at d = 0, smoothly 0 at d = +width
+  float outer = smoothstep(u_width_px, 0.0, d);
+  // Inner taper: 0 at d = -inner, smoothly 1 at d = 0
+  float inner = smoothstep(-u_inner_px, 0.0, d);
+
+  fragColor = vec4(u_color, inner * outer * u_opacity);
+}`;
+
+// ---------------------------------------------------------------------------
+// WebGL helpers
+// ---------------------------------------------------------------------------
+
+type GL2 = WebGL2RenderingContext;
+
+function compileShader(gl: GL2, type: number, src: string): WebGLShader | null {
+  const shader = gl.createShader(type);
+  if (!shader) return null;
+  gl.shaderSource(shader, src);
+  gl.compileShader(shader);
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    console.warn('[shared:halo] Shader compile failed:', gl.getShaderInfoLog(shader));
+    gl.deleteShader(shader);
+    return null;
+  }
+  return shader;
+}
+
+function buildProgram(gl: GL2, vertSrc: string, fragSrc: string): WebGLProgram | null {
+  const vs = compileShader(gl, gl.VERTEX_SHADER, vertSrc);
+  const fs = compileShader(gl, gl.FRAGMENT_SHADER, fragSrc);
+  if (!vs || !fs) return null;
+
+  const prog = gl.createProgram();
+  if (!prog) return null;
+
+  gl.attachShader(prog, vs);
+  gl.attachShader(prog, fs);
+  gl.linkProgram(prog);
+  gl.deleteShader(vs);
+  gl.deleteShader(fs);
+
+  if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) {
+    console.warn('[shared:halo] Shader link failed:', gl.getProgramInfoLog(prog));
+    gl.deleteProgram(prog);
+    return null;
+  }
+  return prog;
+}
+
+// ---------------------------------------------------------------------------
+// Projection helpers — derive globe disc centre and radius from the matrix
+// ---------------------------------------------------------------------------
+
+/**
+ * Column-major 4×4 matrix as a fixed-length tuple.
+ * Using a tuple type (rather than ArrayLike<number>) means numeric literal
+ * index access returns exactly `number` under noUncheckedIndexedAccess.
+ */
+type Mat16 = readonly [
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+];
+
+/**
+ * Multiply a column-major 4×4 matrix by a homogeneous 4-vector.
+ * Returns [x, y, z, w].
+ */
+function mat4MulVec4(m: Mat16, x: number, y: number, z: number, w: number): [number, number, number, number] {
+  return [
+    m[0] * x + m[4] * y + m[8] * z + m[12] * w,
+    m[1] * x + m[5] * y + m[9] * z + m[13] * w,
+    m[2] * x + m[6] * y + m[10] * z + m[14] * w,
+    m[3] * x + m[7] * y + m[11] * z + m[15] * w,
+  ];
+}
+
+/**
+ * Project a globe-space point through the MapLibre projection matrix and
+ * return its NDC position [x, y] after the homogeneous perspective divide.
+ */
+function projectToNDC(m: Mat16, x: number, y: number, z: number): [number, number] {
+  const [cx, cy, , cw] = mat4MulVec4(m, x, y, z, 1);
+  const w = cw === 0 ? 1 : cw;
+  return [cx / w, cy / w];
+}
+
+// ---------------------------------------------------------------------------
+// Public factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a screen-space atmospheric halo custom layer for the Golarion globe.
+ * Register it in the `load` event handler **after** any cloud layers and
+ * **before** pin / icon layers so the halo sits above the globe surface but
+ * below map markers.
+ *
+ * @example
+ * ```ts
+ * map.on('load', () => {
+ *   map.addLayer(createHaloLayer());      // halo above globe, below pins
+ *   map.addLayer({ id: PIN_LAYER, ... }); // pins on top
+ * });
+ * ```
+ */
+export function createHaloLayer(options?: HaloOptions): CustomLayerInterface {
+  const opts = mergeHaloOptions(options);
+
+  // GL resources — allocated in onAdd, freed in onRemove
+  let _gl: GL2 | null = null;
+  let _program: WebGLProgram | null = null;
+  let _vao: WebGLVertexArrayObject | null = null;
+  let _vbo: WebGLBuffer | null = null;
+  let _map: MaplibreMap | null = null;
+
+  // Cached uniform locations
+  let _uViewport: WebGLUniformLocation | null = null;
+  let _uCenterNDC: WebGLUniformLocation | null = null;
+  let _uRadiusPx: WebGLUniformLocation | null = null;
+  let _uWidthPx: WebGLUniformLocation | null = null;
+  let _uInnerPx: WebGLUniformLocation | null = null;
+  let _uColor: WebGLUniformLocation | null = null;
+  let _uOpacity: WebGLUniformLocation | null = null;
+
+  return {
+    id: 'golarion-halo',
+    type: 'custom',
+    // '3d' renders in the same compositing pass as globe tiles and clouds,
+    // respecting the layer stack order so the halo sits above them.
+    renderingMode: '3d',
+
+    onAdd(map: MaplibreMap, gl: WebGLRenderingContext | WebGL2RenderingContext): void {
+      _map = map;
+      _gl = gl as GL2;
+
+      _program = buildProgram(_gl, VERT_SRC, FRAG_SRC);
+      if (!_program) {
+        console.warn('[shared:halo] Shader build failed; atmospheric halo will be absent');
+        return;
+      }
+
+      _vao = _gl.createVertexArray();
+      if (!_vao) {
+        console.warn('[shared:halo] createVertexArray() returned null; atmospheric halo will be absent');
+        _gl.deleteProgram(_program);
+        _program = null;
+        return;
+      }
+
+      _gl.bindVertexArray(_vao);
+
+      _vbo = _gl.createBuffer();
+      _gl.bindBuffer(_gl.ARRAY_BUFFER, _vbo);
+      _gl.bufferData(_gl.ARRAY_BUFFER, QUAD_VERTS, _gl.STATIC_DRAW);
+
+      const aPos = _gl.getAttribLocation(_program, 'a_pos');
+      _gl.enableVertexAttribArray(aPos);
+      _gl.vertexAttribPointer(aPos, 2, _gl.FLOAT, false, 0, 0);
+
+      _gl.bindVertexArray(null);
+      _gl.bindBuffer(_gl.ARRAY_BUFFER, null);
+
+      _uViewport = _gl.getUniformLocation(_program, 'u_viewport');
+      _uCenterNDC = _gl.getUniformLocation(_program, 'u_center_ndc');
+      _uRadiusPx = _gl.getUniformLocation(_program, 'u_radius_px');
+      _uWidthPx = _gl.getUniformLocation(_program, 'u_width_px');
+      _uInnerPx = _gl.getUniformLocation(_program, 'u_inner_px');
+      _uColor = _gl.getUniformLocation(_program, 'u_color');
+      _uOpacity = _gl.getUniformLocation(_program, 'u_opacity');
+
+      console.info('[shared:halo] Atmospheric halo layer added', {
+        widthPx: opts.widthPx,
+        innerFeatherPx: opts.innerFeatherPx,
+        color: opts.color,
+        opacity: opts.opacity,
+      });
+    },
+
+    render(_glCtx: WebGLRenderingContext | WebGL2RenderingContext, input: CustomRenderMethodInput): void {
+      if (!_program || !_vao || !_gl || !_map) return;
+      const gl = _gl;
+
+      // Derive the globe disc centre and radius in NDC from the projection matrix.
+      //
+      // The globe is a unit sphere in MapLibre's globe coordinate system.
+      // Projecting [0,0,0] gives the disc centre (sphere origin → screen centre).
+      // Projecting [1,0,0] (an equatorial edge point) gives the approximate
+      // silhouette edge — accurate within ~6% at zoom 2, well within the soft
+      // inner-feather tolerance.
+      // Cast to Mat16 so literal-index access is typed as number, not
+      // number | undefined (required by noUncheckedIndexedAccess).
+      const m = input.defaultProjectionData.mainMatrix as unknown as Mat16;
+      const centerNDC = projectToNDC(m, 0, 0, 0);
+      const edgeNDC = projectToNDC(m, 1, 0, 0);
+
+      const w = gl.drawingBufferWidth;
+      const h = gl.drawingBufferHeight;
+
+      // Compute radius in physical pixels (accounts for viewport aspect ratio)
+      const dxNDC = edgeNDC[0] - centerNDC[0];
+      const dyNDC = edgeNDC[1] - centerNDC[1];
+      const radiusPx = Math.sqrt((dxNDC * (w / 2)) ** 2 + (dyNDC * (h / 2)) ** 2);
+
+      // Guard against degenerate matrices (e.g. during projection transitions
+      // where the globe might not yet be on screen or the matrix is singular).
+      if (!isFinite(radiusPx) || radiusPx < 1 || radiusPx > 20_000) return;
+
+      // Scale CSS-pixel widths to physical pixels using the canvas DPR.
+      const canvas = _map.getCanvas();
+      const dpr = canvas.width / Math.max(1, canvas.clientWidth);
+      const widthPx = opts.widthPx * dpr;
+      const innerPx = opts.innerFeatherPx * dpr;
+
+      // Save relevant GL state that this layer modifies
+      const prevBlend = gl.isEnabled(gl.BLEND);
+      const prevDepthTest = gl.isEnabled(gl.DEPTH_TEST);
+
+      gl.enable(gl.BLEND);
+      gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+      gl.disable(gl.DEPTH_TEST);
+      gl.depthMask(false);
+
+      gl.useProgram(_program);
+      gl.bindVertexArray(_vao);
+
+      gl.uniform2f(_uViewport, w, h);
+      gl.uniform2f(_uCenterNDC, centerNDC[0], centerNDC[1]);
+      gl.uniform1f(_uRadiusPx, radiusPx);
+      gl.uniform1f(_uWidthPx, widthPx);
+      gl.uniform1f(_uInnerPx, innerPx);
+      gl.uniform3f(_uColor, opts.color[0], opts.color[1], opts.color[2]);
+      gl.uniform1f(_uOpacity, opts.opacity);
+
+      gl.drawArrays(gl.TRIANGLES, 0, 6);
+
+      gl.bindVertexArray(null);
+
+      // Restore GL state
+      if (!prevBlend) gl.disable(gl.BLEND);
+      if (prevDepthTest) gl.enable(gl.DEPTH_TEST);
+      gl.depthMask(true);
+    },
+
+    onRemove(_m: MaplibreMap, gl: WebGLRenderingContext | WebGL2RenderingContext): void {
+      const g = gl as GL2;
+      if (_program) {
+        g.deleteProgram(_program);
+        _program = null;
+      }
+      if (_vbo) {
+        g.deleteBuffer(_vbo);
+        _vbo = null;
+      }
+      if (_vao) {
+        g.deleteVertexArray(_vao);
+        _vao = null;
+      }
+      _gl = null;
+      _map = null;
+    },
+  };
+}

--- a/packages/shared/src/golarion-map/index.ts
+++ b/packages/shared/src/golarion-map/index.ts
@@ -11,3 +11,5 @@ export { startAutoRotate } from './auto-rotate.js';
 export type { AutoRotateOptions } from './auto-rotate.js';
 export { createCloudsLayer, mergeCloudsOptions } from './clouds.js';
 export type { CloudsOptions } from './clouds.js';
+export { createHaloLayer, mergeHaloOptions } from './halo.js';
+export type { HaloOptions, ResolvedHaloOptions } from './halo.js';

--- a/packages/shared/src/golarion-map/index.ts
+++ b/packages/shared/src/golarion-map/index.ts
@@ -13,3 +13,5 @@ export { createCloudsLayer, mergeCloudsOptions } from './clouds.js';
 export type { CloudsOptions } from './clouds.js';
 export { createHaloLayer, mergeHaloOptions } from './halo.js';
 export type { HaloOptions, ResolvedHaloOptions } from './halo.js';
+export { createLimbDarkeningLayer, mergeLimbOptions } from './limb.js';
+export type { LimbOptions, ResolvedLimbOptions } from './limb.js';

--- a/packages/shared/src/golarion-map/limb.test.ts
+++ b/packages/shared/src/golarion-map/limb.test.ts
@@ -9,20 +9,20 @@ import { mergeLimbOptions } from './limb.js';
 describe('mergeLimbOptions — defaults', () => {
   it('returns all defaults when called with no argument', () => {
     const opts = mergeLimbOptions();
-    expect(opts.opacity).toBe(0.3);
-    expect(opts.exponent).toBe(1.5);
+    expect(opts.opacity).toBe(0.5);
+    expect(opts.exponent).toBe(1.0);
   });
 
   it('returns all defaults when called with an empty object', () => {
     const opts = mergeLimbOptions({});
-    expect(opts.opacity).toBe(0.3);
-    expect(opts.exponent).toBe(1.5);
+    expect(opts.opacity).toBe(0.5);
+    expect(opts.exponent).toBe(1.0);
   });
 
   it('returns all defaults when called with undefined', () => {
     const opts = mergeLimbOptions(undefined);
-    expect(opts.opacity).toBe(0.3);
-    expect(opts.exponent).toBe(1.5);
+    expect(opts.opacity).toBe(0.5);
+    expect(opts.exponent).toBe(1.0);
   });
 });
 
@@ -30,15 +30,15 @@ describe('mergeLimbOptions — defaults', () => {
 
 describe('mergeLimbOptions — partial overrides', () => {
   it('applies opacity override while keeping exponent default', () => {
-    const opts = mergeLimbOptions({ opacity: 0.5 });
-    expect(opts.opacity).toBe(0.5);
-    expect(opts.exponent).toBe(1.5);
+    const opts = mergeLimbOptions({ opacity: 0.7 });
+    expect(opts.opacity).toBe(0.7);
+    expect(opts.exponent).toBe(1.0);
   });
 
   it('applies exponent override while keeping opacity default', () => {
     const opts = mergeLimbOptions({ exponent: 3.0 });
     expect(opts.exponent).toBe(3.0);
-    expect(opts.opacity).toBe(0.3);
+    expect(opts.opacity).toBe(0.5);
   });
 });
 

--- a/packages/shared/src/golarion-map/limb.test.ts
+++ b/packages/shared/src/golarion-map/limb.test.ts
@@ -1,0 +1,75 @@
+// Unit tests for pure helpers in limb.ts.
+// WebGL rendering is skipped — custom layers require a GPU context unavailable in jsdom.
+
+import { describe, expect, it } from 'vitest';
+import { mergeLimbOptions } from './limb.js';
+
+// ---- mergeLimbOptions — defaults --------------------------------------------
+
+describe('mergeLimbOptions — defaults', () => {
+  it('returns all defaults when called with no argument', () => {
+    const opts = mergeLimbOptions();
+    expect(opts.opacity).toBe(0.3);
+    expect(opts.exponent).toBe(1.5);
+  });
+
+  it('returns all defaults when called with an empty object', () => {
+    const opts = mergeLimbOptions({});
+    expect(opts.opacity).toBe(0.3);
+    expect(opts.exponent).toBe(1.5);
+  });
+
+  it('returns all defaults when called with undefined', () => {
+    const opts = mergeLimbOptions(undefined);
+    expect(opts.opacity).toBe(0.3);
+    expect(opts.exponent).toBe(1.5);
+  });
+});
+
+// ---- mergeLimbOptions — partial overrides -----------------------------------
+
+describe('mergeLimbOptions — partial overrides', () => {
+  it('applies opacity override while keeping exponent default', () => {
+    const opts = mergeLimbOptions({ opacity: 0.5 });
+    expect(opts.opacity).toBe(0.5);
+    expect(opts.exponent).toBe(1.5);
+  });
+
+  it('applies exponent override while keeping opacity default', () => {
+    const opts = mergeLimbOptions({ exponent: 3.0 });
+    expect(opts.exponent).toBe(3.0);
+    expect(opts.opacity).toBe(0.3);
+  });
+});
+
+// ---- mergeLimbOptions — full override ---------------------------------------
+
+describe('mergeLimbOptions — full override', () => {
+  it('uses all caller-supplied values when every field is provided', () => {
+    const opts = mergeLimbOptions({ opacity: 0.6, exponent: 2.0 });
+    expect(opts.opacity).toBe(0.6);
+    expect(opts.exponent).toBe(2.0);
+  });
+});
+
+// ---- mergeLimbOptions — edge cases ------------------------------------------
+
+describe('mergeLimbOptions — edge cases', () => {
+  it('accepts opacity of 0 (no darkening)', () => {
+    expect(mergeLimbOptions({ opacity: 0 }).opacity).toBe(0);
+  });
+
+  it('accepts opacity of 1 (maximum darkening)', () => {
+    expect(mergeLimbOptions({ opacity: 1 }).opacity).toBe(1);
+  });
+
+  it('accepts exponent of 0 (uniform darkening across entire disc)', () => {
+    expect(mergeLimbOptions({ exponent: 0 }).exponent).toBe(0);
+  });
+
+  it('does not mutate the input options object', () => {
+    const input = { opacity: 0.4 };
+    mergeLimbOptions(input);
+    expect(input).toEqual({ opacity: 0.4 });
+  });
+});

--- a/packages/shared/src/golarion-map/limb.ts
+++ b/packages/shared/src/golarion-map/limb.ts
@@ -1,0 +1,406 @@
+// Screen-space limb darkening for the Golarion globe — player-portal only.
+//
+// Darkens the globe surface near the silhouette, mimicking the reduced
+// brightness at glancing viewing angles (terrain viewed through more
+// atmosphere at the limb). This is a subtle but effective depth cue — the
+// eye reads the gradient as spherical curvature.
+//
+// Implementation: a full-screen quad whose fragment shader computes each
+// pixel's normalised distance from the globe centre and applies the
+// physically-motivated limb darkening law:
+//
+//   darkening = (1 − cos θ)^exponent
+//   where cos θ = sqrt(1 − r²),  r = dist_from_centre / globe_radius
+//
+// Zero at the disc centre, peak at the silhouette. Globe disc centre and
+// radius are derived from defaultProjectionData.clippingPlane each frame —
+// the same rotationally-stable approach as the halo layer.
+//
+// Usage (after style.load, before cloud layer):
+//   import { createLimbDarkeningLayer } from '@foundry-toolkit/shared/golarion-map';
+//   map.on('style.load', () => {
+//     map.addLayer(createLimbDarkeningLayer()); // under the clouds
+//     map.addLayer(createCloudsLayer());
+//   });
+
+import type { CustomLayerInterface, CustomRenderMethodInput, Map as MaplibreMap } from 'maplibre-gl';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Tunable knobs for the limb darkening layer. Both fields are optional;
+ *  the defaults produce a subtle effect that is clearly perceptible as
+ *  curvature without visibly obscuring the map surface. */
+export interface LimbOptions {
+  /** Peak opacity of the dark overlay at the silhouette edge (0–1). Default: 0.3 */
+  opacity?: number;
+  /**
+   * Exponent of the power curve applied after the (1 − cos θ) term.
+   * Higher values concentrate the darkening more tightly at the very edge;
+   * lower values spread it further across the disc.
+   * Default: 1.5 (moderate concentration — visible in the outer ~20% of the radius).
+   */
+  exponent?: number;
+}
+
+export interface ResolvedLimbOptions {
+  opacity: number;
+  exponent: number;
+}
+
+// ---------------------------------------------------------------------------
+// Options merging (exported for unit testing)
+// ---------------------------------------------------------------------------
+
+/** Merge caller-supplied options with per-field defaults. */
+export function mergeLimbOptions(options?: LimbOptions): ResolvedLimbOptions {
+  return {
+    opacity: options?.opacity ?? 0.3,
+    exponent: options?.exponent ?? 1.5,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Geometry — full-screen quad (2 triangles, 6 vertices in NDC)
+// ---------------------------------------------------------------------------
+
+const QUAD_VERTS = new Float32Array([-1, -1, 1, -1, -1, 1, 1, -1, 1, 1, -1, 1]);
+
+// ---------------------------------------------------------------------------
+// GLSL sources
+// ---------------------------------------------------------------------------
+
+/** Vertex shader — passes NDC position straight through. */
+const VERT_SRC = /* glsl */ `#version 300 es
+precision mediump float;
+
+in  vec2 a_pos;
+out vec2 v_ndc;
+
+void main() {
+  gl_Position = vec4(a_pos, 0.0, 1.0);
+  v_ndc = a_pos;
+}`;
+
+/**
+ * Fragment shader — applies limb darkening inside the globe disc.
+ *
+ * For each fragment, r = pixel_distance / globe_radius ∈ [0, 1].
+ *
+ *   cos θ      = sqrt(1 − r²)   (orthographic surface normal angle)
+ *   darkening  = (1 − cos θ)^exponent
+ *
+ * A short smoothstep near r = 1 prevents a hard cut-off at the silhouette.
+ * Fragments at r ≥ 1 are discarded so nothing renders in the void.
+ */
+const FRAG_SRC = /* glsl */ `#version 300 es
+precision mediump float;
+
+uniform vec2  u_viewport;    // physical pixel dimensions [w, h]
+uniform vec2  u_center_ndc;  // globe disc centre in NDC
+uniform float u_radius_px;   // globe disc radius in physical pixels
+uniform float u_opacity;     // peak darkening opacity
+uniform float u_exponent;    // power-curve exponent
+
+in  vec2 v_ndc;
+out vec4 fragColor;
+
+void main() {
+  // Physical-pixel distance from disc centre, accounting for aspect ratio
+  vec2  p_px = (v_ndc - u_center_ndc) * u_viewport * 0.5;
+  float dist  = length(p_px);
+
+  // Normalised radius: 0 at disc centre, 1 at silhouette
+  float r = dist / u_radius_px;
+
+  // Nothing to darken outside the globe
+  if (r >= 1.0) discard;
+
+  // Physically-motivated limb darkening:
+  //   cos θ = component of surface normal along the view direction (ortho approx)
+  //   darkening = (1 − cos θ)^exponent  →  0 at centre, 1 at the very edge
+  float cos_theta = sqrt(max(0.0, 1.0 - r * r));
+  float darkening = pow(1.0 - cos_theta, u_exponent);
+
+  // Soft feather in the outermost ~5 % of the radius to avoid a hard
+  // silhouette line where the overlay meets the void.
+  float edge_fade = smoothstep(1.0, 0.95, r);
+
+  // Output as a black overlay; blended with SRC_ALPHA / ONE_MINUS_SRC_ALPHA
+  // this darkens underlying pixels proportionally.
+  fragColor = vec4(0.0, 0.0, 0.0, darkening * u_opacity * edge_fade);
+}`;
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+type GL2 = WebGL2RenderingContext;
+
+/** Column-major 4×4 matrix as a fixed-length tuple (noUncheckedIndexedAccess). */
+type Mat16 = readonly [
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+];
+
+/** 4-component vector as a fixed-length tuple. */
+type Vec4 = readonly [number, number, number, number];
+
+function mat4MulVec4(m: Mat16, x: number, y: number, z: number, w: number): [number, number, number, number] {
+  return [
+    m[0] * x + m[4] * y + m[8] * z + m[12] * w,
+    m[1] * x + m[5] * y + m[9] * z + m[13] * w,
+    m[2] * x + m[6] * y + m[10] * z + m[14] * w,
+    m[3] * x + m[7] * y + m[11] * z + m[15] * w,
+  ];
+}
+
+function projectToNDC(m: Mat16, x: number, y: number, z: number): [number, number] {
+  const [cx, cy, , cw] = mat4MulVec4(m, x, y, z, 1);
+  const w = cw === 0 ? 1 : cw;
+  return [cx / w, cy / w];
+}
+
+function compileShader(gl: GL2, type: number, src: string): WebGLShader | null {
+  const shader = gl.createShader(type);
+  if (!shader) return null;
+  gl.shaderSource(shader, src);
+  gl.compileShader(shader);
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    console.warn('[shared:limb] Shader compile failed:', gl.getShaderInfoLog(shader));
+    gl.deleteShader(shader);
+    return null;
+  }
+  return shader;
+}
+
+function buildProgram(gl: GL2, vertSrc: string, fragSrc: string): WebGLProgram | null {
+  const vs = compileShader(gl, gl.VERTEX_SHADER, vertSrc);
+  const fs = compileShader(gl, gl.FRAGMENT_SHADER, fragSrc);
+  if (!vs || !fs) return null;
+
+  const prog = gl.createProgram();
+  if (!prog) return null;
+
+  gl.attachShader(prog, vs);
+  gl.attachShader(prog, fs);
+  gl.linkProgram(prog);
+  gl.deleteShader(vs);
+  gl.deleteShader(fs);
+
+  if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) {
+    console.warn('[shared:limb] Shader link failed:', gl.getProgramInfoLog(prog));
+    gl.deleteProgram(prog);
+    return null;
+  }
+  return prog;
+}
+
+// ---------------------------------------------------------------------------
+// Public factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a screen-space limb darkening custom layer for the Golarion globe.
+ * Register it in the `style.load` handler **before** the cloud layer so the
+ * darkening is visible beneath any cloud cover.
+ *
+ * @example
+ * ```ts
+ * map.on('style.load', () => {
+ *   map.setProjection({ type: 'globe' });
+ *   map.addLayer(createLimbDarkeningLayer()); // darkens terrain at the limb
+ *   map.addLayer(createCloudsLayer());         // clouds on top
+ * });
+ * ```
+ */
+export function createLimbDarkeningLayer(options?: LimbOptions): CustomLayerInterface {
+  const opts = mergeLimbOptions(options);
+
+  // GL resources — allocated in onAdd, freed in onRemove
+  let _gl: GL2 | null = null;
+  let _program: WebGLProgram | null = null;
+  let _vao: WebGLVertexArrayObject | null = null;
+  let _vbo: WebGLBuffer | null = null;
+  let _map: MaplibreMap | null = null;
+
+  // Cached uniform locations
+  let _uViewport: WebGLUniformLocation | null = null;
+  let _uCenterNDC: WebGLUniformLocation | null = null;
+  let _uRadiusPx: WebGLUniformLocation | null = null;
+  let _uOpacity: WebGLUniformLocation | null = null;
+  let _uExponent: WebGLUniformLocation | null = null;
+
+  return {
+    id: 'golarion-limb',
+    type: 'custom',
+    renderingMode: '3d',
+
+    onAdd(map: MaplibreMap, gl: WebGLRenderingContext | WebGL2RenderingContext): void {
+      _map = map;
+      _gl = gl as GL2;
+
+      _program = buildProgram(_gl, VERT_SRC, FRAG_SRC);
+      if (!_program) {
+        console.warn('[shared:limb] Shader build failed; limb darkening will be absent');
+        return;
+      }
+
+      _vao = _gl.createVertexArray();
+      if (!_vao) {
+        console.warn('[shared:limb] createVertexArray() returned null; limb darkening will be absent');
+        _gl.deleteProgram(_program);
+        _program = null;
+        return;
+      }
+
+      _gl.bindVertexArray(_vao);
+
+      _vbo = _gl.createBuffer();
+      _gl.bindBuffer(_gl.ARRAY_BUFFER, _vbo);
+      _gl.bufferData(_gl.ARRAY_BUFFER, QUAD_VERTS, _gl.STATIC_DRAW);
+
+      const aPos = _gl.getAttribLocation(_program, 'a_pos');
+      _gl.enableVertexAttribArray(aPos);
+      _gl.vertexAttribPointer(aPos, 2, _gl.FLOAT, false, 0, 0);
+
+      _gl.bindVertexArray(null);
+      _gl.bindBuffer(_gl.ARRAY_BUFFER, null);
+
+      _uViewport = _gl.getUniformLocation(_program, 'u_viewport');
+      _uCenterNDC = _gl.getUniformLocation(_program, 'u_center_ndc');
+      _uRadiusPx = _gl.getUniformLocation(_program, 'u_radius_px');
+      _uOpacity = _gl.getUniformLocation(_program, 'u_opacity');
+      _uExponent = _gl.getUniformLocation(_program, 'u_exponent');
+
+      console.info('[shared:limb] Limb darkening layer added', {
+        opacity: opts.opacity,
+        exponent: opts.exponent,
+      });
+    },
+
+    render(_glCtx: WebGLRenderingContext | WebGL2RenderingContext, input: CustomRenderMethodInput): void {
+      if (!_program || !_vao || !_gl || !_map) return;
+      const gl = _gl;
+
+      // Derive globe disc centre and radius from the clipping plane.
+      // See halo.ts for the full derivation — this is the same approach.
+      const cp = input.defaultProjectionData.clippingPlane as unknown as Vec4;
+      const cnx = cp[0],
+        cny = cp[1],
+        cnz = cp[2],
+        cnd = cp[3];
+      const nlen = Math.sqrt(cnx * cnx + cny * cny + cnz * cnz);
+      if (nlen < 1e-6) return;
+
+      const nx = cnx / nlen,
+        ny = cny / nlen,
+        nz = cnz / nlen;
+      const dd = cnd / nlen;
+      const scx = -dd * nx,
+        scy = -dd * ny,
+        scz = -dd * nz;
+      const sRad = Math.sqrt(Math.max(0, 1 - dd * dd));
+      if (sRad < 1e-6) return;
+
+      // Tangent vector perpendicular to the clip-plane normal
+      let e1x: number, e1y: number, e1z: number;
+      const absNx = Math.abs(nx),
+        absNy = Math.abs(ny),
+        absNz = Math.abs(nz);
+      if (absNx <= absNy && absNx <= absNz) {
+        const el = Math.sqrt(nz * nz + ny * ny);
+        e1x = 0;
+        e1y = nz / el;
+        e1z = -ny / el;
+      } else if (absNy <= absNz) {
+        const el = Math.sqrt(nz * nz + nx * nx);
+        e1x = -nz / el;
+        e1y = 0;
+        e1z = nx / el;
+      } else {
+        const el = Math.sqrt(ny * ny + nx * nx);
+        e1x = ny / el;
+        e1y = -nx / el;
+        e1z = 0;
+      }
+
+      const m = input.defaultProjectionData.mainMatrix as unknown as Mat16;
+      const sil1 = projectToNDC(m, scx + sRad * e1x, scy + sRad * e1y, scz + sRad * e1z);
+      const sil2 = projectToNDC(m, scx - sRad * e1x, scy - sRad * e1y, scz - sRad * e1z);
+
+      const centerNDC: [number, number] = [(sil1[0] + sil2[0]) / 2, (sil1[1] + sil2[1]) / 2];
+
+      const w = gl.drawingBufferWidth;
+      const h = gl.drawingBufferHeight;
+
+      const dxNDC = sil1[0] - centerNDC[0];
+      const dyNDC = sil1[1] - centerNDC[1];
+      const radiusPx = Math.sqrt((dxNDC * (w / 2)) ** 2 + (dyNDC * (h / 2)) ** 2);
+
+      if (!isFinite(radiusPx) || radiusPx < 1 || radiusPx > 20_000) return;
+
+      // Save GL state
+      const prevBlend = gl.isEnabled(gl.BLEND);
+      const prevDepthTest = gl.isEnabled(gl.DEPTH_TEST);
+
+      gl.enable(gl.BLEND);
+      gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+      gl.disable(gl.DEPTH_TEST);
+      gl.depthMask(false);
+
+      gl.useProgram(_program);
+      gl.bindVertexArray(_vao);
+
+      // radiusPx is already in physical pixels (derived from drawingBufferWidth),
+      // so no DPR conversion needed here.
+      gl.uniform2f(_uViewport, w, h);
+      gl.uniform2f(_uCenterNDC, centerNDC[0], centerNDC[1]);
+      gl.uniform1f(_uRadiusPx, radiusPx);
+      gl.uniform1f(_uOpacity, opts.opacity);
+      gl.uniform1f(_uExponent, opts.exponent);
+
+      gl.drawArrays(gl.TRIANGLES, 0, 6);
+
+      gl.bindVertexArray(null);
+
+      // Restore GL state
+      if (!prevBlend) gl.disable(gl.BLEND);
+      if (prevDepthTest) gl.enable(gl.DEPTH_TEST);
+      gl.depthMask(true);
+    },
+
+    onRemove(_m: MaplibreMap, gl: WebGLRenderingContext | WebGL2RenderingContext): void {
+      const g = gl as GL2;
+      if (_program) {
+        g.deleteProgram(_program);
+        _program = null;
+      }
+      if (_vbo) {
+        g.deleteBuffer(_vbo);
+        _vbo = null;
+      }
+      if (_vao) {
+        g.deleteVertexArray(_vao);
+        _vao = null;
+      }
+      _gl = null;
+      _map = null;
+    },
+  };
+}

--- a/packages/shared/src/golarion-map/limb.ts
+++ b/packages/shared/src/golarion-map/limb.ts
@@ -33,13 +33,13 @@ import type { CustomLayerInterface, CustomRenderMethodInput, Map as MaplibreMap 
  *  the defaults produce a subtle effect that is clearly perceptible as
  *  curvature without visibly obscuring the map surface. */
 export interface LimbOptions {
-  /** Peak opacity of the dark overlay at the silhouette edge (0–1). Default: 0.3 */
+  /** Peak opacity of the dark overlay at the silhouette edge (0–1). Default: 0.5 */
   opacity?: number;
   /**
    * Exponent of the power curve applied after the (1 − cos θ) term.
    * Higher values concentrate the darkening more tightly at the very edge;
    * lower values spread it further across the disc.
-   * Default: 1.5 (moderate concentration — visible in the outer ~20% of the radius).
+   * Default: 1.0 — effect is visible across the outer ~30% of the radius.
    */
   exponent?: number;
 }
@@ -56,8 +56,8 @@ export interface ResolvedLimbOptions {
 /** Merge caller-supplied options with per-field defaults. */
 export function mergeLimbOptions(options?: LimbOptions): ResolvedLimbOptions {
   return {
-    opacity: options?.opacity ?? 0.3,
-    exponent: options?.exponent ?? 1.5,
+    opacity: options?.opacity ?? 0.5,
+    exponent: options?.exponent ?? 1.0,
   };
 }
 
@@ -91,8 +91,10 @@ void main() {
  *   cos θ      = sqrt(1 − r²)   (orthographic surface normal angle)
  *   darkening  = (1 − cos θ)^exponent
  *
- * A short smoothstep near r = 1 prevents a hard cut-off at the silhouette.
- * Fragments at r ≥ 1 are discarded so nothing renders in the void.
+ * Zero at the disc centre, increases continuously, maximum at r → 1.
+ * Fragments at r ≥ 1 are discarded. The halo layer handles the soft
+ * silhouette transition outside the disc, so no extra edge feather is
+ * needed here — adding one suppresses the peak darkening at the rim.
  */
 const FRAG_SRC = /* glsl */ `#version 300 es
 precision mediump float;
@@ -119,17 +121,12 @@ void main() {
 
   // Physically-motivated limb darkening:
   //   cos θ = component of surface normal along the view direction (ortho approx)
-  //   darkening = (1 − cos θ)^exponent  →  0 at centre, 1 at the very edge
+  //   darkening = (1 − cos θ)^exponent  →  0 at centre, peaks at r = 1
   float cos_theta = sqrt(max(0.0, 1.0 - r * r));
   float darkening = pow(1.0 - cos_theta, u_exponent);
 
-  // Soft feather in the outermost ~5 % of the radius to avoid a hard
-  // silhouette line where the overlay meets the void.
-  float edge_fade = smoothstep(1.0, 0.95, r);
-
-  // Output as a black overlay; blended with SRC_ALPHA / ONE_MINUS_SRC_ALPHA
-  // this darkens underlying pixels proportionally.
-  fragColor = vec4(0.0, 0.0, 0.0, darkening * u_opacity * edge_fade);
+  // Black overlay: SRC_ALPHA / ONE_MINUS_SRC_ALPHA blend darkens the tiles beneath.
+  fragColor = vec4(0.0, 0.0, 0.0, darkening * u_opacity);
 }`;
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The Golarion globe was reading as a flat disc on the starfield rather than a sphere in space. This PR adds three complementary rendering layers (player-portal only) that together give the globe proper planetary depth:

1. **Atmospheric halo** (`createHaloLayer`) — a soft blue glow ring just outside the silhouette, implemented as a screen-space WebGL quad. Globe silhouette is derived from `clippingPlane` each frame (rotationally stable; an earlier equatorial-point approach caused the ring to pulse during auto-rotation). Defaults: widthPx 18, opacity 0.45, atmospheric blue.

2. **Limb darkening** (`createLimbDarkeningLayer`) — a black overlay inside the globe disc following the physically-motivated law `(1 − cos θ)^n`, where `cos θ = sqrt(1 − r²)`. Zero at the disc centre, peaks (~50%) at the very edge. Registered before the cloud layer so it darkens terrain visible through cloud cover. Defaults: opacity 0.5, exponent 1.0 (effect visible across the outer ~30% of the radius).

`buildMapStyle()` and the dm-tool globe are unchanged throughout.

## Changes
- `packages/shared/src/golarion-map/halo.ts` — new `createHaloLayer()` + types + clip-plane silhouette derivation
- `packages/shared/src/golarion-map/limb.ts` — new `createLimbDarkeningLayer()` + types
- `packages/shared/src/golarion-map/halo.test.ts` / `limb.test.ts` — Vitest coverage of defaults/overrides
- `packages/shared/src/golarion-map/index.ts` — re-exports both new symbols
- `apps/player-portal/src/routes/Globe.tsx` — registers limb (style.load, before clouds) and halo (load, before pins)

## Test plan
- [x] `npm run test -w packages/shared` passes (119 tests across 8 files)
- [x] `npm run typecheck` clean across all workspaces
- [x] `npm run lint` / `format:check` clean
- [x] CI green
- [x] Visual: globe shows curved atmospheric rim + darkened edge, reads clearly as a 3D sphere