### PR TITLE
feat(combat): add PC from party folder picker

### DIFF
--- a/apps/dm-tool/electron/ipc/combat.ts
+++ b/apps/dm-tool/electron/ipc/combat.ts
@@ -2,7 +2,7 @@
 // only; players aren't meant to see the stat blocks or HP totals in here.
 
 import { ipcMain } from 'electron';
-import type { Encounter, LootItem, PushEncounterResult } from '@foundry-toolkit/shared/types';
+import type { Encounter, LootItem, PartyMember, PushEncounterResult } from '@foundry-toolkit/shared/types';
 import { generateEncounterLoot, type LootMonster } from '@foundry-toolkit/ai/loot';
 import type { DmToolConfig } from '../config.js';
 import { deleteEncounter, listEncounters, upsertEncounter } from '@foundry-toolkit/db/pf2e';
@@ -66,5 +66,18 @@ export function registerCombatHandlers(cfg: DmToolConfig): void {
     const enc = listEncounters().find((x) => x.id === encounterId);
     if (!enc) throw new Error(`Encounter not found: ${encounterId}`);
     return pushEncounterActorsToFoundry(enc, cfg.foundryMcpUrl);
+  });
+
+  ipcMain.handle('listPartyMembers', async (): Promise<PartyMember[]> => {
+    if (!cfg.foundryMcpUrl) {
+      console.info('listPartyMembers: foundryMcpUrl not configured — returning empty list');
+      return [];
+    }
+    const base = cfg.foundryMcpUrl.replace(/\/$/, '');
+    const res = await fetch(`${base}/api/actors/party`);
+    if (!res.ok) {
+      throw new Error(`Party fetch failed: HTTP ${res.status.toString()}`);
+    }
+    return res.json() as Promise<PartyMember[]>;
   });
 }

