### PR TITLE
fix(api-bridge): suppress CheckDialogPF2e for portal attack rolls

### DIFF
--- a/apps/foundry-api-bridge/src/commands/handlers/actor/InvokeActorActionHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/InvokeActorActionHandler.ts
@@ -66,7 +66,7 @@ interface ActorsCollection {
   get(id: string): FoundryActor | undefined;
 }
 
-type PF2eActionFn = (options: Record<string, unknown>) => unknown;
+type PF2eActionFn = (options: Record<string, unknown>) => Promise<unknown>;
 
 interface FoundryGame {
   actors: ActorsCollection;

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/InvokeActorActionHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/InvokeActorActionHandler.ts
@@ -427,7 +427,7 @@ async function rollStrikeAction(
   if (!variant) {
     throw new Error(`roll-strike: strike "${strikeSlug}" has no variant ${variantIndex.toString()}`);
   }
-  // skipDialog: true — suppress PF2e's CheckDialogPF2e (situational modifier
+  // skipDialog: true — suppress PF2e's CheckModifiersDialog (situational modifier
   // prompt). Portal players are explicitly requesting the attack; they
   // don't need a dialog step. Consistent with rollStatisticAction.
   await variant.roll({ skipDialog: true });

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/__tests__/InvokeActorActionHandler.test.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/__tests__/InvokeActorActionHandler.test.ts
@@ -683,7 +683,7 @@ describe('invokeActorActionHandler — roll-strike', () => {
     });
 
     const strike = (actor.system as { actions: Array<{ variants: Array<{ roll: jest.Mock }> }> }).actions[0]!;
-    // skipDialog: true — suppress PF2e's CheckDialogPF2e for portal-initiated rolls.
+    // skipDialog: true — suppress PF2e's CheckModifiersDialog for portal-initiated rolls.
     expect(strike.variants[1]!.roll).toHaveBeenCalledWith({ skipDialog: true });
     expect(result).toEqual({ ok: true });
   });

--- a/apps/foundry-api-bridge/src/creator/__tests__/prompt-intercept.test.ts
+++ b/apps/foundry-api-bridge/src/creator/__tests__/prompt-intercept.test.ts
@@ -225,3 +225,116 @@ describe('installPromptInterception — renderDamageModifierDialog', () => {
     expect(callOrder[1]).toMatch(/^close:isRolled=true/);
   });
 });
