### PR TITLE
fix(player-portal): fix white stage-banner gradient in dark mode

### DIFF
--- a/apps/player-portal/src/routes/CharacterCreator.tsx
+++ b/apps/player-portal/src/routes/CharacterCreator.tsx
@@ -235,7 +235,7 @@ export function CharacterCreator(): React.ReactElement {
           {/* Sticky anchor nav — clicking a pill scrolls the matching
               section into view. Filled state still derives from
               `isStepFilled` so users can see what's outstanding. */}
-          <div className="sticky top-0 z-10 -mx-1 mb-4 bg-gradient-to-b from-white via-white/95 to-transparent px-1 pb-2 pt-2">
+          <div className="sticky top-0 z-10 -mx-1 mb-4 bg-stage-gradient px-1 pb-2 pt-2">
             <StepNav steps={STEPS} active={null} onJump={jumpToSection} draft={draft} />
           </div>
 

--- a/apps/player-portal/src/styles/index.css
+++ b/apps/player-portal/src/styles/index.css
@@ -107,6 +107,13 @@
 @utility border-portal-accent-dim {
   border-color: var(--portal-accent-border);
 }
+/* Sticky step-nav scrim: fades from the page background down to transparent
+ * so the nav pill bar appears to float above the scrolling content. Uses
+ * --portal-bg so the fade colour matches both light (cream parchment) and
+ * dark (#0d111e navy) themes automatically. */
+@utility bg-stage-gradient {
+  background: linear-gradient(to bottom, var(--portal-bg), transparent);
+}
 
 /* Reserve scrollbar-gutter space always so the page doesn't horizontally
    shift when content grows past the viewport and a scrollbar appears. */


### PR DESCRIPTION
## Summary

The sticky step-nav scrim at the top of the character creator used hardcoded Tailwind utilities (`from-white via-white/95 to-transparent`) that don't respond to the `[data-portal-theme="dark"]` cascade, rendering a white gradient band over the creator in dark mode.

## Changes

- `src/styles/index.css` — add `@utility bg-stage-gradient` that resolves `linear-gradient(to bottom, var(--portal-bg), transparent)` at runtime, so the fade colour picks up cream parchment in light mode and `#0d111e` navy in dark mode automatically
- `src/routes/CharacterCreator.tsx` — replace the three hardcoded gradient Tailwind classes with the single new utility

## Test plan

- [ ] Open the character creator in dark mode — the step-nav pill bar should fade into the dark background, not sit on a white scrim
- [ ] Verify light mode still shows the cream-parchment fade (no visual regression)