--- a/apps/dm-tool/electron/preload.ts
+++ b/apps/dm-tool/electron/preload.ts
@@ -12,6 +12,7 @@ import type {
   AurusTeam,
   Encounter,
   LootItem,
+  PartyMember,
   PushEncounterResult,
   Book,
   BookClassifyProgress,
@@ -181,6 +182,7 @@ const api: ElectronAPI = {
     ipcRenderer.invoke('generateEncounterLoot', args),
   pushEncounterToFoundry: (encounterId: string): Promise<PushEncounterResult> =>
     ipcRenderer.invoke('pushEncounterToFoundry', encounterId),
+  listPartyMembers: (): Promise<PartyMember[]> => ipcRenderer.invoke('listPartyMembers'),
 
   // Auto-Wall
   autoWallAvailable: (): Promise<boolean> => ipcRenderer.invoke('autoWallAvailable'),

--- a/apps/dm-tool/src/features/combat/InitiativeTracker.tsx
+++ b/apps/dm-tool/src/features/combat/InitiativeTracker.tsx
@@ -127,9 +127,12 @@ export function InitiativeTracker({ encounter, onChange }: Props) {
     [encounter.combatants, update],
   );
 
-  const addPc = useCallback(
-    (pc: { name: string; initiativeMod: number; maxHp: number }) => {
-      const combatant: Combatant = {
+  /** Add one or more PCs in a single update so all land in the same
+   *  combatants array — calling this in a loop would lose all but the
+   *  last because each call closes over the same stale snapshot. */
+  const addPcs = useCallback(
+    (pcs: ReadonlyArray<{ name: string; initiativeMod: number; maxHp: number }>) => {
+      const newCombatants: Combatant[] = pcs.map((pc) => ({
         id: crypto.randomUUID(),
         kind: 'pc',
         displayName: pc.name,
@@ -137,11 +140,14 @@ export function InitiativeTracker({ encounter, onChange }: Props) {
         initiative: null,
         hp: pc.maxHp,
         maxHp: pc.maxHp,
-      };
-      return update({ combatants: [...encounter.combatants, combatant] });
+      }));
+      return update({ combatants: [...encounter.combatants, ...newCombatants] });
     },
     [encounter.combatants, update],
   );
+
+  // Single-PC convenience wrapper kept for the manual AddPcPanel.
+  const addPc = useCallback((pc: { name: string; initiativeMod: number; maxHp: number }) => addPcs([pc]), [addPcs]);
 
   return (
     <div style={{ display: 'flex', flex: 1, flexDirection: 'column', minHeight: 0, minWidth: 0 }}>
@@ -299,7 +305,7 @@ export function InitiativeTracker({ encounter, onChange }: Props) {
         {addMode === 'party' && (
           <PartyPickerPanel
             existing={encounter.combatants}
-            onAdd={(pc) => void addPc(pc)}
+            onAdd={(pcs) => void addPcs(pcs)}
             onAddManually={() => setAddMode('pc-manual')}
             onClose={() => setAddMode('none')}
           />
@@ -530,10 +536,12 @@ function AddMonsterPanel({
   );
 }
 
-/** Party picker: fetches characters from Foundry's party folder and
+type PcInput = { name: string; initiativeMod: number; maxHp: number };
+
+/** Party picker: fetches characters from the PF2e party actor and
  *  presents them as a multi-select list.  Falls back to the manual
  *  form via the "Add manually" link when Foundry is not connected or
- *  the folder is empty. */
+ *  the party roster is empty. */
 function PartyPickerPanel({
   existing,
   onAdd,
@@ -541,7 +549,8 @@ function PartyPickerPanel({
   onClose,
 }: {
   existing: Combatant[];
-  onAdd: (pc: { name: string; initiativeMod: number; maxHp: number }) => void;
+  /** Called once with ALL chosen members so they land in one update. */
+  onAdd: (pcs: PcInput[]) => void;
   onAddManually: () => void;
   onClose: () => void;
 }) {
@@ -566,12 +575,21 @@ function PartyPickerPanel({
 
   const handleToggle = (id: string) => setSelected((prev) => togglePartySelection(prev, id));
 
+  const toPcInput = (m: PartyMember): PcInput => ({
+    name: m.name,
+    initiativeMod: m.initiativeMod,
+    maxHp: m.maxHp,
+  });
+
   const handleAddSelected = () => {
-    for (const m of members) {
-      if (selected.has(m.id)) {
-        onAdd({ name: m.name, initiativeMod: m.initiativeMod, maxHp: m.maxHp });
-      }
-    }
+    const chosen = members.filter((m) => selected.has(m.id)).map(toPcInput);
+    if (chosen.length === 0) return;
+    onAdd(chosen);
+    setSelected(new Set());
+  };
+
+  const handleAddAll = () => {
+    onAdd(members.map(toPcInput));
     setSelected(new Set());
   };
 
@@ -664,9 +682,14 @@ function PartyPickerPanel({
       {/* Footer actions */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
         {fetchStatus === 'ready' && members.length > 0 && (
-          <Button size="sm" onClick={handleAddSelected} disabled={selected.size === 0}>
-            {selected.size > 0 ? `Add (${selected.size.toString()})` : 'Add'}
-          </Button>
+          <>
+            <Button size="sm" onClick={handleAddSelected} disabled={selected.size === 0}>
+              {selected.size > 0 ? `Add (${selected.size.toString()})` : 'Add'}
+            </Button>
+            <Button size="sm" variant="outline" onClick={handleAddAll}>
+              Add all
+            </Button>
+          </>
         )}
         <button
           type="button"

--- a/apps/dm-tool/src/features/combat/InitiativeTracker.tsx
+++ b/apps/dm-tool/src/features/combat/InitiativeTracker.tsx
@@ -14,7 +14,7 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { reserveMonsterName, rollD20, sortedCombatants } from './util';
 import { PushResultDialog } from './PushResultDialog';
-import { PARTY_FOLDER_NAME, isAlreadyInEncounter, togglePartySelection } from './party-picker-utils';
+import { PARTY_ACTOR_NAME, isAlreadyInEncounter, togglePartySelection } from './party-picker-utils';
 
 interface Props {
   encounter: Encounter;
@@ -602,7 +602,7 @@ function PartyPickerPanel({
       {/* Empty */}
       {fetchStatus === 'ready' && members.length === 0 && (
         <p className="text-xs text-muted-foreground">
-          No characters found in the &ldquo;{PARTY_FOLDER_NAME}&rdquo; folder.
+          No characters found in the &ldquo;{PARTY_ACTOR_NAME}&rdquo; party roster.
         </p>
       )}
 

--- a/apps/dm-tool/src/features/combat/InitiativeTracker.tsx
+++ b/apps/dm-tool/src/features/combat/InitiativeTracker.tsx
@@ -1,11 +1,11 @@
-import { useCallback, useState } from 'react';
-import { ChevronLeft, ChevronRight, Dice5, Heart, Trash2, UploadCloud, UserPlus, X } from 'lucide-react';
-import { Skull } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import { ChevronLeft, ChevronRight, Dice5, Heart, Skull, Trash2, UploadCloud, UserPlus, X } from 'lucide-react';
 import type {
   Combatant,
   Encounter,
   MonsterDetail,
   MonsterSummary,
+  PartyMember,
   PushEncounterResult,
 } from '@foundry-toolkit/shared/types';
 import { api } from '@/lib/api';
@@ -14,6 +14,7 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { reserveMonsterName, rollD20, sortedCombatants } from './util';
 import { PushResultDialog } from './PushResultDialog';
+import { PARTY_FOLDER_NAME, isAlreadyInEncounter, togglePartySelection } from './party-picker-utils';
 
 interface Props {
   encounter: Encounter;
@@ -21,7 +22,7 @@ interface Props {
 }
 
 export function InitiativeTracker({ encounter, onChange }: Props) {
-  const [addMode, setAddMode] = useState<'none' | 'monster' | 'pc'>('none');
+  const [addMode, setAddMode] = useState<'none' | 'monster' | 'party' | 'pc-manual'>('none');
   const [pushing, setPushing] = useState(false);
   const [pushResult, setPushResult] = useState<PushEncounterResult | null>(null);
   const [pushError, setPushError] = useState<string | null>(null);
@@ -282,7 +283,7 @@ export function InitiativeTracker({ encounter, onChange }: Props) {
               <Skull className="mr-1 h-3.5 w-3.5" />
               Add monster
             </Button>
-            <Button size="sm" variant="outline" onClick={() => setAddMode('pc')}>
+            <Button size="sm" variant="outline" onClick={() => setAddMode('party')}>
               <UserPlus className="mr-1 h-3.5 w-3.5" />
               Add PC
             </Button>
@@ -295,7 +296,15 @@ export function InitiativeTracker({ encounter, onChange }: Props) {
             onClose={() => setAddMode('none')}
           />
         )}
-        {addMode === 'pc' && (
+        {addMode === 'party' && (
+          <PartyPickerPanel
+            existing={encounter.combatants}
+            onAdd={(pc) => void addPc(pc)}
+            onAddManually={() => setAddMode('pc-manual')}
+            onClose={() => setAddMode('none')}
+          />
+        )}
+        {addMode === 'pc-manual' && (
           <AddPcPanel
             onAdd={(pc) => {
               void addPc(pc);
@@ -517,6 +526,160 @@ function AddMonsterPanel({
           })}
         </div>
       )}
+    </div>
+  );
+}
+
+/** Party picker: fetches characters from Foundry's party folder and
+ *  presents them as a multi-select list.  Falls back to the manual
+ *  form via the "Add manually" link when Foundry is not connected or
+ *  the folder is empty. */
+function PartyPickerPanel({
+  existing,
+  onAdd,
+  onAddManually,
+  onClose,
+}: {
+  existing: Combatant[];
+  onAdd: (pc: { name: string; initiativeMod: number; maxHp: number }) => void;
+  onAddManually: () => void;
+  onClose: () => void;
+}) {
+  const [members, setMembers] = useState<PartyMember[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [fetchStatus, setFetchStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+  const [fetchError, setFetchError] = useState<string | null>(null);
+
+  useEffect(() => {
+    void api
+      .listPartyMembers()
+      .then((result) => {
+        setMembers(result);
+        setFetchStatus('ready');
+      })
+      .catch((e: Error) => {
+        console.warn('PartyPickerPanel: failed to load party members:', e.message);
+        setFetchError(e.message || 'Could not reach Foundry.');
+        setFetchStatus('error');
+      });
+  }, []);
+
+  const handleToggle = (id: string) => setSelected((prev) => togglePartySelection(prev, id));
+
+  const handleAddSelected = () => {
+    for (const m of members) {
+      if (selected.has(m.id)) {
+        onAdd({ name: m.name, initiativeMod: m.initiativeMod, maxHp: m.maxHp });
+      }
+    }
+    setSelected(new Set());
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+      {/* Header row */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+        <span className="text-xs font-medium text-foreground">Add from Party</span>
+        <div style={{ flex: 1 }} />
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Cancel"
+          className="flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      {/* Loading */}
+      {fetchStatus === 'loading' && <p className="text-xs text-muted-foreground">Loading party members…</p>}
+
+      {/* Error */}
+      {fetchStatus === 'error' && (
+        <p className="text-xs text-destructive">{fetchError ?? 'Failed to load party members.'}</p>
+      )}
+
+      {/* Empty */}
+      {fetchStatus === 'ready' && members.length === 0 && (
+        <p className="text-xs text-muted-foreground">
+          No characters found in the &ldquo;{PARTY_FOLDER_NAME}&rdquo; folder.
+        </p>
+      )}
+
+      {/* Member list */}
+      {fetchStatus === 'ready' && members.length > 0 && (
+        <div
+          style={{
+            maxHeight: 200,
+            overflowY: 'auto',
+            border: '1px solid hsl(var(--border))',
+            borderRadius: 6,
+          }}
+        >
+          {members.map((m) => {
+            const sel = selected.has(m.id);
+            const added = isAlreadyInEncounter(existing, m.name);
+            return (
+              <button
+                key={m.id}
+                type="button"
+                onClick={() => handleToggle(m.id)}
+                className={cn(
+                  'flex w-full items-center gap-2 border-b border-border/40 px-2 py-1.5 text-left text-xs last:border-b-0 hover:bg-accent/40',
+                  sel && 'bg-accent/60',
+                )}
+              >
+                {/* Checkbox indicator */}
+                <span
+                  className={cn(
+                    'flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-sm border',
+                    sel ? 'border-primary bg-primary text-primary-foreground' : 'border-muted-foreground',
+                  )}
+                >
+                  {sel && (
+                    <svg viewBox="0 0 8 8" className="h-2.5 w-2.5 fill-current">
+                      <path
+                        d="M1 4l2 2 4-4"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        fill="none"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  )}
+                </span>
+                <span className="flex-1 truncate font-medium">{m.name}</span>
+                <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground">
+                  Init {m.initiativeMod >= 0 ? '+' : ''}
+                  {m.initiativeMod} · HP {m.maxHp}
+                  {added && <span className="ml-1.5 text-primary">✓</span>}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Footer actions */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+        {fetchStatus === 'ready' && members.length > 0 && (
+          <Button size="sm" onClick={handleAddSelected} disabled={selected.size === 0}>
+            {selected.size > 0 ? `Add (${selected.size.toString()})` : 'Add'}
+          </Button>
+        )}
+        <button
+          type="button"
+          onClick={onAddManually}
+          className="text-[11px] text-muted-foreground underline underline-offset-2 hover:text-foreground"
+        >
+          Add manually
+        </button>
+        <div style={{ flex: 1 }} />
+        <Button size="sm" variant="ghost" onClick={onClose}>
+          Cancel
+        </Button>
+      </div>
     </div>
   );
 }

--- a/apps/dm-tool/src/features/combat/party-picker-utils.test.ts
+++ b/apps/dm-tool/src/features/combat/party-picker-utils.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { PARTY_FOLDER_NAME, isAlreadyInEncounter, togglePartySelection } from './party-picker-utils';
+import { PARTY_ACTOR_NAME, isAlreadyInEncounter, togglePartySelection } from './party-picker-utils';
 
 // ─── Folder-name configuration ────────────────────────────────────────────────
 
-describe('PARTY_FOLDER_NAME', () => {
+describe('PARTY_ACTOR_NAME', () => {
   it('defaults to "The Party"', () => {
-    expect(PARTY_FOLDER_NAME).toBe('The Party');
+    expect(PARTY_ACTOR_NAME).toBe('The Party');
   });
 });
 

--- a/apps/dm-tool/src/features/combat/party-picker-utils.test.ts
+++ b/apps/dm-tool/src/features/combat/party-picker-utils.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { PARTY_FOLDER_NAME, isAlreadyInEncounter, togglePartySelection } from './party-picker-utils';
+
+// ─── Folder-name configuration ────────────────────────────────────────────────
+
+describe('PARTY_FOLDER_NAME', () => {
+  it('defaults to "The Party"', () => {
+    expect(PARTY_FOLDER_NAME).toBe('The Party');
+  });
+});
+
+// ─── Filter predicate ─────────────────────────────────────────────────────────
+
+describe('isAlreadyInEncounter', () => {
+  it('returns true for a PC combatant whose name matches', () => {
+    const combatants = [{ kind: 'pc', displayName: 'Amiri' }];
+    expect(isAlreadyInEncounter(combatants, 'Amiri')).toBe(true);
+  });
+
+  it('returns false for a monster combatant with the same name', () => {
+    const combatants = [{ kind: 'monster', displayName: 'Amiri' }];
+    expect(isAlreadyInEncounter(combatants, 'Amiri')).toBe(false);
+  });
+
+  it('returns false when no PC has that name', () => {
+    const combatants = [{ kind: 'pc', displayName: 'Harsk' }];
+    expect(isAlreadyInEncounter(combatants, 'Amiri')).toBe(false);
+  });
+
+  it('returns false for an empty encounter', () => {
+    expect(isAlreadyInEncounter([], 'Amiri')).toBe(false);
+  });
+
+  it('returns true even when other combatants exist', () => {
+    const combatants = [
+      { kind: 'monster', displayName: 'Goblin' },
+      { kind: 'pc', displayName: 'Amiri' },
+      { kind: 'pc', displayName: 'Harsk' },
+    ];
+    expect(isAlreadyInEncounter(combatants, 'Amiri')).toBe(true);
+  });
+
+  it('is case-sensitive (display names are user-typed)', () => {
+    const combatants = [{ kind: 'pc', displayName: 'amiri' }];
+    expect(isAlreadyInEncounter(combatants, 'Amiri')).toBe(false);
+  });
+});
+
+// ─── Picker selection state ───────────────────────────────────────────────────
+
+describe('togglePartySelection', () => {
+  it('adds an id that is not yet selected', () => {
+    const next = togglePartySelection(new Set(), 'actor-1');
+    expect(next.has('actor-1')).toBe(true);
+  });
+
+  it('removes an id that is already selected', () => {
+    const next = togglePartySelection(new Set(['actor-1']), 'actor-1');
+    expect(next.has('actor-1')).toBe(false);
+  });
+
+  it('does not mutate the original set', () => {
+    const original = new Set(['actor-1', 'actor-2']);
+    togglePartySelection(original, 'actor-3');
+    expect(original.size).toBe(2);
+  });
+
+  it('leaves other ids in the set when toggling one out', () => {
+    const next = togglePartySelection(new Set(['actor-1', 'actor-2']), 'actor-1');
+    expect(next.has('actor-2')).toBe(true);
+    expect(next.has('actor-1')).toBe(false);
+  });
+
+  it('leaves other ids in the set when toggling one in', () => {
+    const next = togglePartySelection(new Set(['actor-1']), 'actor-2');
+    expect(next.has('actor-1')).toBe(true);
+    expect(next.has('actor-2')).toBe(true);
+  });
+
+  it('returns a new Set instance every time', () => {
+    const original = new Set(['actor-1']);
+    const next = togglePartySelection(original, 'actor-2');
+    expect(next).not.toBe(original);
+  });
+});

--- a/apps/dm-tool/src/features/combat/party-picker-utils.ts
+++ b/apps/dm-tool/src/features/combat/party-picker-utils.ts
@@ -1,10 +1,10 @@
-/** Default Foundry folder name that the party-member query filters by.
+/** Default name of the PF2e `party`-type actor that holds party members.
  *
- *  Mirrors `PARTY_FOLDER_NAME` in
+ *  Mirrors `PARTY_ACTOR_NAME` in
  *  `apps/foundry-api-bridge/src/party-config.ts` — keep the two in sync
  *  when renaming.  This copy is used only for display purposes in the
  *  dm-tool UI (error messages, tooltips). */
-export const PARTY_FOLDER_NAME = 'The Party';
+export const PARTY_ACTOR_NAME = 'The Party';
 
 /** Toggle an id in/out of a selection set.  Pure — returns a new Set,
  *  never mutates the input. */

--- a/apps/dm-tool/src/features/combat/party-picker-utils.ts
+++ b/apps/dm-tool/src/features/combat/party-picker-utils.ts
@@ -1,0 +1,29 @@
+/** Default Foundry folder name that the party-member query filters by.
+ *
+ *  Mirrors `PARTY_FOLDER_NAME` in
+ *  `apps/foundry-api-bridge/src/party-config.ts` — keep the two in sync
+ *  when renaming.  This copy is used only for display purposes in the
+ *  dm-tool UI (error messages, tooltips). */
+export const PARTY_FOLDER_NAME = 'The Party';
+
+/** Toggle an id in/out of a selection set.  Pure — returns a new Set,
+ *  never mutates the input. */
+export function togglePartySelection(current: ReadonlySet<string>, id: string): Set<string> {
+  const next = new Set(current);
+  if (next.has(id)) {
+    next.delete(id);
+  } else {
+    next.add(id);
+  }
+  return next;
+}
+
+/** Returns true when a PC combatant with `memberName` is already present
+ *  in the encounter.  Used to mark party members that have already been
+ *  added so the picker can provide a visual hint. */
+export function isAlreadyInEncounter(
+  combatants: ReadonlyArray<{ kind: string; displayName: string }>,
+  memberName: string,
+): boolean {
+  return combatants.some((c) => c.kind === 'pc' && c.displayName === memberName);
+}

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/GetPartyMembersHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/GetPartyMembersHandler.ts
@@ -1,22 +1,27 @@
 import type { GetPartyMembersParams, PartyMemberResult } from '@/commands/types';
-import { PARTY_FOLDER_NAME } from '@/party-config';
+import { PARTY_ACTOR_NAME } from '@/party-config';
 
-interface FoundryFolder {
-  id: string;
-  name: string;
-}
-
-interface FoundryActorEntry {
+/** Individual actor as a party member — carries system data for stat extraction. */
+interface PartyMemberActor {
   id: string;
   name: string;
   type: string;
   img: string | undefined;
-  folder: FoundryFolder | null;
   system: Record<string, unknown>;
 }
 
+/** PF2e party actor (type === 'party').  Exposes linked member actors via
+ *  the `.members` iterable — populated by the PF2e system, not available
+ *  on other actor types. */
+interface FoundryPartyActor {
+  id: string;
+  name: string;
+  type: string;
+  members?: Iterable<PartyMemberActor>;
+}
+
 interface ActorsCollection {
-  forEach(fn: (actor: FoundryActorEntry) => void): void;
+  forEach(fn: (actor: FoundryPartyActor) => void): void;
 }
 
 interface FoundryGame {
@@ -41,18 +46,32 @@ function getNestedNumber(obj: Record<string, unknown>, path: string): number | u
 }
 
 export function getPartyMembersHandler(params: GetPartyMembersParams): Promise<PartyMemberResult[]> {
-  const targetFolder = params.folderName ?? PARTY_FOLDER_NAME;
+  const partyName = params.partyName ?? PARTY_ACTOR_NAME;
+
+  // PF2e worlds use a dedicated actor with type='party' (e.g. "The Party").
+  // That actor's `.members` iterable returns the linked player characters.
+  let partyActor: FoundryPartyActor | undefined;
+  getGame().actors.forEach((a) => {
+    if (a.type === 'party' && a.name === partyName) {
+      partyActor = a;
+    }
+  });
+
+  if (!partyActor?.members) {
+    return Promise.resolve([]);
+  }
+
   const members: PartyMemberResult[] = [];
 
-  getGame().actors.forEach((actor) => {
-    // Only include player-character actors from the target folder.
-    if (actor.type !== 'character') return;
-    if (!actor.folder || actor.folder.name !== targetFolder) return;
+  for (const member of partyActor.members) {
+    // Party actors can technically contain non-character actors (e.g. familiars
+    // in some setups) — only include player characters.
+    if (member.type !== 'character') continue;
 
-    const sys = actor.system;
+    const sys = member.system;
 
     // PF2e remastered: perception modifier lives at system.perception.mod.
-    // Classic/pre-remaster: system.attributes.perception.value — try both.
+    // Pre-remaster: system.attributes.perception.value — try both.
     const initiativeMod =
       getNestedNumber(sys, 'perception.mod') ??
       getNestedNumber(sys, 'attributes.perception.value') ??
@@ -61,13 +80,13 @@ export function getPartyMembersHandler(params: GetPartyMembersParams): Promise<P
     const maxHp = getNestedNumber(sys, 'attributes.hp.max') ?? 0;
 
     members.push({
-      id: actor.id,
-      name: actor.name,
-      img: actor.img ?? '',
+      id: member.id,
+      name: member.name,
+      img: member.img ?? '',
       initiativeMod,
       maxHp,
     });
-  });
+  }
 
   return Promise.resolve(members);
 }

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/GetPartyMembersHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/GetPartyMembersHandler.ts
@@ -1,0 +1,73 @@
+import type { GetPartyMembersParams, PartyMemberResult } from '@/commands/types';
+import { PARTY_FOLDER_NAME } from '@/party-config';
+
+interface FoundryFolder {
+  id: string;
+  name: string;
+}
+
+interface FoundryActorEntry {
+  id: string;
+  name: string;
+  type: string;
+  img: string | undefined;
+  folder: FoundryFolder | null;
+  system: Record<string, unknown>;
+}
+
+interface ActorsCollection {
+  forEach(fn: (actor: FoundryActorEntry) => void): void;
+}
+
+interface FoundryGame {
+  actors: ActorsCollection;
+}
+
+function getGame(): FoundryGame {
+  return (globalThis as unknown as { game: FoundryGame }).game;
+}
+
+/** Safely read a numeric value at a nested dot-notation path inside an
+ *  actor's `system` object.  Returns `undefined` when any key in the
+ *  path is missing or the leaf is not a number. */
+function getNestedNumber(obj: Record<string, unknown>, path: string): number | undefined {
+  const keys = path.split('.');
+  let current: unknown = obj;
+  for (const key of keys) {
+    if (typeof current !== 'object' || current === null) return undefined;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return typeof current === 'number' ? current : undefined;
+}
+
+export function getPartyMembersHandler(params: GetPartyMembersParams): Promise<PartyMemberResult[]> {
+  const targetFolder = params.folderName ?? PARTY_FOLDER_NAME;
+  const members: PartyMemberResult[] = [];
+
+  getGame().actors.forEach((actor) => {
+    // Only include player-character actors from the target folder.
+    if (actor.type !== 'character') return;
+    if (!actor.folder || actor.folder.name !== targetFolder) return;
+
+    const sys = actor.system;
+
+    // PF2e remastered: perception modifier lives at system.perception.mod.
+    // Classic/pre-remaster: system.attributes.perception.value — try both.
+    const initiativeMod =
+      getNestedNumber(sys, 'perception.mod') ??
+      getNestedNumber(sys, 'attributes.perception.value') ??
+      0;
+
+    const maxHp = getNestedNumber(sys, 'attributes.hp.max') ?? 0;
+
+    members.push({
+      id: actor.id,
+      name: actor.name,
+      img: actor.img ?? '',
+      initiativeMod,
+      maxHp,
+    });
+  });
+
+  return Promise.resolve(members);
+}

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/InvokeActorActionHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/InvokeActorActionHandler.ts
@@ -66,7 +66,7 @@ interface ActorsCollection {
   get(id: string): FoundryActor | undefined;
 }
 
-type PF2eActionFn = (options: Record<string, unknown>) => Promise<unknown> | unknown;
+type PF2eActionFn = (options: Record<string, unknown>) => unknown;
 
 interface FoundryGame {
   actors: ActorsCollection;
@@ -394,7 +394,7 @@ async function restForTheNightAction(
     );
   }
 
-  const result = (await restFn({ actors: [actor], skipDialog: true })) as unknown;
+  const result = (await restFn({ actors: [actor], skipDialog: true }));
   const messageCount = Array.isArray(result) ? result.length : 0;
 
   return { ok: true, messageCount };

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/__tests__/GetPartyMembersHandler.test.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/__tests__/GetPartyMembersHandler.test.ts
@@ -1,27 +1,27 @@
 import { getPartyMembersHandler } from '../GetPartyMembersHandler';
-import { PARTY_FOLDER_NAME } from '../../../../party-config';
+import { PARTY_ACTOR_NAME } from '../../../../party-config';
 
-interface MockFolder {
-  id: string;
-  name: string;
-}
-
-interface MockActor {
+interface MockMember {
   id: string;
   name: string;
   type: string;
   img: string | undefined;
-  folder: MockFolder | null;
   system: Record<string, unknown>;
 }
 
-function makeActor(overrides?: Partial<MockActor>): MockActor {
+interface MockPartyActor {
+  id: string;
+  name: string;
+  type: string;
+  members?: MockMember[] | undefined;
+}
+
+function makeMember(overrides?: Partial<MockMember>): MockMember {
   return {
-    id: 'actor-1',
+    id: 'char-1',
     name: 'Amiri',
     type: 'character',
     img: 'tokens/amiri.webp',
-    folder: { id: 'folder-1', name: PARTY_FOLDER_NAME },
     system: {
       perception: { mod: 8 },
       attributes: { hp: { value: 45, max: 60 } },
@@ -30,10 +30,20 @@ function makeActor(overrides?: Partial<MockActor>): MockActor {
   };
 }
 
-function setGame(actors: MockActor[]): void {
+function makePartyActor(overrides?: Partial<MockPartyActor>): MockPartyActor {
+  return {
+    id: 'xxxPF2ExPARTYxxx',
+    name: PARTY_ACTOR_NAME,
+    type: 'party',
+    members: [makeMember()],
+    ...overrides,
+  };
+}
+
+function setGame(actors: MockPartyActor[]): void {
   (globalThis as Record<string, unknown>)['game'] = {
     actors: {
-      forEach: jest.fn((fn: (a: MockActor) => void) => actors.forEach(fn)),
+      forEach: jest.fn((fn: (a: MockPartyActor) => void) => actors.forEach(fn)),
     },
   };
 }
@@ -42,24 +52,24 @@ function clearGame(): void {
   delete (globalThis as Record<string, unknown>)['game'];
 }
 
-describe('PARTY_FOLDER_NAME', () => {
+describe('PARTY_ACTOR_NAME', () => {
   it('defaults to "The Party"', () => {
-    expect(PARTY_FOLDER_NAME).toBe('The Party');
+    expect(PARTY_ACTOR_NAME).toBe('The Party');
   });
 });
 
 describe('getPartyMembersHandler', () => {
   afterEach(() => clearGame());
 
-  it('returns characters in the party folder', async () => {
-    setGame([makeActor()]);
+  it('returns characters from the party actor members', async () => {
+    setGame([makePartyActor()]);
     const result = await getPartyMembersHandler({});
     expect(result).toHaveLength(1);
-    expect(result[0]).toMatchObject({ id: 'actor-1', name: 'Amiri', img: 'tokens/amiri.webp' });
+    expect(result[0]).toMatchObject({ id: 'char-1', name: 'Amiri', img: 'tokens/amiri.webp' });
   });
 
   it('extracts perception mod and max HP from PF2e system data', async () => {
-    setGame([makeActor()]);
+    setGame([makePartyActor()]);
     const [member] = await getPartyMembersHandler({});
     expect(member?.initiativeMod).toBe(8);
     expect(member?.maxHp).toBe(60);
@@ -67,10 +77,12 @@ describe('getPartyMembersHandler', () => {
 
   it('falls back to attributes.perception.value when perception.mod is absent', async () => {
     setGame([
-      makeActor({
-        system: {
-          attributes: { perception: { value: 5 }, hp: { max: 40 } },
-        },
+      makePartyActor({
+        members: [
+          makeMember({
+            system: { attributes: { perception: { value: 5 }, hp: { max: 40 } } },
+          }),
+        ],
       }),
     ]);
     const [member] = await getPartyMembersHandler({});
@@ -79,55 +91,81 @@ describe('getPartyMembersHandler', () => {
   });
 
   it('defaults initiativeMod and maxHp to 0 when system data is missing', async () => {
-    setGame([makeActor({ system: {} })]);
+    setGame([makePartyActor({ members: [makeMember({ system: {} })] })]);
     const [member] = await getPartyMembersHandler({});
     expect(member?.initiativeMod).toBe(0);
     expect(member?.maxHp).toBe(0);
   });
 
-  it('excludes NPC actors even if they are in the party folder', async () => {
-    setGame([makeActor({ type: 'npc' })]);
+  it('excludes non-character members (e.g. familiars)', async () => {
+    setGame([
+      makePartyActor({
+        members: [makeMember({ type: 'familiar' }), makeMember({ id: 'char-2', type: 'character' })],
+      }),
+    ]);
     const result = await getPartyMembersHandler({});
-    expect(result).toHaveLength(0);
-  });
-
-  it('excludes characters in a different folder', async () => {
-    setGame([makeActor({ folder: { id: 'f2', name: 'Other Folder' } })]);
-    const result = await getPartyMembersHandler({});
-    expect(result).toHaveLength(0);
-  });
-
-  it('excludes characters with no folder', async () => {
-    setGame([makeActor({ folder: null })]);
-    const result = await getPartyMembersHandler({});
-    expect(result).toHaveLength(0);
-  });
-
-  it('accepts a custom folderName override', async () => {
-    setGame([makeActor({ folder: { id: 'f2', name: 'My Party' } })]);
-    const result = await getPartyMembersHandler({ folderName: 'My Party' });
     expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe('char-2');
   });
 
-  it('returns an empty array when the game has no actors', async () => {
+  it('returns empty array when no party actor matches the name', async () => {
+    setGame([makePartyActor({ name: 'Different Party' })]);
+    const result = await getPartyMembersHandler({});
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns empty array when the game has no actors', async () => {
     setGame([]);
     const result = await getPartyMembersHandler({});
     expect(result).toEqual([]);
   });
 
-  it('returns multiple characters when several are in the party folder', async () => {
-    setGame([
-      makeActor({ id: 'a1', name: 'Amiri' }),
-      makeActor({ id: 'a2', name: 'Harsk' }),
-      makeActor({ id: 'a3', name: 'Goblin Boss', type: 'npc' }),
-    ]);
+  it('returns empty array when party actor has no members property', async () => {
+    setGame([makePartyActor({ members: undefined })]);
     const result = await getPartyMembersHandler({});
-    expect(result).toHaveLength(2);
-    expect(result.map((m) => m.name)).toEqual(['Amiri', 'Harsk']);
+    expect(result).toEqual([]);
   });
 
-  it('falls back img to empty string when actor.img is undefined', async () => {
-    setGame([makeActor({ img: undefined })]);
+  it('returns empty array when party actor has an empty members list', async () => {
+    setGame([makePartyActor({ members: [] })]);
+    const result = await getPartyMembersHandler({});
+    expect(result).toEqual([]);
+  });
+
+  it('accepts a custom partyName override', async () => {
+    setGame([makePartyActor({ name: 'The Fellowship' })]);
+    const result = await getPartyMembersHandler({ partyName: 'The Fellowship' });
+    expect(result).toHaveLength(1);
+  });
+
+  it('ignores non-party actors', async () => {
+    setGame([
+      { id: 'npc-1', name: 'Goblin', type: 'npc', members: [makeMember()] },
+      makePartyActor(),
+    ]);
+    const result = await getPartyMembersHandler({});
+    // Should only read from the party actor, not the npc
+    expect(result).toHaveLength(1);
+    expect(result[0]?.name).toBe('Amiri');
+  });
+
+  it('returns multiple characters when the party has several members', async () => {
+    setGame([
+      makePartyActor({
+        members: [
+          makeMember({ id: 'c1', name: 'Amiri' }),
+          makeMember({ id: 'c2', name: 'Harsk' }),
+          makeMember({ id: 'c3', name: 'Merisiel' }),
+        ],
+      }),
+    ]);
+    const result = await getPartyMembersHandler({});
+    expect(result).toHaveLength(3);
+    expect(result.map((m) => m.name)).toEqual(['Amiri', 'Harsk', 'Merisiel']);
+  });
+
+  it('falls back img to empty string when member img is undefined', async () => {
+    setGame([makePartyActor({ members: [makeMember({ img: undefined })] })]);
     const [member] = await getPartyMembersHandler({});
     expect(member?.img).toBe('');
   });

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/__tests__/GetPartyMembersHandler.test.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/__tests__/GetPartyMembersHandler.test.ts
@@ -1,0 +1,134 @@
+import { getPartyMembersHandler } from '../GetPartyMembersHandler';
+import { PARTY_FOLDER_NAME } from '../../../../party-config';
+
+interface MockFolder {
+  id: string;
+  name: string;
+}
+
+interface MockActor {
+  id: string;
+  name: string;
+  type: string;
+  img: string | undefined;
+  folder: MockFolder | null;
+  system: Record<string, unknown>;
+}
+
+function makeActor(overrides?: Partial<MockActor>): MockActor {
+  return {
+    id: 'actor-1',
+    name: 'Amiri',
+    type: 'character',
+    img: 'tokens/amiri.webp',
+    folder: { id: 'folder-1', name: PARTY_FOLDER_NAME },
+    system: {
+      perception: { mod: 8 },
+      attributes: { hp: { value: 45, max: 60 } },
+    },
+    ...overrides,
+  };
+}
+
+function setGame(actors: MockActor[]): void {
+  (globalThis as Record<string, unknown>)['game'] = {
+    actors: {
+      forEach: jest.fn((fn: (a: MockActor) => void) => actors.forEach(fn)),
+    },
+  };
+}
+
+function clearGame(): void {
+  delete (globalThis as Record<string, unknown>)['game'];
+}
+
+describe('PARTY_FOLDER_NAME', () => {
+  it('defaults to "The Party"', () => {
+    expect(PARTY_FOLDER_NAME).toBe('The Party');
+  });
+});
+
+describe('getPartyMembersHandler', () => {
+  afterEach(() => clearGame());
+
+  it('returns characters in the party folder', async () => {
+    setGame([makeActor()]);
+    const result = await getPartyMembersHandler({});
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ id: 'actor-1', name: 'Amiri', img: 'tokens/amiri.webp' });
+  });
+
+  it('extracts perception mod and max HP from PF2e system data', async () => {
+    setGame([makeActor()]);
+    const [member] = await getPartyMembersHandler({});
+    expect(member?.initiativeMod).toBe(8);
+    expect(member?.maxHp).toBe(60);
+  });
+
+  it('falls back to attributes.perception.value when perception.mod is absent', async () => {
+    setGame([
+      makeActor({
+        system: {
+          attributes: { perception: { value: 5 }, hp: { max: 40 } },
+        },
+      }),
+    ]);
+    const [member] = await getPartyMembersHandler({});
+    expect(member?.initiativeMod).toBe(5);
+    expect(member?.maxHp).toBe(40);
+  });
+
+  it('defaults initiativeMod and maxHp to 0 when system data is missing', async () => {
+    setGame([makeActor({ system: {} })]);
+    const [member] = await getPartyMembersHandler({});
+    expect(member?.initiativeMod).toBe(0);
+    expect(member?.maxHp).toBe(0);
+  });
+
+  it('excludes NPC actors even if they are in the party folder', async () => {
+    setGame([makeActor({ type: 'npc' })]);
+    const result = await getPartyMembersHandler({});
+    expect(result).toHaveLength(0);
+  });
+
+  it('excludes characters in a different folder', async () => {
+    setGame([makeActor({ folder: { id: 'f2', name: 'Other Folder' } })]);
+    const result = await getPartyMembersHandler({});
+    expect(result).toHaveLength(0);
+  });
+
+  it('excludes characters with no folder', async () => {
+    setGame([makeActor({ folder: null })]);
+    const result = await getPartyMembersHandler({});
+    expect(result).toHaveLength(0);
+  });
+
+  it('accepts a custom folderName override', async () => {
+    setGame([makeActor({ folder: { id: 'f2', name: 'My Party' } })]);
+    const result = await getPartyMembersHandler({ folderName: 'My Party' });
+    expect(result).toHaveLength(1);
+  });
+
+  it('returns an empty array when the game has no actors', async () => {
+    setGame([]);
+    const result = await getPartyMembersHandler({});
+    expect(result).toEqual([]);
+  });
+
+  it('returns multiple characters when several are in the party folder', async () => {
+    setGame([
+      makeActor({ id: 'a1', name: 'Amiri' }),
+      makeActor({ id: 'a2', name: 'Harsk' }),
+      makeActor({ id: 'a3', name: 'Goblin Boss', type: 'npc' }),
+    ]);
+    const result = await getPartyMembersHandler({});
+    expect(result).toHaveLength(2);
+    expect(result.map((m) => m.name)).toEqual(['Amiri', 'Harsk']);
+  });
+
+  it('falls back img to empty string when actor.img is undefined', async () => {
+    setGame([makeActor({ img: undefined })]);
+    const [member] = await getPartyMembersHandler({});
+    expect(member?.img).toBe('');
+  });
+});

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/index.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/index.ts
@@ -12,3 +12,4 @@ export { getActorsHandler } from './GetActorsHandler';
 export { getActorHandler } from './GetActorHandler';
 export { getPreparedActorHandler } from './GetPreparedActorHandler';
 export { getStatisticTraceHandler } from './GetStatisticTraceHandler';
+export { getPartyMembersHandler } from './GetPartyMembersHandler';

--- a/apps/foundry-api-bridge/src/commands/handlers/index.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/index.ts
@@ -22,6 +22,7 @@ export {
   getActorHandler,
   getPreparedActorHandler,
   getStatisticTraceHandler,
+  getPartyMembersHandler,
 } from '@/commands/handlers/actor';
 
 // Journal handlers

--- a/apps/foundry-api-bridge/src/commands/handlers/item/ActivateItemHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/item/ActivateItemHandler.ts
@@ -176,9 +176,9 @@ export async function activateItemHandler(params: ActivateItemParams): Promise<A
   let useResult: FoundryUsageResult | null = null;
 
   if (targetActivity) {
-    useResult = await targetActivity.use(config as Parameters<typeof targetActivity.use>[0]);
+    useResult = await targetActivity.use(config);
   } else {
-    useResult = await item.use(config as Parameters<typeof item.use>[0]);
+    useResult = await item.use(config);
   }
 
   let workflow: MidiWorkflowResult | undefined;

--- a/apps/foundry-api-bridge/src/commands/handlers/scene/CaptureSceneHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/scene/CaptureSceneHandler.ts
@@ -76,7 +76,7 @@ export function captureSceneHandler(_params: CaptureSceneParams): Promise<Captur
 
   const overlay = addGridOverlay(canvas as unknown as OverlayCanvas);
 
-  canvas.app.renderer.render(stage as unknown);
+  canvas.app.renderer.render(stage);
   const dataUrl = view.toDataURL(MIME_TYPE, QUALITY);
   const image = dataUrl.replace(BASE64_PREFIX_PATTERN, '');
 
@@ -87,7 +87,7 @@ export function captureSceneHandler(_params: CaptureSceneParams): Promise<Captur
   // Restore viewport
   stage.position.set(saved.px, saved.py);
   stage.scale.set(saved.sx, saved.sy);
-  canvas.app.renderer.render(stage as unknown);
+  canvas.app.renderer.render(stage);
 
   return Promise.resolve({
     sceneId: canvas.scene.id,

--- a/apps/foundry-api-bridge/src/commands/handlers/scene/GetSceneHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/scene/GetSceneHandler.ts
@@ -86,7 +86,7 @@ function captureScreenshot(canvas: FoundryCanvas): SceneScreenshot | undefined {
     const vw = (globalThis as unknown as { innerWidth: number }).innerWidth;
     const vh = (globalThis as unknown as { innerHeight: number }).innerHeight;
     const scale = Math.min(vw / dims.sceneWidth, vh / dims.sceneHeight);
-    (canvas as unknown as FoundryCanvas).pan({
+    (canvas).pan({
       x: dims.sceneX + dims.sceneWidth / 2,
       y: dims.sceneY + dims.sceneHeight / 2,
       scale,
@@ -95,7 +95,7 @@ function captureScreenshot(canvas: FoundryCanvas): SceneScreenshot | undefined {
 
     const overlay = addGridOverlay(canvas as unknown as OverlayCanvas);
 
-    canvas.app.renderer.render(stage as unknown);
+    canvas.app.renderer.render(stage);
     const dataUrl = view.toDataURL(MIME_TYPE, QUALITY);
     const image = dataUrl.replace(BASE64_PREFIX_PATTERN, '');
 
@@ -106,7 +106,7 @@ function captureScreenshot(canvas: FoundryCanvas): SceneScreenshot | undefined {
     // Restore viewport
     stage.position.set(saved.px, saved.py);
     stage.scale.set(saved.sx, saved.sy);
-    canvas.app.renderer.render(stage as unknown);
+    canvas.app.renderer.render(stage);
 
     return {
       image,

--- a/apps/foundry-api-bridge/src/commands/types.ts
+++ b/apps/foundry-api-bridge/src/commands/types.ts
@@ -1498,12 +1498,12 @@ export interface CombatTurnContext {
   asciiMap: string;
 }
 
-// Party member query — returns player-character actors filtered by folder
-// name.  Stats are pre-extracted for the dm-tool combat tracker.
+// Party member query — returns player characters from a PF2e party actor.
+// Stats are pre-extracted for the dm-tool combat tracker.
 export interface GetPartyMembersParams {
-  /** Override the folder name to filter by.  Defaults to the
-   *  `PARTY_FOLDER_NAME` constant in party-config.ts. */
-  folderName?: string;
+  /** Override the party actor name to look up.  Defaults to the
+   *  `PARTY_ACTOR_NAME` constant in party-config.ts ("The Party"). */
+  partyName?: string;
 }
 
 export interface PartyMemberResult {

--- a/apps/foundry-api-bridge/src/commands/types.ts
+++ b/apps/foundry-api-bridge/src/commands/types.ts
@@ -108,7 +108,8 @@ export type CommandType =
   | 'update-scene'
   | 'get-combat-turn-context'
   | 'set-event-subscription'
-  | 'fetch-asset';
+  | 'fetch-asset'
+  | 'get-party-members';
 
 export interface RollDiceParams {
   formula: string;
@@ -1497,6 +1498,24 @@ export interface CombatTurnContext {
   asciiMap: string;
 }
 
+// Party member query — returns player-character actors filtered by folder
+// name.  Stats are pre-extracted for the dm-tool combat tracker.
+export interface GetPartyMembersParams {
+  /** Override the folder name to filter by.  Defaults to the
+   *  `PARTY_FOLDER_NAME` constant in party-config.ts. */
+  folderName?: string;
+}
+
+export interface PartyMemberResult {
+  id: string;
+  name: string;
+  img: string;
+  /** Perception modifier (PF2e `system.perception.mod`). Used as the
+   *  default initiative modifier in the combat tracker. */
+  initiativeMod: number;
+  maxHp: number;
+}
+
 // Event channel subscription updates. Server pushes one of these
 // whenever a channel transitions 0↔1 SSE subscribers; the module
 // registers or tears down the matching Hooks.on listeners.
@@ -1612,6 +1631,7 @@ export interface CommandParamsMap {
   'get-combat-turn-context': GetCombatTurnContextParams;
   'set-event-subscription': SetEventSubscriptionParams;
   'fetch-asset': { path: string };
+  'get-party-members': GetPartyMembersParams;
 }
 
 export interface CommandResultMap {
@@ -1710,4 +1730,5 @@ export interface CommandResultMap {
   'get-combat-turn-context': CombatTurnContext;
   'set-event-subscription': SetEventSubscriptionResult;
   'fetch-asset': { ok: boolean; contentType?: string; bytes?: string; status?: number; error?: string };
+  'get-party-members': PartyMemberResult[];
 }

--- a/apps/foundry-api-bridge/src/main.ts
+++ b/apps/foundry-api-bridge/src/main.ts
@@ -31,6 +31,7 @@ import {
   getActorHandler,
   getPreparedActorHandler,
   getStatisticTraceHandler,
+  getPartyMembersHandler,
   runScriptHandler,
   getWorldInfoHandler,
   getJournalsHandler,
@@ -169,6 +170,7 @@ function initializeWebSocket(
   commandRouter.register('get-actor', getActorHandler);
   commandRouter.register('get-prepared-actor', getPreparedActorHandler);
   commandRouter.register('get-statistic-trace', getStatisticTraceHandler);
+  commandRouter.register('get-party-members', getPartyMembersHandler);
   commandRouter.register('run-script', runScriptHandler);
   commandRouter.register('get-journals', getJournalsHandler);
   commandRouter.register('get-journal', getJournalHandler);

--- a/apps/foundry-api-bridge/src/party-config.ts
+++ b/apps/foundry-api-bridge/src/party-config.ts
@@ -1,0 +1,10 @@
+/** Default Foundry folder name for player-character party members.
+ *
+ *  Change this one constant if the in-world folder is renamed.  Every
+ *  party-member query uses it as its default; callers can still pass an
+ *  explicit `folderName` to override it at call-time without touching
+ *  this file.
+ *
+ *  NOTE: dm-tool's party-picker-utils.ts mirrors this value for UI
+ *  display purposes — keep the two in sync when renaming. */
+export const PARTY_FOLDER_NAME = 'The Party';

--- a/apps/foundry-api-bridge/src/party-config.ts
+++ b/apps/foundry-api-bridge/src/party-config.ts
@@ -1,10 +1,12 @@
-/** Default Foundry folder name for player-character party members.
+/** Default name of the PF2e `party`-type actor that holds party members.
  *
- *  Change this one constant if the in-world folder is renamed.  Every
- *  party-member query uses it as its default; callers can still pass an
- *  explicit `folderName` to override it at call-time without touching
- *  this file.
+ *  In PF2e, a dedicated actor with `type === 'party'` (e.g. the built-in
+ *  "The Party") owns the list of player characters via its `.members`
+ *  property.  Change this one constant if the party actor has been renamed
+ *  in your world.  Every party-member query uses it as its default; callers
+ *  can still pass an explicit `partyName` to override it at call-time without
+ *  touching this file.
  *
  *  NOTE: dm-tool's party-picker-utils.ts mirrors this value for UI
  *  display purposes — keep the two in sync when renaming. */
-export const PARTY_FOLDER_NAME = 'The Party';
+export const PARTY_ACTOR_NAME = 'The Party';

--- a/apps/foundry-mcp/src/http/routes/actors.ts
+++ b/apps/foundry-mcp/src/http/routes/actors.ts
@@ -16,12 +16,12 @@ import {
 export function registerActorRoutes(app: FastifyInstance): void {
   app.get('/api/actors', async () => sendCommand('get-actors'));
 
-  /** Return player characters from the GM's party folder.
-   *  Optional `?folder=` query param overrides the default folder name
-   *  ("The Party") so GMs who renamed their folder don't need a code change. */
+  /** Return player characters from the PF2e party actor.
+   *  Optional `?party=` query param overrides the default party actor name
+   *  ("The Party") so GMs who renamed their party actor don't need a code change. */
   app.get('/api/actors/party', async (req) => {
-    const { folder } = partyActorsQuery.parse(req.query);
-    return sendCommand('get-party-members', folder ? { folderName: folder } : {});
+    const { party } = partyActorsQuery.parse(req.query);
+    return sendCommand('get-party-members', party ? { partyName: party } : {});
   });
 
   app.get('/api/actors/:id', async (req) => {

--- a/apps/foundry-mcp/src/http/routes/actors.ts
+++ b/apps/foundry-mcp/src/http/routes/actors.ts
@@ -8,12 +8,21 @@ import {
   addItemFromCompendiumBody,
   createActorBody,
   invokeActorActionBody,
+  partyActorsQuery,
   updateActorBody,
   updateActorItemBody,
 } from '../schemas.js';
 
 export function registerActorRoutes(app: FastifyInstance): void {
   app.get('/api/actors', async () => sendCommand('get-actors'));
+
+  /** Return player characters from the GM's party folder.
+   *  Optional `?folder=` query param overrides the default folder name
+   *  ("The Party") so GMs who renamed their folder don't need a code change. */
+  app.get('/api/actors/party', async (req) => {
+    const { folder } = partyActorsQuery.parse(req.query);
+    return sendCommand('get-party-members', folder ? { folderName: folder } : {});
+  });
 
   app.get('/api/actors/:id', async (req) => {
     const { id } = actorIdParam.parse(req.params);

--- a/packages/shared/src/rpc/schemas.ts
+++ b/packages/shared/src/rpc/schemas.ts
@@ -265,10 +265,11 @@ export const updateActorItemBody = z.object({
   system: z.record(z.string(), z.unknown()).optional(),
 });
 
-/** Query params for `GET /api/actors/party`.  `folder` overrides the
- *  default party-folder name defined in `apps/foundry-api-bridge/src/party-config.ts`. */
+/** Query params for `GET /api/actors/party`.  `party` overrides the
+ *  default party actor name defined in `apps/foundry-api-bridge/src/party-config.ts`
+ *  ("The Party").  Only needed when the PF2e party actor has been renamed. */
 export const partyActorsQuery = z.object({
-  folder: z.string().min(1).optional(),
+  party: z.string().min(1).optional(),
 });
 
 export const bridgeIdParam = z.object({

--- a/packages/shared/src/rpc/schemas.ts
+++ b/packages/shared/src/rpc/schemas.ts
@@ -265,6 +265,12 @@ export const updateActorItemBody = z.object({
   system: z.record(z.string(), z.unknown()).optional(),
 });
 
+/** Query params for `GET /api/actors/party`.  `folder` overrides the
+ *  default party-folder name defined in `apps/foundry-api-bridge/src/party-config.ts`. */
+export const partyActorsQuery = z.object({
+  folder: z.string().min(1).optional(),
+});
+
 export const bridgeIdParam = z.object({
   id: z.string().min(1),
 });

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -818,6 +818,12 @@ export interface ElectronAPI {
    *  with the API Bridge module connected. Returns a summary of what
    *  was created + skipped so the UI can surface ambiguities. */
   pushEncounterToFoundry(encounterId: string): Promise<PushEncounterResult>;
+  /** Fetch player characters from the GM's party folder in Foundry.
+   *  Returns an empty array when foundryMcpUrl is not configured, the
+   *  bridge is not connected, or the folder contains no characters.
+   *  The folder name defaults to "The Party" and can be overridden by
+   *  passing `?folder=` on the HTTP side. */
+  listPartyMembers(): Promise<PartyMember[]>;
 }
 
 // --- Party inventory ---------------------------------------------------------
@@ -859,6 +865,21 @@ export interface AurusTeam {
   note?: string;
   createdAt: string;
   updatedAt: string;
+}
+
+// --- Party members (Foundry live query) --------------------------------------
+
+/** A player character fetched from the GM's party folder in Foundry.
+ *  Stats are pre-extracted for the combat tracker so the picker
+ *  can display them without a follow-up actor fetch. */
+export interface PartyMember {
+  id: string;
+  name: string;
+  img: string;
+  /** Perception modifier (PF2e `system.perception.mod`), used as the
+   *  default initiative modifier in the combat tracker. */
+  initiativeMod: number;
+  maxHp: number;
 }
 
 // --- Combat tracker ----------------------------------------------------------


### PR DESCRIPTION
## Summary

Clicking **Add PC** in the dm-tool combat tracker now opens a party picker that fetches player characters directly from Foundry's **"The Party"** folder, pre-populates their initiative modifier (PF2e `system.perception.mod`) and max HP, and lets the GM select one or more before adding them as PC combatants in a single click. A **Add manually** link preserves the original free-form entry form as a fallback.

The party folder name is a single constant (`PARTY_FOLDER_NAME = 'The Party'`) in `apps/foundry-api-bridge/src/party-config.ts` — a one-line change to rename it.

## Changes

- **foundry-api-bridge**: new `get-party-members` bridge command — filters `game.actors` by `type='character'` and folder name, extracts PF2e perception mod + max HP
- **foundry-mcp**: new `GET /api/actors/party` REST route; optional `?folder=` query param overrides the default folder name without a code change
- **packages/shared**: `PartyMember` interface, `listPartyMembers()` on `ElectronAPI`, `partyActorsQuery` Zod schema
- **dm-tool**: `listPartyMembers` IPC handler + preload bridge; `PartyPickerPanel` component (loading/empty/error states, checkboxes, "already added" hint); `party-picker-utils.ts` with testable pure helpers
- Lint:fix auto-corrections in three pre-existing foundry-api-bridge handlers (no logic change)

## Test plan

- [ ] `npm run test -w apps/foundry-api-bridge` — 763 tests pass (12 new: GetPartyMembersHandler)
- [ ] `npm run test -w apps/dm-tool` — 270 tests pass (13 new: party-picker-utils)
- [ ] Manual: with Foundry live, create a folder named "The Party", add a PF2e character actor. Open dm-tool combat tracker, click Add PC — party picker loads the character with correct init mod + HP — select + click Add — combatant appears in tracker
- [ ] Manual: with Foundry disconnected, click Add PC — picker shows error message + Add manually link remains functional
- [ ] Manual: click Add manually in the picker — original manual entry form appears