### PR TITLE
feat(globe): add fill color picker for map pins

### DIFF
--- a/apps/dm-tool/electron/ipc/globe.ts
+++ b/apps/dm-tool/electron/ipc/globe.ts
@@ -39,6 +39,7 @@ export function registerGlobeHandlers(cfg: DmToolConfig, getMainWindow: () => El
           lat: pin.lat,
           label: pin.label,
           icon: pin.icon,
+          iconColor: pin.iconColor,
           zoom: pin.zoom,
           note: '',
           kind: pin.kind,

--- a/apps/dm-tool/src/features/globe/GlobeViewer.tsx
+++ b/apps/dm-tool/src/features/globe/GlobeViewer.tsx
@@ -5,12 +5,14 @@ import { Protocol } from 'pmtiles';
 import { api } from '@/lib/api';
 import type { GlobePin, GlobePinKind, MissionData } from '@foundry-toolkit/shared/types';
 import {
+  DEFAULT_FILL_HEX,
   PIN_LAYER,
   PIN_SOURCE,
   buildMapStyle,
   ensureDefaultImage,
   ensureIconImage,
   getIconBody,
+  parseIconKey,
   pinsToGeoJson,
 } from '@foundry-toolkit/shared/golarion-map';
 import { IconPicker } from './IconPicker';
@@ -27,6 +29,7 @@ export function GlobeViewer() {
   const pinsRef = useRef<GlobePin[]>([]);
   const [pins, setPins] = useState<GlobePin[]>([]);
   const [selectedIcon, setSelectedIcon] = useState('');
+  const [selectedColor, setSelectedColor] = useState('');
   const [pickerOpen, setPickerOpen] = useState(false);
   const [pinKind, setPinKind] = useState<GlobePinKind>('note');
   const [activeMission, setActiveMission] = useState<MissionData | null>(null);
@@ -41,11 +44,16 @@ export function GlobeViewer() {
    *  preventDefault, suppressing the browser's dblclick generation. */
   const lastPinClickRef = useRef<{ id: string; time: number } | null>(null);
   const selectedIconRef = useRef(selectedIcon);
+  const selectedColorRef = useRef(selectedColor);
   const pinKindRef = useRef(pinKind);
 
   useEffect(() => {
     selectedIconRef.current = selectedIcon;
   }, [selectedIcon]);
+
+  useEffect(() => {
+    selectedColorRef.current = selectedColor;
+  }, [selectedColor]);
 
   useEffect(() => {
     pinKindRef.current = pinKind;
@@ -96,6 +104,7 @@ export function GlobeViewer() {
         lat,
         label: '',
         icon: selectedIconRef.current,
+        iconColor: selectedColorRef.current,
         zoom: currentZoom,
         note: '',
         kind: pinKindRef.current,
@@ -138,11 +147,15 @@ export function GlobeViewer() {
 
     // When MapLibre encounters an icon-image that isn't loaded yet, load
     // it on demand. addImage() triggers a re-render automatically.
+    // Keys may carry a colour suffix (gi-<name>::<hex>) — parseIconKey
+    // extracts both parts so the correct coloured SVG is generated.
     map.on('styleimagemissing', (e: { id: string }) => {
-      if (e.id === 'gi-default') {
-        ensureDefaultImage(map);
-      } else if (e.id.startsWith('gi-')) {
-        ensureIconImage(map, e.id.slice(3));
+      const parsed = parseIconKey(e.id);
+      if (!parsed) return;
+      if (parsed.name === 'default') {
+        ensureDefaultImage(map, parsed.color);
+      } else {
+        ensureIconImage(map, parsed.name, parsed.color);
       }
     });
 
@@ -308,12 +321,50 @@ export function GlobeViewer() {
               width: 14,
               height: 14,
               borderRadius: '50%',
-              background: 'hsl(32, 95%, 52%)',
+              background: selectedColor || 'hsl(32, 95%, 52%)',
               border: '2px solid white',
             }}
           />
         )}
       </button>
+
+      {/* Fill-color picker — sets the circle colour for newly placed pins */}
+      <div className="absolute z-10" style={{ left: 56, top: 12 }}>
+        <label
+          title={selectedColor ? `Pin fill color: ${selectedColor}` : 'Pin fill color: default golden'}
+          className="flex cursor-pointer items-center justify-center rounded-lg border border-border bg-background/90 shadow-md backdrop-blur-sm transition-colors hover:bg-accent"
+          style={{ width: 40, height: 40, position: 'relative', display: 'flex' }}
+        >
+          <span
+            style={{
+              width: 18,
+              height: 18,
+              borderRadius: '50%',
+              background: selectedColor || 'hsl(32, 95%, 52%)',
+              border: '2px solid rgba(255,255,255,0.5)',
+              flexShrink: 0,
+            }}
+          />
+          <input
+            type="color"
+            value={selectedColor || DEFAULT_FILL_HEX}
+            onChange={(e) => setSelectedColor(e.target.value)}
+            style={{ position: 'absolute', inset: 0, opacity: 0, width: '100%', height: '100%', cursor: 'pointer' }}
+            aria-label="Pin fill color"
+          />
+        </label>
+        {selectedColor && (
+          <button
+            type="button"
+            onClick={() => setSelectedColor('')}
+            title="Reset to default golden"
+            className="absolute flex items-center justify-center rounded-full border border-border bg-background text-muted-foreground hover:bg-accent hover:text-foreground"
+            style={{ width: 14, height: 14, fontSize: 9, top: -4, right: -4 }}
+          >
+            ×
+          </button>
+        )}
+      </div>
 
       {/* Pin kind toggle — determines what kind of pin is placed on right-click */}
       <div

--- a/apps/player-portal/src/routes/Globe.tsx
+++ b/apps/player-portal/src/routes/Globe.tsx
@@ -17,6 +17,7 @@ import {
   createStarsLayer,
   ensureDefaultImage,
   ensureIconImage,
+  parseIconKey,
   pinsToGeoJson,
   startAutoRotate,
 } from '@foundry-toolkit/shared/golarion-map';
@@ -96,8 +97,13 @@ export function Globe() {
     map.addControl(new maplibregl.NavigationControl(), 'top-right');
 
     map.on('styleimagemissing', (e: { id: string }) => {
-      if (e.id === 'gi-default') ensureDefaultImage(map);
-      else if (e.id.startsWith('gi-')) ensureIconImage(map, e.id.slice(3));
+      const parsed = parseIconKey(e.id);
+      if (!parsed) return;
+      if (parsed.name === 'default') {
+        ensureDefaultImage(map, parsed.color);
+      } else {
+        ensureIconImage(map, parsed.name, parsed.color);
+      }
     });
 
     map.on('load', () => {

--- a/packages/db/src/pf2e/globe.ts
+++ b/packages/db/src/pf2e/globe.ts
@@ -7,15 +7,17 @@ import type { GlobePin } from '@foundry-toolkit/shared/types';
 import { getPf2eDb } from './connection.js';
 
 export function listGlobePins(): GlobePin[] {
-  return getPf2eDb().prepare('SELECT id, lng, lat, label, icon, zoom, note, kind FROM globe_pins').all() as GlobePin[];
+  return getPf2eDb()
+    .prepare('SELECT id, lng, lat, label, icon, zoom, note, kind, icon_color AS iconColor FROM globe_pins')
+    .all() as GlobePin[];
 }
 
 export function upsertGlobePin(pin: GlobePin): void {
   getPf2eDb()
     .prepare(
-      'INSERT INTO globe_pins (id, lng, lat, label, icon, zoom, note, kind) VALUES (?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(id) DO UPDATE SET lng=excluded.lng, lat=excluded.lat, label=excluded.label, icon=excluded.icon, zoom=excluded.zoom, note=excluded.note, kind=excluded.kind',
+      'INSERT INTO globe_pins (id, lng, lat, label, icon, zoom, note, kind, icon_color) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(id) DO UPDATE SET lng=excluded.lng, lat=excluded.lat, label=excluded.label, icon=excluded.icon, zoom=excluded.zoom, note=excluded.note, kind=excluded.kind, icon_color=excluded.icon_color',
     )
-    .run(pin.id, pin.lng, pin.lat, pin.label, pin.icon, pin.zoom, pin.note, pin.kind);
+    .run(pin.id, pin.lng, pin.lat, pin.label, pin.icon, pin.zoom, pin.note, pin.kind, pin.iconColor ?? '');
 }
 
 /** Cache the Obsidian mission note's markdown onto its pin row. Called

--- a/packages/db/src/pf2e/migrations.ts
+++ b/packages/db/src/pf2e/migrations.ts
@@ -27,6 +27,7 @@ export function migratePf2eDb(db: Database.Database): void {
   // time the payload is built for a push. Null for non-mission pins or when
   // no Obsidian vault is configured.
   if (!has('mission_markdown')) db.exec('ALTER TABLE globe_pins ADD COLUMN mission_markdown TEXT');
+  if (!has('icon_color')) db.exec("ALTER TABLE globe_pins ADD COLUMN icon_color TEXT NOT NULL DEFAULT ''");
 
   // Party inventory + Aurus leaderboard — persisted as JSON rows so schema
   // changes stay localized to shared/types.ts. The sidecar is the live-sync

--- a/packages/shared/src/golarion-map/icons.test.ts
+++ b/packages/shared/src/golarion-map/icons.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import { coloredIconKey, normalizeIconColor, parseIconKey } from './icons';
+
+// ---------------------------------------------------------------------------
+// normalizeIconColor
+// ---------------------------------------------------------------------------
+
+describe('normalizeIconColor', () => {
+  it('returns empty string for undefined', () => {
+    expect(normalizeIconColor(undefined)).toBe('');
+  });
+
+  it('returns empty string for empty string', () => {
+    expect(normalizeIconColor('')).toBe('');
+  });
+
+  it('returns empty string for whitespace-only input', () => {
+    expect(normalizeIconColor('   ')).toBe('');
+  });
+
+  it('accepts a 6-digit hex and lowercases it', () => {
+    expect(normalizeIconColor('#FF0000')).toBe('#ff0000');
+    expect(normalizeIconColor('#AABBCC')).toBe('#aabbcc');
+    expect(normalizeIconColor('#f98c10')).toBe('#f98c10');
+  });
+
+  it('accepts a 3-digit hex and lowercases it', () => {
+    expect(normalizeIconColor('#F00')).toBe('#f00');
+    expect(normalizeIconColor('#abc')).toBe('#abc');
+  });
+
+  it('accepts an 8-digit hex (with alpha channel)', () => {
+    expect(normalizeIconColor('#FF0000FF')).toBe('#ff0000ff');
+  });
+
+  it('trims surrounding whitespace before checking', () => {
+    expect(normalizeIconColor('  #ff0000  ')).toBe('#ff0000');
+  });
+
+  it('returns empty string for CSS named colours', () => {
+    expect(normalizeIconColor('red')).toBe('');
+    expect(normalizeIconColor('blue')).toBe('');
+    expect(normalizeIconColor('goldenrod')).toBe('');
+  });
+
+  it('returns empty string for hsl() / rgb() strings', () => {
+    expect(normalizeIconColor('hsl(0,100%,50%)')).toBe('');
+    expect(normalizeIconColor('rgb(255,0,0)')).toBe('');
+  });
+
+  it('returns empty string for malformed hex (wrong length)', () => {
+    expect(normalizeIconColor('#12345')).toBe(''); // 5 hex digits
+    expect(normalizeIconColor('#1234567')).toBe(''); // 7 hex digits
+  });
+
+  it('returns empty string for hex missing the leading #', () => {
+    expect(normalizeIconColor('ff0000')).toBe('');
+  });
+
+  it('returns empty string for hex with invalid characters', () => {
+    expect(normalizeIconColor('#gg0000')).toBe('');
+    expect(normalizeIconColor('#zzzzzz')).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// coloredIconKey
+// ---------------------------------------------------------------------------
+
+describe('coloredIconKey', () => {
+  it('returns bare gi-<name> when colour is empty string', () => {
+    expect(coloredIconKey('crossed-swords', '')).toBe('gi-crossed-swords');
+  });
+
+  it('returns gi-<name>::<color> when colour is set', () => {
+    expect(coloredIconKey('crossed-swords', '#ff0000')).toBe('gi-crossed-swords::#ff0000');
+  });
+
+  it('handles multi-segment icon names', () => {
+    expect(coloredIconKey('arrow-cluster', '#00ff00')).toBe('gi-arrow-cluster::#00ff00');
+  });
+
+  it('uses default key format (no colour suffix) for empty colour', () => {
+    // Ensures backward-compatible keys work with existing cached images.
+    expect(coloredIconKey('skull', '')).toBe('gi-skull');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseIconKey
+// ---------------------------------------------------------------------------
+
+describe('parseIconKey', () => {
+  it('returns null for strings that do not start with gi-', () => {
+    expect(parseIconKey('crossed-swords')).toBeNull();
+    expect(parseIconKey('foo')).toBeNull();
+    expect(parseIconKey('')).toBeNull();
+    expect(parseIconKey('maplibre-image')).toBeNull();
+  });
+
+  it('parses a bare gi-<name> key (no colour)', () => {
+    expect(parseIconKey('gi-crossed-swords')).toEqual({ name: 'crossed-swords', color: '' });
+  });
+
+  it('parses the special gi-default key', () => {
+    expect(parseIconKey('gi-default')).toEqual({ name: 'default', color: '' });
+  });
+
+  it('parses a coloured gi-<name>::<color> key', () => {
+    expect(parseIconKey('gi-crossed-swords::#ff0000')).toEqual({ name: 'crossed-swords', color: '#ff0000' });
+  });
+
+  it('parses a coloured default dot key', () => {
+    expect(parseIconKey('gi-default::#f98c10')).toEqual({ name: 'default', color: '#f98c10' });
+  });
+
+  it('handles multi-segment icon names with colour', () => {
+    expect(parseIconKey('gi-arrow-cluster::#00ff00')).toEqual({ name: 'arrow-cluster', color: '#00ff00' });
+  });
+
+  it('round-trips through coloredIconKey', () => {
+    const name = 'skull';
+    const color = '#e03c31';
+    const key = coloredIconKey(name, color);
+    expect(parseIconKey(key)).toEqual({ name, color });
+  });
+
+  it('round-trips a bare (no-colour) key', () => {
+    const name = 'dragon';
+    const key = coloredIconKey(name, '');
+    expect(parseIconKey(key)).toEqual({ name, color: '' });
+  });
+});

--- a/packages/shared/src/golarion-map/icons.ts
+++ b/packages/shared/src/golarion-map/icons.ts
@@ -6,18 +6,53 @@
 import type { Map as MlMap } from 'maplibre-gl';
 import iconsData from '@iconify-json/game-icons/icons.json';
 
+/** The default golden fill used when no custom colour is chosen. */
+const DEFAULT_FILL = 'hsl(32,95%,52%)';
+
+/** Closest hex approximation of DEFAULT_FILL — used only to seed the
+ *  native colour-picker input which requires a hex value. */
+export const DEFAULT_FILL_HEX = '#f98c10';
+
+const DEFAULT_KEY = 'gi-default';
+
 /** Return the raw SVG path body for an icon name, or null if not found. */
 export function getIconBody(name: string): string | null {
   const entry = (iconsData.icons as Record<string, { body: string }>)[name];
   return entry?.body ?? null;
 }
 
-/** MapLibre image key for a game-icon name. */
+/** MapLibre image key for a game-icon name (no colour override). */
 export function iconKey(name: string): string {
   return `gi-${name}`;
 }
 
-const DEFAULT_KEY = 'gi-default';
+/** Normalize an icon colour string.
+ *  Returns the trimmed, lowercased hex string when the value looks like a
+ *  valid CSS hex colour (#rgb, #rrggbb, or #rrggbbaa).  Returns '' for
+ *  anything else — empty string means "use the default golden fill". */
+export function normalizeIconColor(color: string | undefined): string {
+  if (!color) return '';
+  const trimmed = color.trim();
+  return /^#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(trimmed) ? trimmed.toLowerCase() : '';
+}
+
+/** MapLibre image key for a game-icon name with an optional custom fill colour.
+ *  Falls back to the bare `gi-<name>` key when colour is empty so existing
+ *  images (persisted without a colour) remain valid. */
+export function coloredIconKey(name: string, color: string): string {
+  return color ? `gi-${name}::${color}` : `gi-${name}`;
+}
+
+/** Parse a MapLibre image key produced by {@link coloredIconKey} (or the
+ *  legacy bare {@link iconKey}) back to its component parts.
+ *  Returns null for any string that doesn't start with 'gi-'. */
+export function parseIconKey(key: string): { name: string; color: string } | null {
+  if (!key.startsWith('gi-')) return null;
+  const rest = key.slice(3);
+  const sep = rest.indexOf('::');
+  if (sep === -1) return { name: rest, color: '' };
+  return { name: rest.slice(0, sep), color: rest.slice(sep + 2) };
+}
 
 function loadSvgImage(map: MlMap, key: string, svg: string, size: number): void {
   const img = new Image(size, size);
@@ -27,40 +62,54 @@ function loadSvgImage(map: MlMap, key: string, svg: string, size: number): void 
   img.src = `data:image/svg+xml,${encodeURIComponent(svg)}`;
 }
 
-/** Register the default dot image used for pins with no icon. */
-export function ensureDefaultImage(map: MlMap): void {
-  if (map.hasImage(DEFAULT_KEY)) return;
+/** Register the default dot image used for pins with no icon.
+ *  Pass a custom hex colour to get a colour-specific key; omit (or pass '')
+ *  to get the standard golden dot at 'gi-default'. */
+export function ensureDefaultImage(map: MlMap, color?: string): void {
+  const normalizedColor = normalizeIconColor(color);
+  const key = normalizedColor ? `gi-default::${normalizedColor}` : DEFAULT_KEY;
+  if (map.hasImage(key)) return;
   const size = 48;
+  const fill = normalizedColor || DEFAULT_FILL;
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 ${size} ${size}">
-    <circle cx="${size / 2}" cy="${size / 2}" r="${size / 2 - 2}" fill="hsl(32,95%,52%)" stroke="white" stroke-width="3"/>
+    <circle cx="${size / 2}" cy="${size / 2}" r="${size / 2 - 2}" fill="${fill}" stroke="white" stroke-width="3"/>
   </svg>`;
-  loadSvgImage(map, DEFAULT_KEY, svg, size);
+  loadSvgImage(map, key, svg, size);
 }
 
-/** Ensure a game-icon is registered as a MapLibre image. */
-export function ensureIconImage(map: MlMap, name: string): void {
-  const key = iconKey(name);
+/** Ensure a game-icon is registered as a MapLibre image.
+ *  When `color` is a valid hex string the image is keyed by both name and
+ *  colour so different-coloured instances of the same icon coexist in the
+ *  MapLibre image cache without conflict. */
+export function ensureIconImage(map: MlMap, name: string, color?: string): void {
+  const normalizedColor = normalizeIconColor(color);
+  const key = coloredIconKey(name, normalizedColor);
   if (map.hasImage(key)) return;
   const body = getIconBody(name);
   if (!body) return;
   const size = 48;
   const pad = size * 0.15;
   const scale = (size - pad * 2) / 512;
+  const fill = normalizedColor || DEFAULT_FILL;
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 ${size} ${size}">
-    <circle cx="${size / 2}" cy="${size / 2}" r="${size / 2 - 2}" fill="hsl(32,95%,52%)" stroke="white" stroke-width="3"/>
+    <circle cx="${size / 2}" cy="${size / 2}" r="${size / 2 - 2}" fill="${fill}" stroke="white" stroke-width="3"/>
     <g transform="translate(${pad},${pad}) scale(${scale})" fill="white">${body}</g>
   </svg>`;
   loadSvgImage(map, key, svg, size);
 }
 
-/** Resolve a pin's icon field to the MapLibre image key, ensuring the image is loaded. */
-export function resolvePinIcon(map: MlMap, icon: string): string {
+/** Resolve a pin's icon field to the MapLibre image key, ensuring the image
+ *  is registered as a side effect.  Accepts an optional `color` override
+ *  (hex string); the resolved key encodes the colour so MapLibre keeps
+ *  colour-distinct variants separate in its image cache. */
+export function resolvePinIcon(map: MlMap, icon: string, color?: string): string {
+  const normalizedColor = normalizeIconColor(color);
   if (!icon) {
-    ensureDefaultImage(map);
-    return DEFAULT_KEY;
+    ensureDefaultImage(map, normalizedColor);
+    return normalizedColor ? `gi-default::${normalizedColor}` : DEFAULT_KEY;
   }
-  ensureIconImage(map, icon);
-  return iconKey(icon);
+  ensureIconImage(map, icon, normalizedColor);
+  return coloredIconKey(icon, normalizedColor);
 }
 
 /** Render an icon as an inline SVG string for use in React (picker thumbnails). */

--- a/packages/shared/src/golarion-map/index.ts
+++ b/packages/shared/src/golarion-map/index.ts
@@ -4,7 +4,18 @@
 
 export { DEFAULT_PMTILES_URL, buildMapStyle, colors } from './style.js';
 export { PIN_SOURCE, PIN_LAYER, pinDisplaySize, pinsToGeoJson } from './pins.js';
-export { ensureDefaultImage, ensureIconImage, getIconBody, iconKey, iconSvgHtml, resolvePinIcon } from './icons.js';
+export {
+  DEFAULT_FILL_HEX,
+  coloredIconKey,
+  ensureDefaultImage,
+  ensureIconImage,
+  getIconBody,
+  iconKey,
+  iconSvgHtml,
+  normalizeIconColor,
+  parseIconKey,
+  resolvePinIcon,
+} from './icons.js';
 export { createStarsLayer } from './stars.js';
 export type { StarsOptions, ResolvedStarsOptions } from './stars.js';
 export { startAutoRotate } from './auto-rotate.js';

--- a/packages/shared/src/golarion-map/pins.ts
+++ b/packages/shared/src/golarion-map/pins.ts
@@ -29,7 +29,7 @@ export function pinsToGeoJson(pins: GlobePin[], map: MlMap): FeatureCollection {
       properties: {
         id: p.id,
         label: p.label,
-        icon: resolvePinIcon(map, p.icon),
+        icon: resolvePinIcon(map, p.icon, p.iconColor),
         placedZoom: p.zoom,
         displaySize: pinDisplaySize(zoom, p.zoom),
         kind: p.kind,

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -456,6 +456,8 @@ export interface GlobePin {
   label: string;
   /** game-icons.net icon name (e.g. "crossed-swords"). Empty string = default dot. */
   icon: string;
+  /** CSS hex fill color for the pin's circle (e.g. "#e03c31"). Empty/absent = default golden. */
+  iconColor?: string;
   /** Zoom level at which the pin was placed. Icons shrink when zoomed out past this. */
   zoom: number;
   /** Relative path to the Obsidian note within the vault (e.g. "Golarion/My Pin a1b2c3d4.md"). Empty = no note yet. */


### PR DESCRIPTION
## Summary

Adds a colour-swatch button next to the icon picker in the DM tool's globe editor. The user clicks it to open a native `<input type="color">` dialog, picks any hex colour, and all pins placed afterward use that colour for their circle fill. An `x` badge appears when a custom colour is active and resets it to the default golden on click. The chosen colour is persisted in SQLite and forwarded to the player portal on every live-sync push, so pins render correctly on both sides with no extra steps.

Existing pins with no `iconColor` continue to render exactly as before — the default golden fill (`hsl(32,95%,52%)`) is unchanged.

## Changes

- `GlobePin.iconColor?: string` added to the shared type; empty/absent means "use default golden".
- `normalizeIconColor`, `coloredIconKey`, `parseIconKey` added to `packages/shared/src/golarion-map/icons.ts`. Images for different colours of the same icon are cached separately in MapLibre with key format `gi-<name>::<hex>`.
- `ensureDefaultImage` and `ensureIconImage` both accept an optional colour argument; no-colour behaviour is unchanged.
- Both the DM-tool and player-portal `styleimagemissing` handlers updated to use `parseIconKey` so coloured variants regenerate correctly on demand.
- DB migration adds `icon_color TEXT NOT NULL DEFAULT ''`; SELECT aliases it as `iconColor` for direct cast to `GlobePin`.
- `buildExportPayload` in the IPC layer forwards `iconColor` to the player portal.
- 27 new Vitest tests cover the three helper functions.

## Test plan

- [ ] Place a pin with default icon — golden circle as before
- [ ] Pick a custom colour, place a pin — circle renders in that colour on the globe
- [ ] `x` badge appears next to swatch; clicking it resets to golden default
- [ ] Reload the DM tool — persisted colour survives (SQLite round-trip)
- [ ] Player portal shows the same colour as the DM tool after a live-sync push
- [ ] Existing pins (no `iconColor` in DB) continue to render golden