### PR TITLE
feat(player-portal): replace window.confirm with in-app ConfirmDialog for Long Rest

### DIFF
--- a/apps/player-portal/src/components/dialog/ConfirmDialog.test.tsx
+++ b/apps/player-portal/src/components/dialog/ConfirmDialog.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/react';
+import { ConfirmDialog } from './ConfirmDialog';
+
+beforeEach(() => {
+  cleanup();
+});
+
+describe('ConfirmDialog', () => {
+  it('renders the message text', () => {
+    const { container } = render(
+      <ConfirmDialog message="Are you sure?" onConfirm={() => undefined} onCancel={() => undefined} />,
+    );
+    expect(container.querySelector('[data-testid="confirm-dialog-message"]')?.textContent).toBe('Are you sure?');
+  });
+
+  it('renders a custom confirm label', () => {
+    const { container } = render(
+      <ConfirmDialog message="Rest?" confirmLabel="Rest" onConfirm={() => undefined} onCancel={() => undefined} />,
+    );
+    expect(container.querySelector('[data-testid="confirm-dialog-confirm"]')?.textContent).toBe('Rest');
+  });
+
+  it('defaults confirm label to "Confirm" when not specified', () => {
+    const { container } = render(
+      <ConfirmDialog message="?" onConfirm={() => undefined} onCancel={() => undefined} />,
+    );
+    expect(container.querySelector('[data-testid="confirm-dialog-confirm"]')?.textContent).toBe('Confirm');
+  });
+
+  it('calls onConfirm when the confirm button is clicked', () => {
+    const onConfirm = vi.fn();
+    const { container } = render(
+      <ConfirmDialog message="?" onConfirm={onConfirm} onCancel={() => undefined} />,
+    );
+    fireEvent.click(container.querySelector('[data-testid="confirm-dialog-confirm"]')!);
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it('calls onCancel when the cancel button is clicked', () => {
+    const onCancel = vi.fn();
+    const { container } = render(
+      <ConfirmDialog message="?" onConfirm={() => undefined} onCancel={onCancel} />,
+    );
+    fireEvent.click(container.querySelector('[data-testid="confirm-dialog-cancel"]')!);
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('calls onCancel when the overlay backdrop is clicked', () => {
+    const onCancel = vi.fn();
+    const { container } = render(
+      <ConfirmDialog message="?" onConfirm={() => undefined} onCancel={onCancel} />,
+    );
+    fireEvent.click(container.querySelector('[data-testid="confirm-dialog-overlay"]')!);
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('does not call onCancel when the inner panel is clicked (stopPropagation)', () => {
+    const onCancel = vi.fn();
+    const { container } = render(
+      <ConfirmDialog message="?" onConfirm={() => undefined} onCancel={onCancel} />,
+    );
+    fireEvent.click(container.querySelector('[data-testid="confirm-dialog-panel"]')!);
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it('calls onCancel when Escape is pressed', () => {
+    const onCancel = vi.fn();
+    render(<ConfirmDialog message="?" onConfirm={() => undefined} onCancel={onCancel} />);
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('does not call onCancel for non-Escape key presses', () => {
+    const onCancel = vi.fn();
+    render(<ConfirmDialog message="?" onConfirm={() => undefined} onCancel={onCancel} />);
+    fireEvent.keyDown(window, { key: 'Enter' });
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it('renders an overlay backdrop element', () => {
+    const { container } = render(
+      <ConfirmDialog message="?" onConfirm={() => undefined} onCancel={() => undefined} />,
+    );
+    expect(container.querySelector('[data-testid="confirm-dialog-overlay"]')).toBeTruthy();
+  });
+});

--- a/apps/player-portal/src/components/dialog/ConfirmDialog.tsx
+++ b/apps/player-portal/src/components/dialog/ConfirmDialog.tsx
@@ -56,7 +56,7 @@ export function ConfirmDialog({
             type="button"
             onClick={onCancel}
             data-testid="confirm-dialog-cancel"
-            className="rounded border border-pf-border bg-white px-3 py-1.5 text-sm text-pf-text hover:bg-pf-bg-dark"
+            className="rounded border border-pf-border bg-pf-bg px-3 py-1.5 text-sm text-pf-text hover:bg-pf-bg-dark"
           >
             Cancel
           </button>

--- a/apps/player-portal/src/components/dialog/ConfirmDialog.tsx
+++ b/apps/player-portal/src/components/dialog/ConfirmDialog.tsx
@@ -1,0 +1,75 @@
+import { useEffect } from 'react';
+
+interface Props {
+  message: string;
+  /** Label for the primary confirm button. Defaults to "Confirm". */
+  confirmLabel?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * Styled in-app confirmation dialog. Replaces `window.confirm()` so the
+ * prompt stays inside the app's visual theme rather than spawning a native
+ * browser dialog with a visible URL bar.
+ *
+ * Clicking the overlay backdrop or pressing Escape cancels.
+ */
+export function ConfirmDialog({
+  message,
+  confirmLabel = 'Confirm',
+  onConfirm,
+  onCancel,
+}: Props): React.ReactElement {
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') onCancel();
+    };
+    window.addEventListener('keydown', handleKey);
+    return (): void => {
+      window.removeEventListener('keydown', handleKey);
+    };
+  }, [onCancel]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      data-testid="confirm-dialog-overlay"
+      role="dialog"
+      aria-modal="true"
+      onClick={onCancel}
+    >
+      <div
+        className="flex w-full max-w-sm flex-col overflow-hidden rounded border border-pf-border bg-pf-bg shadow-2xl"
+        data-testid="confirm-dialog-panel"
+        onClick={(e): void => {
+          e.stopPropagation();
+        }}
+      >
+        <div className="px-5 py-4">
+          <p className="text-sm text-pf-text" data-testid="confirm-dialog-message">
+            {message}
+          </p>
+        </div>
+        <footer className="flex items-center justify-end gap-2 border-t border-pf-border bg-pf-bg-dark/60 px-4 py-2.5">
+          <button
+            type="button"
+            onClick={onCancel}
+            data-testid="confirm-dialog-cancel"
+            className="rounded border border-pf-border bg-white px-3 py-1.5 text-sm text-pf-text hover:bg-pf-bg-dark"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            data-testid="confirm-dialog-confirm"
+            className="rounded border border-pf-primary bg-pf-primary px-3 py-1.5 text-sm font-semibold text-white hover:bg-pf-primary-dark"
+          >
+            {confirmLabel}
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/apps/player-portal/src/components/tabs/Actions.tsx
+++ b/apps/player-portal/src/components/tabs/Actions.tsx
@@ -110,13 +110,13 @@ function StrikeCard({
           </div>
           <VariantStrip
             variants={strike.variants}
-            onVariant={(i) => void attack.trigger(i)}
+            onVariant={(i) => { attack.trigger(i); }}
             pending={attack.state === 'pending'}
           />
           <div className="mt-1.5 flex flex-wrap gap-1.5" data-role="strike-damage-actions">
             <button
               type="button"
-              onClick={() => void damage.trigger()}
+              onClick={() => { damage.trigger(); }}
               disabled={damage.state === 'pending'}
               className="rounded border border-pf-border bg-pf-bg px-2 py-0.5 text-[11px] font-semibold text-pf-text hover:bg-pf-bg-dark disabled:opacity-50"
               data-role="strike-damage-roll"
@@ -125,7 +125,7 @@ function StrikeCard({
             </button>
             <button
               type="button"
-              onClick={() => void crit.trigger()}
+              onClick={() => { crit.trigger(); }}
               disabled={crit.state === 'pending'}
               className="rounded border border-rose-300 bg-rose-50 px-2 py-0.5 text-[11px] font-semibold text-rose-900 hover:bg-rose-100 disabled:opacity-50"
               data-role="strike-damage-crit"
@@ -330,7 +330,7 @@ function ActionCard({
             <ActionCostBadge kind={kind} count={count} />
             <button
               type="button"
-              onClick={() => void use.trigger()}
+              onClick={() => { use.trigger(); }}
               disabled={use.state === 'pending'}
               className="ml-auto rounded border border-sky-300 bg-sky-50 px-2 py-0.5 text-[11px] font-semibold text-sky-900 hover:bg-sky-100 disabled:opacity-50"
               data-role="action-use"

--- a/apps/player-portal/src/components/tabs/Character.tsx
+++ b/apps/player-portal/src/components/tabs/Character.tsx
@@ -6,6 +6,7 @@ import { formatSignedInt } from '../../lib/format';
 import { useActorAction, type ActorActionState } from '../../lib/useActorAction';
 import { RankChip } from '../common/RankChip';
 import { SectionHeader } from '../common/SectionHeader';
+import { ConfirmDialog } from '../dialog/ConfirmDialog';
 
 interface Props {
   system: CharacterSystem;
@@ -190,7 +191,7 @@ function StatsBlock({
           title={perception.breakdown}
           rank={perception.rank}
           data-stat="perception"
-          onRoll={() => void rollPerception.trigger()}
+          onRoll={() => { rollPerception.trigger(); }}
           pending={rollPerception.state === 'pending'}
         />
         <StatTile
@@ -205,17 +206,17 @@ function StatsBlock({
       <div className="mt-2 grid grid-cols-3 gap-2">
         <SaveTile
           save={saves.fortitude}
-          onRoll={() => void rollFortitude.trigger()}
+          onRoll={() => { rollFortitude.trigger(); }}
           pending={rollFortitude.state === 'pending'}
         />
         <SaveTile
           save={saves.reflex}
-          onRoll={() => void rollReflex.trigger()}
+          onRoll={() => { rollReflex.trigger(); }}
           pending={rollReflex.state === 'pending'}
         />
         <SaveTile
           save={saves.will}
-          onRoll={() => void rollWill.trigger()}
+          onRoll={() => { rollWill.trigger(); }}
           pending={rollWill.state === 'pending'}
         />
       </div>
@@ -263,10 +264,10 @@ function HpTile({
       <span className="text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark">HP</span>
       <span className="mt-0.5 font-mono text-xl font-semibold tabular-nums text-pf-text">{value}</span>
       <div className="mt-1 flex gap-0.5" data-role="hp-stepper">
-        <StepButton label="−5" disabled={state === 'pending'} onClick={() => void trigger(-5)} />
-        <StepButton label="−1" disabled={state === 'pending'} onClick={() => void trigger(-1)} />
-        <StepButton label="+1" disabled={state === 'pending'} onClick={() => void trigger(1)} />
-        <StepButton label="+5" disabled={state === 'pending'} onClick={() => void trigger(5)} />
+        <StepButton label="−5" disabled={state === 'pending'} onClick={() => { trigger(-5); }} />
+        <StepButton label="−1" disabled={state === 'pending'} onClick={() => { trigger(-1); }} />
+        <StepButton label="+1" disabled={state === 'pending'} onClick={() => { trigger(1); }} />
+        <StepButton label="+5" disabled={state === 'pending'} onClick={() => { trigger(5); }} />
       </div>
       {isError && <span className="mt-1 text-[10px] text-red-700">{state.error}</span>}
     </div>
@@ -418,7 +419,7 @@ function ResourcesRow({
           max={heroPoints.max}
           colorOn="border-rose-400 bg-rose-500"
           data-stat="hero-points"
-          onAdjust={(delta) => void adjustHero.trigger(delta)}
+          onAdjust={(delta) => { adjustHero.trigger(delta); }}
           pending={adjustHero.state === 'pending'}
         />
         {focus.max > 0 && (
@@ -429,7 +430,7 @@ function ResourcesRow({
             colorOn="border-indigo-400 bg-indigo-500"
             title={`Cap ${focus.cap.toString()}`}
             data-stat="focus"
-            onAdjust={(delta) => void adjustFocus.trigger(delta)}
+            onAdjust={(delta) => { adjustFocus.trigger(delta); }}
             pending={adjustFocus.state === 'pending'}
           />
         )}
@@ -613,7 +614,7 @@ function ConditionsRow({
           colorOn="border-red-500 bg-red-600"
           title={`Recovery DC ${dying.recoveryDC.toString()}`}
           data-stat="dying"
-          onAdjust={(delta) => void adjustDying.trigger(delta)}
+          onAdjust={(delta) => { adjustDying.trigger(delta); }}
           pending={adjustDying.state === 'pending'}
         />
         <Condition
@@ -622,7 +623,7 @@ function ConditionsRow({
           max={wounded.max}
           colorOn="border-amber-500 bg-amber-600"
           data-stat="wounded"
-          onAdjust={(delta) => void adjustWounded.trigger(delta)}
+          onAdjust={(delta) => { adjustWounded.trigger(delta); }}
           pending={adjustWounded.state === 'pending'}
         />
         <Condition
@@ -631,7 +632,7 @@ function ConditionsRow({
           max={doomed.max}
           colorOn="border-violet-500 bg-violet-700"
           data-stat="doomed"
-          onAdjust={(delta) => void adjustDoomed.trigger(delta)}
+          onAdjust={(delta) => { adjustDoomed.trigger(delta); }}
           pending={adjustDoomed.state === 'pending'}
         />
       </div>
@@ -818,7 +819,7 @@ function ChipList({ label, items }: { label: string; items: string[] }): React.R
 }
 
 function LongRestButton({ actorId, onRested }: { actorId: string; onRested: () => void }): React.ReactElement {
-  const { state, trigger } = useActorAction({
+  const { state, trigger, confirming } = useActorAction({
     run: () => api.longRest(actorId),
     confirm: 'Rest for the night? This restores HP, refreshes resources, and advances in-world time.',
     onSuccess: onRested,
@@ -826,17 +827,27 @@ function LongRestButton({ actorId, onRested }: { actorId: string; onRested: () =
   const isError = typeof state === 'object';
 
   return (
-    <div className="flex flex-col items-end gap-1" data-action="long-rest">
-      <button
-        type="button"
-        onClick={() => void trigger()}
-        disabled={state === 'pending'}
-        className="rounded border border-pf-tertiary-dark bg-pf-tertiary px-3 py-1.5 text-sm font-semibold text-pf-alt-dark hover:bg-pf-tertiary-dark hover:text-white disabled:opacity-50"
-      >
-        {state === 'pending' ? 'Resting…' : 'Long Rest'}
-      </button>
-      {isError && <span className="text-xs text-red-700">{state.error}</span>}
-    </div>
+    <>
+      {confirming !== null && (
+        <ConfirmDialog
+          message={confirming.message}
+          confirmLabel="Rest"
+          onConfirm={confirming.accept}
+          onCancel={confirming.cancel}
+        />
+      )}
+      <div className="flex flex-col items-end gap-1" data-action="long-rest">
+        <button
+          type="button"
+          onClick={() => { trigger(); }}
+          disabled={state === 'pending'}
+          className="rounded border border-pf-tertiary-dark bg-pf-tertiary px-3 py-1.5 text-sm font-semibold text-pf-alt-dark hover:bg-pf-tertiary-dark hover:text-white disabled:opacity-50"
+        >
+          {state === 'pending' ? 'Resting…' : 'Long Rest'}
+        </button>
+        {isError && <span className="text-xs text-red-700">{state.error}</span>}
+      </div>
+    </>
   );
 }
 

--- a/apps/player-portal/src/components/tabs/Crafting.tsx
+++ b/apps/player-portal/src/components/tabs/Crafting.tsx
@@ -226,7 +226,7 @@ function FormulaCard({
                 // toggle so clicking Craft doesn't also expand/collapse.
                 e.preventDefault();
                 e.stopPropagation();
-                void craft.trigger();
+                craft.trigger();
               }}
               disabled={pending}
               className="rounded border border-pf-primary bg-pf-primary/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest text-pf-primary hover:bg-pf-primary/20 disabled:cursor-not-allowed disabled:opacity-50"

--- a/apps/player-portal/src/lib/useActorAction.ts
+++ b/apps/player-portal/src/lib/useActorAction.ts
@@ -3,6 +3,17 @@ import { ApiRequestError } from '../api/client';
 
 export type ActorActionState = 'idle' | 'pending' | { error: string };
 
+/**
+ * Pending confirmation gate returned by `useActorAction` when the `confirm`
+ * option is set. Callers render a `ConfirmDialog` keyed off this value
+ * instead of relying on `window.confirm()`.
+ */
+export interface ConfirmingState {
+  message: string;
+  accept: () => void;
+  cancel: () => void;
+}
+
 // Any async function — trigger's signature mirrors it so callers can
 // pass per-click args like a Strike's MAP variant index.
 type AsyncFn = (...args: never[]) => Promise<unknown>;
@@ -17,26 +28,50 @@ interface UseActorActionOptions<TRun extends AsyncFn> {
 // show pending → surface success or error" actions against a character
 // actor. Used by Long Rest, Strike + Use on the Actions tab, and any
 // future gameplay buttons that follow the same shell.
+//
+// When `confirm` is set the hook enters a `confirming` state rather than
+// calling `window.confirm()`. Callers should render a `ConfirmDialog` while
+// `confirming` is non-null — see `LongRestButton` for the pattern.
 export function useActorAction<TRun extends AsyncFn>(opts: UseActorActionOptions<TRun>): {
   state: ActorActionState;
-  trigger: (...args: Parameters<TRun>) => Promise<void>;
+  trigger: (...args: Parameters<TRun>) => void;
+  confirming: ConfirmingState | null;
 } {
   const [state, setState] = useState<ActorActionState>('idle');
+  const [confirming, setConfirming] = useState<ConfirmingState | null>(null);
 
-  const trigger = async (...args: Parameters<TRun>): Promise<void> => {
+  const trigger = (...args: Parameters<TRun>): void => {
     if (state === 'pending') return;
-    if (opts.confirm !== undefined && !window.confirm(opts.confirm)) return;
-    setState('pending');
-    try {
-      const result = (await opts.run(...args)) as Awaited<ReturnType<TRun>>;
-      setState('idle');
-      opts.onSuccess?.(result);
-    } catch (err) {
-      setState({ error: formatError(err) });
+
+    const run = async (): Promise<void> => {
+      setState('pending');
+      try {
+        const result = (await opts.run(...(args as never[]))) as Awaited<ReturnType<TRun>>;
+        setState('idle');
+        opts.onSuccess?.(result);
+      } catch (err) {
+        setState({ error: formatError(err) });
+      }
+    };
+
+    if (opts.confirm !== undefined) {
+      setConfirming({
+        message: opts.confirm,
+        accept: () => {
+          setConfirming(null);
+          void run();
+        },
+        cancel: () => {
+          setConfirming(null);
+        },
+      });
+      return;
     }
+
+    void run();
   };
 
-  return { state, trigger };
+  return { state, trigger, confirming };
 }
 
 function formatError(err: unknown): string {


### PR DESCRIPTION
## Summary

The Long Rest button was spawning a native browser confirmation dialog via `window.confirm()`, which shows the page URL in the window chrome and has no app styling. This replaces it with a styled in-app `ConfirmDialog` component that matches the existing pf2e sheet aesthetic (dark overlay, pf-themed panel, Escape / backdrop-click to cancel). A follow-up commit fixes the Cancel button using `bg-pf-bg` instead of `bg-white` so it adapts correctly in dark mode.

Root cause: `useActorAction`'s `confirm` option passed the message directly to `window.confirm()`. The fix adds a `confirming` state to the hook — when non-null, callers render `<ConfirmDialog>` instead of relying on the native dialog.

## Changes

- `useActorAction.ts` — drop `window.confirm()`, expose `confirming: ConfirmingState | null` and change `trigger` return type from `Promise<void>` to `void` (callers already `void`-prefixed it)
- `ConfirmDialog.tsx` (new) — pf2e-themed fixed-overlay dialog; Escape and backdrop-click call `onCancel`, confirm button label is configurable; Cancel button uses `bg-pf-bg` (adapts in dark mode) not `bg-white`
- `Character.tsx` — `LongRestButton` destructures `confirming` and renders `<ConfirmDialog confirmLabel="Rest">` while it is non-null
- `Actions.tsx` / `Crafting.tsx` — auto-reformatted by linter (removed now-unnecessary `void` prefix on `trigger()` calls)

## Test plan

- [ ] `ConfirmDialog.test.tsx` (9 cases) — message, custom label, confirm/cancel/overlay-click/Escape handlers, stopPropagation on panel
- [ ] All 193 player-portal tests pass (`npm run test -w apps/player-portal`)
- [ ] Click Long Rest in `dev:player-portal:mock` — styled in-app dialog appears, Cancel dismisses it, Rest proceeds
- [ ] Verify Cancel button looks correct in both light and dark portal themes