### PR TITLE
feat(dispatcher): add generic Foundry dispatcher + typed PF2e client (spike #74)

### DIFF
--- a/apps/foundry-api-bridge/src/commands/handlers/dispatch/DispatchHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/dispatch/DispatchHandler.ts
@@ -1,0 +1,220 @@
+// Layer 0 — generic Foundry dispatcher.
+//
+// Accepts { class, id, method, args } and dispatches to:
+//   game[collection].get(id)[method](...args)
+//
+// Supported classes and their collection mappings are declared in
+// CLASS_TO_COLLECTION.  To extend, add a new entry there — no other change
+// required.
+//
+// Marshaling:
+//   Inbound  — args of shape { __doc, id } are resolved to live documents.
+//   Outbound — Document returns serialized via .toObject(); others pass through.
+//
+// Errors propagate to the caller unchanged (no swallowing).
+
+import type { DispatchParams, DispatchResult } from '@/commands/types';
+
+// ─── Collection resolver ────────────────────────────────────────────────────
+
+/**
+ * Maps Foundry / PF2e class names → world collection names (the property
+ * accessed via game[collection]).  Extend this table to add new document
+ * types; no other changes are required in the dispatcher.
+ */
+const CLASS_TO_COLLECTION: Readonly<Record<string, string>> = {
+  Actor: 'actors',
+  CharacterPF2e: 'actors',
+  NPCPF2e: 'actors',
+  VehiclePF2e: 'actors',
+  HazardPF2e: 'actors',
+  FamiliarPF2e: 'actors',
+  Item: 'items',
+  JournalEntry: 'journal',
+};
+
+const SUPPORTED_CLASSES = Object.keys(CLASS_TO_COLLECTION).join(', ');
+
+function resolveCollection(className: string): string {
+  const collection = CLASS_TO_COLLECTION[className];
+  if (collection === undefined) {
+    throw new Error(`Dispatcher: unsupported class '${className}'. Supported: ${SUPPORTED_CLASSES}`);
+  }
+  return collection;
+}
+
+// ─── Inbound arg marshaling ──────────────────────────────────────────────────
+
+interface DocRef {
+  __doc: string;
+  id: string;
+}
+
+function isDocRef(arg: unknown): arg is DocRef {
+  if (typeof arg !== 'object' || arg === null) return false;
+  const obj = arg as Record<string, unknown>;
+  return typeof obj['__doc'] === 'string' && typeof obj['id'] === 'string';
+}
+
+function unmarshalArg(arg: unknown, gameObj: Record<string, unknown>): unknown {
+  if (!isDocRef(arg)) return arg;
+
+  const collection = CLASS_TO_COLLECTION[arg.__doc];
+  if (collection === undefined) {
+    console.warn(
+      `Foundry API Bridge | Dispatch: DocRef has unknown class '${arg.__doc}' — passing arg through unchanged`,
+    );
+    return arg;
+  }
+
+  const coll = gameObj[collection];
+  if (coll == null || typeof (coll as { get?: unknown }).get !== 'function') {
+    console.warn(
+      `Foundry API Bridge | Dispatch: collection '${collection}' unavailable for DocRef — passing arg through`,
+    );
+    return arg;
+  }
+
+  return (coll as { get: (id: string) => unknown }).get(arg.id);
+}
+
+function unmarshalArgs(args: unknown[], gameObj: Record<string, unknown>): unknown[] {
+  return args.map((a) => unmarshalArg(a, gameObj));
+}
+
+// ─── Dot-path method resolver ────────────────────────────────────────────────
+//
+// Path syntax:
+//   'applyDamage'                            → target.applyDamage
+//   'saves.fortitude.roll'                   → target.saves.fortitude.roll
+//   'system.actions[@slug:my-sword].rollDamage'
+//     → target.system.actions.find(a =>
+//         a.slug === 'my-sword' ||
+//         a.item?.slug === 'my-sword' ||
+//         a.item?.name === 'my-sword'
+//       ).rollDamage
+//
+// The LAST segment is the method name; all prior segments traverse properties.
+
+const ARRAY_SLUG_RE = /^(.+)\[@slug:(.+)\]$/;
+
+function resolvePath(target: object, path: string): (...args: unknown[]) => unknown {
+  const segments = path.split('.');
+  const methodName = segments.pop();
+
+  if (!methodName) {
+    throw new Error(`Dispatcher: empty method path`);
+  }
+
+  let current: unknown = target;
+
+  for (const segment of segments) {
+    const match = ARRAY_SLUG_RE.exec(segment);
+
+    if (match !== null) {
+      // Array-element lookup: 'actions[@slug:my-sword]'
+      const prop = match[1] as string;
+      const slug = match[2] as string;
+
+      const arr = (current as Record<string, unknown>)[prop];
+      if (!Array.isArray(arr)) {
+        throw new Error(`Dispatcher: '${prop}' is not an array (segment '${segment}')`);
+      }
+
+      current = arr.find((item: unknown) => {
+        if (typeof item !== 'object' || item === null) return false;
+        const obj = item as Record<string, unknown>;
+        if (obj['slug'] === slug) return true;
+        const child = obj['item'] as Record<string, unknown> | undefined;
+        return child?.['slug'] === slug || child?.['name'] === slug;
+      });
+
+      if (current == null) {
+        throw new Error(`Dispatcher: no element with slug '${slug}' found in '${prop}'`);
+      }
+    } else {
+      // Plain property traversal
+      if (typeof current !== 'object' || current === null) {
+        throw new Error(`Dispatcher: cannot traverse '${segment}' — value is not an object`);
+      }
+      current = (current as Record<string, unknown>)[segment];
+      if (current == null) {
+        throw new Error(`Dispatcher: property '${segment}' not found`);
+      }
+    }
+  }
+
+  if (typeof current !== 'object' || current === null) {
+    throw new Error(`Dispatcher: cannot call '${methodName}' — resolved context is not an object`);
+  }
+
+  const fn = (current as Record<string, unknown>)[methodName];
+  if (typeof fn !== 'function') {
+    throw new Error(`Dispatcher: '${methodName}' is not a function (got ${typeof fn})`);
+  }
+
+  return (fn as (...a: unknown[]) => unknown).bind(current);
+}
+
+// ─── Outbound result marshaling ──────────────────────────────────────────────
+
+function marshalResult(raw: unknown): unknown {
+  if (raw == null) return null;
+  if (typeof raw === 'object') {
+    const obj = raw as Record<string, unknown>;
+    if (typeof obj['toObject'] === 'function') {
+      return (obj['toObject'] as () => unknown)();
+    }
+  }
+  return raw;
+}
+
+// ─── Foundry global ─────────────────────────────────────────────────────────
+
+declare const game: Record<string, unknown>;
+
+// ─── Handler ────────────────────────────────────────────────────────────────
+
+export async function dispatchHandler(params: DispatchParams): Promise<DispatchResult> {
+  const { class: className, id, method, args = [] } = params;
+
+  // Log at the boundary.  Do NOT log full args — they can contain large
+  // document payloads or secrets.
+  console.info(
+    `Foundry API Bridge | Dispatch: class=${className} id=${id.slice(0, 8)} method=${method}`,
+  );
+
+  const collection = resolveCollection(className);
+  const coll = game[collection];
+
+  if (coll == null || typeof (coll as { get?: unknown }).get !== 'function') {
+    throw new Error(`Dispatcher: collection '${collection}' not available on game`);
+  }
+
+  const doc = (coll as { get: (id: string) => unknown }).get(id);
+  if (doc == null) {
+    throw new Error(`Dispatcher: ${className} document not found (id '${id}')`);
+  }
+
+  const unmarshaledArgs = unmarshalArgs(args, game);
+
+  let raw: unknown;
+  try {
+    const fn = resolvePath(doc, method);
+    raw = await fn(...unmarshaledArgs);
+  } catch (error) {
+    console.error(
+      `Foundry API Bridge | Dispatch error: class=${className} id=${id.slice(0, 8)} method=${method}`,
+      error,
+    );
+    throw error;
+  }
+
+  const result = marshalResult(raw);
+  const wasDocument = result !== raw && raw != null;
+  console.info(
+    `Foundry API Bridge | Dispatch result: method=${method} wasDocument=${String(wasDocument)}`,
+  );
+
+  return { result };
+}

--- a/apps/foundry-api-bridge/src/commands/handlers/dispatch/__tests__/DispatchHandler.test.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/dispatch/__tests__/DispatchHandler.test.ts
@@ -1,0 +1,279 @@
+import { dispatchHandler } from '../DispatchHandler';
+
+// ─── Game mock setup ─────────────────────────────────────────────────────────
+
+const rollSaveMock = jest.fn();
+const applyDamageMock = jest.fn();
+const longswordRollDamageMock = jest.fn();
+const shortswordRollDamageMock = jest.fn();
+
+const mockActor = {
+  id: 'actor-001',
+  name: 'Test Character',
+  applyDamage: applyDamageMock,
+  saves: {
+    fortitude: { roll: rollSaveMock },
+    reflex: { roll: jest.fn() },
+    will: { roll: jest.fn() },
+  },
+  system: {
+    actions: [
+      {
+        slug: 'longsword',
+        item: { slug: 'longsword', name: 'Longsword' },
+        rollDamage: longswordRollDamageMock,
+      },
+      {
+        slug: 'shortsword',
+        item: { slug: 'shortsword', name: 'Shortsword' },
+        rollDamage: shortswordRollDamageMock,
+      },
+    ],
+  },
+};
+
+const mockItem = {
+  id: 'item-001',
+  name: 'Test Item',
+};
+
+const mockGame = {
+  actors: { get: jest.fn() },
+  items: { get: jest.fn() },
+};
+
+(global as Record<string, unknown>)['game'] = mockGame;
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('dispatchHandler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGame.actors.get.mockReturnValue(mockActor);
+    mockGame.items.get.mockReturnValue(mockItem);
+    rollSaveMock.mockResolvedValue({ total: 18, formula: '1d20+6' });
+    applyDamageMock.mockResolvedValue(undefined);
+    longswordRollDamageMock.mockResolvedValue({ formula: '2d6+4', total: 10 });
+    shortswordRollDamageMock.mockResolvedValue({ formula: '1d6+4', total: 7 });
+  });
+
+  // ─── Happy path ────────────────────────────────────────────────────────────
+
+  describe('happy path', () => {
+    it('resolves the collection, calls the method, and wraps the result', async () => {
+      const result = await dispatchHandler({
+        class: 'CharacterPF2e',
+        id: 'actor-001',
+        method: 'saves.fortitude.roll',
+        args: [{ skipDialog: true }],
+      });
+
+      expect(mockGame.actors.get).toHaveBeenCalledWith('actor-001');
+      expect(rollSaveMock).toHaveBeenCalledWith({ skipDialog: true });
+      expect(result).toEqual({ result: { total: 18, formula: '1d20+6' } });
+    });
+
+    it('calls a top-level method (no dot traversal)', async () => {
+      applyDamageMock.mockResolvedValue(null);
+      await dispatchHandler({
+        class: 'CharacterPF2e',
+        id: 'actor-001',
+        method: 'applyDamage',
+        args: [10],
+      });
+      expect(applyDamageMock).toHaveBeenCalledWith(10);
+    });
+
+    it('defaults args to [] when omitted from params', async () => {
+      rollSaveMock.mockResolvedValue({ total: 12 });
+      await dispatchHandler({
+        class: 'CharacterPF2e',
+        id: 'actor-001',
+        method: 'saves.fortitude.roll',
+      });
+      expect(rollSaveMock).toHaveBeenCalledWith();
+    });
+
+    it('resolves array elements by slug via [@slug:X] convention', async () => {
+      const result = await dispatchHandler({
+        class: 'CharacterPF2e',
+        id: 'actor-001',
+        method: 'system.actions[@slug:longsword].rollDamage',
+        args: [{}],
+      });
+      expect(longswordRollDamageMock).toHaveBeenCalledWith({});
+      expect(shortswordRollDamageMock).not.toHaveBeenCalled();
+      expect(result).toEqual({ result: { formula: '2d6+4', total: 10 } });
+    });
+
+    it('routes to the Item collection for class=Item', async () => {
+      const getNameFn = jest.fn().mockReturnValue('Test Item');
+      (mockItem as Record<string, unknown>)['getName'] = getNameFn;
+
+      await dispatchHandler({ class: 'Item', id: 'item-001', method: 'getName' });
+
+      expect(mockGame.items.get).toHaveBeenCalledWith('item-001');
+      expect(getNameFn).toHaveBeenCalled();
+    });
+  });
+
+  // ─── Inbound arg marshaling ────────────────────────────────────────────────
+
+  describe('document arg marshaling (inbound)', () => {
+    it('resolves a DocRef arg to the actual document', async () => {
+      const methodSpy = jest.fn().mockResolvedValue(null);
+      (mockActor as Record<string, unknown>)['methodWithDocArg'] = methodSpy;
+
+      await dispatchHandler({
+        class: 'CharacterPF2e',
+        id: 'actor-001',
+        method: 'methodWithDocArg',
+        args: [{ __doc: 'Item', id: 'item-001' }],
+      });
+
+      // The DocRef should be replaced by the actual item object
+      expect(methodSpy).toHaveBeenCalledWith(mockItem);
+    });
+
+    it('passes non-DocRef args through unchanged', async () => {
+      const methodSpy = jest.fn().mockResolvedValue(null);
+      (mockActor as Record<string, unknown>)['plainMethod'] = methodSpy;
+
+      await dispatchHandler({
+        class: 'CharacterPF2e',
+        id: 'actor-001',
+        method: 'plainMethod',
+        args: [42, 'hello', { plain: true }],
+      });
+
+      expect(methodSpy).toHaveBeenCalledWith(42, 'hello', { plain: true });
+    });
+
+    it('warns and passes through a DocRef with an unknown class', async () => {
+      const methodSpy = jest.fn().mockResolvedValue(null);
+      (mockActor as Record<string, unknown>)['methodWithBadRef'] = methodSpy;
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      await dispatchHandler({
+        class: 'CharacterPF2e',
+        id: 'actor-001',
+        method: 'methodWithBadRef',
+        args: [{ __doc: 'UnknownClass', id: 'x' }],
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('UnknownClass'));
+      // The DocRef object itself is passed through unchanged
+      expect(methodSpy).toHaveBeenCalledWith({ __doc: 'UnknownClass', id: 'x' });
+      warnSpy.mockRestore();
+    });
+  });
+
+  // ─── Outbound result marshaling ────────────────────────────────────────────
+
+  describe('document result marshaling (outbound)', () => {
+    it('serializes Document results via .toObject()', async () => {
+      const serialized = { id: 'x', name: 'Some Actor', serialized: true };
+      const docResult = { name: 'Some Actor', toObject: jest.fn().mockReturnValue(serialized) };
+      applyDamageMock.mockResolvedValue(docResult);
+
+      const result = await dispatchHandler({
+        class: 'CharacterPF2e',
+        id: 'actor-001',
+        method: 'applyDamage',
+        args: [5],
+      });
+
+      expect(docResult.toObject).toHaveBeenCalled();
+      expect(result.result).toEqual(serialized);
+    });
+
+    it('passes through non-Document results unchanged', async () => {
+      rollSaveMock.mockResolvedValue({ total: 20, formula: '1d20+7', isCritical: true });
+
+      const result = await dispatchHandler({
+        class: 'CharacterPF2e',
+        id: 'actor-001',
+        method: 'saves.fortitude.roll',
+        args: [{}],
+      });
+
+      expect(result.result).toEqual({ total: 20, formula: '1d20+7', isCritical: true });
+    });
+
+    it('returns { result: null } when the method returns undefined', async () => {
+      applyDamageMock.mockResolvedValue(undefined);
+
+      const result = await dispatchHandler({
+        class: 'CharacterPF2e',
+        id: 'actor-001',
+        method: 'applyDamage',
+        args: [10],
+      });
+
+      expect(result.result).toBeNull();
+    });
+  });
+
+  // ─── Error cases ───────────────────────────────────────────────────────────
+
+  describe('error handling', () => {
+    it('throws with a clear message when the class is not in the resolver', async () => {
+      await expect(
+        dispatchHandler({ class: 'UnknownClass', id: 'x', method: 'foo' }),
+      ).rejects.toThrow(/unsupported class 'UnknownClass'/);
+    });
+
+    it('throws when the document is not found', async () => {
+      mockGame.actors.get.mockReturnValue(undefined);
+
+      await expect(
+        dispatchHandler({ class: 'CharacterPF2e', id: 'missing', method: 'applyDamage' }),
+      ).rejects.toThrow(/document not found/);
+    });
+
+    it('throws when the method is not a function', async () => {
+      await expect(
+        dispatchHandler({ class: 'CharacterPF2e', id: 'actor-001', method: 'noSuchMethod' }),
+      ).rejects.toThrow(/'noSuchMethod' is not a function/);
+    });
+
+    it('throws when a traversal property does not exist', async () => {
+      await expect(
+        dispatchHandler({ class: 'CharacterPF2e', id: 'actor-001', method: 'badPath.method' }),
+      ).rejects.toThrow(/property 'badPath' not found/i);
+    });
+
+    it('throws when the [@slug:X] lookup finds no matching element', async () => {
+      await expect(
+        dispatchHandler({
+          class: 'CharacterPF2e',
+          id: 'actor-001',
+          method: 'system.actions[@slug:ghost-weapon].rollDamage',
+        }),
+      ).rejects.toThrow(/no element with slug 'ghost-weapon'/i);
+    });
+
+    it('propagates Foundry method errors without swallowing', async () => {
+      rollSaveMock.mockRejectedValue(new Error('Foundry internal error'));
+
+      await expect(
+        dispatchHandler({
+          class: 'CharacterPF2e',
+          id: 'actor-001',
+          method: 'saves.fortitude.roll',
+        }),
+      ).rejects.toThrow('Foundry internal error');
+    });
+
+    it('throws when [@slug:X] is applied to a non-array property', async () => {
+      await expect(
+        dispatchHandler({
+          class: 'CharacterPF2e',
+          id: 'actor-001',
+          // 'saves' is an object, not an array
+          method: 'saves[@slug:fortitude].roll',
+        }),
+      ).rejects.toThrow(/not an array/i);
+    });
+  });
+});

