### PR TITLE
fix(player-portal): replace hardcoded text-neutral-900 with text-pf-text across character sheet tabs

### DIFF
--- a/apps/player-portal/src/components/common/ModifierTooltip.tsx
+++ b/apps/player-portal/src/components/common/ModifierTooltip.tsx
@@ -23,7 +23,7 @@ export function ModifierTooltip({ title, breakdown, modifiers }: Props): React.R
         'group-hover:visible',
       ].join(' ')}
     >
-      <div className="mb-1 text-sm font-semibold text-neutral-900">{t(title)}</div>
+      <div className="mb-1 text-sm font-semibold text-pf-text">{t(title)}</div>
       <div className="mb-2 text-pf-text-muted">{breakdown}</div>
       {active.length > 0 && (
         <ul className="space-y-0.5">

--- a/apps/player-portal/src/components/tabs/Actions.tsx
+++ b/apps/player-portal/src/components/tabs/Actions.tsx
@@ -93,7 +93,7 @@ function StrikeCard({
         />
         <div className="min-w-0 flex-1">
           <div className="flex items-baseline justify-between gap-2">
-            <span className="truncate text-sm font-medium text-neutral-900">
+            <span className="truncate text-sm font-medium text-pf-text">
               {strike.label}
               {strike.quantity > 1 && (
                 <span className="ml-2 text-xs font-normal text-pf-text-muted">×{strike.quantity}</span>
@@ -322,7 +322,7 @@ function ActionCard({
               type="button"
               onClick={toggle}
               aria-expanded={expanded}
-              className="min-w-0 truncate text-left text-sm font-medium text-neutral-900 hover:underline"
+              className="min-w-0 truncate text-left text-sm font-medium text-pf-text hover:underline"
               data-testid="action-card-toggle"
             >
               {item.name}

--- a/apps/player-portal/src/components/tabs/Background.tsx
+++ b/apps/player-portal/src/components/tabs/Background.tsx
@@ -84,7 +84,7 @@ function DemographicsBlock({ details }: { details: CharacterDetails }): React.Re
         {populated.map(([label, value]) => (
           <div key={label} className="flex items-baseline gap-2" data-field={label.toLowerCase()}>
             <dt className="text-[10px] font-semibold uppercase tracking-widest text-neutral-500">{label}</dt>
-            <dd className="text-neutral-900">{value}</dd>
+            <dd className="text-pf-text">{value}</dd>
           </div>
         ))}
       </dl>
@@ -111,7 +111,7 @@ function PersonalityBlock({ bio }: { bio: CharacterBiography }): React.ReactElem
             <dt className="w-28 shrink-0 text-[10px] font-semibold uppercase tracking-widest text-neutral-500">
               {label}
             </dt>
-            <dd className="text-neutral-900">{value}</dd>
+            <dd className="text-pf-text">{value}</dd>
           </div>
         ))}
       </dl>
@@ -137,7 +137,7 @@ function ListCol({ label, entries }: { label: string; entries: string[] }): Reac
   return (
     <div data-list={label.toLowerCase()}>
       <h3 className="mb-1 text-[11px] font-semibold uppercase tracking-widest text-neutral-600">{label}</h3>
-      <ul className="list-disc space-y-0.5 pl-5 text-sm text-neutral-900">
+      <ul className="list-disc space-y-0.5 pl-5 text-sm text-pf-text">
         {entries.map((e, i) => (
           <li key={`${label}-${i.toString()}`}>{e}</li>
         ))}
@@ -163,7 +163,7 @@ function SocialBlock({ bio }: { bio: CharacterBiography }): React.ReactElement |
             <dt className="w-28 shrink-0 text-[10px] font-semibold uppercase tracking-widest text-neutral-500">
               {label}
             </dt>
-            <dd className="text-neutral-900">{value}</dd>
+            <dd className="text-pf-text">{value}</dd>
           </div>
         ))}
       </dl>
@@ -185,7 +185,7 @@ function TextBlock({
     <div data-section={dataSection ?? title.toLowerCase()}>
       <SectionHeader>{title}</SectionHeader>
       <div
-        className="max-w-none text-sm leading-relaxed text-neutral-900 [&_p]:my-2 [&_p]:leading-relaxed"
+        className="max-w-none text-sm leading-relaxed text-pf-text [&_p]:my-2 [&_p]:leading-relaxed"
         // Safe: source is our own Foundry world, not untrusted user input.
         dangerouslySetInnerHTML={{ __html: html }}
       />

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -591,7 +591,7 @@ function ItemRow({
           <img src={item.img} alt="" className="h-8 w-8 flex-shrink-0 rounded border border-pf-border bg-pf-bg-dark" />
           <div className="min-w-0 flex-1">
             <div className="flex items-baseline gap-2">
-              <span className="truncate text-sm text-neutral-900">{item.name}</span>
+              <span className="truncate text-sm text-pf-text">{item.name}</span>
               {item.system.quantity > 1 && (
                 <span className="flex-shrink-0 text-xs text-pf-text-muted">×{item.system.quantity}</span>
               )}

--- a/apps/player-portal/src/components/tabs/Proficiencies.tsx
+++ b/apps/player-portal/src/components/tabs/Proficiencies.tsx
@@ -130,7 +130,7 @@ function SkillRow({ skill, spanFull }: { skill: SkillStatistic; spanFull?: boole
       data-statistic={skill.slug}
     >
       <Modifier value={skill.value} />
-      <span className="flex-1 truncate text-sm text-neutral-900">{renderLabel(skill.label, skill.lore === true)}</span>
+      <span className="flex-1 truncate text-sm text-pf-text">{renderLabel(skill.label, skill.lore === true)}</span>
       <RankChip rank={skill.rank} />
       <ModifierTooltip title={skill.label} breakdown={skill.breakdown} modifiers={skill.modifiers} />
     </li>
@@ -158,7 +158,7 @@ function MartialRow({
       title={prof.breakdown}
     >
       <Modifier value={prof.value} />
-      <span className="flex-1 truncate text-sm text-neutral-900">{label}</span>
+      <span className="flex-1 truncate text-sm text-pf-text">{label}</span>
       <RankChip rank={prof.rank} />
     </li>
   );
@@ -172,8 +172,8 @@ function ClassDCRow({ classDC, spanFull }: { classDC: ClassDC; spanFull: boolean
         spanFull ? 'sm:col-span-2' : '',
       ].join(' ')}
     >
-      <span className="inline-flex w-8 justify-end font-mono text-sm tabular-nums text-neutral-900">{classDC.dc}</span>
-      <span className="flex-1 truncate text-sm text-neutral-900">{classDC.label}</span>
+      <span className="inline-flex w-8 justify-end font-mono text-sm tabular-nums text-pf-text">{classDC.dc}</span>
+      <span className="flex-1 truncate text-sm text-pf-text">{classDC.label}</span>
       <RankChip rank={classDC.rank} />
       <ModifierTooltip title={classDC.label} breakdown={classDC.breakdown} modifiers={classDC.modifiers} />
     </li>


### PR DESCRIPTION
## Summary

Action names (Actions tab) and skill names (Proficiencies tab) were unreadable in dark mode because they used Tailwind's `text-neutral-900` — a hardcoded near-black — instead of the theme-aware `text-pf-text` utility that reads from `--color-pf-text` (light: `#1c1c1c`, dark: `#e8e4dc`). The same hardcoded class was used consistently across all sheet tabs, so this fix covers them all.

## Changes

- `tabs/Actions.tsx` — strike name label and action card toggle button name
- `tabs/Proficiencies.tsx` — skill rows, martial proficiency rows, class DC value and label
- `tabs/Background.tsx` — demographics/personality/social `dd` values, edicts/anathema list items, rich-text biography block
- `tabs/Inventory.tsx` — container item name in the expandable row
- `common/ModifierTooltip.tsx` — tooltip title (renders on `bg-pf-bg` which is dark in dark mode)

`PromptDialog.tsx` still uses `text-neutral-900` but its panel is also `bg-white` (not theme-aware), so it needs a coordinated fix tracked separately.

## Test plan

- [ ] Toggle to dark mode on the character sheet — action names, skill names, proficiency rows, background fields, and inventory item names all render in a readable light colour
- [ ] Toggle back to light mode — everything still reads in the expected dark colour
- [ ] CI green (183 Vitest tests pass, 0 lint errors)