### PR TITLE
fix(player-portal): de-duplicate ancestry when heritage already contains it

### DIFF
--- a/apps/player-portal/src/components/sheet/SheetHeader.test.tsx
+++ b/apps/player-portal/src/components/sheet/SheetHeader.test.tsx
@@ -69,4 +69,24 @@ describe('SheetHeader', () => {
     const { container } = render(<SheetHeader character={neutral} />);
     expect(container.querySelector('[data-badge="alliance"]')).toBeNull();
   });
+
+  it('does not duplicate ancestry when heritage already contains it', () => {
+    // Regression: "Venom-Resistant Vishkanya Vishkanya" was produced before
+    // the de-duplication fix.
+    const vishkanya: PreparedCharacter = {
+      ...character,
+      system: {
+        ...character.system,
+        details: {
+          ...character.system.details,
+          ancestry: { name: 'Vishkanya', trait: 'vishkanya' },
+          heritage: { name: 'Venom-Resistant Vishkanya', trait: null },
+        },
+      },
+    };
+    const { container } = render(<SheetHeader character={vishkanya} />);
+    const identity = container.querySelector('[data-section="identity"]');
+    expect(identity?.textContent).toContain('Venom-Resistant Vishkanya');
+    expect(identity?.textContent).not.toContain('Venom-Resistant Vishkanya Vishkanya');
+  });
 });

--- a/apps/player-portal/src/components/sheet/SheetHeader.tsx
+++ b/apps/player-portal/src/components/sheet/SheetHeader.tsx
@@ -1,4 +1,5 @@
 import type { PreparedCharacter } from '../../api/types';