--- a/apps/foundry-api-bridge/src/commands/handlers/dispatch/index.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/dispatch/index.ts
@@ -1,0 +1,1 @@
+export { dispatchHandler } from './DispatchHandler';

--- a/apps/foundry-api-bridge/src/commands/handlers/index.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/index.ts
@@ -135,3 +135,6 @@ export {
 
 // Event channel handlers
 export { createSetEventSubscriptionHandler } from '@/commands/handlers/events';
+
+// Generic Foundry dispatcher (Layer 0)
+export { dispatchHandler } from '@/commands/handlers/dispatch';

--- a/apps/foundry-api-bridge/src/commands/types.ts
+++ b/apps/foundry-api-bridge/src/commands/types.ts
@@ -109,7 +109,8 @@ export type CommandType =
   | 'get-combat-turn-context'
   | 'set-event-subscription'
   | 'fetch-asset'
-  | 'get-party-members';
+  | 'get-party-members'
+  | 'dispatch';
 
 export interface RollDiceParams {
   formula: string;
@@ -1519,6 +1520,27 @@ export interface PartyMemberResult {
 // Event channel subscription updates. Server pushes one of these
 // whenever a channel transitions 0↔1 SSE subscribers; the module
 // registers or tears down the matching Hooks.on listeners.
+// Generic Foundry dispatcher. One command type handles any document class +
+// method combination; the bridge resolves the collection, traverses the
+// dot-path, unmarshals DocRef args, and marshals Document results.
+export interface DispatchParams {
+  /** Foundry / PF2e class name, e.g. 'CharacterPF2e', 'Actor', 'Item'. */
+  class: string;
+  /** Foundry document id. */
+  id: string;
+  /** Dot-path method: 'applyDamage', 'saves.fortitude.roll',
+   *  'system.actions[@slug:longsword].rollDamage'. */
+  method: string;
+  /** Positional args.  DocRef objects ({__doc, id}) resolved to live docs. */
+  args?: unknown[];
+}
+
+export interface DispatchResult {
+  /** JSON-serializable return value. Documents are serialized via .toObject().
+   *  void / undefined becomes null. */
+  result: unknown;
+}
+
 export interface SetEventSubscriptionParams {
   channel: string;
   active: boolean;
@@ -1632,6 +1654,7 @@ export interface CommandParamsMap {
   'set-event-subscription': SetEventSubscriptionParams;
   'fetch-asset': { path: string };
   'get-party-members': GetPartyMembersParams;
+  'dispatch': DispatchParams;
 }
 
 export interface CommandResultMap {
@@ -1731,4 +1754,5 @@ export interface CommandResultMap {
   'set-event-subscription': SetEventSubscriptionResult;
   'fetch-asset': { ok: boolean; contentType?: string; bytes?: string; status?: number; error?: string };
   'get-party-members': PartyMemberResult[];
+  'dispatch': DispatchResult;
 }

--- a/apps/foundry-api-bridge/src/main.ts
+++ b/apps/foundry-api-bridge/src/main.ts
@@ -110,6 +110,7 @@ import {
   updateRollTableHandler,
   deleteRollTableHandler,
   createSetEventSubscriptionHandler,
+  dispatchHandler,
   type SetEventSubscriptionParams,
 } from '@/commands';
 
@@ -270,6 +271,10 @@ function initializeWebSocket(
   commandRouter.register('create-roll-table', createRollTableHandler);
   commandRouter.register('update-roll-table', updateRollTableHandler);
   commandRouter.register('delete-roll-table', deleteRollTableHandler);
+
+  // Generic Foundry dispatcher (Layer 0). One command handles any
+  // document class + method combination without a dedicated handler.
+  commandRouter.register('dispatch', dispatchHandler);
 
   // Scene actions
   commandRouter.register('activate-scene', activateSceneHandler);

--- a/apps/foundry-mcp/src/http/app.ts
+++ b/apps/foundry-mcp/src/http/app.ts
@@ -4,6 +4,7 @@ import { log } from '../logger.js';
 import { registerActorRoutes } from './routes/actors.js';
 import { registerAssetRoutes } from './routes/assets.js';
 import { registerCompendiumRoutes } from './routes/compendium.js';
+import { registerDispatchRoute } from './routes/dispatch.js';
 import { registerEvalRoutes } from './routes/eval.js';
 import { registerEventRoutes } from './routes/events.js';
 import { registerPromptRoutes } from './routes/prompts.js';
@@ -70,6 +71,7 @@ export async function buildHttpApp(): Promise<FastifyInstance> {
 
   registerActorRoutes(app);
   registerAssetRoutes(app);
+  registerDispatchRoute(app);
   registerCompendiumRoutes(app);
   registerEvalRoutes(app);
   registerEventRoutes(app);

--- a/apps/foundry-mcp/src/http/routes/dispatch.ts
+++ b/apps/foundry-mcp/src/http/routes/dispatch.ts
@@ -1,0 +1,17 @@
+// POST /api/dispatch — generic Foundry method dispatcher.
+//
+// Accepts { class, id, method, args } and routes to the bridge's 'dispatch'
+// command, which resolves game[collection].get(id)[method](...args) inside the
+// Foundry module.  See apps/foundry-api-bridge/src/commands/handlers/dispatch/
+// for the full marshaling spec.
+
+import type { FastifyInstance } from 'fastify';
+import { sendCommand } from '../../bridge.js';
+import { dispatchRequestSchema } from '../schemas.js';
+
+export function registerDispatchRoute(app: FastifyInstance): void {
+  app.post('/api/dispatch', async (req) => {
+    const body = dispatchRequestSchema.parse(req.body);
+    return sendCommand('dispatch', body as Record<string, unknown>);
+  });
+}

--- a/apps/player-portal/package.json
+++ b/apps/player-portal/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@foundry-toolkit/pf2e-rules": "*",
     "@foundry-toolkit/shared": "*",
     "@tailwindcss/postcss": "^4.2.2",
     "@testing-library/dom": "^10.4.0",

--- a/apps/player-portal/src/api/client.ts
+++ b/apps/player-portal/src/api/client.ts
@@ -5,6 +5,8 @@ import type {
   AdjustActorConditionResponse,
   AdjustActorResourceResponse,
   CreateActorBody,
+  DispatchRequest,
+  DispatchResponse,
   Pf2eRollMode,
   Pf2eStatisticSlug,
   RollActorStatisticResponse,
@@ -131,6 +133,11 @@ export const api = {
       'roll-statistic',
       rollMode !== undefined ? { statistic, rollMode } : { statistic },
     ),
+  // Generic Foundry dispatcher — Layer 0. Sends { class, id, method, args }
+  // to POST /api/dispatch and returns { result: unknown }. Normally called
+  // indirectly via createPf2eClient(api.dispatch) from packages/pf2e-rules.
+  dispatch: (req: DispatchRequest): Promise<DispatchResponse> =>
+    request<DispatchResponse>('/dispatch', { method: 'POST', body: req }),
   resolvePrompt: (bridgeId: string, value: unknown): Promise<{ ok: boolean }> =>
     request<{ ok: boolean }>(`/prompts/${bridgeId}/resolve`, { method: 'POST', body: { value } }),
   uploadAsset: (body: UploadAssetBody): Promise<UploadAssetResult> =>

--- a/apps/player-portal/src/components/tabs/Character.test.tsx
+++ b/apps/player-portal/src/components/tabs/Character.test.tsx
@@ -1,13 +1,28 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import { render, cleanup, within } from '@testing-library/react';
+import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest';
+import { render, cleanup, fireEvent, within, act } from '@testing-library/react';
 import amiri from '../../fixtures/amiri-prepared.json';
 import type { CharacterSystem } from '../../api/types';
 import { Character } from './Character';
+import { api } from '../../api/client';
+
+// Mock the api client. The existing render-only tests never trigger api calls,
+// so this mock is safe for the whole file.  The new dispatcher test below
+// inspects `api.dispatch` directly.
+vi.mock('../../api/client', () => ({
+  api: {
+    dispatch: vi.fn().mockResolvedValue({ result: null }),
+    rollActorStatistic: vi.fn().mockResolvedValue({}),
+    adjustActorResource: vi.fn().mockResolvedValue({}),
+    adjustActorCondition: vi.fn().mockResolvedValue({}),
+    longRest: vi.fn().mockResolvedValue({}),
+  },
+}));
 
 // Amiri — level-1 human barbarian. Verified values pulled from the live
 // /prepared payload: str+4 (key), dex+2, con+2, int+0, wis+0, cha+1,
 // AC 18, HP 22/22, Perception +5, Fort +7, Ref +5, Will +5, Class DC 17.
 const system = (amiri as unknown as { system: CharacterSystem }).system;
+
 
 describe('Character tab', () => {
   afterEach(() => {
@@ -223,5 +238,63 @@ describe('Character tab', () => {
     expect(tile?.textContent).toContain('+2');
     expect(tile?.textContent).toContain('15/20');
     expect(tile?.textContent).toContain('Raised');
+  });
+});
+
+// ─── Dispatcher end-to-end: fortitude save button ───────────────────────────
+//
+// Verifies that the fortitude save tile calls api.dispatch with the expected
+// DispatchRequest shape.  This is the end-to-end spike test validating that
+// the pf2e-rules Layer 1 client is wired into the Character sheet correctly.
+
+describe('Character tab — fortitude save wired through dispatcher', () => {
+  beforeEach(() => {
+    vi.mocked(api.dispatch).mockClear();
+    vi.mocked(api.dispatch).mockResolvedValue({ result: null });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('clicking the Fortitude save tile calls api.dispatch with the right DispatchRequest', async () => {
+    const { container } = render(
+      <Character system={system} actorId="test-actor" onActorChanged={() => undefined} />,
+    );
+
+    const fortTile = container.querySelector('[data-stat="save-fortitude"]') as HTMLButtonElement;
+    expect(fortTile, 'fortitude tile should render as a button').toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(fortTile);
+    });
+
+    expect(api.dispatch).toHaveBeenCalledWith({
+      class: 'CharacterPF2e',
+      id: 'test-actor',
+      method: 'saves.fortitude.roll',
+      args: [{}],
+    });
+  });
+
+  it('reflex and will tiles still call rollActorStatistic (not dispatch)', async () => {
+    const { container } = render(
+      <Character system={system} actorId="test-actor" onActorChanged={() => undefined} />,
+    );
+
+    const reflexTile = container.querySelector('[data-stat="save-reflex"]') as HTMLButtonElement;
+    const willTile = container.querySelector('[data-stat="save-will"]') as HTMLButtonElement;
+
+    await act(async () => {
+      fireEvent.click(reflexTile);
+    });
+    await act(async () => {
+      fireEvent.click(willTile);
+    });
+
+    // Only fortitude goes through dispatch — reflex and will still use rollActorStatistic.
+    expect(api.dispatch).not.toHaveBeenCalled();
+    expect(api.rollActorStatistic).toHaveBeenCalledWith('test-actor', 'reflex');
+    expect(api.rollActorStatistic).toHaveBeenCalledWith('test-actor', 'will');
   });
 });

--- a/apps/player-portal/src/components/tabs/Character.tsx
+++ b/apps/player-portal/src/components/tabs/Character.tsx
@@ -1,3 +1,4 @@
+import { createPf2eClient } from '@foundry-toolkit/pf2e-rules';
 import { api } from '../../api/client';
 import type { AbilityKey, CharacterSystem, IWREntry, Save, Shield, Speed } from '../../api/types';
 import { ABILITY_KEYS } from '../../api/types';
@@ -167,8 +168,12 @@ function StatsBlock({
   const rollPerception = useActorAction({
     run: () => api.rollActorStatistic(actorId, 'perception'),
   });
+  // Fortitude is wired through the pf2e-rules Layer 1 client → generic
+  // dispatcher (Layer 0), validating the end-to-end dispatcher round-trip.
+  // createPf2eClient is pure and cheap; recreating per render is intentional
+  // for the spike — follow-up can memoize if profiling shows it matters.
   const rollFortitude = useActorAction({
-    run: () => api.rollActorStatistic(actorId, 'fortitude'),
+    run: () => createPf2eClient(api.dispatch).character(actorId).rollSave('fortitude'),
   });
   const rollReflex = useActorAction({
     run: () => api.rollActorStatistic(actorId, 'reflex'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -163,6 +163,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@foundry-toolkit/pf2e-rules": "*",
         "@foundry-toolkit/shared": "*",
         "@tailwindcss/postcss": "^4.2.2",
         "@testing-library/dom": "^10.4.0",

--- a/packages/pf2e-rules/src/encounter.ts
+++ b/packages/pf2e-rules/src/encounter.ts
@@ -14,7 +14,9 @@ export function creatureXp(creatureLevel: number, partyLevel: number): number {
   const d = creatureLevel - partyLevel;
   if (d <= -5) return 0;
   if (d >= 5) return 200;
-  return [10, 15, 20, 30, 40, 60, 80, 120, 160][d + 4];
+  // d is in [-4, 4] after the guards above, so index [0, 8] is always valid.
+
+  return [10, 15, 20, 30, 40, 60, 80, 120, 160][d + 4]!;
 }
 
 /** XP → threat-tier label. Thresholds match CRB Table 10-2. */

--- a/packages/pf2e-rules/src/index.ts
+++ b/packages/pf2e-rules/src/index.ts
@@ -1,2 +1,3 @@
 export * from './encounter.js';
+export * from './pf2e-client.js';
 export * from './treasure.js';

--- a/packages/pf2e-rules/src/pf2e-client.test.ts
+++ b/packages/pf2e-rules/src/pf2e-client.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createPf2eClient, type DispatchFn, type DispatchResponse } from './pf2e-client';
+
+// Helper: create a dispatch spy that resolves to { result: null } by default.
+function makeDispatch(): { dispatch: DispatchFn; spy: ReturnType<typeof vi.fn> } {
+  const spy = vi.fn().mockResolvedValue({ result: null });
+  return { dispatch: spy as DispatchFn, spy };
+}
+
+describe('createPf2eClient', () => {
+  // ─── character().rollSave ────────────────────────────────────────────────
+
+  describe('character().rollSave', () => {
+    it('dispatches class=CharacterPF2e, method=saves.fortitude.roll', async () => {
+      const { dispatch, spy } = makeDispatch();
+      await createPf2eClient(dispatch).character('actor-001').rollSave('fortitude');
+
+      expect(spy).toHaveBeenCalledOnce();
+      expect(spy).toHaveBeenCalledWith({
+        class: 'CharacterPF2e',
+        id: 'actor-001',
+        method: 'saves.fortitude.roll',
+        args: [{}],
+      });
+    });
+
+    it('dispatches saves.reflex.roll for type=reflex', async () => {
+      const { dispatch, spy } = makeDispatch();
+      await createPf2eClient(dispatch).character('actor-002').rollSave('reflex');
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ method: 'saves.reflex.roll', id: 'actor-002' }));
+    });
+
+    it('dispatches saves.will.roll for type=will', async () => {
+      const { dispatch, spy } = makeDispatch();
+      await createPf2eClient(dispatch).character('actor-003').rollSave('will');
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ method: 'saves.will.roll' }));
+    });
+
+    it('passes opts through in args[0]', async () => {
+      const { dispatch, spy } = makeDispatch();
+      const opts = { skipDialog: true, rollMode: 'gmroll' as const };
+      await createPf2eClient(dispatch).character('actor-001').rollSave('fortitude', opts);
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ args: [opts] }));
+    });
+
+    it('defaults opts to {} when omitted', async () => {
+      const { dispatch, spy } = makeDispatch();
+      await createPf2eClient(dispatch).character('actor-001').rollSave('fortitude');
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ args: [{}] }));
+    });
+
+    it('returns the DispatchResponse from the dispatch function', async () => {
+      const { dispatch } = makeDispatch();
+      const expected: DispatchResponse = { result: { total: 17, formula: '1d20+6' } };
+      vi.mocked(dispatch).mockResolvedValueOnce(expected);
+
+      const resp = await createPf2eClient(dispatch).character('actor-001').rollSave('fortitude');
+      expect(resp).toEqual(expected);
+    });
+  });
+
+  // ─── character().applyDamage ─────────────────────────────────────────────
+
+  describe('character().applyDamage', () => {
+    it('dispatches method=applyDamage with amount as args[0]', async () => {
+      const { dispatch, spy } = makeDispatch();
+      await createPf2eClient(dispatch).character('actor-001').applyDamage(12);
+
+      expect(spy).toHaveBeenCalledWith({
+        class: 'CharacterPF2e',
+        id: 'actor-001',
+        method: 'applyDamage',
+        args: [12, {}],
+      });
+    });
+
+    it('passes opts through in args[1]', async () => {
+      const { dispatch, spy } = makeDispatch();
+      const opts = { multiplier: 0.5 };
+      await createPf2eClient(dispatch).character('actor-001').applyDamage(8, opts);
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ args: [8, opts] }));
+    });
+
+    it('defaults opts to {} when omitted', async () => {
+      const { dispatch, spy } = makeDispatch();
+      await createPf2eClient(dispatch).character('actor-001').applyDamage(5);
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ args: [5, {}] }));
+    });
+  });
+
+  // ─── weapon().rollDamage ─────────────────────────────────────────────────
+
+  describe('weapon().rollDamage', () => {
+    it('dispatches with the @slug array-lookup convention', async () => {
+      const { dispatch, spy } = makeDispatch();
+      await createPf2eClient(dispatch).weapon('actor-001', 'longsword').rollDamage();
+
+      expect(spy).toHaveBeenCalledWith({
+        class: 'CharacterPF2e',
+        id: 'actor-001',
+        method: 'system.actions[@slug:longsword].rollDamage',
+        args: [{}],
+      });
+    });
+
+    it('interpolates arbitrary strike slugs into the method path', async () => {
+      const { dispatch, spy } = makeDispatch();
+      await createPf2eClient(dispatch).weapon('actor-001', 'my-battle-axe').rollDamage();
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ method: 'system.actions[@slug:my-battle-axe].rollDamage' }),
+      );
+    });
+
+    it('passes opts through in args[0]', async () => {
+      const { dispatch, spy } = makeDispatch();
+      const opts = { critical: true };
+      await createPf2eClient(dispatch).weapon('actor-001', 'longsword').rollDamage(opts);
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ args: [opts] }));
+    });
+
+    it('defaults opts to {} when omitted', async () => {
+      const { dispatch, spy } = makeDispatch();
+      await createPf2eClient(dispatch).weapon('actor-001', 'longsword').rollDamage();
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ args: [{}] }));
+    });
+
+    it('uses the actorId supplied to weapon(), not character()', async () => {
+      const { dispatch, spy } = makeDispatch();
+      await createPf2eClient(dispatch).weapon('specific-actor', 'dagger').rollDamage();
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ id: 'specific-actor' }));
+    });
+  });
+});

