### PR TITLE
fix(dm-tool): apply monster facet filters client-side in listMonsters

### DIFF
--- a/apps/dm-tool/electron/compendium/prepared.test.ts
+++ b/apps/dm-tool/electron/compendium/prepared.test.ts
@@ -140,7 +140,7 @@ describe('searchMonsters', () => {
 });
 
 describe('listMonsters', () => {
-  it('returns every match when no keywords are supplied (no server-side filters)', async () => {
+  it('fetches all matches with no server-side facet filters (client-side post-filter only)', async () => {
     const search = vi.fn().mockResolvedValue({
       matches: [
         monsterMatch({ name: 'A', level: 1 }),
@@ -149,14 +149,9 @@ describe('listMonsters', () => {
       ],
     });
     const api = fakeApi({ searchCompendium: search });
-    // Non-keyword filters are intentionally ignored. Pack selection is
-    // the only filter sent over the wire; text search happens
-    // client-side against the returned list.
-    const out = await createPreparedCompendium(api).listMonsters({
-      levels: [3, 7],
-      traits: ['fire'],
-    });
-    expect(out.map((s) => s.name)).toEqual(['A', 'B', 'C']);
+    // The server call must NOT receive q / traits / maxLevel — those are
+    // applied client-side. Pack selection is the only thing sent over the wire.
+    await createPreparedCompendium(api).listMonsters({ levels: [3, 7], traits: ['fire'] });
     expect(search).toHaveBeenCalledWith(
       expect.objectContaining({
         limit: 10000,
@@ -168,6 +163,121 @@ describe('listMonsters', () => {
     expect(call).not.toHaveProperty('traits');
     expect(call).not.toHaveProperty('maxLevel');
     expect(call).not.toHaveProperty('documentType');
+  });
+
+  // ----- client-side filter regression tests -----
+  // These tests cover the bug where facet filters (level, rarity, size, etc.)
+  // were accepted by the UI but silently ignored — every filter change left
+  // the monster list unchanged.
+
+  it('filters by level range client-side', async () => {
+    const search = vi.fn().mockResolvedValue({
+      matches: [
+        monsterMatch({ name: 'A', level: 1 }),
+        monsterMatch({ name: 'B', level: 5 }),
+        monsterMatch({ name: 'C', level: 9 }),
+      ],
+    });
+    const api = fakeApi({ searchCompendium: search });
+    const out = await createPreparedCompendium(api).listMonsters({ levels: [3, 7] });
+    expect(out.map((s) => s.name)).toEqual(['B']);
+  });
+
+  it('filters by rarity client-side (case-insensitive)', async () => {
+    const search = vi.fn().mockResolvedValue({
+      matches: [
+        monsterMatch({ name: 'Common', rarity: 'common' }),
+        monsterMatch({ name: 'Rare', rarity: 'rare' }),
+        monsterMatch({ name: 'Uncommon', rarity: 'uncommon' }),
+      ],
+    });
+    const api = fakeApi({ searchCompendium: search });
+    const out = await createPreparedCompendium(api).listMonsters({ rarities: ['Rare'] });
+    expect(out.map((s) => s.name)).toEqual(['Rare']);
+  });
+
+  it('filters by size client-side', async () => {
+    const search = vi.fn().mockResolvedValue({
+      matches: [
+        monsterMatch({ name: 'Tiny', size: 'tiny' }),
+        monsterMatch({ name: 'Large', size: 'large' }),
+        monsterMatch({ name: 'Huge', size: 'huge' }),
+      ],
+    });
+    const api = fakeApi({ searchCompendium: search });
+    const out = await createPreparedCompendium(api).listMonsters({ sizes: ['large', 'huge'] });
+    expect(out.map((s) => s.name)).toEqual(['Large', 'Huge']);
+  });
+
+  it('filters by creature type client-side (case-insensitive)', async () => {
+    const search = vi.fn().mockResolvedValue({
+      matches: [
+        monsterMatch({ name: 'A Dragon', creatureType: 'Dragon' }),
+        monsterMatch({ name: 'A Humanoid', creatureType: 'Humanoid' }),
+        monsterMatch({ name: 'An Undead', creatureType: 'Undead' }),
+      ],
+    });
+    const api = fakeApi({ searchCompendium: search });
+    const out = await createPreparedCompendium(api).listMonsters({ creatureTypes: ['humanoid', 'undead'] });
+    expect(out.map((s) => s.name)).toEqual(['A Humanoid', 'An Undead']);
+  });
+
+  it('filters by traits client-side (all selected traits must be present)', async () => {
+    const search = vi.fn().mockResolvedValue({
+      matches: [
+        monsterMatch({ name: 'Dragon', traits: ['dragon', 'fire'] }),
+        monsterMatch({ name: 'Fire Elemental', traits: ['fire', 'elemental'] }),
+        monsterMatch({ name: 'Goblin', traits: ['humanoid', 'goblin'] }),
+      ],
+    });
+    const api = fakeApi({ searchCompendium: search });
+    // Only the dragon has BOTH dragon AND fire traits
+    const out = await createPreparedCompendium(api).listMonsters({ traits: ['dragon', 'fire'] });
+    expect(out.map((s) => s.name)).toEqual(['Dragon']);
+  });
+
+  it('filters by source client-side', async () => {
+    const search = vi.fn().mockResolvedValue({
+      matches: [
+        monsterMatch({ name: 'A', source: 'Bestiary' }),
+        monsterMatch({ name: 'B', source: 'Bestiary 2' }),
+        monsterMatch({ name: 'C', source: 'Monster Core' }),
+      ],
+    });
+    const api = fakeApi({ searchCompendium: search });
+    const out = await createPreparedCompendium(api).listMonsters({ sources: ['Bestiary', 'Monster Core'] });
+    expect(out.map((s) => s.name)).toEqual(['A', 'C']);
+  });
+
+  it('filters by hp range client-side', async () => {
+    const search = vi.fn().mockResolvedValue({
+      matches: [
+        monsterMatch({ name: 'Weak', hp: 20 }),
+        monsterMatch({ name: 'Medium', hp: 100 }),
+        monsterMatch({ name: 'Strong', hp: 300 }),
+      ],
+    });
+    const api = fakeApi({ searchCompendium: search });
+    const out = await createPreparedCompendium(api).listMonsters({ hpMin: 50, hpMax: 200 });
+    expect(out.map((s) => s.name)).toEqual(['Medium']);
+  });
+
+  it('stacks keyword + facet filters (AND semantics across filter types)', async () => {
+    const search = vi.fn().mockResolvedValue({
+      matches: [
+        monsterMatch({ name: 'Young Red Dragon', level: 10, rarity: 'uncommon', traits: ['dragon', 'fire'] }),
+        monsterMatch({ name: 'Young Blue Dragon', level: 10, rarity: 'rare', traits: ['dragon', 'electricity'] }),
+        monsterMatch({ name: 'Ancient Red Dragon', level: 19, rarity: 'uncommon', traits: ['dragon', 'fire'] }),
+      ],
+    });
+    const api = fakeApi({ searchCompendium: search });
+    // keyword 'young' + levels [1,15] + rarities ['uncommon'] → only Young Red Dragon
+    const out = await createPreparedCompendium(api).listMonsters({
+      keywords: 'young',
+      levels: [1, 15],
+      rarities: ['uncommon'],
+    });
+    expect(out.map((s) => s.name)).toEqual(['Young Red Dragon']);
   });
 
   it('filters matches client-side by keyword (name substring)', async () => {

--- a/apps/dm-tool/electron/compendium/prepared.ts
+++ b/apps/dm-tool/electron/compendium/prepared.ts
@@ -178,6 +178,71 @@ async function searchMonsters(api: CompendiumApi, packIds: readonly string[], qu
   return results.map((r, i) => formatMonsterForChat(r, i + 1)).join('\n\n');
 }
 
+/** Apply all facet filters that are not expressed in the server-side
+ *  searchCompendium call. The mcp wire contract does not yet support level
+ *  ranges, rarity, size, creature type, trait lists, sources, or stat-range
+ *  filters — so we fetch the full match list and narrow in-process.
+ *
+ *  String comparisons are case-insensitive so UI-facing filter values
+ *  (e.g. 'Uncommon', 'HUMANOID') match whatever case the server returns.
+ *
+ *  Stat fields (hp/ac/fort/ref/will) default to 0 when absent from the match
+ *  (cache-cold path). A stat-range filter therefore excludes cache-cold entries
+ *  that don't meet the threshold — this is intentional: we can't verify the
+ *  stat for an uncached monster.
+ */
+function filterMonsterMatchesClientSide(matches: CompendiumMatch[], params: MonsterSearchParams): CompendiumMatch[] {
+  return matches.filter((m) => {
+    // Level range
+    if (params.levels != null) {
+      const [min, max] = params.levels;
+      const lvl = m.level ?? 0;
+      if (lvl < min || lvl > max) return false;
+    }
+
+    // Rarity — facets surface lowercase values; compare case-insensitively
+    if (params.rarities && params.rarities.length > 0) {
+      const matchRarity = (m.rarity ?? 'common').toLowerCase();
+      if (!params.rarities.some((r) => r.toLowerCase() === matchRarity)) return false;
+    }
+
+    // Size
+    if (params.sizes && params.sizes.length > 0) {
+      const matchSize = (m.size ?? '').toLowerCase();
+      if (!matchSize || !params.sizes.some((s) => s.toLowerCase() === matchSize)) return false;
+    }
+
+    // Creature type
+    if (params.creatureTypes && params.creatureTypes.length > 0) {
+      const matchType = (m.creatureType ?? '').toLowerCase();
+      if (!matchType || !params.creatureTypes.some((ct) => ct.toLowerCase() === matchType)) return false;
+    }
+
+    // Traits — ALL selected traits must appear on the monster
+    if (params.traits && params.traits.length > 0) {
+      const mTraits = (m.traits ?? []).map((t) => t.toLowerCase());
+      if (!params.traits.every((t) => mTraits.includes(t.toLowerCase()))) return false;
+    }
+
+    // Source — publication title
+    if (params.sources && params.sources.length > 0) {
+      const matchSource = (m.source ?? '').toLowerCase();
+      if (!matchSource || !params.sources.some((s) => s.toLowerCase() === matchSource)) return false;
+    }
+
+    // Numeric stat ranges
+    if (params.hpMin != null && (m.hp ?? 0) < params.hpMin) return false;
+    if (params.hpMax != null && (m.hp ?? 0) > params.hpMax) return false;
+    if (params.acMin != null && (m.ac ?? 0) < params.acMin) return false;
+    if (params.acMax != null && (m.ac ?? 0) > params.acMax) return false;
+    if (params.fortMin != null && (m.fort ?? 0) < params.fortMin) return false;
+    if (params.refMin != null && (m.ref ?? 0) < params.refMin) return false;
+    if (params.willMin != null && (m.will ?? 0) < params.willMin) return false;
+
+    return true;
+  });
+}
+
 async function listMonsters(
   api: CompendiumApi,
   packIds: readonly string[],
@@ -207,16 +272,21 @@ async function listMonsters(
           return tokens.every((tok) => name.includes(tok) || traits.some((t) => t.includes(tok)));
         });
 
-  const summaries = filtered.map(monsterMatchToSummary);
+  // Apply all client-side facet filters that aren't expressed in the
+  // server-side wire call (level range, rarity, size, creature type,
+  // traits, source, and numeric stat ranges).
+  const facetFiltered = filterMonsterMatchesClientSide(filtered, params);
+
+  const summaries = facetFiltered.map(monsterMatchToSummary);
 
   // Warn when the mcp server's cache wasn't warm for these packs — stats
   // (hp/ac/saves) will be 0 on every grid chip until the cache warms and
   // the user triggers a fresh query. This typically resolves within seconds
   // of Foundry connecting; it's a transient state, not an error.
-  const statslesCount = filtered.filter((m) => m.hp === undefined).length;
+  const statslesCount = facetFiltered.filter((m) => m.hp === undefined).length;
   if (statslesCount > 0) {
     console.warn(
-      `[compendium] ${statslesCount.toString()} of ${filtered.length.toString()} monster matches missing stats (hp/ac/saves). ` +
+      `[compendium] ${statslesCount.toString()} of ${facetFiltered.length.toString()} monster matches missing stats (hp/ac/saves). ` +
         `mcp cache may still be warming for the requested packs — grid chips will show 0 until the cache is ready.`,
       { packIds },
     );
@@ -224,17 +294,15 @@ async function listMonsters(
 
   const sortBy = params.sortBy ?? 'level';
   const sortDir = params.sortDir ?? 'asc';
-  if (sortBy === 'name' || sortBy === 'level') {
-    summaries.sort((a, b) => {
-      const av = sortBy === 'name' ? a.name : a.level;
-      const bv = sortBy === 'name' ? b.name : b.level;
-      if (typeof av === 'string' && typeof bv === 'string') {
-        return sortDir === 'desc' ? bv.localeCompare(av) : av.localeCompare(bv);
-      }
-      const diff = (av as number) - (bv as number);
-      return sortDir === 'desc' ? -diff : diff;
-    });
-  }
+  summaries.sort((a, b) => {
+    const av = sortBy === 'name' ? a.name : sortBy === 'hp' ? a.hp : sortBy === 'ac' ? a.ac : a.level;
+    const bv = sortBy === 'name' ? b.name : sortBy === 'hp' ? b.hp : sortBy === 'ac' ? b.ac : b.level;
+    if (typeof av === 'string' && typeof bv === 'string') {
+      return sortDir === 'desc' ? bv.localeCompare(av) : av.localeCompare(bv);
+    }
+    const diff = (av as number) - (bv as number);
+    return sortDir === 'desc' ? -diff : diff;
+  });
 
   return summaries;
 }


### PR DESCRIPTION
## Summary

`listMonsters` fetched all compendium matches and applied keyword text search, but never ran the remaining `MonsterSearchParams` fields (levels, rarities, sizes, creatureTypes, traits, sources, hp/ac/save ranges) through any filter. Every filter toggle in the monster tab changed UI state correctly but produced an identical IPC response, making the list appear frozen regardless of what was selected.

Root cause: the file's preamble comment described the intended "fetch all + post-filter in JS" pattern but `filterMonsterMatchesClientSide` was never written (the items browser had an equivalent function; monsters didn't).

Fix: add `filterMonsterMatchesClientSide` — mirrors `filterItemMatchesClientSide` — called after keyword filtering in `listMonsters`. Also expand sort to cover the `hp` and `ac` `sortBy` variants already defined in the type.

## Changes
- `prepared.ts`: add `filterMonsterMatchesClientSide`; call it after keyword filtering; expand sort to handle `hp`/`ac`
- `prepared.test.ts`: correct the stale test that asserted the broken behaviour; add per-filter regression tests for level range, rarity, size, creature type, traits, source, hp range, and stacked keyword+facet filtering

## Test plan
- [ ] `npm run test -w apps/dm-tool` — all 265 tests pass
- [ ] Monster tab: select a rarity -> list narrows; select a level range -> list narrows; clear all -> full list returns