### PR TITLE
fix(shared): constrain MissionBriefing card width and clear Electron title-bar overlay

### DIFF
--- a/packages/shared/src/MissionBriefing.tsx
+++ b/packages/shared/src/MissionBriefing.tsx
@@ -165,22 +165,30 @@ export function MissionBriefing({ mission, onClose, actions }: Props) {
   const secondaryObjectives = mission.objectives.filter((o) => !o.isPrimary);
 
   return (
+    // Backdrop: fixed full-screen overlay that scrolls when the parchment is
+    // taller than the viewport. flex + justifyContent:center is the reliable
+    // way to constrain the inner card width — block-flow margin:auto inside
+    // overflow-y:auto fixed containers is inconsistent in Chromium.
+    // paddingTop 64 px on the inner div clears dm-tool's 54 px titleBarOverlay
+    // (hidden title bar, Electron native min/max/close rendered over content).
     <div
       className="fixed inset-0 z-50 overflow-y-auto"
-      style={{ background: 'rgba(0, 0, 0, 0.75)', backdropFilter: 'blur(4px)' }}
+      style={{
+        background: 'rgba(0, 0, 0, 0.75)',
+        backdropFilter: 'blur(4px)',
+        display: 'flex',
+        justifyContent: 'center',
+      }}
       onClick={onClose}
     >
-      {/*
-       * max-w-3xl via Tailwind alone can fail to materialise under Tailwind 4 JIT
-       * during hot-reload (see dm-tool CLAUDE.md gotcha), so maxWidth is also set
-       * as an inline style. paddingTop of 64 px clears the 54 px native window-
-       * control overlay that dm-tool adds via titleBarOverlay (hidden title bar with
-       * Electron's native min/max/close buttons rendered over the content area).
-       * The extra ~10 px gap is harmless in any browser-based consumer.
-       */}
       <div
-        className="mx-auto w-full max-w-3xl px-8 pb-8"
-        style={{ maxWidth: 680, paddingTop: 64 }}
+        style={{
+          width: '100%',
+          maxWidth: 680,
+          padding: '64px 32px 32px',
+          alignSelf: 'flex-start',
+          flexShrink: 0,
+        }}
         onClick={(e) => e.stopPropagation()}
       >
         {/* Toolbar */}

--- a/packages/shared/src/MissionBriefing.tsx
+++ b/packages/shared/src/MissionBriefing.tsx
@@ -170,7 +170,19 @@ export function MissionBriefing({ mission, onClose, actions }: Props) {
       style={{ background: 'rgba(0, 0, 0, 0.75)', backdropFilter: 'blur(4px)' }}
       onClick={onClose}
     >
-      <div className="mx-auto w-full max-w-3xl p-8" onClick={(e) => e.stopPropagation()}>
+      {/*
+       * max-w-3xl via Tailwind alone can fail to materialise under Tailwind 4 JIT
+       * during hot-reload (see dm-tool CLAUDE.md gotcha), so maxWidth is also set
+       * as an inline style. paddingTop of 64 px clears the 54 px native window-
+       * control overlay that dm-tool adds via titleBarOverlay (hidden title bar with
+       * Electron's native min/max/close buttons rendered over the content area).
+       * The extra ~10 px gap is harmless in any browser-based consumer.
+       */}
+      <div
+        className="mx-auto w-full max-w-3xl px-8 pb-8"
+        style={{ maxWidth: 680, paddingTop: 64 }}
+        onClick={(e) => e.stopPropagation()}
+      >
         {/* Toolbar */}
         <div className="mb-3 flex justify-end gap-2">
           {actions}


### PR DESCRIPTION
## Summary

Two visual bugs in the globe-panel mission card:

1. **Full-width card** — `max-width + margin:auto` on a block inside a `fixed overflow-y:auto` container does not reliably constrain the card width in Chromium: the block-flow containing-block resolution makes `width:100%` fill the full viewport with no room for `margin:auto` to distribute. Fixed by adding `display:flex; justify-content:center` to the backdrop div and making the inner card a flex item (`max-width:680; align-self:flex-start`).

2. **Buttons hidden under native window controls** — dm-tool uses `titleBarStyle:"hidden"` with `titleBarOverlay` (height 54 px), so Electron's min/max/close buttons float over the content area from y=0. Bumped top padding to 64 px (54 px overlay + 10 px gap). The extra top space is harmless in browser-based consumers (player-portal).

## Changes
- `packages/shared/src/MissionBriefing.tsx`: backdrop becomes a flex centering container; inner div switches from Tailwind width classes to pure inline `maxWidth:680 / padding:64px 32px 32px / alignSelf:flex-start / flexShrink:0`

## Test plan
- [ ] Open a mission pin in dm-tool globe — card should be ~680 px wide, centred, with "Link Note" / "Close" buttons visible below the native window controls
- [ ] Verify backdrop click still closes the card
- [ ] Verify player-portal mission display is unaffected (slightly more top padding, parchment no wider than 680 px)
- [ ] Verify tall parchments (many objectives/threats) still scroll correctly