--- a/packages/pf2e-rules/src/pf2e-client.ts
+++ b/packages/pf2e-rules/src/pf2e-client.ts
@@ -1,0 +1,147 @@
+// Layer 1 — typed PF2e client.
+//
+// Hand-curated wrappers over the generic Foundry dispatcher (Layer 0).  Each
+// method builds a DispatchRequest — the right class, document id, dot-path
+// method, and args — and calls `dispatch`, which routes to
+// game[collection].get(id)[method](...args) inside the Foundry module.
+//
+// The types below are intentionally inlined (no import from shared) so that
+// this package stays zero-dep. They are structurally compatible with
+// DispatchRequest / DispatchResponse from @foundry-toolkit/shared/rpc, so
+// consumers that import both see no type mismatches.
+
+// ─── Wire types (inlined) ───────────────────────────────────────────────────
+
+/**
+ * Request shape sent to the generic Foundry dispatcher.
+ * Structurally identical to DispatchRequest in @foundry-toolkit/shared/rpc.
+ */
+export interface DispatchRequest {
+  class: string;
+  id: string;
+  method: string;
+  args: unknown[];
+}
+
+/**
+ * Response envelope returned by the dispatcher on success.
+ * Structurally identical to DispatchResponse in @foundry-toolkit/shared/rpc.
+ */
+export interface DispatchResponse {
+  result: unknown;
+}
+
+// ─── DispatchFn ─────────────────────────────────────────────────────────────
+
+/**
+ * Function that executes a dispatch request over the bridge.
+ *
+ * In player-portal, pass `api.dispatch`.
+ * In tests, pass a vi.fn() / jest.fn() spy.
+ */
+export type DispatchFn = (req: DispatchRequest) => Promise<DispatchResponse>;
+
+// ─── Client factory ─────────────────────────────────────────────────────────
+
+/**
+ * Create a typed PF2e client — Layer 1 wrappers over the generic dispatcher.
+ *
+ * Each method translates a semantic PF2e operation into a DispatchRequest
+ * and calls `dispatch`.  The dispatch function is injected so consumers can
+ * provide real transport (player-portal) or a mock (tests) without changing
+ * the wrapper logic.
+ *
+ * @param dispatch - function that sends a DispatchRequest and returns the result.
+ *
+ * @example
+ * // In player-portal:
+ * const pf2e = createPf2eClient(api.dispatch);
+ * await pf2e.character(actorId).rollSave('fortitude');
+ *
+ * @example
+ * // In tests:
+ * const mockDispatch = vi.fn().mockResolvedValue({ result: null });
+ * const pf2e = createPf2eClient(mockDispatch);
+ */
+export function createPf2eClient(dispatch: DispatchFn) {
+  return {
+    /**
+     * Wrappers bound to a CharacterPF2e actor by id.
+     *
+     * @param actorId - Foundry document id of the CharacterPF2e actor.
+     */
+    character(actorId: string) {
+      return {
+        /**
+         * Roll a saving throw via the dispatcher.
+         *
+         * Dispatches: `actor.saves[type].roll(opts)`
+         *
+         * @param type - 'fortitude' | 'reflex' | 'will'
+         * @param opts - PF2e CheckRollContext options, e.g. `{ skipDialog, rollMode }`.
+         *   Passed through to Foundry's roll method verbatim.
+         */
+        rollSave(type: 'fortitude' | 'reflex' | 'will', opts: Record<string, unknown> = {}): Promise<DispatchResponse> {
+          return dispatch({
+            class: 'CharacterPF2e',
+            id: actorId,
+            method: `saves.${type}.roll`,
+            args: [opts],
+          });
+        },
+
+        /**
+         * Apply damage to the actor via the dispatcher.
+         *
+         * Dispatches: `actor.applyDamage(amount, opts)`
+         *
+         * @param amount - positive integer damage amount (pre-resistance / DR).
+         * @param opts   - PF2e ApplyDamageParams (multiplier, damageType, …).
+         */
+        applyDamage(amount: number, opts: Record<string, unknown> = {}): Promise<DispatchResponse> {
+          return dispatch({
+            class: 'CharacterPF2e',
+            id: actorId,
+            method: 'applyDamage',
+            args: [amount, opts],
+          });
+        },
+      };
+    },
+
+    /**
+     * Wrappers bound to a Strike action on a CharacterPF2e actor.
+     *
+     * @param actorId    - Foundry document id of the actor.
+     * @param strikeSlug - slug of the weapon / strike action
+     *   (matched against action.item.slug in actor.system.actions).
+     */
+    weapon(actorId: string, strikeSlug: string) {
+      return {
+        /**
+         * Roll damage for a named strike via the dispatcher.
+         *
+         * Dispatches: `actor.system.actions[@slug:<strikeSlug>].rollDamage(opts)`
+         *
+         * The `[@slug:X]` notation is the dispatcher's array-lookup convention:
+         * it finds the first element in actor.system.actions where
+         * item.slug === strikeSlug (also checks .slug / .item.name).
+         *
+         * @param opts - PF2e DamageRollParams, e.g. `{ critical: true }`.
+         *
+         * Known limitation (spike): if the strikeSlug contains characters that
+         * conflict with the `[@slug:X]` parser (e.g. `]`) the lookup will fail.
+         * Follow-up: sanitize or encode the slug in the dispatcher resolver.
+         */
+        rollDamage(opts: Record<string, unknown> = {}): Promise<DispatchResponse> {
+          return dispatch({
+            class: 'CharacterPF2e',
+            id: actorId,
+            method: `system.actions[@slug:${strikeSlug}].rollDamage`,
+            args: [opts],
+          });
+        },
+      };
+    },
+  };
+}

