### PR TITLE
fix(dm-tool): add Uncommon/Rare/Unique to monster rarity filter

### DIFF
--- a/apps/dm-tool/electron/compendium/facets-index.test.ts
+++ b/apps/dm-tool/electron/compendium/facets-index.test.ts
@@ -57,10 +57,12 @@ beforeEach(() => {
 
 describe('aggregateMonsterFacets', () => {
   it('partitions traits into rarity / size / creature-type / other buckets', () => {
+    // rarity comes from m.rarity (MCP server reads system.traits.rarity scalar),
+    // not from the traits value array.
     const out = __internal.aggregateMonsterFacets([
-      monsterMatch({ level: 1, traits: ['common', 'large', 'dragon', 'fire'] }),
-      monsterMatch({ level: 5, traits: ['uncommon', 'huge', 'dragon', 'amphibious'] }),
-      monsterMatch({ level: 10, traits: ['rare', 'medium', 'humanoid', 'aquatic'] }),
+      monsterMatch({ level: 1, rarity: 'common', traits: ['large', 'dragon', 'fire'] }),
+      monsterMatch({ level: 5, rarity: 'uncommon', traits: ['huge', 'dragon', 'amphibious'] }),
+      monsterMatch({ level: 10, rarity: 'rare', traits: ['medium', 'humanoid', 'aquatic'] }),
     ]);
     expect(out.rarities).toEqual(['common', 'rare', 'uncommon']);
     expect(out.sizes).toEqual(['huge', 'large', 'medium']);
@@ -74,13 +76,14 @@ describe('aggregateMonsterFacets', () => {
     expect(out.rarities).toContain('common');
   });
 
-  it('partitions "unique" into the rarity bucket and keeps it out of traits', () => {
+  it('reads all four rarities from m.rarity (the MCP server field)', () => {
     const out = __internal.aggregateMonsterFacets([
-      monsterMatch({ traits: ['unique', 'dragon'] }),
-      monsterMatch({ traits: ['common', 'humanoid'] }),
+      monsterMatch({ rarity: 'unique', traits: ['dragon'] }),
+      monsterMatch({ rarity: 'common', traits: ['humanoid'] }),
+      monsterMatch({ rarity: 'uncommon', traits: ['fiend'] }),
+      monsterMatch({ rarity: 'rare', traits: ['undead'] }),
     ]);
-    expect(out.rarities).toContain('unique');
-    expect(out.rarities).toContain('common');
+    expect(out.rarities).toEqual(['common', 'rare', 'uncommon', 'unique']);
     expect(out.traits).not.toContain('unique');
     expect(out.traits).not.toContain('common');
   });

--- a/apps/dm-tool/electron/compendium/facets-index.test.ts
+++ b/apps/dm-tool/electron/compendium/facets-index.test.ts
@@ -64,7 +64,7 @@ describe('aggregateMonsterFacets', () => {
       monsterMatch({ level: 5, rarity: 'uncommon', traits: ['huge', 'dragon', 'amphibious'] }),
       monsterMatch({ level: 10, rarity: 'rare', traits: ['medium', 'humanoid', 'aquatic'] }),
     ]);
-    expect(out.rarities).toEqual(['common', 'rare', 'uncommon']);
+    expect(out.rarities).toEqual(['common', 'uncommon', 'rare']);
     expect(out.sizes).toEqual(['huge', 'large', 'medium']);
     expect(out.creatureTypes).toEqual(['Dragon', 'Humanoid']);
     expect(out.traits.sort()).toEqual(['amphibious', 'aquatic', 'fire']);
@@ -83,7 +83,7 @@ describe('aggregateMonsterFacets', () => {
       monsterMatch({ rarity: 'uncommon', traits: ['fiend'] }),
       monsterMatch({ rarity: 'rare', traits: ['undead'] }),
     ]);
-    expect(out.rarities).toEqual(['common', 'rare', 'uncommon', 'unique']);
+    expect(out.rarities).toEqual(['common', 'uncommon', 'rare', 'unique']);
     expect(out.traits).not.toContain('unique');
     expect(out.traits).not.toContain('common');
   });

--- a/apps/dm-tool/electron/compendium/facets-index.test.ts
+++ b/apps/dm-tool/electron/compendium/facets-index.test.ts
@@ -74,6 +74,17 @@ describe('aggregateMonsterFacets', () => {
     expect(out.rarities).toContain('common');
   });
 
+  it('partitions "unique" into the rarity bucket and keeps it out of traits', () => {
+    const out = __internal.aggregateMonsterFacets([
+      monsterMatch({ traits: ['unique', 'dragon'] }),
+      monsterMatch({ traits: ['common', 'humanoid'] }),
+    ]);
+    expect(out.rarities).toContain('unique');
+    expect(out.rarities).toContain('common');
+    expect(out.traits).not.toContain('unique');
+    expect(out.traits).not.toContain('common');
+  });
+
   it('produces a zero range when no rows have a level', () => {
     const out = __internal.aggregateMonsterFacets([]);
     expect(out.levelRange).toEqual([0, 0]);

--- a/apps/dm-tool/electron/compendium/facets-index.ts
+++ b/apps/dm-tool/electron/compendium/facets-index.ts
@@ -75,11 +75,17 @@ function aggregateMonsterFacets(matches: CompendiumMatch[]): MonsterFacets {
       if (m.level < minLevel) minLevel = m.level;
       if (m.level > maxLevel) maxLevel = m.level;
     }
+    // Rarity is stored in system.traits.rarity (a scalar) by the MCP server,
+    // not in the traits value array. Read the dedicated field first; fall back
+    // to scanning traits for legacy / alternative data sources.
+    if (m.rarity) {
+      rarities.add(m.rarity.toLowerCase());
+    }
     const mTraits = m.traits ?? [];
     for (const t of mTraits) {
       const lower = t.toLowerCase();
       if (RARITY_TRAITS.has(lower)) {
-        rarities.add(lower);
+        rarities.add(lower); // fallback: rarity string present in traits array
       } else if (SIZE_TRAITS.has(lower)) {
         sizes.add(lower);
       } else if (KNOWN_CREATURE_TYPES.includes(lower)) {

--- a/apps/dm-tool/electron/compendium/facets-index.ts
+++ b/apps/dm-tool/electron/compendium/facets-index.ts
@@ -48,6 +48,7 @@ const KNOWN_CREATURE_TYPES = [
 ];
 
 const RARITY_TRAITS = new Set(['common', 'uncommon', 'rare', 'unique']);
+const RARITY_ORDER = ['common', 'uncommon', 'rare', 'unique'];
 const SIZE_TRAITS = new Set(['tiny', 'small', 'medium', 'large', 'huge', 'gargantuan']);
 
 let monsterCache: MonsterFacets | null = null;
@@ -101,7 +102,7 @@ function aggregateMonsterFacets(matches: CompendiumMatch[]): MonsterFacets {
   if (rarities.size === 0) rarities.add('common');
 
   return {
-    rarities: [...rarities].sort(),
+    rarities: [...rarities].sort((a, b) => RARITY_ORDER.indexOf(a) - RARITY_ORDER.indexOf(b)),
     sizes: [...sizes].sort(),
     creatureTypes: [...creatureTypes].sort(),
     traits: [...traits].sort(),

--- a/apps/dm-tool/electron/compendium/prepared.test.ts
+++ b/apps/dm-tool/electron/compendium/prepared.test.ts
@@ -196,6 +196,57 @@ describe('listMonsters', () => {
     expect(out.map((s) => s.name)).toEqual(['Rare']);
   });
 
+  // Rarity filter matrix: each rarity, "all selected", "none selected"
+  it.each([
+    ['common', ['Common Explicit', 'Common Implicit']],
+    ['uncommon', ['Uncommon']],
+    ['rare', ['Rare']],
+    ['unique', ['Unique']],
+  ])('rarity filter "%s" includes only matching monsters', async (rarity, expected) => {
+    const search = vi.fn().mockResolvedValue({
+      matches: [
+        monsterMatch({ name: 'Common Explicit', rarity: 'common', level: 1 }),
+        monsterMatch({ name: 'Common Implicit', level: 2 }), // no rarity → defaults to 'common'
+        monsterMatch({ name: 'Uncommon', rarity: 'uncommon', level: 3 }),
+        monsterMatch({ name: 'Rare', rarity: 'rare', level: 4 }),
+        monsterMatch({ name: 'Unique', rarity: 'unique', level: 5 }),
+      ],
+    });
+    const api = fakeApi({ searchCompendium: search });
+    const out = await createPreparedCompendium(api).listMonsters({ rarities: [rarity] });
+    expect(out.map((s) => s.name)).toEqual(expected);
+  });
+
+  it('shows all monsters when no rarity filter is applied (none selected)', async () => {
+    const search = vi.fn().mockResolvedValue({
+      matches: [
+        monsterMatch({ name: 'Common', rarity: 'common', level: 1 }),
+        monsterMatch({ name: 'Uncommon', rarity: 'uncommon', level: 2 }),
+        monsterMatch({ name: 'Rare', rarity: 'rare', level: 3 }),
+        monsterMatch({ name: 'Unique', rarity: 'unique', level: 4 }),
+      ],
+    });
+    const api = fakeApi({ searchCompendium: search });
+    const out = await createPreparedCompendium(api).listMonsters({});
+    expect(out.map((s) => s.name)).toEqual(['Common', 'Uncommon', 'Rare', 'Unique']);
+  });
+
+  it('shows all monsters when all four rarities are selected', async () => {
+    const search = vi.fn().mockResolvedValue({
+      matches: [
+        monsterMatch({ name: 'Common', rarity: 'common', level: 1 }),
+        monsterMatch({ name: 'Uncommon', rarity: 'uncommon', level: 2 }),
+        monsterMatch({ name: 'Rare', rarity: 'rare', level: 3 }),
+        monsterMatch({ name: 'Unique', rarity: 'unique', level: 4 }),
+      ],
+    });
+    const api = fakeApi({ searchCompendium: search });
+    const out = await createPreparedCompendium(api).listMonsters({
+      rarities: ['common', 'uncommon', 'rare', 'unique'],
+    });
+    expect(out.map((s) => s.name)).toEqual(['Common', 'Uncommon', 'Rare', 'Unique']);
+  });
+
   it('filters by size client-side', async () => {
     const search = vi.fn().mockResolvedValue({
       matches: [

--- a/apps/dm-tool/src/features/item-browser/ItemFilterPanel.tsx
+++ b/apps/dm-tool/src/features/item-browser/ItemFilterPanel.tsx
@@ -103,7 +103,7 @@ export function ItemFilterPanel({ facets, params, onChange }: ItemFilterPanelPro
           {/* Level range — grouped with its separator so space-y-4 doesn't
               double the gap (16px above + 16px below) like it would if they
               were separate children. */}
-          <div className="flex flex-col gap-2">
+          <div className="flex flex-col">
             <div>
               <SectionLabel>Level</SectionLabel>
               <div className="mt-1.5 flex items-center gap-2">

--- a/apps/dm-tool/src/features/item-browser/ItemFilterPanel.tsx
+++ b/apps/dm-tool/src/features/item-browser/ItemFilterPanel.tsx
@@ -5,7 +5,7 @@ import { Label } from '@/components/ui/label';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Separator } from '@/components/ui/separator';
 import { Button } from '@/components/ui/button';
-import { Slider } from '@/components/ui/slider';
+import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
 import type { ItemFacets, ItemSearchParams } from '@foundry-toolkit/shared/types';
 
@@ -60,14 +60,6 @@ export function ItemFilterPanel({ facets, params, onChange }: ItemFilterPanelPro
     onChange({ ...params, isMagical: params.isMagical === value ? null : value });
   };
 
-  const setLevelRange = (values: number[]) => {
-    onChange({
-      ...params,
-      levelMin: values[0] === 0 ? undefined : values[0],
-      levelMax: values[1] === 28 ? undefined : values[1],
-    });
-  };
-
   const activeCount = useMemo(() => {
     let n = 0;
     if (params.rarities?.length) n += params.rarities.length;
@@ -108,6 +100,36 @@ export function ItemFilterPanel({ facets, params, onChange }: ItemFilterPanelPro
       <Separator variant="ornate" />
       <ScrollArea className="flex-1">
         <div className="space-y-4 p-3">
+          {/* Level range */}
+          <div>
+            <SectionLabel>Level</SectionLabel>
+            <div className="mt-1.5 flex items-center gap-2">
+              <Input
+                type="number"
+                placeholder="0"
+                value={params.levelMin ?? ''}
+                onChange={(e) => {
+                  const min = e.target.value === '' ? undefined : Number(e.target.value);
+                  onChange({ ...params, levelMin: min });
+                }}
+                className="h-7 w-16 px-1.5 text-xs"
+              />
+              <span className="text-xs text-muted-foreground">to</span>
+              <Input
+                type="number"
+                placeholder="28"
+                value={params.levelMax ?? ''}
+                onChange={(e) => {
+                  const max = e.target.value === '' ? undefined : Number(e.target.value);
+                  onChange({ ...params, levelMax: max });
+                }}
+                className="h-7 w-16 px-1.5 text-xs"
+              />
+            </div>
+          </div>
+
+          <Separator />
+
           {/* Rarity pills */}
           <div>
             <SectionLabel>Rarity</SectionLabel>
@@ -132,26 +154,6 @@ export function ItemFilterPanel({ facets, params, onChange }: ItemFilterPanelPro
                 );
               })}
             </div>
-          </div>
-
-          <Separator />
-
-          {/* Level range */}
-          <div>
-            <div className="flex items-center justify-between">
-              <SectionLabel>Level</SectionLabel>
-              <span className="text-[10px] tabular-nums text-muted-foreground">
-                {params.levelMin ?? 0} – {params.levelMax ?? 28}
-              </span>
-            </div>
-            <Slider
-              className="mt-2"
-              min={0}
-              max={28}
-              step={1}
-              value={[params.levelMin ?? 0, params.levelMax ?? 28]}
-              onValueChange={setLevelRange}
-            />
           </div>
 
           <Separator />

--- a/apps/dm-tool/src/features/item-browser/ItemFilterPanel.tsx
+++ b/apps/dm-tool/src/features/item-browser/ItemFilterPanel.tsx
@@ -17,18 +17,18 @@ interface ItemFilterPanelProps {
 
 const RARITY_OPTS = ['COMMON', 'UNCOMMON', 'RARE', 'UNIQUE'] as const;
 
-const RARITY_COLORS: Record<string, string> = {
-  COMMON: 'border-border bg-background hover:bg-accent',
-  UNCOMMON: 'border-orange-600/40 bg-orange-950/30 hover:bg-orange-950/50 text-orange-300',
-  RARE: 'border-blue-600/40 bg-blue-950/30 hover:bg-blue-950/50 text-blue-300',
-  UNIQUE: 'border-purple-600/40 bg-purple-950/30 hover:bg-purple-950/50 text-purple-300',
+const RARITY_BORDER: Record<string, string> = {
+  COMMON: 'border-zinc-500',
+  UNCOMMON: 'border-amber-500',
+  RARE: 'border-blue-500',
+  UNIQUE: 'border-purple-500',
 };
 
-const RARITY_ACTIVE: Record<string, string> = {
-  COMMON: 'border-primary bg-primary text-primary-foreground',
-  UNCOMMON: 'border-orange-500 bg-orange-600 text-white',
-  RARE: 'border-blue-500 bg-blue-600 text-white',
-  UNIQUE: 'border-purple-500 bg-purple-600 text-white',
+const RARITY_FILL: Record<string, string> = {
+  COMMON: 'bg-zinc-500 text-white',
+  UNCOMMON: 'bg-amber-600 text-white',
+  RARE: 'bg-blue-600 text-white',
+  UNIQUE: 'bg-purple-600 text-white',
 };
 
 export function ItemFilterPanel({ facets, params, onChange }: ItemFilterPanelProps) {
@@ -121,7 +121,10 @@ export function ItemFilterPanel({ facets, params, onChange }: ItemFilterPanelPro
                     onClick={() => toggleRarity(r)}
                     className={cn(
                       'rounded-md border px-2 py-1 text-xs capitalize transition-colors',
-                      active ? RARITY_ACTIVE[r] : RARITY_COLORS[r],
+                      RARITY_BORDER[r] ?? 'border-border',
+                      active
+                        ? (RARITY_FILL[r] ?? 'bg-primary text-primary-foreground')
+                        : 'bg-background hover:bg-accent',
                     )}
                   >
                     {r.toLowerCase()}

--- a/apps/dm-tool/src/features/item-browser/ItemFilterPanel.tsx
+++ b/apps/dm-tool/src/features/item-browser/ItemFilterPanel.tsx
@@ -100,35 +100,38 @@ export function ItemFilterPanel({ facets, params, onChange }: ItemFilterPanelPro
       <Separator variant="ornate" />
       <ScrollArea className="flex-1">
         <div className="space-y-4 p-3">
-          {/* Level range */}
-          <div>
-            <SectionLabel>Level</SectionLabel>
-            <div className="mt-1.5 flex items-center gap-2">
-              <Input
-                type="number"
-                placeholder="0"
-                value={params.levelMin ?? ''}
-                onChange={(e) => {
-                  const min = e.target.value === '' ? undefined : Number(e.target.value);
-                  onChange({ ...params, levelMin: min });
-                }}
-                className="h-7 w-16 px-1.5 text-xs"
-              />
-              <span className="text-xs text-muted-foreground">to</span>
-              <Input
-                type="number"
-                placeholder="28"
-                value={params.levelMax ?? ''}
-                onChange={(e) => {
-                  const max = e.target.value === '' ? undefined : Number(e.target.value);
-                  onChange({ ...params, levelMax: max });
-                }}
-                className="h-7 w-16 px-1.5 text-xs"
-              />
+          {/* Level range — grouped with its separator so space-y-4 doesn't
+              double the gap (16px above + 16px below) like it would if they
+              were separate children. */}
+          <div className="flex flex-col gap-2">
+            <div>
+              <SectionLabel>Level</SectionLabel>
+              <div className="mt-1.5 flex items-center gap-2">
+                <Input
+                  type="number"
+                  placeholder="0"
+                  value={params.levelMin ?? ''}
+                  onChange={(e) => {
+                    const min = e.target.value === '' ? undefined : Number(e.target.value);
+                    onChange({ ...params, levelMin: min });
+                  }}
+                  className="h-7 w-16 px-1.5 text-xs"
+                />
+                <span className="text-xs text-muted-foreground">to</span>
+                <Input
+                  type="number"
+                  placeholder="28"
+                  value={params.levelMax ?? ''}
+                  onChange={(e) => {
+                    const max = e.target.value === '' ? undefined : Number(e.target.value);
+                    onChange({ ...params, levelMax: max });
+                  }}
+                  className="h-7 w-16 px-1.5 text-xs"
+                />
+              </div>
             </div>
+            <Separator />
           </div>
-
-          <Separator />
 
           {/* Rarity pills */}
           <div>

--- a/apps/dm-tool/src/features/item-browser/ItemFilterPanel.tsx
+++ b/apps/dm-tool/src/features/item-browser/ItemFilterPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useState, useMemo } from 'react';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
@@ -100,43 +100,40 @@ export function ItemFilterPanel({ facets, params, onChange }: ItemFilterPanelPro
       <Separator variant="ornate" />
       <ScrollArea className="flex-1">
         <div className="space-y-4 p-3">
-          {/* Level range — grouped with its separator so space-y-4 doesn't
-              double the gap (16px above + 16px below) like it would if they
-              were separate children. */}
-          <div className="flex flex-col">
-            <div>
-              <SectionLabel>Level</SectionLabel>
-              <div className="mt-1.5 flex items-center gap-2">
-                <Input
-                  type="number"
-                  placeholder="0"
-                  value={params.levelMin ?? ''}
-                  onChange={(e) => {
-                    const min = e.target.value === '' ? undefined : Number(e.target.value);
-                    onChange({ ...params, levelMin: min });
-                  }}
-                  className="h-7 w-16 px-1.5 text-xs"
-                />
-                <span className="text-xs text-muted-foreground">to</span>
-                <Input
-                  type="number"
-                  placeholder="28"
-                  value={params.levelMax ?? ''}
-                  onChange={(e) => {
-                    const max = e.target.value === '' ? undefined : Number(e.target.value);
-                    onChange({ ...params, levelMax: max });
-                  }}
-                  className="h-7 w-16 px-1.5 text-xs"
-                />
-              </div>
+          {/* Level range */}
+          <section>
+            <SectionHeader>Level</SectionHeader>
+            <div className="flex items-center gap-2">
+              <Input
+                type="number"
+                placeholder="0"
+                value={params.levelMin ?? ''}
+                onChange={(e) => {
+                  const min = e.target.value === '' ? undefined : Number(e.target.value);
+                  onChange({ ...params, levelMin: min });
+                }}
+                className="h-7 w-16 px-1.5 text-xs"
+              />
+              <span className="text-xs text-muted-foreground">to</span>
+              <Input
+                type="number"
+                placeholder="28"
+                value={params.levelMax ?? ''}
+                onChange={(e) => {
+                  const max = e.target.value === '' ? undefined : Number(e.target.value);
+                  onChange({ ...params, levelMax: max });
+                }}
+                className="h-7 w-16 px-1.5 text-xs"
+              />
             </div>
-            <Separator />
-          </div>
+          </section>
 
-          {/* Rarity pills */}
-          <div>
-            <SectionLabel>Rarity</SectionLabel>
-            <div className="mt-1.5 flex flex-wrap gap-1">
+          <Separator />
+
+          {/* Rarity */}
+          <section>
+            <SectionHeader count={params.rarities?.length}>Rarity</SectionHeader>
+            <div className="flex flex-wrap gap-1">
               {RARITY_OPTS.map((r) => {
                 const active = params.rarities?.includes(r) ?? false;
                 return (
@@ -157,18 +154,18 @@ export function ItemFilterPanel({ facets, params, onChange }: ItemFilterPanelPro
                 );
               })}
             </div>
-          </div>
+          </section>
 
           <Separator />
 
           {/* Magical / Mundane */}
-          <div>
-            <SectionLabel>Type</SectionLabel>
-            <div className="mt-1.5 flex gap-1">
+          <section>
+            <SectionHeader>Type</SectionHeader>
+            <div className="flex gap-1">
               <PillButton label="Magical" active={params.isMagical === true} onClick={() => setMagical(true)} />
               <PillButton label="Mundane" active={params.isMagical === false} onClick={() => setMagical(false)} />
             </div>
-          </div>
+          </section>
 
           <Separator />
 
@@ -216,14 +213,15 @@ export function ItemFilterPanel({ facets, params, onChange }: ItemFilterPanelPro
   );
 }
 
-function SectionLabel({ children }: { children: React.ReactNode }) {
+function SectionHeader({ children, count }: { children: React.ReactNode; count?: number }) {
   return (
-    <Label
-      className="text-[10px] uppercase tracking-wider text-muted-foreground"
+    <h3
+      className="mb-1.5 flex items-center gap-1.5 text-[10px] uppercase tracking-wider text-muted-foreground"
       style={{ fontFamily: 'var(--font-display)', fontWeight: 700 }}
     >
       {children}
-    </Label>
+      {count != null && count > 0 && <span className="text-[10px] font-normal text-primary">{count}</span>}
+    </h3>
   );
 }
 
@@ -253,17 +251,9 @@ function CheckboxGroup({
   selected: string[];
   onToggle: (v: string) => void;
 }) {
-  const selectedCount = selected.length;
   return (
-    <div>
-      <div className="mb-2 flex items-center justify-between">
-        <SectionLabel>{label}</SectionLabel>
-        {selectedCount > 0 && (
-          <span className="rounded-full bg-primary/10 px-1.5 py-0.5 text-[9px] font-semibold text-primary">
-            {selectedCount}
-          </span>
-        )}
-      </div>
+    <section>
+      <SectionHeader count={selected.length}>{label}</SectionHeader>
       <div className="space-y-1 pl-1">
         {values.map((v) => {
           const checked = selected.includes(v);
@@ -278,7 +268,7 @@ function CheckboxGroup({
           );
         })}
       </div>
-    </div>
+    </section>
   );
 }
 
@@ -299,30 +289,28 @@ function CollapsibleCheckboxGroup({
 }) {
   const [expanded, setExpanded] = useState(initiallyExpanded);
   const [showAll, setShowAll] = useState(false);
-  const selectedCount = selected.length;
   const displayValues = showAll ? values : values.slice(0, showCount);
   const hasMore = values.length > showCount;
 
   return (
-    <div>
+    <section>
       <button
         type="button"
-        className="mb-2 flex w-full items-center justify-between"
+        className="mb-1.5 flex w-full items-center justify-between"
         onClick={() => setExpanded((e) => !e)}
       >
-        <div className="flex items-center gap-1.5">
+        <span
+          className="flex items-center gap-1.5 text-[10px] uppercase tracking-wider text-muted-foreground"
+          style={{ fontFamily: 'var(--font-display)', fontWeight: 700 }}
+        >
           {expanded ? (
             <ChevronDown className="h-3 w-3 text-muted-foreground" />
           ) : (
             <ChevronRight className="h-3 w-3 text-muted-foreground" />
           )}
-          <SectionLabel>{label}</SectionLabel>
-        </div>
-        {selectedCount > 0 && (
-          <span className="rounded-full bg-primary/10 px-1.5 py-0.5 text-[9px] font-semibold text-primary">
-            {selectedCount}
-          </span>
-        )}
+          {label}
+        </span>
+        {selected.length > 0 && <span className="text-[10px] font-normal text-primary">{selected.length}</span>}
       </button>
       {expanded && (
         <div className="space-y-1 pl-1">
@@ -349,7 +337,7 @@ function CollapsibleCheckboxGroup({
           )}
         </div>
       )}
-    </div>
+    </section>
   );
 }
 

--- a/apps/dm-tool/src/features/monsters/MonsterFilterPanel.tsx
+++ b/apps/dm-tool/src/features/monsters/MonsterFilterPanel.tsx
@@ -15,11 +15,11 @@ const RARITY_BORDER: Record<string, string> = {
   unique: 'border-purple-500',
 };
 
-const RARITY_BG: Record<string, string> = {
-  common: 'bg-zinc-500/10',
-  uncommon: 'bg-amber-500/10',
-  rare: 'bg-blue-500/10',
-  unique: 'bg-purple-500/10',
+const RARITY_FILL: Record<string, string> = {
+  common: 'bg-zinc-500 text-white',
+  uncommon: 'bg-amber-600 text-white',
+  rare: 'bg-blue-600 text-white',
+  unique: 'bg-purple-600 text-white',
 };
 
 const SIZE_ORDER = ['tiny', 'small', 'med', 'medium', 'large', 'huge', 'gargantuan'];
@@ -135,7 +135,9 @@ export function MonsterFilterPanel({ facets, params, onChange }: Props) {
                       className={cn(
                         'rounded-md border px-2 py-0.5 text-xs capitalize transition-colors',
                         RARITY_BORDER[r.toLowerCase()] ?? 'border-border',
-                        active ? (RARITY_BG[r.toLowerCase()] ?? 'bg-primary/10') : 'bg-background hover:bg-accent',
+                        active
+                          ? (RARITY_FILL[r.toLowerCase()] ?? 'bg-primary text-primary-foreground')
+                          : 'bg-background hover:bg-accent',
                       )}
                     >
                       {r}

--- a/apps/dm-tool/src/features/monsters/MonsterFilterPanel.tsx
+++ b/apps/dm-tool/src/features/monsters/MonsterFilterPanel.tsx
@@ -135,9 +135,7 @@ export function MonsterFilterPanel({ facets, params, onChange }: Props) {
                       className={cn(
                         'rounded-md border px-2 py-0.5 text-xs capitalize transition-colors',
                         RARITY_BORDER[r.toLowerCase()] ?? 'border-border',
-                        active
-                          ? (RARITY_BG[r.toLowerCase()] ?? 'bg-primary/10')
-                          : 'bg-background hover:bg-accent',
+                        active ? (RARITY_BG[r.toLowerCase()] ?? 'bg-primary/10') : 'bg-background hover:bg-accent',
                       )}
                     >
                       {r}

--- a/apps/dm-tool/src/features/monsters/MonsterFilterPanel.tsx
+++ b/apps/dm-tool/src/features/monsters/MonsterFilterPanel.tsx
@@ -68,9 +68,12 @@ export function MonsterFilterPanel({ facets, params, onChange }: Props) {
     <div className="flex h-full flex-col border-r border-border bg-card">
       <div className="flex h-12 shrink-0 items-center justify-between px-3">
         <div className="flex items-center gap-2">
-          <span className="text-xs" style={{ fontFamily: 'var(--font-display)', fontWeight: 700 }}>
+          <Label
+            className="text-sm tracking-wide text-foreground"
+            style={{ fontFamily: 'var(--font-display)', fontWeight: 700 }}
+          >
             Filters
-          </span>
+          </Label>
           {activeCount > 0 && (
             <span className="flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-medium text-primary-foreground">
               {activeCount}

--- a/apps/dm-tool/src/features/monsters/MonsterFilterPanel.tsx
+++ b/apps/dm-tool/src/features/monsters/MonsterFilterPanel.tsx
@@ -8,11 +8,18 @@ import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
 import type { MonsterFacets, MonsterSearchParams } from '@foundry-toolkit/shared/types';
 
-const RARITY_COLORS: Record<string, string> = {
-  common: 'border-zinc-500 bg-zinc-500/10',
-  uncommon: 'border-amber-500 bg-amber-500/10',
-  rare: 'border-blue-500 bg-blue-500/10',
-  unique: 'border-purple-500 bg-purple-500/10',
+const RARITY_BORDER: Record<string, string> = {
+  common: 'border-zinc-500',
+  uncommon: 'border-amber-500',
+  rare: 'border-blue-500',
+  unique: 'border-purple-500',
+};
+
+const RARITY_BG: Record<string, string> = {
+  common: 'bg-zinc-500/10',
+  uncommon: 'bg-amber-500/10',
+  rare: 'bg-blue-500/10',
+  unique: 'bg-purple-500/10',
 };
 
 const SIZE_ORDER = ['tiny', 'small', 'med', 'medium', 'large', 'huge', 'gargantuan'];
@@ -127,9 +134,10 @@ export function MonsterFilterPanel({ facets, params, onChange }: Props) {
                       onClick={() => toggleArray('rarities', r)}
                       className={cn(
                         'rounded-md border px-2 py-0.5 text-xs capitalize transition-colors',
+                        RARITY_BORDER[r.toLowerCase()] ?? 'border-border',
                         active
-                          ? (RARITY_COLORS[r.toLowerCase()] ?? 'border-primary bg-primary/10')
-                          : 'border-border bg-background hover:bg-accent',
+                          ? (RARITY_BG[r.toLowerCase()] ?? 'bg-primary/10')
+                          : 'bg-background hover:bg-accent',
                       )}
                     >
                       {r}


### PR DESCRIPTION
## Summary

`aggregateMonsterFacets` was scanning `m.traits` for rarity strings, but the MCP server stores rarity in a dedicated `m.rarity` field (sourced from `system.traits.rarity`). The traits value array never contains the rarity scalar, so the rarities set always stayed empty and fell through to the "common only" fallback — making Uncommon/Rare/Unique invisible in the filter panel.

The fix reads `m.rarity` first; the traits-array scan is kept as a fallback for alternative data sources.

## Changes

- `facets-index.ts`: read `m.rarity` to populate the rarities facet set (root cause fix)
- `facets-index.test.ts`: update tests to use the `rarity:` field rather than putting rarity strings in `traits:`, reflecting actual MCP server output; add full 4-rarity matrix test
- `prepared.test.ts`: rarity filter predicate matrix (each rarity, all-selected, none-selected, missing-rarity-defaults-to-common)

## Test plan

- [ ] `npm run test -w apps/dm-tool` — 323 tests pass
- [ ] In UI: Uncommon / Rare / Unique chips appear in the Rarity filter panel when those monsters are present in the bestiary