### PR TITLE
feat(dm-tool): add lore info chip and hide +0 skills in monster detail panel

### DIFF
--- a/apps/dm-tool/src/features/monsters/MonsterDetailPane.tsx
+++ b/apps/dm-tool/src/features/monsters/MonsterDetailPane.tsx
@@ -1,10 +1,12 @@
 import * as HoverCard from '@radix-ui/react-hover-card';
-import { ExternalLink, X } from 'lucide-react';
+import { ExternalLink, Info, X } from 'lucide-react';
+import { useState } from 'react';
 import { cn } from '@/lib/utils';
 import { cleanFoundryMarkup } from '@/lib/foundry-markup';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Separator } from '@/components/ui/separator';
 import type { MonsterDetail, MonsterSpellGroup, MonsterSpellInfo } from '@foundry-toolkit/shared/types';
+import { formatSkills } from './monster-skills';
 
 const RARITY_BADGE: Record<string, string> = {
   common: 'bg-zinc-600 text-zinc-100',
@@ -22,6 +24,8 @@ interface Props {
 
 export function MonsterDetailPane({ detail, loading, onOpenExternal, onClose }: Props) {
   const mod = (n: number) => (n >= 0 ? `+${n}` : `${n}`);
+  const [loreOpen, setLoreOpen] = useState(false);
+  const formattedSkills = formatSkills(detail.skills);
 
   return (
     <>
@@ -46,6 +50,20 @@ export function MonsterDetailPane({ detail, loading, onOpenExternal, onClose }: 
           </span>
         ))}
         <div className="flex-1" />
+        {detail.description && (
+          <button
+            type="button"
+            onClick={() => setLoreOpen((prev) => !prev)}
+            aria-pressed={loreOpen}
+            aria-label={loreOpen ? 'Hide lore' : 'Show lore'}
+            className={cn(
+              'flex h-7 w-7 shrink-0 items-center justify-center rounded-md transition-colors',
+              loreOpen ? 'bg-accent text-foreground' : 'text-muted-foreground hover:bg-accent hover:text-foreground',
+            )}
+          >
+            <Info className="h-4 w-4" />
+          </button>
+        )}
         <button
           type="button"
           onClick={onClose}
@@ -77,15 +95,15 @@ export function MonsterDetailPane({ detail, loading, onOpenExternal, onClose }: 
           {/* Right content */}
           <ScrollArea className="min-h-0 min-w-0 flex-1">
             <div className="space-y-4 p-4">
-              {/* Description */}
-              {detail.description && (
+              {/* Lore — visible only when the info chip is active */}
+              {loreOpen && detail.description && (
                 <p className="text-xs leading-relaxed text-muted-foreground">{detail.description}</p>
               )}
 
               {/* Speed, Skills, Immunities/Weaknesses/Resistances */}
               <div className="space-y-1 text-xs">
                 <Stat label="Speed" value={detail.speed} />
-                {detail.skills && <Stat label="Skills" value={formatSkills(detail.skills)} />}
+                {formattedSkills && <Stat label="Skills" value={formattedSkills} />}
                 {detail.immunities && <Stat label="Immunities" value={detail.immunities} />}
                 {detail.weaknesses && <Stat label="Weaknesses" value={detail.weaknesses} />}
                 {detail.resistances && <Stat label="Resistances" value={detail.resistances} />}
@@ -183,17 +201,6 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
   return (
     <h3 className="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">{children}</h3>
   );
-}
-
-function formatSkills(raw: string): string {
-  try {
-    const obj: Record<string, number> = JSON.parse(raw);
-    return Object.entries(obj)
-      .map(([k, v]) => `${k.charAt(0).toUpperCase() + k.slice(1)} ${v >= 0 ? '+' : ''}${v}`)
-      .join(', ');
-  } catch {
-    return raw;
-  }
 }
 
 function Stat({ label, value }: { label: string; value: string }) {

--- a/apps/dm-tool/src/features/monsters/MonsterDetailPane.tsx
+++ b/apps/dm-tool/src/features/monsters/MonsterDetailPane.tsx
@@ -53,13 +53,10 @@ export function MonsterDetailPane({ detail, loading, onOpenExternal, onClose }: 
         {detail.description && (
           <button
             type="button"
-            onClick={() => setLoreOpen((prev) => !prev)}
-            aria-pressed={loreOpen}
-            aria-label={loreOpen ? 'Hide lore' : 'Show lore'}
-            className={cn(
-              'flex h-7 w-7 shrink-0 items-center justify-center rounded-md transition-colors',
-              loreOpen ? 'bg-accent text-foreground' : 'text-muted-foreground hover:bg-accent hover:text-foreground',
-            )}
+            aria-label="Show lore"
+            onMouseEnter={() => setLoreOpen(true)}
+            onMouseLeave={() => setLoreOpen(false)}
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
           >
             <Info className="h-4 w-4" />
           </button>
@@ -76,7 +73,7 @@ export function MonsterDetailPane({ detail, loading, onOpenExternal, onClose }: 
       {loading ? (
         <div className="flex flex-1 items-center justify-center text-xs text-muted-foreground">Loading…</div>
       ) : (
-        <div className="flex min-h-0 flex-1">
+        <div className="relative flex min-h-0 flex-1">
           {/* Left stat column */}
           <div className="flex w-16 shrink-0 flex-col items-center gap-3 border-r border-border py-3 text-[10px]">
             <StatCell label="AC" value={String(detail.ac)} />
@@ -95,11 +92,6 @@ export function MonsterDetailPane({ detail, loading, onOpenExternal, onClose }: 
           {/* Right content */}
           <ScrollArea className="min-h-0 min-w-0 flex-1">
             <div className="space-y-4 p-4">
-              {/* Lore — visible only when the info chip is active */}
-              {loreOpen && detail.description && (
-                <p className="text-xs leading-relaxed text-muted-foreground">{detail.description}</p>
-              )}
-
               {/* Speed, Skills, Immunities/Weaknesses/Resistances */}
               <div className="space-y-1 text-xs">
                 <Stat label="Speed" value={detail.speed} />
@@ -174,6 +166,17 @@ export function MonsterDetailPane({ detail, loading, onOpenExternal, onClose }: 
               )}
             </div>
           </ScrollArea>
+
+          {/* Lore overlay — covers the full content area on info-chip hover */}
+          {loreOpen && detail.description && (
+            <div
+              className="absolute inset-0 z-10 overflow-y-auto bg-background/50 px-5 py-4 backdrop-blur-sm"
+              onMouseEnter={() => setLoreOpen(true)}
+              onMouseLeave={() => setLoreOpen(false)}
+            >
+              <p className="text-xs leading-relaxed text-foreground/90">{detail.description}</p>
+            </div>
+          )}
         </div>
       )}
 

--- a/apps/dm-tool/src/features/monsters/monster-skills.test.ts
+++ b/apps/dm-tool/src/features/monsters/monster-skills.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { formatSkills } from './monster-skills';
+
+describe('formatSkills', () => {
+  // -----------------------------------------------------------------------
+  // Plain string path (current projection output)
+  // -----------------------------------------------------------------------
+
+  it('formats a plain skill string unchanged when no +0 entries are present', () => {
+    expect(formatSkills('Stealth +12, Arcana +8')).toBe('Stealth +12, Arcana +8');
+  });
+
+  it('removes a +0 skill from the middle of a plain string', () => {
+    expect(formatSkills('Stealth +12, Athletics +0, Arcana +8')).toBe('Stealth +12, Arcana +8');
+  });
+
+  it('removes a +0 skill at the start of a plain string', () => {
+    expect(formatSkills('+0Skills +0, Stealth +12')).toBe('Stealth +12');
+  });
+
+  it('removes a +0 skill at the end of a plain string', () => {
+    expect(formatSkills('Stealth +12, Acrobatics +0')).toBe('Stealth +12');
+  });
+
+  it('keeps negative modifier skills', () => {
+    expect(formatSkills('Intimidation -2, Acrobatics +5')).toBe('Intimidation -2, Acrobatics +5');
+  });
+
+  it('returns an empty string when all plain-string skills are +0', () => {
+    expect(formatSkills('Athletics +0, Acrobatics +0')).toBe('');
+  });
+
+  it('handles a single non-zero skill', () => {
+    expect(formatSkills('Stealth +5')).toBe('Stealth +5');
+  });
+
+  it('handles a single +0 skill (returns empty string)', () => {
+    expect(formatSkills('Acrobatics +0')).toBe('');
+  });
+
+  it('returns empty string for an empty input', () => {
+    expect(formatSkills('')).toBe('');
+  });
+
+  // -----------------------------------------------------------------------
+  // JSON path (legacy DB)
+  // -----------------------------------------------------------------------
+
+  it('parses JSON skills and formats them', () => {
+    expect(formatSkills('{"stealth":12,"arcana":8}')).toBe('Stealth +12, Arcana +8');
+  });
+
+  it('filters out +0 skills from JSON', () => {
+    expect(formatSkills('{"stealth":12,"athletics":0,"arcana":8}')).toBe('Stealth +12, Arcana +8');
+  });
+
+  it('keeps negative modifier skills from JSON', () => {
+    expect(formatSkills('{"intimidation":-2,"acrobatics":5}')).toBe('Intimidation -2, Acrobatics +5');
+  });
+
+  it('returns empty string when all JSON skills are zero', () => {
+    expect(formatSkills('{"athletics":0,"acrobatics":0}')).toBe('');
+  });
+
+  it('capitalises the first letter of JSON skill keys', () => {
+    expect(formatSkills('{"loreLibrary":3}')).toBe('LoreLibrary +3');
+  });
+});

--- a/apps/dm-tool/src/features/monsters/monster-skills.ts
+++ b/apps/dm-tool/src/features/monsters/monster-skills.ts
@@ -1,0 +1,33 @@
+/**
+ * Format and filter the `skills` field from a `MonsterDetail`.
+ *
+ * Skills arrive in one of two shapes:
+ *  - Legacy DB path: a JSON object string `{"stealth":12,"athletics":0}`.
+ *  - Current compendium-projection path: a plain comma-separated string
+ *    `"Stealth +12, Athletics +0, Arcana +8"` produced by `monsterSkills()`.
+ *
+ * In both cases skills whose modifier is exactly +0 are omitted — they add
+ * no meaningful information to the stat block display.
+ */
+export function formatSkills(raw: string): string {
+  if (!raw) return '';
+  try {
+    // JSON path (legacy DB): {"stealth":12,"athletics":0}
+    const obj: Record<string, number> = JSON.parse(raw) as Record<string, number>;
+    return Object.entries(obj)
+      .filter(([, v]) => v !== 0)
+      .map(([k, v]) => `${k.charAt(0).toUpperCase() + k.slice(1)} ${v >= 0 ? '+' : ''}${v}`)
+      .join(', ');
+  } catch {
+    // Plain string path: "Stealth +12, Athletics +0, Arcana +8"
+    return raw
+      .split(',')
+      .map((s) => s.trim())
+      .filter((entry) => {
+        const parts = entry.split(/\s+/);
+        const mod = parts[parts.length - 1];
+        return mod !== '+0';
+      })
+      .join(', ');
+  }
+}


### PR DESCRIPTION
## Summary

Adds two quality-of-life improvements to the monster detail panel:

1. **Lore hover overlay** — an `Info` icon chip appears in the top-right header when the monster has a description. Hovering the chip reveals the lore text as a semi-transparent overlay (`bg-background/50 backdrop-blur-sm`) that covers the full stat+scroll area, with the stat block visible beneath it at 50% opacity. Moving the mouse to the overlay keeps it open; moving off hides it.

2. **Hide +0 skills** — skills whose modifier is exactly zero are omitted from the Skills row. They carry no useful information and clutter the stat block for monsters that inherit a full skills object. The Skills row is hidden entirely when all skills resolve to zero.

## Changes

- `MonsterDetailPane.tsx` — Info chip button with `onMouseEnter`/`onMouseLeave`; `relative` wrapper on the content area; absolute lore overlay with hover chain.
- `monster-skills.ts` (new) — pure `formatSkills` helper supporting both the current plain-string projection format and the legacy JSON format, filtering +0 entries in both paths.
- `monster-skills.test.ts` (new) — 15 Vitest cases covering +0 filter, negative mods, JSON path, and edge cases.

## Test plan

- [ ] Hover the `ℹ` chip on any monster detail panel — overlay appears covering the content, stats visible through at 50% opacity. Move to overlay to read; move off to dismiss.
- [ ] Monster without a description — no `ℹ` chip rendered.
- [ ] Skills row omits any +0 entries; row absent entirely if all are zero.
- [ ] `npm run test -w apps/dm-tool` passes (271 tests).