+
+// ─── CheckDialogPF2e suppression ─────────────────────────────────────────
+//
+// PF2e's CheckDialogPF2e (attack / check modifier prompt) resolves its
+// internal Promise by submitting its form, not by calling close() directly.
+// Calling close() would cancel the roll (resolves with null). The hook
+// removes the element from the DOM (prevent flash) then dispatches a submit
+// event on the detached form so the activateListeners handler fires and the
+// roll proceeds with the form's default (zero) modifier values.
+
+describe('installPromptInterception — renderCheckDialogPF2e', () => {
+  it('registers a renderCheckDialogPF2e hook', () => {
+    installPromptInterception([]);
+    const names = hooksMock.registered.map((h) => h.name);
+    expect(names).toContain('renderCheckDialogPF2e');
+  });
+
+  it('removes the element from DOM and dispatches submit on the form', () => {
+    installPromptInterception([]);
+
+    const removeMock = jest.fn();
+    const dispatchMock = jest.fn();
+    const formEl = { dispatchEvent: dispatchMock };
+    const $html = {
+      remove: removeMock,
+      find: jest.fn().mockImplementation((selector: string) => ({
+        get: (i: number): unknown => (selector === 'form' && i === 0 ? formEl : undefined),
+      })),
+    };
+    const app = { close: jest.fn().mockResolvedValue(undefined) };
+
+    hooksMock.fire('renderCheckDialogPF2e', app, $html);
+
+    expect(removeMock).toHaveBeenCalled();
+    expect(dispatchMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'submit' }));
+    // close() must NOT be called: it would resolve with null (cancel the roll).
+    expect(app.close).not.toHaveBeenCalled();
+  });
+
+  it('removes DOM before dispatching submit to prevent visual flash', () => {
+    installPromptInterception([]);
+
+    const callOrder: string[] = [];
+    const formEl = {
+      dispatchEvent: jest.fn(() => { callOrder.push('submit'); }),
+    };
+    const $html = {
+      remove: jest.fn(() => { callOrder.push('remove'); }),
+      find: jest.fn().mockImplementation((selector: string) => ({
+        get: (i: number): unknown => (selector === 'form' && i === 0 ? formEl : undefined),
+      })),
+    };
+    const app = { close: jest.fn().mockResolvedValue(undefined) };
+
+    hooksMock.fire('renderCheckDialogPF2e', app, $html);
+
+    expect(callOrder).toEqual(['remove', 'submit']);
+  });
+
+  it('falls back to clicking button[type="submit"] when no form element exists', () => {
+    installPromptInterception([]);
+
+    const removeMock = jest.fn();
+    const clickMock = jest.fn();
+    const btn = { click: clickMock };
+    const $html = {
+      remove: removeMock,
+      find: jest.fn().mockImplementation((selector: string) => ({
+        get: (i: number): unknown =>
+          selector === 'button[type="submit"]' && i === 0 ? btn : undefined,
+      })),
+    };
+    const app = { close: jest.fn().mockResolvedValue(undefined) };
+
+    hooksMock.fire('renderCheckDialogPF2e', app, $html);
+
+    expect(removeMock).toHaveBeenCalled();
+    expect(clickMock).toHaveBeenCalled();
+    expect(app.close).not.toHaveBeenCalled();
+  });
+
+  it('calls app.close() as a last resort when neither form nor button is found', async () => {
+    installPromptInterception([]);
+
+    const $html = {
+      remove: jest.fn(),
+      find: jest.fn().mockReturnValue({ get: (): undefined => undefined }),
+    };
+    const app = { close: jest.fn().mockResolvedValue(undefined) };
+
+    hooksMock.fire('renderCheckDialogPF2e', app, $html);
+    await Promise.resolve();
+
+    expect(app.close).toHaveBeenCalled();
+  });
+
+  it('does not call app.close() when the form submit path succeeds', () => {
+    installPromptInterception([]);
+
+    const $html = {
+      remove: jest.fn(),
+      find: jest.fn().mockImplementation((selector: string) => ({
+        get: (i: number): unknown =>
+          selector === 'form' && i === 0 ? { dispatchEvent: jest.fn() } : undefined,
+      })),
+    };
+    const app = { close: jest.fn().mockResolvedValue(undefined) };
+
+    hooksMock.fire('renderCheckDialogPF2e', app, $html);
+
+    expect(app.close).not.toHaveBeenCalled();
+  });
+});

--- a/apps/foundry-api-bridge/src/creator/__tests__/prompt-intercept.test.ts
+++ b/apps/foundry-api-bridge/src/creator/__tests__/prompt-intercept.test.ts
@@ -226,20 +226,20 @@ describe('installPromptInterception — renderDamageModifierDialog', () => {
   });
 });
 
-// ─── CheckDialogPF2e suppression ─────────────────────────────────────────
+// ─── CheckModifiersDialog suppression ─────────────────────────────────────────
 //
-// PF2e's CheckDialogPF2e (attack / check modifier prompt) resolves its
+// PF2e's CheckModifiersDialog (attack / check modifier prompt) resolves its
 // internal Promise by submitting its form, not by calling close() directly.
 // Calling close() would cancel the roll (resolves with null). The hook
 // removes the element from the DOM (prevent flash) then dispatches a submit
 // event on the detached form so the activateListeners handler fires and the
 // roll proceeds with the form's default (zero) modifier values.
 
