### PR TITLE
fix(dm-tool): replace window.confirm in combat tracker delete with in-app modal

### DIFF
--- a/apps/dm-tool/src/features/combat/EncounterList.test.tsx
+++ b/apps/dm-tool/src/features/combat/EncounterList.test.tsx
@@ -1,0 +1,96 @@
+/** @vitest-environment happy-dom */
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { Encounter } from '@foundry-toolkit/shared/types';
+import { EncounterList } from './EncounterList';
+
+function mkEncounter(id: string, name: string): Encounter {
+  return {
+    id,
+    name,
+    combatants: [],
+    turnIndex: 0,
+    round: 1,
+    loot: [],
+    allowInventedItems: false,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+const ENC_A = mkEncounter('enc-1', 'Goblin Ambush');
+const ENC_B = mkEncounter('enc-2', 'Dragon Fight');
+
+function renderList(onDelete = vi.fn()) {
+  render(
+    <EncounterList
+      encounters={[ENC_A, ENC_B]}
+      activeId="enc-1"
+      loading={false}
+      onSelect={vi.fn()}
+      onCreate={vi.fn()}
+      onDelete={onDelete}
+    />,
+  );
+  return { onDelete };
+}
+
+describe('EncounterList — delete confirmation modal', () => {
+  it('does not call onDelete immediately when the trash button is clicked', () => {
+    const { onDelete } = renderList();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Goblin Ambush' }));
+
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it('opens a dialog showing the encounter name when the trash button is clicked', () => {
+    renderList();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Goblin Ambush' }));
+
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByText(/goblin ambush/i)).toBeTruthy();
+  });
+
+  it('calls onDelete with the correct encounter id when the user confirms', () => {
+    const { onDelete } = renderList();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Goblin Ambush' }));
+    const dialog = screen.getByRole('dialog');
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete' }));
+
+    expect(onDelete).toHaveBeenCalledOnce();
+    expect(onDelete).toHaveBeenCalledWith('enc-1');
+  });
+
+  it('does not call onDelete when the user cancels', () => {
+    const { onDelete } = renderList();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Goblin Ambush' }));
+    const dialog = screen.getByRole('dialog');
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it('dismisses the dialog after the user confirms', () => {
+    const { onDelete } = renderList();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Goblin Ambush' }));
+    const dialog = screen.getByRole('dialog');
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete' }));
+
+    expect(onDelete).toHaveBeenCalledWith('enc-1');
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('opens the correct encounter name for a second encounter', () => {
+    renderList();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Dragon Fight' }));
+
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByText(/dragon fight/i)).toBeTruthy();
+  });
+});

--- a/apps/dm-tool/src/features/combat/EncounterList.tsx
+++ b/apps/dm-tool/src/features/combat/EncounterList.tsx
@@ -1,6 +1,16 @@
+import { type MouseEvent, useState } from 'react';
 import { Plus, Trash2 } from 'lucide-react';
 import type { Encounter } from '@foundry-toolkit/shared/types';
 import { cn } from '@/lib/utils';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
 
 interface Props {
   encounters: Encounter[];
@@ -12,6 +22,28 @@ interface Props {
 }
 
 export function EncounterList({ encounters, activeId, loading, onSelect, onCreate, onDelete }: Props) {
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+
+  const pendingEncounter = pendingDeleteId != null ? (encounters.find((e) => e.id === pendingDeleteId) ?? null) : null;
+
+  function handleDeleteRequest(ev: MouseEvent<HTMLButtonElement>, id: string, name: string): void {
+    ev.stopPropagation();
+    console.info('[EncounterList] delete confirm shown — encounter id:', id, 'name:', name);
+    setPendingDeleteId(id);
+  }
+
+  function handleConfirm(): void {
+    if (pendingDeleteId == null) return;
+    console.info('[EncounterList] delete confirmed — encounter id:', pendingDeleteId);
+    onDelete(pendingDeleteId);
+    setPendingDeleteId(null);
+  }
+
+  function handleDismiss(): void {
+    console.info('[EncounterList] delete dismissed — encounter id:', pendingDeleteId);
+    setPendingDeleteId(null);
+  }
+
   return (
     <>
       <div
@@ -65,10 +97,7 @@ export function EncounterList({ encounters, activeId, loading, onSelect, onCreat
               </div>
               <button
                 type="button"
-                onClick={(ev) => {
-                  ev.stopPropagation();
-                  if (window.confirm(`Delete encounter "${e.name}"?`)) onDelete(e.id);
-                }}
+                onClick={(ev) => handleDeleteRequest(ev, e.id, e.name)}
                 aria-label={`Delete ${e.name}`}
                 className="rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-destructive/15 hover:text-destructive group-hover:opacity-100"
               >
@@ -78,6 +107,30 @@ export function EncounterList({ encounters, activeId, loading, onSelect, onCreat
           ))
         )}
       </div>
+
+      <Dialog
+        open={pendingDeleteId !== null}
+        onOpenChange={(open) => {
+          if (!open) handleDismiss();
+        }}
+      >
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Delete encounter</DialogTitle>
+            <DialogDescription>
+              Delete &ldquo;{pendingEncounter?.name ?? ''}&rdquo;? This cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" size="sm" onClick={handleDismiss}>
+              Cancel
+            </Button>
+            <Button variant="destructive" size="sm" onClick={handleConfirm}>
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }


### PR DESCRIPTION
## Summary

The encounter list's delete button was calling `window.confirm()`, spawning a native Windows dialog that breaks the app's visual consistency. Replaced with the Radix Dialog already used elsewhere in dm-tool (SettingsDialog, TaggerDialog), keeping the same look and feel as the rest of the UI.

## Changes

- `EncounterList.tsx`: remove `window.confirm`; add `pendingDeleteId` state; render a controlled `<Dialog>` with Cancel and Delete (destructive) buttons; log `console.info` on show, confirm, and dismiss
- `EncounterList.test.tsx`: new Vitest component test (happy-dom) covering the confirm flow — no immediate delete on click, dialog shows encounter name, confirm fires `onDelete` with correct id, cancel does not fire, dialog dismisses after confirm

## Test plan

- [x] `npm run test -w apps/dm-tool` — 263 tests pass
- [x] `npm run typecheck -w apps/dm-tool` — clean
- [x] `npm run lint:fix` — no new errors (2 pre-existing warnings unrelated to this change)
- [x] `npm run format:check` — clean