### PR TITLE
fix(dm-tool): pin chat and settings icons to trailing edge of header

### DIFF
--- a/apps/dm-tool/src/App.tsx
+++ b/apps/dm-tool/src/App.tsx
@@ -140,7 +140,7 @@ function MainApp() {
               />
             </div>
           )}
-        <div className="flex items-center gap-1" style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}>
+        <div className="ml-auto flex items-center gap-1" style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}>
           <button
             type="button"
             aria-label="Toggle chat"


### PR DESCRIPTION
## Summary
The Chat and Settings icons in the dm-tool header bar shifted leftward on tabs that hide the search box (tools, globe, inventory, aurus, combat). The search box uses `flex-1` to push the icons to the right when present, but without it they fell back to normal flex flow, landing in a different horizontal position.

Adding `ml-auto` to the button container anchors it to the trailing edge at all times, making the icon position invariant to the search box's visibility.

## Changes
- `apps/dm-tool/src/App.tsx`: add `ml-auto` to the chat/settings button container div

## Test plan
- [ ] Switch between Maps/Books/Monsters/Items (search visible) and Tools/Globe/Inventory/Aurus/Combat (search hidden) — Chat and Settings icons stay at the same horizontal position