### PR TITLE
feat(dm-tool): close detail panels on Escape key

### DIFF
--- a/apps/dm-tool/src/features/item-browser/ItemBrowser.tsx
+++ b/apps/dm-tool/src/features/item-browser/ItemBrowser.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
+import { useEscapeToClose } from '@/hooks/useEscapeToClose';
 import { ResizableSidebar } from '@/components/ResizableSidebar';
 import { DetailOverlay } from '@/components/FloatingPanel';
 import { ItemFilterPanel } from './ItemFilterPanel';
@@ -85,6 +86,7 @@ export function ItemBrowser({ keywords = '' }: { keywords?: string }) {
   );
 
   const handleClose = useCallback(() => setClosing(true), []);
+  useEscapeToClose(handleClose, selectedId !== null);
   const handleClosed = useCallback(() => {
     setSelectedId(null);
     setClosing(false);

--- a/apps/dm-tool/src/features/map-browser/MapBrowser.tsx
+++ b/apps/dm-tool/src/features/map-browser/MapBrowser.tsx
@@ -9,6 +9,7 @@ import { ThumbnailGrid, type ThumbnailItem } from './ThumbnailGrid';
 import { DetailPane } from './DetailPane';
 import { TaggerDialog } from './TaggerDialog';
 import { useFacets, useMapSearch, usePackMapping } from './useMaps';
+import { useEscapeToClose } from '@/hooks/useEscapeToClose';
 import { api } from '@/lib/api';
 import { cn } from '@/lib/utils';
 import type { MapSummary, SearchParams } from '@foundry-toolkit/shared/types';
@@ -138,6 +139,7 @@ export function MapBrowser({
   const [detailClosing, setDetailClosing] = useState(false);
 
   const closeDetail = useCallback(() => setDetailClosing(true), []);
+  useEscapeToClose(closeDetail, selectedFileName !== null);
   const handleDetailClosed = useCallback(() => {
     setSelectedFileName(null);
     setActiveVariants(null);

--- a/apps/dm-tool/src/features/monsters/MonsterBrowser.tsx
+++ b/apps/dm-tool/src/features/monsters/MonsterBrowser.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import { ResizableSidebar } from '@/components/ResizableSidebar';
 import { DetailOverlay } from '@/components/FloatingPanel';
+import { useEscapeToClose } from '@/hooks/useEscapeToClose';
 import { MonsterFilterPanel } from './MonsterFilterPanel';
 import { MonsterCardGrid } from './MonsterCardGrid';
 import { MonsterDetailPane } from './MonsterDetailPane';
@@ -38,6 +39,7 @@ export function MonsterBrowser({ keywords = '' }: { keywords?: string }) {
   );
 
   const handleClose = useCallback(() => setClosing(true), []);
+  useEscapeToClose(handleClose, selectedMonster !== null);
   const handleClosed = useCallback(() => {
     setSelectedMonster(null);
     setClosing(false);

--- a/apps/dm-tool/src/hooks/useEscapeToClose.test.ts
+++ b/apps/dm-tool/src/hooks/useEscapeToClose.test.ts
@@ -1,0 +1,124 @@
+/** @vitest-environment happy-dom */
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useEscapeToClose } from './useEscapeToClose';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+function fireEscapeOn(target: EventTarget): void {
+  target.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+}
+
+describe('useEscapeToClose', () => {
+  it('calls onClose when Escape is pressed and isOpen is true', () => {
+    const onClose = vi.fn();
+    renderHook(() => useEscapeToClose(onClose, true));
+
+    fireEscapeOn(document);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onClose when isOpen is false', () => {
+    const onClose = vi.fn();
+    renderHook(() => useEscapeToClose(onClose, false));
+
+    fireEscapeOn(document);
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('does not call onClose for non-Escape keys', () => {
+    const onClose = vi.fn();
+    renderHook(() => useEscapeToClose(onClose, true));
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('removes the listener after unmount', () => {
+    const onClose = vi.fn();
+    const { unmount } = renderHook(() => useEscapeToClose(onClose, true));
+
+    unmount();
+    fireEscapeOn(document);
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('removes the listener when isOpen flips to false', () => {
+    const onClose = vi.fn();
+    const { rerender } = renderHook(({ open }: { open: boolean }) => useEscapeToClose(onClose, open), {
+      initialProps: { open: true },
+    });
+
+    rerender({ open: false });
+    fireEscapeOn(document);
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('re-attaches the listener when isOpen flips back to true', () => {
+    const onClose = vi.fn();
+    const { rerender } = renderHook(({ open }: { open: boolean }) => useEscapeToClose(onClose, open), {
+      initialProps: { open: false },
+    });
+
+    rerender({ open: true });
+    fireEscapeOn(document);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the latest onClose callback without re-registering the listener', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { rerender } = renderHook(({ cb }: { cb: () => void }) => useEscapeToClose(cb, true), {
+      initialProps: { cb: first },
+    });
+
+    rerender({ cb: second });
+    fireEscapeOn(document);
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onClose when Escape originates from an <input>', () => {
+    const onClose = vi.fn();
+    renderHook(() => useEscapeToClose(onClose, true));
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    fireEscapeOn(input);
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('does not call onClose when Escape originates from a <textarea>', () => {
+    const onClose = vi.fn();
+    renderHook(() => useEscapeToClose(onClose, true));
+
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    fireEscapeOn(textarea);
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('does not call onClose when Escape originates from a contenteditable element', () => {
+    const onClose = vi.fn();
+    renderHook(() => useEscapeToClose(onClose, true));
+
+    const div = document.createElement('div');
+    div.contentEditable = 'true';
+    document.body.appendChild(div);
+    fireEscapeOn(div);
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/apps/dm-tool/src/hooks/useEscapeToClose.ts
+++ b/apps/dm-tool/src/hooks/useEscapeToClose.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Attaches a global keydown listener that calls onClose when Escape is pressed,
+ * but only while isOpen is true. The listener is removed when isOpen flips to false
+ * or the component unmounts.
+ *
+ * Skips closing when the event originates from an input, textarea, or contenteditable
+ * element so that Escape in a filter field doesn't accidentally close the panel.
+ *
+ * The callback is held in a ref so that stale-closure updates to onClose never
+ * force the listener to be torn down and re-registered.
+ */
+export function useEscapeToClose(onClose: () => void, isOpen: boolean): void {
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent): void => {
+      if (e.key !== 'Escape') return;
+      const target = e.target as HTMLElement | null;
+      if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement || target?.isContentEditable) {
+        return;
+      }
+      onCloseRef.current();
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen]);
+}


### PR DESCRIPTION
## Summary
Pressing Escape now dismisses the monster, item, and map detail panels in dm-tool. The close goes through the existing `handleClose`/`closeDetail` path so the slide-out animation plays normally. Escape is ignored when the keydown originates from an `<input>`, `<textarea>`, or `contenteditable` element so filter fields can still handle Escape without closing the panel.

## Changes
- New `useEscapeToClose(onClose, isOpen)` hook in `apps/dm-tool/src/hooks/` — attaches a `keydown` listener to `document` only while `isOpen` is true, uses a ref to hold the callback so stale closures never force listener re-registration
- Wired into `MonsterBrowser`, `ItemBrowser`, and `MapBrowser` with a single `useEscapeToClose(handleClose, selected !== null)` line each
- 10 Vitest tests covering: open/closed state, non-Escape keys, unmount cleanup, isOpen toggling, callback ref freshness, and input/textarea/contenteditable exclusion

## Panels covered
- Monster detail (`MonsterBrowser` → `MonsterDetailPane`)
- Item detail (`ItemBrowser` → `ItemDetailPane`)
- Map detail (`MapBrowser` → `DetailPane`)

## Deliberately skipped
None — all three detail panel patterns in dm-tool are covered.

## Test plan
- [ ] Open a monster/item/map detail panel and press Escape — panel slides out
- [ ] Press Escape with focus in the keyword search input — panel stays open
- [ ] `npm run test -w apps/dm-tool` passes (267 tests)