### PR TITLE
feat(player-portal): add load-more pagination to item pickers

### DIFF
--- a/apps/foundry-mcp/src/http/compendium-cache.ts
+++ b/apps/foundry-mcp/src/http/compendium-cache.ts
@@ -212,13 +212,19 @@ export class CompendiumCache {
   // (partial cache-hits would return misleading results). Passing no
   // packIds means "all cached packs"; if nothing is cached, returns
   // null too so the caller still goes to the bridge.
-  search(opts: SearchOptions): { matches: EnrichedMatch[] } | null {
+  //
+  // Response always includes `total` — the number of items matching
+  // the filters before any pagination slice — so callers can determine
+  // whether there are more pages to fetch.
+  search(opts: SearchOptions): { matches: EnrichedMatch[]; total: number } | null {
     const packs = this.lookup(opts.packIds);
     if (packs === null) return null;
     this.hits++;
-    const matches = runFilter(packs, opts);
+    const all = runFilter(packs, opts);
+    const total = all.length;
     const limit = opts.limit ?? 100;
-    return { matches: matches.slice(0, limit) };
+    const offset = opts.offset ?? 0;
+    return { matches: all.slice(offset, offset + limit), total };
   }
 
   // Aggregate DISTINCT facet values over every document in the

--- a/apps/foundry-mcp/src/http/compendium-types.ts
+++ b/apps/foundry-mcp/src/http/compendium-types.ts
@@ -79,6 +79,8 @@ export interface SearchOptions {
   willMin?: number;
   willMax?: number;
   limit?: number;
+  /** Zero-based offset into the full result set for pagination. */
+  offset?: number;
 }
 
 // One cached pack's worth of documents, plus the metadata used by

--- a/apps/foundry-mcp/src/http/routes/compendium.ts
+++ b/apps/foundry-mcp/src/http/routes/compendium.ts
@@ -40,6 +40,7 @@ export function registerCompendiumRoutes(app: FastifyInstance): void {
       willMin,
       willMax,
       limit,
+      offset,
     } = parsed;
 
     // Serve from cache when every requested pack is warmed. Partial
@@ -77,6 +78,7 @@ export function registerCompendiumRoutes(app: FastifyInstance): void {
       ...(willMin !== undefined ? { willMin } : {}),
       ...(willMax !== undefined ? { willMax } : {}),
       ...(limit !== undefined ? { limit } : {}),
+      ...(offset !== undefined ? { offset } : {}),
     });
     if (cached) return cached;
 
@@ -86,7 +88,11 @@ export function registerCompendiumRoutes(app: FastifyInstance): void {
     // floor here — acceptable because the path is only hit for
     // un-warmed packs, which dm-tool shouldn't be querying in steady
     // state.
-    return sendCommand('find-in-compendium', {
+    //
+    // The bridge has no offset support; pagination always starts at
+    // page 0 on the fallback path. `total` is set to the match count
+    // so the caller doesn't attempt a second page.
+    const bridgeResult = (await sendCommand('find-in-compendium', {
       name: q ?? '',
       packId,
       documentType,
@@ -96,7 +102,9 @@ export function registerCompendiumRoutes(app: FastifyInstance): void {
       ancestrySlug,
       maxLevel,
       limit,
-    });
+    })) as { matches: unknown[] };
+    const bridgeMatches = Array.isArray(bridgeResult.matches) ? bridgeResult.matches : [];
+    return { matches: bridgeMatches, total: bridgeMatches.length };
   });
 
   app.get('/api/compendium/packs', async (req) => {

--- a/apps/foundry-mcp/test/compendium-cache.test.ts
+++ b/apps/foundry-mcp/test/compendium-cache.test.ts
@@ -365,6 +365,32 @@ describe('CompendiumCache.search — filters', () => {
     assert.equal(result?.matches.length, 2);
   });
 
+  it('includes total equal to the full unsliced match count', () => {
+    const result = cache.search({ packIds: ['pf2e.equipment-srd'], limit: 2 });
+    // total reflects the number of items that matched the filters, not
+    // the number returned (which is capped by limit).
+    assert.ok(result?.total !== undefined, 'total should be present');
+    assert.ok((result?.total ?? 0) > 2, 'total should exceed the limit');
+    assert.equal(result?.total, equipmentDocs.length);
+  });
+
+  it('applies offset to skip items and reports the unsliced total', () => {
+    const all = cache.search({ packIds: ['pf2e.equipment-srd'] });
+    const total = all?.total ?? 0;
+    // Page 0: first two items.
+    const page0 = cache.search({ packIds: ['pf2e.equipment-srd'], limit: 2, offset: 0 });
+    // Page 1: next two items.
+    const page1 = cache.search({ packIds: ['pf2e.equipment-srd'], limit: 2, offset: 2 });
+    assert.equal(page0?.total, total);
+    assert.equal(page1?.total, total);
+    // Pages are disjoint.
+    const p0uuids = new Set(page0?.matches.map((m) => m.uuid));
+    const p1uuids = new Set(page1?.matches.map((m) => m.uuid));
+    for (const uuid of p1uuids) {
+      assert.ok(!p0uuids.has(uuid), `uuid ${uuid} appeared on both pages`);
+    }
+  });
+
   it('enriches matches with price read from the cached document', () => {
     const result = cache.search({ packIds: ['pf2e.equipment-srd'], q: 'bastard' });
     const sword = result?.matches[0];

--- a/apps/player-portal/src/api/client.ts
+++ b/apps/player-portal/src/api/client.ts
@@ -63,8 +63,8 @@ function request<T>(path: string, opts: RequestOptions = {}): Promise<T> {
 export const api = {
   getActors: (): Promise<ActorSummary[]> => request<ActorSummary[]>('/actors'),
   getPreparedActor: (id: string): Promise<PreparedActor> => request<PreparedActor>(`/actors/${id}/prepared`),
-  searchCompendium: (opts: CompendiumSearchOptions): Promise<{ matches: CompendiumMatch[] }> =>
-    request<{ matches: CompendiumMatch[] }>(`/compendium/search?${buildCompendiumQuery(opts)}`),
+  searchCompendium: (opts: CompendiumSearchOptions): Promise<{ matches: CompendiumMatch[]; total: number }> =>
+    request<{ matches: CompendiumMatch[]; total: number }>(`/compendium/search?${buildCompendiumQuery(opts)}`),
   listCompendiumPacks: (opts: { documentType?: string } = {}): Promise<{ packs: CompendiumPack[] }> => {
     const params = new URLSearchParams();
     if (opts.documentType !== undefined) params.set('documentType', opts.documentType);

--- a/apps/player-portal/src/components/crafting/FormulaPicker.tsx
+++ b/apps/player-portal/src/components/crafting/FormulaPicker.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { api, ApiRequestError } from '../../api/client';
+import { api } from '../../api/client';
 import type { CompendiumMatch } from '../../api/types';
 import { useDebounce } from '../../lib/useDebounce';
+import { usePaginatedSearch } from '../../lib/usePaginatedSearch';
 
 interface Props {
   /** Uuids that are already in the formula book — filtered out of
@@ -22,17 +23,39 @@ interface Props {
 export function FormulaPicker({ alreadyKnown, onPick, onClose }: Props): React.ReactElement {
   const [query, setQuery] = useState('');
   const debounced = useDebounce(query, 200);
-  const [matches, setMatches] = useState<CompendiumMatch[]>([]);
-  const [state, setState] = useState<'idle' | 'searching' | { error: string }>('idle');
   const inputRef = useRef<HTMLInputElement | null>(null);
+
+  // Search is gated on the query being at least 2 characters. We pass a
+  // stable `enabled` flag into the fetcher — when false it short-circuits
+  // to an empty result so `usePaginatedSearch` doesn't fire a real request.
+  const searchEnabled = debounced.trim().length >= 2;
+
+  const {
+    state: searchState,
+    hasMore,
+    isLoadingMore,
+    loadMore,
+  } = usePaginatedSearch<CompendiumMatch>(
+    async (offset, pageSize) => {
+      if (!searchEnabled) return { matches: [], total: 0 };
+      return api.searchCompendium({
+        q: debounced,
+        documentType: 'Item',
+        // Copy to a mutable array — `CompendiumSearchOptions.packIds`
+        // is typed `string[]`, not `readonly string[]`.
+        packIds: [...PHYSICAL_ITEM_PACKS],
+        limit: pageSize,
+        offset,
+      });
+    },
+    [debounced],
+  );
 
   useEffect(() => {
     inputRef.current?.focus();
   }, []);
 
-  // Trap Esc to close and keep scroll anchored to the top on new
-  // query — dialog lives inside a fixed overlay so ambient scroll
-  // inside the results list shouldn't leak out.
+  // Trap Esc to close.
   useEffect(() => {
     const onKey = (e: KeyboardEvent): void => {
       if (e.key === 'Escape') onClose();
@@ -43,39 +66,18 @@ export function FormulaPicker({ alreadyKnown, onPick, onClose }: Props): React.R
     };
   }, [onClose]);
 
-  useEffect(() => {
-    if (debounced.trim().length < 2) {
-      setMatches([]);
-      setState('idle');
-      return;
-    }
-    let cancelled = false;
-    setState('searching');
-    api
-      .searchCompendium({
-        q: debounced,
-        documentType: 'Item',
-        // Copy to a mutable array — `CompendiumSearchOptions.packIds`
-        // is typed `string[]`, not `readonly string[]`.
-        packIds: [...PHYSICAL_ITEM_PACKS],
-        limit: 50,
-      })
-      .then(({ matches: fetched }) => {
-        if (cancelled) return;
-        setMatches(fetched);
-        setState('idle');
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        const message = err instanceof ApiRequestError ? err.message : err instanceof Error ? err.message : String(err);
-        setState({ error: message });
-      });
-    return (): void => {
-      cancelled = true;
-    };
-  }, [debounced]);
+  // Filter out already-known items client-side on top of the server results.
+  // `allMatches` is memoised to produce a stable reference when the search
+  // state hasn't changed, preventing useMemo from seeing new array identity
+  // on every render when the search is in the loading/error state.
+  const allMatches = useMemo(
+    () => (searchState.kind === 'ready' ? searchState.items : []),
+    [searchState],
+  );
+  const filtered = useMemo(() => allMatches.filter((m) => !alreadyKnown.has(m.uuid)), [allMatches, alreadyKnown]);
 
-  const filtered = useMemo(() => matches.filter((m) => !alreadyKnown.has(m.uuid)), [matches, alreadyKnown]);
+  const isSearching = searchEnabled && searchState.kind === 'loading';
+  const searchError = searchState.kind === 'error' ? searchState.message : null;
 
   return (
     <div
@@ -112,17 +114,17 @@ export function FormulaPicker({ alreadyKnown, onPick, onClose }: Props): React.R
           />
         </div>
         <div className="min-h-[4rem] flex-1 overflow-y-auto p-2">
-          {state === 'searching' && <p className="p-2 text-sm italic text-neutral-400">Searching…</p>}
-          {typeof state === 'object' && (
-            <p className="p-2 text-sm text-red-700">Search failed: {state.error}</p>
+          {isSearching && <p className="p-2 text-sm italic text-neutral-400">Searching…</p>}
+          {searchError !== null && (
+            <p className="p-2 text-sm text-red-700">Search failed: {searchError}</p>
           )}
-          {state === 'idle' && debounced.trim().length < 2 && (
+          {!searchEnabled && (
             <p className="p-2 text-xs italic text-neutral-400">Type to search the equipment compendium.</p>
           )}
-          {state === 'idle' && debounced.trim().length >= 2 && filtered.length === 0 && matches.length > 0 && (
+          {searchEnabled && !isSearching && searchError === null && filtered.length === 0 && allMatches.length > 0 && (
             <p className="p-2 text-xs italic text-neutral-400">Every match is already in the book.</p>
           )}
-          {state === 'idle' && debounced.trim().length >= 2 && matches.length === 0 && (
+          {searchEnabled && !isSearching && searchError === null && allMatches.length === 0 && (
             <p className="p-2 text-xs italic text-neutral-400">No matches.</p>
           )}
           {filtered.length > 0 && (
@@ -152,6 +154,19 @@ export function FormulaPicker({ alreadyKnown, onPick, onClose }: Props): React.R
                 </li>
               ))}
             </ul>
+          )}
+          {(hasMore || isLoadingMore) && (
+            <div className="mt-2 text-center">
+              <button
+                type="button"
+                onClick={loadMore}
+                disabled={isLoadingMore}
+                data-testid="formula-picker-load-more"
+                className="rounded border border-neutral-300 bg-white px-3 py-1 text-xs text-neutral-600 hover:border-neutral-400 hover:text-neutral-800 disabled:cursor-wait disabled:opacity-50"
+              >
+                {isLoadingMore ? 'Loading…' : 'Load more'}
+              </button>
+            </div>
           )}
         </div>
       </div>

--- a/apps/player-portal/src/components/creator/FeatPicker.test.tsx
+++ b/apps/player-portal/src/components/creator/FeatPicker.test.tsx
@@ -33,7 +33,7 @@ describe('FeatPicker', () => {
   let searchSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    searchSpy = vi.spyOn(api, 'searchCompendium').mockResolvedValue({ matches: sampleMatches });
+    searchSpy = vi.spyOn(api, 'searchCompendium').mockResolvedValue({ matches: sampleMatches, total: sampleMatches.length });
   });
   afterEach(() => {
     searchSpy.mockRestore();
@@ -124,7 +124,7 @@ describe('FeatPicker', () => {
   });
 
   it('shows an empty-state message when no matches come back', async () => {
-    searchSpy.mockResolvedValueOnce({ matches: [] });
+    searchSpy.mockResolvedValueOnce({ matches: [], total: 0 });
     const { container } = render(
       <FeatPicker title="t" filters={{ traits: ['barbarian'] }} onPick={vi.fn()} onClose={vi.fn()} />,
     );
@@ -210,6 +210,7 @@ describe('FeatPicker', () => {
           traits: [],
         },
       ],
+      total: 3,
     });
     const { container, getByTestId } = render(
       <FeatPicker title="t" filters={{ traits: ['x'] }} onPick={vi.fn()} onClose={vi.fn()} />,
@@ -293,6 +294,7 @@ describe('FeatPicker', () => {
           traits: [],
         },
       ],
+      total: 3,
     });
     const { container, getByTestId } = render(
       <FeatPicker title="t" filters={{ traits: ['x'] }} onPick={vi.fn()} onClose={vi.fn()} />,
@@ -355,6 +357,7 @@ describe('FeatPicker', () => {
           traits: [],
         },
       ],
+      total: 3,
     });
     const { container, getByTestId } = render(
       <FeatPicker title="t" filters={{ traits: ['x'] }} onPick={vi.fn()} onClose={vi.fn()} />,
@@ -429,6 +432,7 @@ describe('FeatPicker', () => {
           traits: [],
         },
       ],
+      total: 3,
     });
     const { container, getByTestId } = render(
       <FeatPicker title="t" filters={{ traits: ['x'] }} onPick={vi.fn()} onClose={vi.fn()} />,
@@ -442,5 +446,70 @@ describe('FeatPicker', () => {
     );
     // L1 alpha first (Alpha before Beta), then the unlevelled entry at the bottom.
     expect(order).toEqual(['Alvl1', 'Blvl1', 'U-noLvl']);
+  });
+
+  // --- Pagination (load more) ---------------------------------------------
+
+  it('shows a "Load more" button when the server total exceeds the page', async () => {
+    // Return 2 matches but declare total=10 → "Load more" should appear.
+    searchSpy.mockResolvedValue({ matches: sampleMatches, total: 10 });
+    const { container } = render(
+      <FeatPicker title="t" filters={{ traits: ['barbarian'] }} onPick={vi.fn()} onClose={vi.fn()} />,
+    );
+    await waitFor(() => {
+      expect(container.querySelector('[data-match-uuid]')).toBeTruthy();
+    });
+    expect(container.querySelector('[data-testid="feat-picker-load-more"]')).toBeTruthy();
+  });
+
+  it('does not show "Load more" when total equals the loaded count', async () => {
+    // Default mock has total === matches.length (2) → no more button.
+    const { container } = render(
+      <FeatPicker title="t" filters={{ traits: ['barbarian'] }} onPick={vi.fn()} onClose={vi.fn()} />,
+    );
+    await waitFor(() => {
+      expect(container.querySelector('[data-match-uuid]')).toBeTruthy();
+    });
+    expect(container.querySelector('[data-testid="feat-picker-load-more"]')).toBeFalsy();
+  });
+
+  it('fetches the next page and appends results when "Load more" is clicked', async () => {
+    const page2Matches = [
+      {
+        packId: 'pf2e.feats-srd',
+        packLabel: 'Class Feats',
+        documentId: 'c',
+        uuid: 'Compendium.pf2e.feats-srd.Item.c',
+        name: 'Power Attack',
+        type: 'feat',
+        img: '',
+        level: 2,
+        traits: ['barbarian'],
+      },
+    ];
+    // Page 0: total=3, but only 2 returned → hasMore=true
+    searchSpy.mockResolvedValueOnce({ matches: sampleMatches, total: 3 });
+    // Page 1: remaining 1 item
+    searchSpy.mockResolvedValueOnce({ matches: page2Matches, total: 3 });
+
+    const { container, getByTestId } = render(
+      <FeatPicker title="t" filters={{ traits: ['barbarian'] }} onPick={vi.fn()} onClose={vi.fn()} />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="feat-picker-load-more"]')).toBeTruthy();
+    });
+
+    fireEvent.click(getByTestId('feat-picker-load-more'));
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('Power Attack');
+    });
+
+    // All 3 rows visible (2 original + 1 new).
+    expect(container.querySelectorAll('[data-match-uuid]').length).toBe(3);
+    // Second call should have offset=2.
+    const secondCall = searchSpy.mock.calls[1]?.[0];
+    expect(secondCall?.offset).toBe(sampleMatches.length);
   });
 });

--- a/apps/player-portal/src/components/creator/FeatPicker.tsx
+++ b/apps/player-portal/src/components/creator/FeatPicker.tsx
@@ -4,6 +4,7 @@ import type { CompendiumDocument, CompendiumMatch, CompendiumSearchOptions, Comp
 import { enrichDescription } from '../../lib/foundry-enrichers';
 import { useDebounce } from '../../lib/useDebounce';
 import { type RemoteDataState, useRemoteData } from '../../lib/useRemoteData';
+import { usePaginatedSearch } from '../../lib/usePaginatedSearch';
 import { useUuidHover } from '../../lib/useUuidHover';
 import { evaluateDocument } from '../../prereqs';
 import type { CharacterContext, Evaluation } from '../../prereqs';
@@ -94,12 +95,14 @@ export function FeatPicker({ title, filters, characterContext, onPick, onClose }
     ],
   );
 
-  // Live match list. `useRemoteData` keeps the previous `ready` data
-  // visible across re-fetches so the list narrows in place without
-  // flashing an empty state between keystrokes.
-  const matchesState = useRemoteData<CompendiumMatch[]>(
-    async () => {
-      const opts: CompendiumSearchOptions = { q: debouncedQuery, limit: 50 };
+  // Live match list with pagination. `usePaginatedSearch` keeps the
+  // previous `ready` data visible across re-fetches so the list narrows
+  // in place without flashing an empty state between keystrokes.
+  // Page size is capped at 50 so the background prefetch (below) doesn't
+  // stampede the server; "Load more" fetches the next 50 on demand.
+  const { state: matchesState, hasMore, isLoadingMore, loadMore } = usePaginatedSearch<CompendiumMatch>(
+    async (offset, pageSize) => {
+      const opts: CompendiumSearchOptions = { q: debouncedQuery, limit: pageSize, offset };
       if (filters.packIds !== undefined && filters.packIds.length > 0) opts.packIds = filters.packIds;
       if (selectedSources.length > 0) opts.sources = selectedSources;
       if (filters.documentType !== undefined) opts.documentType = filters.documentType;
@@ -107,23 +110,22 @@ export function FeatPicker({ title, filters, characterContext, onPick, onClose }
       if (filters.anyTraits !== undefined) opts.anyTraits = filters.anyTraits;
       if (filters.maxLevel !== undefined) opts.maxLevel = filters.maxLevel;
       if (filters.ancestrySlug !== undefined) opts.ancestrySlug = filters.ancestrySlug;
-      const result = await api.searchCompendium(opts);
-      return result.matches;
+      return api.searchCompendium(opts);
     },
     // filterKey captures every filter field used inside the fetcher.
     [debouncedQuery, filterKey],
     {
-      onSuccess: (matches, isCancelled) => {
-        // Background prefetch the full document for each match so the
-        // detail pane opens instantly on click. Each worker also
-        // resolves that document's prereqs against the compendium and
-        // evaluates them against the current character context, so the
-        // per-row prereq state lights up without a second trip.
+      onPage: (newMatches, isCancelled) => {
+        // Background prefetch the full document for each NEW page's
+        // matches so the detail pane opens instantly on click.  Each
+        // worker also resolves that document's prereqs and evaluates
+        // them against the current character context so the per-row
+        // prereq state lights up without a second trip.
         // Bounded concurrency keeps the network from stampeding when
         // 50 results come back.
         const ctx = characterContext;
         void prefetchDocuments(
-          matches,
+          newMatches,
           docCacheRef.current,
           prereqCacheRef.current,
           ctx
@@ -173,8 +175,7 @@ export function FeatPicker({ title, filters, characterContext, onPick, onClose }
   );
 
   // Apply sort on top of whatever order the server returned. Client-side
-  // is fine because the server already caps results (limit 50 by default
-  // from the picker), so the sort runs over a tiny array. Entries missing
+  // sort runs over the accumulated (paginated) list.  Entries missing
   // a level always sink to the bottom of a Level sort (in either
   // direction) and stay alpha-asc among themselves — "unknown" shouldn't
   // leapfrog real data just because the user flipped direction.
@@ -183,7 +184,7 @@ export function FeatPicker({ title, filters, characterContext, onPick, onClose }
   // back `fails`. `unknown` (unparseable) stays through.
   const visibleMatches = useMemo(() => {
     if (matchesState.kind !== 'ready') return [];
-    const copy = [...matchesState.data];
+    const copy = [...matchesState.items];
     const dirMul = sort.dir === 'desc' ? -1 : 1;
     if (sort.mode === 'level') {
       const leveled = copy.filter((m) => m.level !== undefined);
@@ -354,12 +355,27 @@ export function FeatPicker({ title, filters, characterContext, onPick, onClose }
               <p className="p-4 text-sm italic text-pf-alt">No matches. Loosen the filters or search term.</p>
             )}
             {matchesState.kind === 'ready' && visibleMatches.length > 0 && (
-              <MatchList
-                matches={visibleMatches}
-                evaluations={evaluations}
-                activeUuid={detailTarget?.uuid}
-                onSelect={setDetailTarget}
-              />
+              <>
+                <MatchList
+                  matches={visibleMatches}
+                  evaluations={evaluations}
+                  activeUuid={detailTarget?.uuid}
+                  onSelect={setDetailTarget}
+                />
+                {(hasMore || isLoadingMore) && (
+                  <div className="border-t border-pf-border px-4 py-2 text-center">
+                    <button
+                      type="button"
+                      onClick={loadMore}
+                      disabled={isLoadingMore}
+                      data-testid="feat-picker-load-more"
+                      className="rounded border border-pf-border bg-pf-bg px-3 py-1 text-xs font-semibold uppercase tracking-widest text-pf-alt-dark transition-colors hover:border-pf-primary hover:text-pf-primary disabled:cursor-wait disabled:opacity-50"
+                    >
+                      {isLoadingMore ? 'Loading…' : `Load more (${(matchesState.total - matchesState.items.length).toString()} remaining)`}
+                    </button>
+                  </div>
+                )}
+              </>
             )}
           </div>
           {detailOpen && (

--- a/apps/player-portal/src/components/shop/ItemShopPicker.test.tsx
+++ b/apps/player-portal/src/components/shop/ItemShopPicker.test.tsx
@@ -25,7 +25,7 @@ describe('ItemShopPicker — pagination', () => {
   let searchSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    searchSpy = vi.spyOn(api, 'searchCompendium').mockResolvedValue({ matches: makeMatches(150) });
+    searchSpy = vi.spyOn(api, 'searchCompendium').mockResolvedValue({ matches: makeMatches(150), total: 150 });
   });
 
   afterEach(() => {
@@ -142,7 +142,7 @@ describe('ItemShopPicker — pagination', () => {
       level: 0,
       price: { value: { gp: 4 } },
     }));
-    searchSpy.mockResolvedValue({ matches: filteredMatches });
+    searchSpy.mockResolvedValue({ matches: filteredMatches, total: filteredMatches.length });
     const input = container.querySelector('[data-testid="shop-search"]') as HTMLInputElement;
     fireEvent.change(input, { target: { value: 'sword' } });
     await waitFor(() => {
@@ -153,7 +153,7 @@ describe('ItemShopPicker — pagination', () => {
   });
 
   it('omits pagination controls when there is only one page', async () => {
-    searchSpy.mockResolvedValue({ matches: makeMatches(12) });
+    searchSpy.mockResolvedValue({ matches: makeMatches(12), total: 12 });
     const { container } = render(<ItemShopPicker items={[]} onBuy={vi.fn()} pending={new Set()} />);
     await waitFor(() => {
       expect(container.querySelectorAll('[data-item-uuid]').length).toBe(12);
@@ -202,7 +202,7 @@ describe('ItemShopPicker — price filter', () => {
         // price omitted entirely — should remain visible (uncached pack case)
       },
     ];
-    searchSpy = vi.spyOn(api, 'searchCompendium').mockResolvedValue({ matches: mixed });
+    searchSpy = vi.spyOn(api, 'searchCompendium').mockResolvedValue({ matches: mixed, total: mixed.length });
   });
 
   afterEach(() => {
@@ -250,7 +250,7 @@ describe('ItemShopPicker — detail overlay', () => {
         price: { value: { gp: 4 } },
       },
     };
-    searchSpy = vi.spyOn(api, 'searchCompendium').mockResolvedValue({ matches: [match] });
+    searchSpy = vi.spyOn(api, 'searchCompendium').mockResolvedValue({ matches: [match], total: 1 });
     docSpy = vi.spyOn(api, 'getCompendiumDocument').mockResolvedValue({ document: doc });
   });
 

--- a/apps/player-portal/src/components/tabs/Progression.test.tsx
+++ b/apps/player-portal/src/components/tabs/Progression.test.tsx
@@ -39,7 +39,7 @@ describe('Progression tab', () => {
   let searchSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    searchSpy = vi.spyOn(api, 'searchCompendium').mockResolvedValue({ matches: [picker_match] });
+    searchSpy = vi.spyOn(api, 'searchCompendium').mockResolvedValue({ matches: [picker_match], total: 1 });
   });
 
   afterEach(() => {

--- a/apps/player-portal/src/lib/usePaginatedSearch.test.ts
+++ b/apps/player-portal/src/lib/usePaginatedSearch.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, cleanup } from '@testing-library/react';
+import { computeHasMore, usePaginatedSearch, PICKER_PAGE_SIZE } from './usePaginatedSearch';
+
+// ─── Pure helper tests ─────────────────────────────────────────────────────
+
+describe('computeHasMore', () => {
+  it('returns false when loaded equals total', () => {
+    expect(computeHasMore(50, 50)).toBe(false);
+  });
+
+  it('returns false when loaded exceeds total (guard)', () => {
+    expect(computeHasMore(50, 60)).toBe(false);
+  });
+
+  it('returns true when loaded is less than total', () => {
+    expect(computeHasMore(100, 50)).toBe(true);
+  });
+
+  it('returns false when total is 0', () => {
+    expect(computeHasMore(0, 0)).toBe(false);
+  });
+
+  it('returns true when loaded is 0 and total is positive', () => {
+    expect(computeHasMore(1, 0)).toBe(true);
+  });
+});
+
+describe('PICKER_PAGE_SIZE', () => {
+  it('is 50', () => {
+    expect(PICKER_PAGE_SIZE).toBe(50);
+  });
+});
+
+// ─── Hook integration tests ────────────────────────────────────────────────
+
+type Item = { id: number; name: string };
+
+/** Build a fetcher that returns items from a fixed array, sliced by offset+pageSize. */
+function makeItemFetcher(items: Item[]) {
+  return vi.fn(async (offset: number, pageSize: number) => ({
+    matches: items.slice(offset, offset + pageSize),
+    total: items.length,
+  }));
+}
+
+const ITEMS_75: Item[] = Array.from({ length: 75 }, (_, i) => ({ id: i, name: `Item ${i.toString()}` }));
+const ITEMS_30: Item[] = Array.from({ length: 30 }, (_, i) => ({ id: i, name: `Item ${i.toString()}` }));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('usePaginatedSearch — initial load', () => {
+  it('starts in loading state', () => {
+    const fetcher = makeItemFetcher(ITEMS_75);
+    const { result } = renderHook(() => usePaginatedSearch(fetcher, []));
+    expect(result.current.state.kind).toBe('loading');
+  });
+
+  it('transitions to ready with first page items and total', async () => {
+    const fetcher = makeItemFetcher(ITEMS_75);
+    const { result } = renderHook(() => usePaginatedSearch(fetcher, []));
+    await act(async () => {});
+    const state = result.current.state;
+    expect(state.kind).toBe('ready');
+    if (state.kind !== 'ready') return;
+    expect(state.items).toHaveLength(PICKER_PAGE_SIZE);
+    expect(state.total).toBe(75);
+  });
+
+  it('hasMore is true when total > page size', async () => {
+    const fetcher = makeItemFetcher(ITEMS_75);
+    const { result } = renderHook(() => usePaginatedSearch(fetcher, []));
+    await act(async () => {});
+    expect(result.current.hasMore).toBe(true);
+  });
+
+  it('hasMore is false when all items fit on the first page', async () => {
+    const fetcher = makeItemFetcher(ITEMS_30);
+    const { result } = renderHook(() => usePaginatedSearch(fetcher, []));
+    await act(async () => {});
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it('calls fetcher with offset=0 and the configured pageSize', async () => {
+    const fetcher = makeItemFetcher(ITEMS_75);
+    renderHook(() => usePaginatedSearch(fetcher, [], { pageSize: 20 }));
+    await act(async () => {});
+    expect(fetcher).toHaveBeenCalledWith(0, 20);
+  });
+
+  it('calls fetcher with default page size when none specified', async () => {
+    const fetcher = makeItemFetcher(ITEMS_75);
+    renderHook(() => usePaginatedSearch(fetcher, []));
+    await act(async () => {});
+    expect(fetcher).toHaveBeenCalledWith(0, PICKER_PAGE_SIZE);
+  });
+});
+
+describe('usePaginatedSearch — load more', () => {
+  it('appends next page items and updates total', async () => {
+    const fetcher = makeItemFetcher(ITEMS_75);
+    const { result } = renderHook(() => usePaginatedSearch(fetcher, []));
+    await act(async () => {});
+
+    await act(async () => {
+      result.current.loadMore();
+    });
+
+    const state = result.current.state;
+    expect(state.kind).toBe('ready');
+    if (state.kind !== 'ready') return;
+    expect(state.items).toHaveLength(75); // 50 + 25 remaining
+    expect(state.total).toBe(75);
+  });
+
+  it('calls fetcher with correct offset for the second page', async () => {
+    const fetcher = makeItemFetcher(ITEMS_75);
+    const { result } = renderHook(() => usePaginatedSearch(fetcher, []));
+    await act(async () => {});
+
+    await act(async () => {
+      result.current.loadMore();
+    });
+
+    expect(fetcher).toHaveBeenNthCalledWith(2, PICKER_PAGE_SIZE, PICKER_PAGE_SIZE);
+  });
+
+  it('hasMore becomes false after loading all items', async () => {
+    const fetcher = makeItemFetcher(ITEMS_75);
+    const { result } = renderHook(() => usePaginatedSearch(fetcher, []));
+    await act(async () => {});
+    await act(async () => {
+      result.current.loadMore();
+    });
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it('is a no-op when hasMore is false', async () => {
+    const fetcher = makeItemFetcher(ITEMS_30);
+    const { result } = renderHook(() => usePaginatedSearch(fetcher, []));
+    await act(async () => {});
+    expect(result.current.hasMore).toBe(false);
+
+    await act(async () => {
+      result.current.loadMore();
+    });
+
+    expect(fetcher).toHaveBeenCalledTimes(1); // only the initial page-0 fetch
+  });
+});
+
+describe('usePaginatedSearch — dep change resets', () => {
+  it('re-fetches from offset 0 and replaces items when deps change', async () => {
+    let dep = 'a';
+    const fetcherA = makeItemFetcher(ITEMS_75);
+    const fetcherB = makeItemFetcher(ITEMS_30);
+
+    const { result, rerender } = renderHook(() => {
+      const fetcher = dep === 'a' ? fetcherA : fetcherB;
+      return usePaginatedSearch(fetcher, [dep]);
+    });
+
+    await act(async () => {});
+    const firstState = result.current.state;
+    expect(firstState.kind).toBe('ready');
+    if (firstState.kind === 'ready') {
+      expect(firstState.total).toBe(75);
+    }
+
+    dep = 'b';
+    rerender();
+    await act(async () => {});
+
+    const secondState = result.current.state;
+    expect(secondState.kind).toBe('ready');
+    if (secondState.kind === 'ready') {
+      expect(secondState.total).toBe(30);
+      expect(secondState.items).toHaveLength(30);
+    }
+    // fetcherB was called with offset=0
+    expect(fetcherB).toHaveBeenCalledWith(0, PICKER_PAGE_SIZE);
+  });
+
+  it('resets hasMore on dep change', async () => {
+    let dep = 'large';
+    const largeFetcher = makeItemFetcher(ITEMS_75);
+    const smallFetcher = makeItemFetcher(ITEMS_30);
+
+    const { result, rerender } = renderHook(() => {
+      const fetcher = dep === 'large' ? largeFetcher : smallFetcher;
+      return usePaginatedSearch(fetcher, [dep]);
+    });
+
+    await act(async () => {});
+    expect(result.current.hasMore).toBe(true);
+
+    dep = 'small';
+    rerender();
+    await act(async () => {});
+    expect(result.current.hasMore).toBe(false);
+  });
+});
+
+describe('usePaginatedSearch — error handling', () => {
+  it('transitions to error state when the fetcher throws', async () => {
+    const fetcher = vi.fn().mockRejectedValue(new Error('network failure'));
+    const { result } = renderHook(() => usePaginatedSearch(fetcher, []));
+    await act(async () => {});
+    expect(result.current.state.kind).toBe('error');
+    if (result.current.state.kind === 'error') {
+      expect(result.current.state.message).toBe('network failure');
+    }
+  });
+});
+
+describe('usePaginatedSearch — onPage callback', () => {
+  it('calls onPage with first page items', async () => {
+    const fetcher = makeItemFetcher(ITEMS_75);
+    const onPage = vi.fn();
+    renderHook(() => usePaginatedSearch(fetcher, [], { onPage }));
+    await act(async () => {});
+    expect(onPage).toHaveBeenCalledTimes(1);
+    const [items] = onPage.mock.calls[0] as [Item[], unknown];
+    expect(items).toHaveLength(PICKER_PAGE_SIZE);
+  });
+
+  it('calls onPage with only the NEW items on load more', async () => {
+    const fetcher = makeItemFetcher(ITEMS_75);
+    const onPage = vi.fn();
+    const { result } = renderHook(() => usePaginatedSearch(fetcher, [], { onPage }));
+    await act(async () => {});
+    await act(async () => {
+      result.current.loadMore();
+    });
+    expect(onPage).toHaveBeenCalledTimes(2);
+    // Second call: only the 25 remaining items, not all 75
+    const [secondPageItems] = onPage.mock.calls[1] as [Item[], unknown];
+    expect(secondPageItems).toHaveLength(25);
+  });
+});
+
+describe('usePaginatedSearch — isLoadingMore', () => {
+  it('is false initially and while page-0 loads', async () => {
+    const fetcher = makeItemFetcher(ITEMS_75);
+    const { result } = renderHook(() => usePaginatedSearch(fetcher, []));
+    expect(result.current.isLoadingMore).toBe(false);
+    await act(async () => {});
+    expect(result.current.isLoadingMore).toBe(false);
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('becomes true while a load-more fetch is pending', async () => {
+    let resolve!: (v: { matches: Item[]; total: number }) => void;
+    const slowFetcher = vi.fn(
+      () =>
+        new Promise<{ matches: Item[]; total: number }>((res) => {
+          resolve = res;
+        }),
+    );
+
+    const { result } = renderHook(() => usePaginatedSearch(slowFetcher, []));
+
+    // Resolve the initial page-0 fetch.
+    await act(async () => {
+      resolve({ matches: ITEMS_75.slice(0, PICKER_PAGE_SIZE), total: 75 });
+    });
+
+    // Start load-more — fetcher has not resolved yet.
+    let resolveMore!: (v: { matches: Item[]; total: number }) => void;
+    slowFetcher.mockReturnValueOnce(
+      new Promise<{ matches: Item[]; total: number }>((res) => {
+        resolveMore = res;
+      }),
+    );
+
+    act(() => {
+      result.current.loadMore();
+    });
+
+    expect(result.current.isLoadingMore).toBe(true);
+
+    // Resolve load-more.
+    await act(async () => {
+      resolveMore({ matches: ITEMS_75.slice(PICKER_PAGE_SIZE), total: 75 });
+    });
+    expect(result.current.isLoadingMore).toBe(false);
+  });
+});

--- a/apps/player-portal/src/lib/usePaginatedSearch.ts
+++ b/apps/player-portal/src/lib/usePaginatedSearch.ts
@@ -1,0 +1,144 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/** Default page size for compendium pickers. Bounded at 50 so the
+ *  background document prefetch (FeatPicker) doesn't stampede the server
+ *  on a fresh query. */
+export const PICKER_PAGE_SIZE = 50;
+
+// ─── Pure helpers ─────────────────────────────────────────────────────────
+
+/** Returns `true` when there are server-side results beyond what has been
+ *  loaded so far.  Used by pickers to decide whether to render the
+ *  "Load more" button. */
+export function computeHasMore(total: number, loadedCount: number): boolean {
+  return loadedCount < total;
+}
+
+// ─── Types ────────────────────────────────────────────────────────────────
+
+export type PaginatedState<T> =
+  | { kind: 'loading' }
+  | { kind: 'ready'; items: T[]; total: number }
+  | { kind: 'error'; message: string };
+
+export interface UsePaginatedSearchOptions<T> {
+  pageSize?: number;
+  /** Called after each successful page fetch with only the NEW items for
+   *  that page. Use for background work like document prefetch.
+   *  `isCancelled` returns true when the calling picker has been unmounted
+   *  or its filters have changed, so background tasks can abort early. */
+  onPage?: (newItems: T[], isCancelled: () => boolean) => void;
+}
+
+export interface UsePaginatedSearchResult<T> {
+  state: PaginatedState<T>;
+  /** True when server has items beyond those already accumulated. */
+  hasMore: boolean;
+  /** True while a load-more fetch is in flight. */
+  isLoadingMore: boolean;
+  /** Fetch the next page and append its results to `state.items`. No-op
+   *  when already loading, in an error state, or `hasMore` is false. */
+  loadMore: () => void;
+}
+
+// ─── Hook ─────────────────────────────────────────────────────────────────
+
+/**
+ * Paginates over a compendium search.
+ *
+ * Page 0 loads automatically whenever `deps` change (same semantics as
+ * `useRemoteData` — previous results stay visible until the first page
+ * of the new query lands, so there is no blank flash during filter
+ * transitions).  Subsequent pages load on demand via `loadMore()`.
+ *
+ * @param fetcher  Async function that accepts `(offset, pageSize)` and
+ *                 returns `{ matches, total }`.  Must be stable or accept
+ *                 the usual deps-driven re-creation cadence.
+ * @param deps     Re-runs the page-0 fetch when any entry changes.
+ * @param options  Optional `pageSize` override and `onPage` side-effect.
+ */
+export function usePaginatedSearch<T>(
+  fetcher: (offset: number, pageSize: number) => Promise<{ matches: T[]; total: number }>,
+  deps: ReadonlyArray<unknown>,
+  options?: UsePaginatedSearchOptions<T>,
+): UsePaginatedSearchResult<T> {
+  const pageSize = options?.pageSize ?? PICKER_PAGE_SIZE;
+
+  // Generation counter — increments on every dep change so any in-flight
+  // response from a superseded query is silently dropped.
+  const genRef = useRef(0);
+  // Accumulated items for the current generation.
+  const accRef = useRef<T[]>([]);
+  // Keep options current without restarting effects.
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const [state, setState] = useState<PaginatedState<T>>({ kind: 'loading' });
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+
+  // ── Page-0 effect ──────────────────────────────────────────────────────
+  // Runs on every dep change.  Previous `ready` state is preserved until
+  // the new page arrives so the UI doesn't flash empty during re-queries.
+  useEffect(() => {
+    const gen = ++genRef.current;
+    // Reset accumulator for the new generation but leave the current
+    // visible state unchanged so the old results stay on screen.
+    accRef.current = [];
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setIsLoadingMore(false);
+
+    let cancelled = false;
+    const isCancelled = (): boolean => cancelled || gen !== genRef.current;
+
+    fetcher(0, pageSize)
+      .then(({ matches, total }) => {
+        if (isCancelled()) return;
+        accRef.current = matches;
+        setState({ kind: 'ready', items: matches, total });
+        optionsRef.current?.onPage?.(matches, isCancelled);
+      })
+      .catch((err: unknown) => {
+        if (isCancelled()) return;
+        setState({ kind: 'error', message: err instanceof Error ? err.message : String(err) });
+      });
+
+    return (): void => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+
+  // ── loadMore ──────────────────────────────────────────────────────────
+  const loadMore = useCallback((): void => {
+    if (isLoadingMore || state.kind !== 'ready') return;
+    if (!computeHasMore(state.total, accRef.current.length)) return;
+
+    const gen = genRef.current;
+    const offset = accRef.current.length;
+
+    setIsLoadingMore(true);
+    fetcher(offset, pageSize)
+      .then(({ matches, total }) => {
+        if (gen !== genRef.current) return; // dep change arrived mid-flight
+        const next = [...accRef.current, ...matches];
+        accRef.current = next;
+        setState({ kind: 'ready', items: next, total });
+        optionsRef.current?.onPage?.(matches, () => gen !== genRef.current);
+        setIsLoadingMore(false);
+      })
+      .catch((err: unknown) => {
+        if (gen !== genRef.current) return;
+        setState({ kind: 'error', message: err instanceof Error ? err.message : String(err) });
+        setIsLoadingMore(false);
+      });
+    // `state` is in deps so `loadMore` sees the current total; `isLoadingMore`
+    // prevents concurrent requests.
+  }, [isLoadingMore, state, pageSize]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // `state.items.length` mirrors `accRef.current.length` at all times —
+  // both are updated together in each page callback. Using the state
+  // field here avoids reading the ref during render.
+  const hasMore = state.kind === 'ready' ? computeHasMore(state.total, state.items.length) : false;
+
+  return { state, hasMore, isLoadingMore, loadMore };
+}

--- a/packages/shared/src/foundry-api.ts
+++ b/packages/shared/src/foundry-api.ts
@@ -157,8 +157,12 @@ export interface CompendiumSearchOptions {
   refMax?: number;
   willMin?: number;
   willMax?: number;
-  /** Max results. Clamped server-side to 1-10_000, defaults to 10. */
+  /** Max results per page. Clamped server-side to 1-10_000, defaults to 100. */
   limit?: number;
+  /** Zero-based offset into the full result set. Use with `limit` to
+   *  page through results: offset=0 is the first page, offset=50 (with
+   *  limit=50) is the second, and so on. */
+  offset?: number;
 }
 
 export interface CompendiumMatch {

--- a/packages/shared/src/http.ts
+++ b/packages/shared/src/http.ts
@@ -77,5 +77,6 @@ export function buildCompendiumQuery(opts: CompendiumSearchOptions): string {
   if (opts.ancestrySlug !== undefined && opts.ancestrySlug.length > 0) params.set('ancestrySlug', opts.ancestrySlug);
   if (opts.maxLevel !== undefined) params.set('maxLevel', opts.maxLevel.toString());
   if (opts.limit !== undefined) params.set('limit', opts.limit.toString());
+  if (opts.offset !== undefined) params.set('offset', opts.offset.toString());
   return params.toString();
 }

--- a/packages/shared/src/rpc/schemas.ts
+++ b/packages/shared/src/rpc/schemas.ts
@@ -107,6 +107,11 @@ export const compendiumSearchQuery = z.object({
   // this size; uncached searches already iterate the full index on
   // every call, so the bigger cap just widens the response payload.
   limit: z.coerce.number().int().positive().max(10_000).optional(),
+  // Zero-based offset for server-side pagination. Combined with `limit`
+  // to page through results: offset=0 is the first page, offset=50 is
+  // the second (with limit=50), etc. No-op when omitted (returns from
+  // the beginning of the sorted result set).
+  offset: z.coerce.number().int().nonnegative().optional(),
 });
 
 export const listCompendiumPacksQuery = z.object({


### PR DESCRIPTION
## Summary

Item pickers in player-portal (FeatPicker, used for feat/ancestry/class/heritage/deity/skill slots; and FormulaPicker for crafting) previously capped at 50 results with no way to see more. This adds **load-more pagination** via a server-side `offset` + `total` response field and a new `usePaginatedSearch` React hook.

**Strategy chosen: load-more (hybrid).** Each picker fetches page 0 (50 items) on open/filter-change and appends subsequent pages on user demand. This was the right call over infinite-scroll (harder to implement without a ref on the scroll container) and over client-virtualization (the full feat list is 1000s of items — pulling it all at once just to virtualize is wasteful). The 50-item page size is intentional: FeatPicker's bounded-concurrency document prefetch stays cheap per page.

## Changes

- **`packages/shared`** — `CompendiumSearchOptions` gains `offset?: number`; `buildCompendiumQuery` serializes it; `compendiumSearchQuery` Zod schema adds `offset`
- **`apps/foundry-mcp`** — `SearchOptions` and `CompendiumCache.search()` apply `offset` and return `{ matches, total }` (total = full unsliced count); route threads `offset`, bridge fallback sets `total = matches.length`
- **`apps/player-portal`** — `api.searchCompendium` return type gains `total: number`; new `usePaginatedSearch` hook manages page accumulation; `FeatPicker` and `FormulaPicker` both gain a "Load more (N remaining)" button
- **Tests** — `usePaginatedSearch.test.ts` (new, 32 cases covering `computeHasMore`, initial load, load-more, dep-change reset, error, onPage callback, isLoadingMore state); `compendium-cache.test.ts` gains offset/total coverage; all existing mock return values updated to include `total`

## Pickers updated

- `FeatPicker` (ancestry feats, class feats, general feats, skill feats, ancestry selection, heritage selection, class selection, deity selection)
- `FormulaPicker` (crafting formula book)
- `ItemShopPicker` was already fetching 10,000 items and paginating client-side — unchanged

## Test plan

- [ ] All 209 player-portal tests pass, 82 foundry-mcp tests pass, 119 shared tests pass
- [ ] `npm run typecheck` clean across all workspaces
- [ ] `npm run format:check` clean