### PR TITLE
fix(player-portal): filter character list to PF2e player characters only

### DIFF
--- a/apps/foundry-api-bridge/src/commands/handlers/actor/GetActorsHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/GetActorsHandler.ts
@@ -23,6 +23,11 @@ export function getActorsHandler(_params: Record<string, never>): Promise<ActorS
   const actors: ActorSummary[] = [];
 
   getGame().actors.forEach((actor) => {
+    // Only return PF2e player-character actors. NPCs, familiars, loot
+    // containers, vehicles, and party actors are not relevant to the
+    // player portal's character list.
+    if (actor.type !== 'character') return;
+
     actors.push({
       id: actor.id,
       name: actor.name,

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/InvokeActorActionHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/InvokeActorActionHandler.ts
@@ -66,7 +66,7 @@ interface ActorsCollection {
   get(id: string): FoundryActor | undefined;
 }
 
-type PF2eActionFn = (options: Record<string, unknown>) => Promise<unknown> | unknown;
+type PF2eActionFn = (options: Record<string, unknown>) => unknown;
 
 interface FoundryGame {
   actors: ActorsCollection;
@@ -394,7 +394,7 @@ async function restForTheNightAction(
     );
   }
 
-  const result = (await restFn({ actors: [actor], skipDialog: true })) as unknown;
+  const result = (await restFn({ actors: [actor], skipDialog: true }));
   const messageCount = Array.isArray(result) ? result.length : 0;
 
   return { ok: true, messageCount };

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/__tests__/GetActorsHandler.test.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/__tests__/GetActorsHandler.test.ts
@@ -36,7 +36,7 @@ describe('getActorsHandler', () => {
     clearGame();
   });
 
-  it('should return all actors with correct fields', async () => {
+  it('should return only player character actors, excluding npcs and other types', async () => {
     setGame([
       createMockActor({ id: 'a1', name: 'Gandalf', type: 'npc', img: 'tokens/gandalf.webp' }),
       createMockActor({ id: 'a2', name: 'Frodo', type: 'character', img: 'tokens/frodo.webp' }),
@@ -45,11 +45,7 @@ describe('getActorsHandler', () => {
 
     const result = await getActorsHandler({} as Record<string, never>);
 
-    expect(result).toEqual([
-      { id: 'a1', name: 'Gandalf', type: 'npc', img: 'tokens/gandalf.webp' },
-      { id: 'a2', name: 'Frodo', type: 'character', img: 'tokens/frodo.webp' },
-      { id: 'a3', name: 'Wagon', type: 'vehicle', img: 'tokens/wagon.webp' },
-    ]);
+    expect(result).toEqual([{ id: 'a2', name: 'Frodo', type: 'character', img: 'tokens/frodo.webp' }]);
   });
 
   it('should return empty array for empty collection', async () => {
@@ -60,6 +56,19 @@ describe('getActorsHandler', () => {
     expect(result).toEqual([]);
   });
 
+  it('should return empty array when all actors are non-characters', async () => {
+    setGame([
+      createMockActor({ id: 'a1', type: 'npc' }),
+      createMockActor({ id: 'a2', type: 'vehicle' }),
+      createMockActor({ id: 'a3', type: 'familiar' }),
+      createMockActor({ id: 'a4', type: 'loot' }),
+    ]);
+
+    const result = await getActorsHandler({} as Record<string, never>);
+
+    expect(result).toHaveLength(0);
+  });
+
   it('should fallback img to empty string when undefined', async () => {
     setGame([createMockActor({ id: 'a1', name: 'No Image', img: undefined })]);
 
@@ -68,7 +77,7 @@ describe('getActorsHandler', () => {
     expect(result[0]?.img).toBe('');
   });
 
-  it('should return single actor as array of one', async () => {
+  it('should return single character actor as array of one', async () => {
     setGame([createMockActor({ id: 'solo', name: 'Solo' })]);
 
     const result = await getActorsHandler({} as Record<string, never>);
@@ -77,18 +86,20 @@ describe('getActorsHandler', () => {
     expect(result[0]?.id).toBe('solo');
   });
 
-  it('should include all actor types without filtering', async () => {
+  it('should exclude all non-character actor types', async () => {
     setGame([
-      createMockActor({ id: 'a1', type: 'character' }),
-      createMockActor({ id: 'a2', type: 'npc' }),
-      createMockActor({ id: 'a3', type: 'vehicle' }),
-      createMockActor({ id: 'a4', type: 'group' }),
+      createMockActor({ id: 'c1', type: 'character' }),
+      createMockActor({ id: 'n1', type: 'npc' }),
+      createMockActor({ id: 'v1', type: 'vehicle' }),
+      createMockActor({ id: 'g1', type: 'group' }),
+      createMockActor({ id: 'f1', type: 'familiar' }),
+      createMockActor({ id: 'l1', type: 'loot' }),
     ]);
 
     const result = await getActorsHandler({} as Record<string, never>);
 
-    expect(result).toHaveLength(4);
-    const types = result.map((a) => a.type);
-    expect(types).toEqual(['character', 'npc', 'vehicle', 'group']);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe('c1');
+    expect(result[0]?.type).toBe('character');
   });
 });

--- a/apps/foundry-api-bridge/src/commands/handlers/item/ActivateItemHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/item/ActivateItemHandler.ts
@@ -176,9 +176,9 @@ export async function activateItemHandler(params: ActivateItemParams): Promise<A
   let useResult: FoundryUsageResult | null = null;
 
   if (targetActivity) {
-    useResult = await targetActivity.use(config as Parameters<typeof targetActivity.use>[0]);
+    useResult = await targetActivity.use(config);
   } else {
-    useResult = await item.use(config as Parameters<typeof item.use>[0]);
+    useResult = await item.use(config);
   }
 
   let workflow: MidiWorkflowResult | undefined;

--- a/apps/foundry-api-bridge/src/commands/handlers/scene/CaptureSceneHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/scene/CaptureSceneHandler.ts
@@ -76,7 +76,7 @@ export function captureSceneHandler(_params: CaptureSceneParams): Promise<Captur
 
   const overlay = addGridOverlay(canvas as unknown as OverlayCanvas);
 
-  canvas.app.renderer.render(stage as unknown);
+  canvas.app.renderer.render(stage);
   const dataUrl = view.toDataURL(MIME_TYPE, QUALITY);
   const image = dataUrl.replace(BASE64_PREFIX_PATTERN, '');
 
@@ -87,7 +87,7 @@ export function captureSceneHandler(_params: CaptureSceneParams): Promise<Captur
   // Restore viewport
   stage.position.set(saved.px, saved.py);
   stage.scale.set(saved.sx, saved.sy);
-  canvas.app.renderer.render(stage as unknown);
+  canvas.app.renderer.render(stage);
 
   return Promise.resolve({
     sceneId: canvas.scene.id,

--- a/apps/foundry-api-bridge/src/commands/handlers/scene/GetSceneHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/scene/GetSceneHandler.ts
@@ -86,7 +86,7 @@ function captureScreenshot(canvas: FoundryCanvas): SceneScreenshot | undefined {
     const vw = (globalThis as unknown as { innerWidth: number }).innerWidth;
     const vh = (globalThis as unknown as { innerHeight: number }).innerHeight;
     const scale = Math.min(vw / dims.sceneWidth, vh / dims.sceneHeight);
-    (canvas as unknown as FoundryCanvas).pan({
+    (canvas).pan({
       x: dims.sceneX + dims.sceneWidth / 2,
       y: dims.sceneY + dims.sceneHeight / 2,
       scale,
@@ -95,7 +95,7 @@ function captureScreenshot(canvas: FoundryCanvas): SceneScreenshot | undefined {
 
     const overlay = addGridOverlay(canvas as unknown as OverlayCanvas);
 
-    canvas.app.renderer.render(stage as unknown);
+    canvas.app.renderer.render(stage);
     const dataUrl = view.toDataURL(MIME_TYPE, QUALITY);
     const image = dataUrl.replace(BASE64_PREFIX_PATTERN, '');
 
@@ -106,7 +106,7 @@ function captureScreenshot(canvas: FoundryCanvas): SceneScreenshot | undefined {
     // Restore viewport
     stage.position.set(saved.px, saved.py);
     stage.scale.set(saved.sx, saved.sy);
-    canvas.app.renderer.render(stage as unknown);
+    canvas.app.renderer.render(stage);
 
     return {
       image,

--- a/apps/player-portal/src/components/ActorList.test.tsx
+++ b/apps/player-portal/src/components/ActorList.test.tsx
@@ -18,7 +18,7 @@ describe('ActorList', () => {
     vi.restoreAllMocks();
   });
 
-  it('renders actor names on success', async () => {
+  it('renders player character names', async () => {
     vi.stubGlobal(
       'fetch',
       mockFetch([
@@ -30,7 +30,8 @@ describe('ActorList', () => {
     await waitFor(() => {
       expect(screen.getByText('Amiri')).toBeTruthy();
     });
-    expect(screen.getByText('Bandit')).toBeTruthy();
+    // NPCs must not appear in the character list
+    expect(screen.queryByText('Bandit')).toBeNull();
   });
 
   it('renders the API error envelope on failure', async () => {
@@ -51,6 +52,17 @@ describe('ActorList', () => {
     });
     expect(screen.getByText(/Start Foundry/)).toBeTruthy();
   });
+
+  it('renders empty-state when the list contains only non-character actors', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch([{ id: 'n1', name: 'Goblin Boss', type: 'npc', img: '' }]),
+    );
+    render(<ActorList />);
+    await waitFor(() => {
+      expect(screen.getByText(/No player characters in the world yet/)).toBeTruthy();
+    });
+  });
 });
 
 describe('env', () => {
@@ -62,7 +74,7 @@ describe('env', () => {
   it('renders empty-state when no actors', async () => {
     render(<ActorList />);
     await waitFor(() => {
-      expect(screen.getByText(/No actors in the world yet/)).toBeTruthy();
+      expect(screen.getByText(/No player characters in the world yet/)).toBeTruthy();
     });
   });
 });

--- a/apps/player-portal/src/components/ActorList.tsx
+++ b/apps/player-portal/src/components/ActorList.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { api, ApiRequestError } from '../api/client';
 import type { ActorSummary } from '../api/types';
+import { isPlayerCharacter } from '../lib/actor-utils';
 
 type State =
   | { kind: 'loading' }
@@ -46,15 +47,18 @@ export function ActorList({ onSelect }: Props = {}): React.ReactElement {
     );
   }
 
-  if (state.actors.length === 0) {
-    return <p className="text-sm text-pf-text-muted">No actors in the world yet.</p>;
+  // The bridge already filters to characters only; this is a defensive
+  // second layer in case a stale bridge or mock returns mixed actor types.
+  const characters = state.actors.filter(isPlayerCharacter);
+
+  if (characters.length === 0) {
+    return <p className="text-sm text-pf-text-muted">No player characters in the world yet.</p>;
   }
 
   return (
     <ul className="divide-y divide-pf-border rounded border border-pf-border">
-      {state.actors.map((actor) => {
-        const isCharacter = actor.type === 'character';
-        const clickable = isCharacter && onSelect !== undefined;
+      {characters.map((actor) => {
+        const clickable = onSelect !== undefined;
         return (
           <li
             key={actor.id}
@@ -71,7 +75,6 @@ export function ActorList({ onSelect }: Props = {}): React.ReactElement {
             }
           >
             <span className="flex-1 truncate font-medium">{actor.name}</span>
-            <span className="text-xs uppercase tracking-wide text-pf-text-muted">{actor.type}</span>
             {clickable && <span className="text-pf-text-muted">→</span>}
           </li>
         );

--- a/apps/player-portal/src/lib/actor-utils.test.ts
+++ b/apps/player-portal/src/lib/actor-utils.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { isPlayerCharacter } from './actor-utils';
+
+describe('isPlayerCharacter', () => {
+  it('returns true for type "character"', () => {
+    expect(isPlayerCharacter({ type: 'character' })).toBe(true);
+  });
+
+  it.each(['npc', 'familiar', 'loot', 'vehicle', 'party', 'hazard'])(
+    'returns false for type "%s"',
+    (type) => {
+      expect(isPlayerCharacter({ type })).toBe(false);
+    },
+  );
+});

--- a/apps/player-portal/src/lib/actor-utils.ts
+++ b/apps/player-portal/src/lib/actor-utils.ts
@@ -1,0 +1,10 @@
+import type { ActorSummary } from '../api/types';
+
+/** Returns true only for PF2e player-character actors (`type === 'character'`).
+ *  Used to exclude NPCs, familiars, loot containers, vehicles, and party
+ *  actors from the character list. The primary filter is applied at the
+ *  foundry-api-bridge level so the wire payload stays small; this helper
+ *  provides a defensive second layer in the UI and a testable predicate. */
+export function isPlayerCharacter(actor: Pick<ActorSummary, 'type'>): boolean {
+  return actor.type === 'character';
+}


### PR DESCRIPTION
## Summary

The characters page listed all Foundry actors — NPCs, familiars, loot containers, vehicles, party actors — alongside PCs. This changes the filter so only `type === 'character'` actors appear.

The primary filter is pushed to `foundry-api-bridge`'s `GetActorsHandler`, so the WebSocket response from Foundry only carries player-character actors (smaller wire payload). `ActorList.tsx` adds a defensive second-layer filter via an extracted `isPlayerCharacter(actor)` pure helper, which removes the now-redundant per-row `isCharacter` check and the actor-type badge (always "character" after filtering).

## Changes

- `apps/foundry-api-bridge/src/commands/handlers/actor/GetActorsHandler.ts` — skip non-`'character'` actors in the `forEach`
- `apps/player-portal/src/lib/actor-utils.ts` — new `isPlayerCharacter` pure predicate
- `apps/player-portal/src/lib/actor-utils.test.ts` — Vitest coverage for the predicate against all PF2e non-character types
- `apps/player-portal/src/components/ActorList.tsx` — filter via `isPlayerCharacter`; simplify row (remove type badge, remove dead `isCharacter` flag)
- `apps/foundry-api-bridge/src/commands/handlers/actor/__tests__/GetActorsHandler.test.ts` — updated Jest expectations; added tests for all-NPC list and mixed-type list
- `apps/player-portal/src/components/ActorList.test.tsx` — assert NPC absent; add test for all-NPC empty-state
- Pre-existing lint fixes in `InvokeActorActionHandler`, `ActivateItemHandler`, `CaptureSceneHandler`, `GetSceneHandler` (surfaced by `lint:fix`)

## Test plan

- [ ] `npm run test -w apps/player-portal` — 191 tests pass (new `actor-utils` + updated `ActorList`)
- [ ] `npm run test -w apps/foundry-api-bridge` — 752 tests pass (updated `GetActorsHandler`)
- [ ] `npm run typecheck -w apps/player-portal` — clean
- [ ] `npm run type-check -w apps/foundry-api-bridge` — clean
- [ ] Live: characters page shows only PC actors, no NPCs or other types