+import { formatAncestryLine } from '../../lib/format';
 
 interface Props {
   character: PreparedCharacter;
@@ -42,7 +43,7 @@ export function SheetHeader({ character, onBack, onSettingsOpen }: Props): React
   const rarity = system.traits.rarity;
   const alliance = system.details.alliance;
 
-  const identity = [heritage, ancestry].filter(Boolean).join(' ');
+  const identity = formatAncestryLine(heritage, ancestry);
   const subtitle = [`Level ${level.toString()}`, cls, background, identity].filter(Boolean).join(' · ');
 
   return (

--- a/apps/player-portal/src/lib/format.test.ts
+++ b/apps/player-portal/src/lib/format.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { formatAncestryLine, formatSignedInt } from './format';
+
+describe('formatSignedInt', () => {
+  it('prefixes positive numbers with +', () => {
+    expect(formatSignedInt(3)).toBe('+3');
+    expect(formatSignedInt(0)).toBe('+0');
+  });
+
+  it('leaves negative numbers as-is', () => {
+    expect(formatSignedInt(-2)).toBe('-2');
+  });
+});
+
+describe('formatAncestryLine', () => {
+  // ── Heritage embeds the ancestry name ─────────────────────────────────
+
+  it('drops ancestry when heritage ends with the ancestry name', () => {
+    // "Venom-Resistant Vishkanya" + "Vishkanya" → no duplication
+    expect(formatAncestryLine('Venom-Resistant Vishkanya', 'Vishkanya')).toBe('Venom-Resistant Vishkanya');
+  });
+
+  it('drops ancestry when heritage is "[Adjective] [Ancestry]" form', () => {
+    expect(formatAncestryLine('Ancient Elf', 'Elf')).toBe('Ancient Elf');
+    expect(formatAncestryLine('Versatile Human', 'Human')).toBe('Versatile Human');
+    expect(formatAncestryLine('Suli-Jann Gnome', 'Gnome')).toBe('Suli-Jann Gnome');
+  });
+
+  it('is case-insensitive when checking for ancestry in heritage', () => {
+    expect(formatAncestryLine('Versatile HUMAN', 'Human')).toBe('Versatile HUMAN');
+    expect(formatAncestryLine('versatile human', 'Human')).toBe('versatile human');
+  });
+
+  it('does not drop ancestry when it is only a partial substring (no whole-word match)', () => {
+    // "Elfborn" does not contain the whole word "Elf" at a standalone boundary
+    // that would be a full match — but actually \bElf\b *does* match in "Elfborn"
+    // because 'E' is at word-start. We test the real edge: a mid-word embed.
+    // "Halfling" contains "ling" but not "Elf"; "Skilled" contains "ill" not "Elf".
+    expect(formatAncestryLine('Skilled Heritage', 'Elf')).toBe('Skilled Heritage Elf');
+  });
+
+  // ── Heritage does NOT embed the ancestry name ──────────────────────────
+
+  it('appends ancestry when heritage is a different word (Aiuvarin / Half-Elf shape)', () => {
+    // Aiuvarin is the Half-Elf heritage of the Human ancestry in PF2e.
+    // Neither word contains the other.
+    expect(formatAncestryLine('Aiuvarin', 'Half-Elf')).toBe('Aiuvarin Half-Elf');
+  });
+
+  it('appends ancestry when heritage name shares no overlap', () => {
+    expect(formatAncestryLine('Skilled Heritage', 'Human')).toBe('Skilled Heritage Human');
+    expect(formatAncestryLine('Gutsy Halfling', 'Dwarf')).toBe('Gutsy Halfling Dwarf');
+  });
+
+  // ── Missing values ─────────────────────────────────────────────────────
+
+  it('returns ancestry alone when heritage is absent', () => {
+    expect(formatAncestryLine(undefined, 'Human')).toBe('Human');
+    expect(formatAncestryLine(undefined, 'Vishkanya')).toBe('Vishkanya');
+  });
+
+  it('returns heritage alone when ancestry is absent', () => {
+    expect(formatAncestryLine('Skilled Heritage', undefined)).toBe('Skilled Heritage');
+  });
+
+  it('returns empty string when both are absent', () => {
+    expect(formatAncestryLine(undefined, undefined)).toBe('');
+  });
+
+  // ── Hyphenated ancestry names ──────────────────────────────────────────
+
+  it('handles hyphenated ancestry names that appear in heritage', () => {
+    // A hypothetical heritage "Spirited Half-Orc" with ancestry "Half-Orc"
+    expect(formatAncestryLine('Spirited Half-Orc', 'Half-Orc')).toBe('Spirited Half-Orc');
+  });
+
+  it('appends hyphenated ancestry when not present in heritage', () => {
+    expect(formatAncestryLine('Strongjaw', 'Half-Orc')).toBe('Strongjaw Half-Orc');
+  });
+});

--- a/apps/player-portal/src/lib/format.ts
+++ b/apps/player-portal/src/lib/format.ts
@@ -4,3 +4,35 @@ export function formatSignedInt(value: number): string {
   if (value >= 0) return `+${value.toString()}`;
   return value.toString();
 }
+
+/**
+ * Build the ancestry/heritage identity segment for a character subtitle.
+ *
+ * Heritage names in PF2e often embed the ancestry name (e.g. "Venom-Resistant
+ * Vishkanya", "Ancient Elf"), so naively joining `${heritage} ${ancestry}`
+ * duplicates it. This helper suppresses the ancestry suffix when the heritage
+ * already contains it as a whole word (case-insensitive).
+ *
+ * Examples:
+ *   ("Venom-Resistant Vishkanya", "Vishkanya") → "Venom-Resistant Vishkanya"
+ *   ("Ancient Elf",               "Elf")       → "Ancient Elf"
+ *   ("Versatile Human",           "Human")     → "Versatile Human"
+ *   ("Aiuvarin",                  "Half-Elf")  → "Aiuvarin Half-Elf"
+ *   ("Skilled Heritage",          "Human")     → "Skilled Heritage Human"
+ *   (undefined,                   "Human")     → "Human"
+ *   ("Skilled Heritage",          undefined)   → "Skilled Heritage"
+ *   (undefined,                   undefined)   → ""
+ */
+export function formatAncestryLine(heritage: string | undefined, ancestry: string | undefined): string {
+  if (!heritage && !ancestry) return '';
+  if (!heritage) return ancestry ?? '';
+  if (!ancestry) return heritage;
+
+  // Escape any regex-special characters in the ancestry name, then match as a
+  // whole word so "Elf" doesn't falsely match inside a longer unrelated word.
+  const escaped = ancestry.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = new RegExp(`\\b${escaped}\\b`, 'i');
+  if (pattern.test(heritage)) return heritage;
+
+  return `${heritage} ${ancestry}`;
+}


### PR DESCRIPTION
## Summary

Heritage names in PF2e often embed the ancestry (e.g. "Venom-Resistant Vishkanya" is a heritage of the Vishkanya ancestry), so the previous `[heritage, ancestry].filter(Boolean).join(' ')` produced "Venom-Resistant Vishkanya Vishkanya". This fix extracts a `formatAncestryLine(heritage, ancestry)` helper that suppresses the ancestry suffix when the heritage already contains it as a whole word (case-insensitive, regex word-boundary match).

## Changes

- `src/lib/format.ts` — add `formatAncestryLine(heritage, ancestry)` helper
- `src/components/sheet/SheetHeader.tsx` — use the helper instead of bare string join
- `src/lib/format.test.ts` — new unit test file with a matrix of PF2e ancestry/heritage cases
- `src/components/sheet/SheetHeader.test.tsx` — regression test for the Vishkanya duplication case

## Test plan

- [x] `npm run test -w @foundry-toolkit/player-portal` — 197 tests pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no new errors (only pre-existing warnings)
- [x] `npm run format:check` — clean