-describe('installPromptInterception — renderCheckDialogPF2e', () => {
-  it('registers a renderCheckDialogPF2e hook', () => {
+describe('installPromptInterception — renderCheckModifiersDialog', () => {
+  it('registers a renderCheckModifiersDialog hook', () => {
     installPromptInterception([]);
     const names = hooksMock.registered.map((h) => h.name);
-    expect(names).toContain('renderCheckDialogPF2e');
+    expect(names).toContain('renderCheckModifiersDialog');
   });
 
   it('removes the element from DOM and dispatches submit on the form', () => {
@@ -256,7 +256,7 @@ describe('installPromptInterception — renderCheckDialogPF2e', () => {
     };
     const app = { close: jest.fn().mockResolvedValue(undefined) };
 
-    hooksMock.fire('renderCheckDialogPF2e', app, $html);
+    hooksMock.fire('renderCheckModifiersDialog', app, $html);
 
     expect(removeMock).toHaveBeenCalled();
     expect(dispatchMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'submit' }));
@@ -279,7 +279,7 @@ describe('installPromptInterception — renderCheckDialogPF2e', () => {
     };
     const app = { close: jest.fn().mockResolvedValue(undefined) };
 
-    hooksMock.fire('renderCheckDialogPF2e', app, $html);
+    hooksMock.fire('renderCheckModifiersDialog', app, $html);
 
     expect(callOrder).toEqual(['remove', 'submit']);
   });
@@ -299,7 +299,7 @@ describe('installPromptInterception — renderCheckDialogPF2e', () => {
     };
     const app = { close: jest.fn().mockResolvedValue(undefined) };
 
-    hooksMock.fire('renderCheckDialogPF2e', app, $html);
+    hooksMock.fire('renderCheckModifiersDialog', app, $html);
 
     expect(removeMock).toHaveBeenCalled();
     expect(clickMock).toHaveBeenCalled();
@@ -315,7 +315,7 @@ describe('installPromptInterception — renderCheckDialogPF2e', () => {
     };
     const app = { close: jest.fn().mockResolvedValue(undefined) };
 
-    hooksMock.fire('renderCheckDialogPF2e', app, $html);
+    hooksMock.fire('renderCheckModifiersDialog', app, $html);
     await Promise.resolve();
 
     expect(app.close).toHaveBeenCalled();
@@ -333,7 +333,7 @@ describe('installPromptInterception — renderCheckDialogPF2e', () => {
     };
     const app = { close: jest.fn().mockResolvedValue(undefined) };
 
-    hooksMock.fire('renderCheckDialogPF2e', app, $html);
+    hooksMock.fire('renderCheckModifiersDialog', app, $html);
 
     expect(app.close).not.toHaveBeenCalled();
   });

--- a/apps/foundry-api-bridge/src/creator/prompt-intercept.ts
+++ b/apps/foundry-api-bridge/src/creator/prompt-intercept.ts
@@ -76,12 +76,14 @@ interface DamageModifierDialogApp {
   close(options?: { force?: boolean }): Promise<void>;
 }
 
-// PF2e's CheckDialogPF2e shows before attack / check rolls when the user
-// has "Show Check Dialogs" enabled. Unlike DamageModifierDialog it has no
-// `isRolled` flag: close() resolves the internal Promise with null (cancel),
-// and the roll proceeds only when the form is submitted (the Roll button).
+// PF2e's CheckModifiersDialog shows before attack / check rolls when the user
+// has "Show Check Dialogs" enabled. The class name is CheckModifiersDialog
+// (src/module/system/check/dialog.ts), so the AppV1 hook is
+// renderCheckModifiersDialog. Unlike DamageModifierDialog it has no `isRolled`
+// flag: close() resolves the internal Promise with false (cancel), and the
+// roll proceeds only when the form is submitted (the Roll button).
 // We suppress it by dispatching a submit event on the detached form element.
-interface CheckDialogPF2eApp {
+interface CheckModifiersDialogApp {
   close(options?: { force?: boolean }): Promise<void>;
 }
 
@@ -141,33 +143,34 @@ export function installPromptInterception(wsClients: readonly WebSocketClient[])
     void app.close();
   });
 
-  // Suppress PF2e's CheckDialogPF2e (attack / check modifier dialog).
+  // Suppress PF2e's CheckModifiersDialog (attack / check modifier dialog).
   //
-  // PF2e renders CheckDialogPF2e before attack rolls when "Show Check Dialogs"
-  // is enabled in the system settings. The dialog asks for situational
-  // modifiers (+/− bonuses). Portal players cannot see it, so the attack
-  // stalls until someone clicks in Foundry — even though rollStrikeAction
-  // passes skipDialog: true, PF2e still fires the render hook.
+  // PF2e renders CheckModifiersDialog before attack rolls when "Show Check
+  // Dialogs" is enabled in the system settings (src/module/system/check/
+  // dialog.ts). The strike variant's roll() in document.ts builds checkContext
+  // as a plain object and never forwards skipDialog from AttackRollParams, so
+  // passing skipDialog:true to variant.roll() is silently ignored — the dialog
+  // appears whenever game.user.settings.showCheckDialogs is true.
   //
   // Unlike DamageModifierDialog (where setting app.isRolled=true before
-  // close() signals "proceed"), CheckDialogPF2e resolves its internal Promise
-  // only when the form is submitted. Calling close() directly resolves with
-  // null (cancel) and aborts the roll.
+  // close() signals "proceed"), CheckModifiersDialog resolves its internal
+  // Promise only when the form is submitted. Calling close() directly calls
+  // resolve(false) (cancel) and aborts the roll.
   //
   // Fix:
   //   1. Remove $html from the DOM synchronously — prevents any visual flash
   //      and eliminates the 200 ms slideUp zombie-element race.
-  //   2. Dispatch a native "submit" event on the detached form element.
-  //      jQuery handlers registered via .on() use addEventListener internally
-  //      and fire on detached nodes, so the activateListeners submit handler
-  //      fires, resolves the Promise with the form's current (default, zero)
-  //      modifier values, and calls close() on the detached node (no-op).
+  //   2. Dispatch a native "submit" event on the detached <form> element.
+  //      The activateListeners submit handler is a native addEventListener on
+  //      $html[0] (the outer .app wrapper); the submit event bubbles from the
+  //      form up to it, calling resolve(true) → the attack proceeds with the
+  //      form's current (default, zero) modifier values.
   //   3. Fall back to clicking button[type="submit"] if no <form> is present.
   //   4. Last resort: app.close() — cancels the roll but unblocks the stall.
   //
   // @ts-expect-error — Hooks is untyped
-  Hooks.on('renderCheckDialogPF2e', (app: CheckDialogPF2eApp, $html: unknown) => {
-    console.info('Foundry API Bridge | Suppressing CheckDialogPF2e — triggering Roll with defaults');
+  Hooks.on('renderCheckModifiersDialog', (app: CheckModifiersDialogApp, $html: unknown) => {
+    console.info('Foundry API Bridge | Suppressing CheckModifiersDialog — triggering Roll with defaults');
     const jq = $html as JQueryLike;
     // Detach from DOM synchronously to prevent visual flash.
     jq.remove();
@@ -184,12 +187,14 @@ export function installPromptInterception(wsClients: readonly WebSocketClient[])
     }
     // Neither found — close() cancels the roll but at least unblocks the stall.
     console.warn(
-      'Foundry API Bridge | CheckDialogPF2e: no form or submit button found — closing (roll will be cancelled)',
+      'Foundry API Bridge | CheckModifiersDialog: no form or submit button found — closing (roll will be cancelled)',
     );
     void app.close();
   });
 
-  console.log('Foundry API Bridge | Prompt interception installed (PickAThingPrompt, DamageModifierDialog, CheckDialogPF2e)');
+  console.log(
+    'Foundry API Bridge | Prompt interception installed (PickAThingPrompt, DamageModifierDialog, CheckModifiersDialog)',
+  );
 }
 
 async function handlePrompt(app: PickAThingPromptApp, wsClients: readonly WebSocketClient[]): Promise<void> {

--- a/apps/foundry-api-bridge/src/creator/prompt-intercept.ts
+++ b/apps/foundry-api-bridge/src/creator/prompt-intercept.ts
@@ -76,6 +76,23 @@ interface DamageModifierDialogApp {
   close(options?: { force?: boolean }): Promise<void>;
 }
 
+// PF2e's CheckDialogPF2e shows before attack / check rolls when the user
+// has "Show Check Dialogs" enabled. Unlike DamageModifierDialog it has no
+// `isRolled` flag: close() resolves the internal Promise with null (cancel),
+// and the roll proceeds only when the form is submitted (the Roll button).
+// We suppress it by dispatching a submit event on the detached form element.
+interface CheckDialogPF2eApp {
+  close(options?: { force?: boolean }): Promise<void>;
+}
+
+// Minimal jQuery-compatible surface for AppV1 render hooks.  AppV1 passes
+// $html as a jQuery-wrapped root .app element; .find() returns a jQuery
+// collection from which .get(0) yields the underlying HTMLElement.
+interface JQueryLike {
+  find(selector: string): { get(index: 0): HTMLElement | undefined };
+  remove(): void;
+}
+
 export function installPromptInterception(wsClients: readonly WebSocketClient[]): void {
   // @ts-expect-error — Foundry's Hooks global is untyped in this module
   Hooks.on(HOOK_NAME, (app: PickAThingPromptApp) => {
@@ -124,7 +141,55 @@ export function installPromptInterception(wsClients: readonly WebSocketClient[])
     void app.close();
   });
 
-  console.log('Foundry API Bridge | ChoiceSet prompt interception installed');
+  // Suppress PF2e's CheckDialogPF2e (attack / check modifier dialog).
+  //
+  // PF2e renders CheckDialogPF2e before attack rolls when "Show Check Dialogs"
+  // is enabled in the system settings. The dialog asks for situational
+  // modifiers (+/− bonuses). Portal players cannot see it, so the attack
+  // stalls until someone clicks in Foundry — even though rollStrikeAction
+  // passes skipDialog: true, PF2e still fires the render hook.
+  //
+  // Unlike DamageModifierDialog (where setting app.isRolled=true before
+  // close() signals "proceed"), CheckDialogPF2e resolves its internal Promise
+  // only when the form is submitted. Calling close() directly resolves with
+  // null (cancel) and aborts the roll.
+  //
+  // Fix:
+  //   1. Remove $html from the DOM synchronously — prevents any visual flash
+  //      and eliminates the 200 ms slideUp zombie-element race.
+  //   2. Dispatch a native "submit" event on the detached form element.
+  //      jQuery handlers registered via .on() use addEventListener internally
+  //      and fire on detached nodes, so the activateListeners submit handler
+  //      fires, resolves the Promise with the form's current (default, zero)
+  //      modifier values, and calls close() on the detached node (no-op).
+  //   3. Fall back to clicking button[type="submit"] if no <form> is present.
+  //   4. Last resort: app.close() — cancels the roll but unblocks the stall.
+  //
+  // @ts-expect-error — Hooks is untyped
+  Hooks.on('renderCheckDialogPF2e', (app: CheckDialogPF2eApp, $html: unknown) => {
+    console.info('Foundry API Bridge | Suppressing CheckDialogPF2e — triggering Roll with defaults');
+    const jq = $html as JQueryLike;
+    // Detach from DOM synchronously to prevent visual flash.
+    jq.remove();
+    // Trigger the dialog's resolve path with default modifier values (0).
+    const form = jq.find('form').get(0);
+    if (form) {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+      return;
+    }
+    const submitBtn = jq.find('button[type="submit"]').get(0);
+    if (submitBtn) {
+      submitBtn.click();
+      return;
+    }
+    // Neither found — close() cancels the roll but at least unblocks the stall.
+    console.warn(
+      'Foundry API Bridge | CheckDialogPF2e: no form or submit button found — closing (roll will be cancelled)',
+    );
+    void app.close();
+  });
+
+  console.log('Foundry API Bridge | Prompt interception installed (PickAThingPrompt, DamageModifierDialog, CheckDialogPF2e)');
 }
 
 async function handlePrompt(app: PickAThingPromptApp, wsClients: readonly WebSocketClient[]): Promise<void> {

--- a/apps/player-portal/src/components/tabs/Actions.test.tsx
+++ b/apps/player-portal/src/components/tabs/Actions.test.tsx
@@ -1,5 +1,21 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import { render, cleanup, fireEvent, within } from '@testing-library/react';
+
+// ─── API mock ─────────────────────────────────────────────────────────────
+// Hoisted so the module resolver sees it before Actions.tsx imports api/client.
+
+const rollStrikeMock = vi.fn().mockResolvedValue({ ok: true });
+const rollStrikeDamageMock = vi.fn().mockResolvedValue({ ok: true });
+const useItemMock = vi.fn().mockResolvedValue({ ok: true, itemId: 'x', itemName: 'x' });
+
+vi.mock('../../api/client', () => ({
+  api: {
+    rollStrike: (...args: unknown[]) => rollStrikeMock(...args),
+    rollStrikeDamage: (...args: unknown[]) => rollStrikeDamageMock(...args),
+    useItem: (...args: unknown[]) => useItemMock(...args),
+  },
+  ApiRequestError: class ApiRequestError extends Error {},
+}));
 import amiri from '../../fixtures/amiri-prepared.json';
 import type { Ability, AbilityKey, PreparedActorItem, Strike } from '../../api/types';
 import { Actions } from './Actions';
@@ -159,5 +175,95 @@ describe('Actions tab — action items', () => {
     expect(body, 'description body').toBeTruthy();
     // Rage's description starts with "You tap into your inner fury".
     expect(body?.textContent).toContain('inner fury');
+  });
+});
+
+// ─── Attack-button relay path ─────────────────────────────────────────────
+// Verifies that clicking a MAP variant button or a Damage/Crit button calls
+// the correct api method with the correct arguments, confirming the player-
+// portal side of the relay path is wired correctly end-to-end.
+
+describe('Actions tab — attack-button relay path', () => {
+  beforeEach(() => {
+    rollStrikeMock.mockClear();
+    rollStrikeDamageMock.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('calls api.rollStrike with variantIndex=0 when the first attack button is clicked', () => {
+    const { container } = render(
+      <Actions actorId="test-actor" onItemUsed={() => undefined} actions={actions} items={items} />,
+    );
+    const card = container.querySelector('[data-strike-slug="bastard-sword"]') as HTMLElement;
+    const firstBtn = card.querySelector('[data-variant-index="0"]') as HTMLElement;
+
+    fireEvent.click(firstBtn);
+
+    // rollStrike is called synchronously inside trigger() before the await.
+    expect(rollStrikeMock).toHaveBeenCalledWith('test-actor', 'bastard-sword', 0);
+  });
+
+  it('calls api.rollStrike with variantIndex=1 for the second attack (MAP −5)', () => {
+    const { container } = render(
+      <Actions actorId="test-actor" onItemUsed={() => undefined} actions={actions} items={items} />,
+    );
+    const card = container.querySelector('[data-strike-slug="bastard-sword"]') as HTMLElement;
+    const secondBtn = card.querySelector('[data-variant-index="1"]') as HTMLElement;
+
+    fireEvent.click(secondBtn);
+
+    expect(rollStrikeMock).toHaveBeenCalledWith('test-actor', 'bastard-sword', 1);
+  });
+
+  it('calls api.rollStrike with variantIndex=2 for the third attack (MAP −10)', () => {
+    const { container } = render(
+      <Actions actorId="test-actor" onItemUsed={() => undefined} actions={actions} items={items} />,
+    );
+    const card = container.querySelector('[data-strike-slug="bastard-sword"]') as HTMLElement;
+    const thirdBtn = card.querySelector('[data-variant-index="2"]') as HTMLElement;
+
+    fireEvent.click(thirdBtn);
+
+    expect(rollStrikeMock).toHaveBeenCalledWith('test-actor', 'bastard-sword', 2);
+  });
+
+  it('calls api.rollStrikeDamage(critical=false) when the Damage button is clicked', () => {
+    const { container } = render(
+      <Actions actorId="test-actor" onItemUsed={() => undefined} actions={actions} items={items} />,
+    );
+    const card = container.querySelector('[data-strike-slug="bastard-sword"]') as HTMLElement;
+    const damageBtn = card.querySelector('[data-role="strike-damage-roll"]') as HTMLElement;
+
+    fireEvent.click(damageBtn);
+
+    expect(rollStrikeDamageMock).toHaveBeenCalledWith('test-actor', 'bastard-sword', false);
+  });
+
+  it('calls api.rollStrikeDamage(critical=true) when the Crit button is clicked', () => {
+    const { container } = render(
+      <Actions actorId="test-actor" onItemUsed={() => undefined} actions={actions} items={items} />,
+    );
+    const card = container.querySelector('[data-strike-slug="bastard-sword"]') as HTMLElement;
+    const critBtn = card.querySelector('[data-role="strike-damage-crit"]') as HTMLElement;
+
+    fireEvent.click(critBtn);
+
+    expect(rollStrikeDamageMock).toHaveBeenCalledWith('test-actor', 'bastard-sword', true);
+  });
+
+  it('passes the correct strike slug for each weapon', () => {
+    const { container } = render(
+      <Actions actorId="test-actor" onItemUsed={() => undefined} actions={actions} items={items} />,
+    );
+    // Click the javelin's first attack variant.
+    const javelinCard = container.querySelector('[data-strike-slug="javelin"]') as HTMLElement;
+    const javelinFirst = javelinCard.querySelector('[data-variant-index="0"]') as HTMLElement;
+
+    fireEvent.click(javelinFirst);
+
+    expect(rollStrikeMock).toHaveBeenCalledWith('test-actor', 'javelin', 0);
   });
 });


### PR DESCRIPTION
## Summary

PF2e fires \`renderCheckDialogPF2e\` before attack rolls when the user has "Show Check Dialogs" enabled. The dialog asks for situational modifiers; portal players can't see it, so every MAP attack button stalled indefinitely waiting for a Foundry-side click.

\`CheckDialogPF2e\` extends \`fav1.api.Application\` (AppV1), not Foundry's \`Dialog\`, so the generic \`renderDialog\` / \`renderDialogV2\` hooks from PR #71 never fire for it. \`rollStrikeAction\` already passes \`skipDialog: true\` to \`variant.roll()\`, but PF2e renders the dialog regardless.

The fix adds a \`renderCheckDialogPF2e\` hook in \`prompt-intercept.ts\` that mirrors the \`renderDamageModifierDialog\` pattern — with one key difference: \`DamageModifierDialog\` resolves its internal Promise via \`close()\` (after setting \`isRolled = true\`), while \`CheckDialogPF2e\` resolves only when the form is submitted. Calling \`close()\` directly would cancel the roll. Instead the hook removes \`\$html\` from the DOM synchronously (prevents visual flash, eliminates slideUp race), then dispatches a native \`submit\` event on the detached form element. jQuery handlers attached via \`.on()\` use \`addEventListener\` internally and fire on detached nodes, so the \`activateListeners\` submit handler fires, resolves the Promise with the dialog's default (zero) modifier values, and the attack proceeds normally.

## Changes

- **\`apps/foundry-api-bridge/src/creator/prompt-intercept.ts\`** — \`CheckDialogPF2eApp\` + \`JQueryLike\` interfaces; \`renderCheckDialogPF2e\` hook: remove → dispatch submit → fallback click → fallback close. Updates the module-level log message to list all three intercepted hook names.
- **\`apps/foundry-api-bridge/src/creator/__tests__/prompt-intercept.test.ts\`** — 6 new tests for the hook: registration, form-submit path, DOM-remove-before-submit ordering, button-click fallback, last-resort \`close()\`, and no-close when form path succeeds.
- **\`apps/player-portal/src/components/tabs/Actions.test.tsx\`** — 6 new tests asserting each MAP variant button (indices 0/1/2) and the Damage/Crit buttons invoke \`api.rollStrike\` / \`api.rollStrikeDamage\` with the correct \`actorId\`, \`strikeSlug\`, and \`variantIndex\` / \`critical\` arguments.
- **\`apps/foundry-api-bridge/src/commands/handlers/actor/InvokeActorActionHandler.ts\`** — resolve rebase conflict: keep \`Promise<unknown>\` (more precise than main's \`unknown\`) for \`PF2eActionFn\` return type.

## Test plan

- [x] \`npm run test -w apps/foundry-api-bridge\` — 758 tests pass (6 new)
- [x] \`npm run test -w apps/player-portal\` — 224 tests pass (6 new)
- [x] \`npm run lint -w apps/foundry-api-bridge\` — clean
- [x] \`npm run format:check\` — clean
- [x] \`npm run type-check -w apps/foundry-api-bridge\` — clean
- [x] \`npm run typecheck -w apps/player-portal\` — clean

Closes #72