--- a/packages/pf2e-rules/src/treasure.ts
+++ b/packages/pf2e-rules/src/treasure.ts
@@ -33,7 +33,9 @@ export const TREASURE_PER_LEVEL_GP: Record<number, number> = {
  *  given party level. Falls back to level 10 for out-of-table inputs so
  *  callers don't crash on unexpected levels. */
 export function moderatePerEncounterGp(partyLevel: number): number {
-  return (TREASURE_PER_LEVEL_GP[partyLevel] ?? TREASURE_PER_LEVEL_GP[10]) / 4;
+  // Level 10 is always present in the table; the fallback is guaranteed non-undefined.
+
+  return (TREASURE_PER_LEVEL_GP[partyLevel] ?? TREASURE_PER_LEVEL_GP[10]!) / 4;
 }
 
 /** Treasure budget (gp) for an encounter of the given XP threat at the

--- a/packages/shared/src/rpc/dispatch.test.ts
+++ b/packages/shared/src/rpc/dispatch.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import {
+  dispatchRequestSchema,
+  dispatchResponseSchema,
+  docRefSchema,
+  type DispatchRequest,
+  type DispatchResponse,
+  type DocRef,
+} from './dispatch';
+
+describe('dispatch wire types', () => {
+  // ─── docRefSchema ──────────────────────────────────────────────────────────
+
+  describe('docRefSchema', () => {
+    it('parses a valid DocRef', () => {
+      const ref: DocRef = docRefSchema.parse({ __doc: 'Actor', id: 'abc123' });
+      expect(ref.__doc).toBe('Actor');
+      expect(ref.id).toBe('abc123');
+    });
+
+    it('rejects a DocRef with an empty __doc', () => {
+      expect(() => docRefSchema.parse({ __doc: '', id: 'abc' })).toThrow();
+    });
+
+    it('rejects a DocRef with a missing id field', () => {
+      expect(() => docRefSchema.parse({ __doc: 'Actor' })).toThrow();
+    });
+  });
+
+  // ─── dispatchRequestSchema ─────────────────────────────────────────────────
+
+  describe('dispatchRequestSchema', () => {
+    it('round-trips a minimal request (no args supplied)', () => {
+      const input = { class: 'CharacterPF2e', id: 'actor-001', method: 'saves.fortitude.roll' };
+      const parsed: DispatchRequest = dispatchRequestSchema.parse(input);
+      expect(parsed.class).toBe('CharacterPF2e');
+      expect(parsed.id).toBe('actor-001');
+      expect(parsed.method).toBe('saves.fortitude.roll');
+      expect(parsed.args).toEqual([]);
+    });
+
+    it('defaults args to [] when omitted', () => {
+      const parsed = dispatchRequestSchema.parse({ class: 'Actor', id: 'x', method: 'applyDamage' });
+      expect(parsed.args).toEqual([]);
+    });
+
+    it('round-trips a request with explicit args', () => {
+      const input: DispatchRequest = {
+        class: 'CharacterPF2e',
+        id: 'actor-001',
+        method: 'applyDamage',
+        args: [10, { multiplier: 0.5 }],
+      };
+      const parsed = dispatchRequestSchema.parse(input);
+      expect(parsed.args).toEqual([10, { multiplier: 0.5 }]);
+    });
+
+    it('accepts args containing DocRef objects', () => {
+      const parsed = dispatchRequestSchema.parse({
+        class: 'Actor',
+        id: 'abc',
+        method: 'someMethod',
+        args: [{ __doc: 'Item', id: 'item-1' }, 42, 'hello'],
+      });
+      expect(parsed.args).toHaveLength(3);
+      expect(parsed.args[0]).toEqual({ __doc: 'Item', id: 'item-1' });
+    });
+
+    it('accepts array-lookup method paths', () => {
+      const parsed = dispatchRequestSchema.parse({
+        class: 'CharacterPF2e',
+        id: 'actor-001',
+        method: 'system.actions[@slug:my-sword].rollDamage',
+        args: [{}],
+      });
+      expect(parsed.method).toBe('system.actions[@slug:my-sword].rollDamage');
+    });
+
+    it('rejects an empty class', () => {
+      expect(() => dispatchRequestSchema.parse({ class: '', id: 'abc', method: 'foo' })).toThrow();
+    });
+
+    it('rejects an empty method', () => {
+      expect(() => dispatchRequestSchema.parse({ class: 'Actor', id: 'abc', method: '' })).toThrow();
+    });
+
+    it('round-trips via JSON serialization', () => {
+      const req: DispatchRequest = {
+        class: 'CharacterPF2e',
+        id: 'x1',
+        method: 'applyDamage',
+        args: [10, { multiplier: 1 }],
+      };
+      const round = dispatchRequestSchema.parse(JSON.parse(JSON.stringify(req)));
+      expect(round).toEqual(req);
+    });
+  });
+
+  // ─── dispatchResponseSchema ────────────────────────────────────────────────
+
+  describe('dispatchResponseSchema', () => {
+    it('parses a null result (void / undefined method return)', () => {
+      const resp: DispatchResponse = dispatchResponseSchema.parse({ result: null });
+      expect(resp.result).toBeNull();
+    });
+
+    it('parses a numeric result', () => {
+      const resp = dispatchResponseSchema.parse({ result: 42 });
+      expect(resp.result).toBe(42);
+    });
+
+    it('parses an object result (serialized Document)', () => {
+      const resp = dispatchResponseSchema.parse({
+        result: { id: 'abc', name: 'Test Actor', type: 'character' },
+      });
+      expect((resp.result as Record<string, unknown>)['name']).toBe('Test Actor');
+    });
+
+    it('round-trips a roll result shape', () => {
+      const raw = { result: { total: 17, formula: '1d20+5', dice: [] } };
+      const parsed = dispatchResponseSchema.parse(raw);
+      expect(parsed).toEqual(raw);
+    });
+
+    it('round-trips via JSON serialization', () => {
+      const resp: DispatchResponse = { result: { ok: true, data: [1, 2, 3] } };
+      const round = dispatchResponseSchema.parse(JSON.parse(JSON.stringify(resp)));
+      expect(round).toEqual(resp);
+    });
+  });
+});

--- a/packages/shared/src/rpc/dispatch.ts
+++ b/packages/shared/src/rpc/dispatch.ts
@@ -1,0 +1,72 @@
+// Wire types for the generic Foundry dispatcher (Layer 0).
+//
+// The dispatcher accepts { class, id, method, args } and routes to
+// game[collection].get(id)[method](...args) inside the Foundry module.
+// Two marshaling concerns are handled transparently:
+//   Inbound : DocRef args resolved to live documents before the method call.
+//   Outbound: Document results serialized via .toObject(); others pass through.
+//
+// Consumed by:
+//   - apps/foundry-api-bridge  — DispatchHandler registers the command
+//   - packages/pf2e-rules      — createPf2eClient builds typed DispatchRequests
+//   - apps/player-portal       — api.dispatch sends POST /api/dispatch
+
+import { z } from 'zod/v4';
+
+// ─── DocRef ─────────────────────────────────────────────────────────────────
+
+/**
+ * A DocRef arg tells the dispatcher to resolve `game[collection].get(id)`
+ * before passing the value to the target method.  Use when the Foundry API
+ * expects a live Document object rather than a plain id string.
+ */
+export const docRefSchema = z.object({
+  __doc: z.string().min(1),
+  id: z.string().min(1),
+});
+
+export type DocRef = z.infer<typeof docRefSchema>;
+
+// ─── Request ─────────────────────────────────────────────────────────────────
+
+/**
+ * Full request shape sent to `POST /api/dispatch`.
+ *
+ * `method` supports:
+ *   - Simple names:   'applyDamage'
+ *   - Dot-paths:      'saves.fortitude.roll'
+ *   - Array lookup:   'system.actions[@slug:longsword].rollDamage'
+ *     → finds the first element in actor.system.actions where
+ *       item.slug === 'longsword' (also checks .slug / .item.name).
+ */
+export const dispatchRequestSchema = z.object({
+  /** Foundry / PF2e class name used to resolve the world collection.
+   *  Supported: 'Actor', 'CharacterPF2e', 'NPCPF2e', 'VehiclePF2e',
+   *  'HazardPF2e', 'FamiliarPF2e', 'Item', 'JournalEntry'.  */
+  class: z.string().min(1),
+  /** Foundry document id. */
+  id: z.string().min(1),
+  /** Dot-path to the method to call on the resolved document. */
+  method: z.string().min(1),
+  /** Positional arguments.  DocRef objects are resolved to live documents
+   *  before dispatch; all other values are passed through as-is. */
+  args: z.array(z.unknown()).default([]),
+});
+
+export type DispatchRequest = z.infer<typeof dispatchRequestSchema>;
+
+// ─── Response ────────────────────────────────────────────────────────────────
+
+/**
+ * Response envelope from `POST /api/dispatch` on success (HTTP 2xx).
+ * On error the HTTP status is 4xx/5xx and the body is `{ error: string }`.
+ *
+ * Document return values are serialized via `.toObject()`.
+ * void / undefined returns become `null`.
+ */
+export const dispatchResponseSchema = z.object({
+  /** JSON-serializable return value from the Foundry method call. */
+  result: z.unknown(),
+});
+
+export type DispatchResponse = z.infer<typeof dispatchResponseSchema>;

--- a/packages/shared/src/rpc/index.ts
+++ b/packages/shared/src/rpc/index.ts
@@ -5,6 +5,7 @@
 // import a typed body shape without redeclaring it.
 
 export * from './dialog.js';
+export * from './dispatch.js';
 
 import type { z } from 'zod/v4';
 


### PR DESCRIPTION
## Summary

Validates the three-layer dispatcher architecture from issue #74 in a single cohesive spike. A real button on the player-portal character sheet (Fortitude save) now round-trips through the new dispatcher and produces the same outcome as the old path.

**Architecture:** `player-portal → api.dispatch() → POST /api/dispatch → foundry-mcp → sendCommand('dispatch') → foundry-api-bridge DispatchHandler → game[collection].get(id)[method](...args) → result → DispatchResponse → client`

### Layer 0 — Generic dispatcher (`apps/foundry-api-bridge`)

New `dispatch` command type. Handler resolves the collection, traverses a dot-path (optionally with array element lookup), calls the method, marshals the result.

**Supported document classes:**

| Class | Collection |
|---|---|
| `Actor`, `CharacterPF2e`, `NPCPF2e`, `VehiclePF2e`, `HazardPF2e`, `FamiliarPF2e` | `actors` |
| `Item` | `items` |
| `JournalEntry` | `journal` |

Extend by adding an entry to `CLASS_TO_COLLECTION` in `DispatchHandler.ts` — no other changes required.

**Path syntax:**
- Simple: `'applyDamage'`, `'saves.fortitude.roll'`
- Array element lookup: `'system.actions[@slug:longsword].rollDamage'` — finds the first element in `actor.system.actions` where `item.slug` (or `.slug` / `.item.name`) matches the slug.

**Marshaling:**
- Inbound: args of shape `{ __doc: 'ClassName', id: '...' }` resolved to live Foundry documents before the call.
- Outbound: if the return value has a `.toObject()` method it is called (Document serialization); otherwise the value passes through as-is. `void`/`undefined` becomes `null`.

Errors from Foundry methods propagate to the caller unchanged — no swallowing.

### Layer 1 — Typed PF2e client (`packages/pf2e-rules`)

Three wrappers via `createPf2eClient(dispatch)`:

```ts
pf2e.character(actorId).rollSave('fortitude' | 'reflex' | 'will', opts?)
  // → saves.<type>.roll

pf2e.character(actorId).applyDamage(amount, opts?)
  // → applyDamage

pf2e.weapon(actorId, strikeSlug).rollDamage(opts?)
  // → system.actions[@slug:<strikeSlug>].rollDamage
```

Types (`DispatchRequest`, `DispatchResponse`, `DispatchFn`) are inlined in `pf2e-client.ts` so the package stays zero-dep. They are structurally identical to the shared Zod-inferred types.

### End-to-end wired button

**Fortitude save tile** on the Character sheet (`Character.tsx → StatsBlock`). Clicking it now dispatches:

```json
{ "class": "CharacterPF2e", "id": "<actorId>", "method": "saves.fortitude.roll", "args": [{}] }
```

Reflex and Will remain on the existing `rollActorStatistic` path — only the minimum needed to validate the round-trip was changed.

## Known limitations / deferred to follow-up

- `[@slug:X]` array lookup: slugs containing `]` will break the regex. Follow-up: sanitize or encode.
- No server-side auth/rate-limiting on `POST /api/dispatch` (acceptable for personal use).
- `pf2e-rules` added as a `devDependency` of `player-portal` (new dep-graph edge). Follow-up: evaluate if `createPf2eClient` should move to `shared` to keep the graph tidy.
- Reflex and Will saves, weapon damage rolls, and `applyDamage` are tested through the Layer 1 wrappers but not wired end-to-end in the UI — follow-up PR after spike validation.
- Layer 2 composite helpers are out of scope.

## Test plan

- [x] `packages/shared` — 9 new round-trip tests for `DispatchRequest`, `DispatchResponse`, `DocRef` schemas
- [x] `apps/foundry-api-bridge` — 19 new Jest tests: happy path, DocRef inbound marshaling, Document outbound marshaling, method-not-found, class-not-resolvable, array lookup failure, Foundry error propagation
- [x] `packages/pf2e-rules` — 18 new Vitest tests: each wrapper method with full arg/opts coverage
- [x] `apps/player-portal` — 2 new Vitest tests: fortitude tile calls `api.dispatch` with correct payload; reflex/will still use `rollActorStatistic`
- [x] All 4 workspace test suites green (790 Jest + 436 Vitest tests total)
- [x] Typecheck clean across all workspaces
- [x] Lint clean (root ESLint pass + all workspace lint scripts)

Closes #74