### PR TITLE
feat(dm-tool): use token image inline, hover reveals full monster art

### DIFF
--- a/apps/dm-tool/src/features/monsters/MonsterDetailPane.tsx
+++ b/apps/dm-tool/src/features/monsters/MonsterDetailPane.tsx
@@ -1,8 +1,10 @@
+import * as HoverCard from '@radix-ui/react-hover-card';
 import { Info, X } from 'lucide-react';
 import { useState } from 'react';
 import { cn } from '@/lib/utils';
 import type { MonsterDetail } from '@foundry-toolkit/shared/types';
 import { CreatureDetailPane } from '../creatures/CreatureDetailPane';
+import { resolveMonsterArtAssets } from './monster-art';
 
 const RARITY_BADGE: Record<string, string> = {
   common: 'bg-zinc-600 text-zinc-100',
@@ -20,11 +22,13 @@ interface Props {
 
 export function MonsterDetailPane({ detail, loading, onOpenExternal, onClose }: Props) {
   const [loreOpen, setLoreOpen] = useState(false);
+  const artAssets = resolveMonsterArtAssets(detail.tokenUrl, detail.imageUrl);
 
   return (
     <>
       {/* Header: identity chrome — name, badges, traits, lore toggle, close */}
       <div className="flex shrink-0 items-center gap-2 border-b border-border px-4 py-2">
+        <ArtHoverCard name={detail.name} portraitSrc={artAssets.portraitSrc} artSrc={artAssets.artSrc} />
         <h2 className="shrink-0 text-sm font-semibold">{detail.name}</h2>
         <span className="shrink-0 rounded bg-accent px-1.5 py-0.5 text-[11px] font-medium tabular-nums">
           Lvl {detail.level}
@@ -90,5 +94,47 @@ export function MonsterDetailPane({ detail, loading, onOpenExternal, onClose }: 
         </div>
       )}
     </>
+  );
+}
+
+/** Small inline portrait; hovering reveals the full monster art. */
+function ArtHoverCard({
+  name,
+  portraitSrc,
+  artSrc,
+}: {
+  name: string;
+  portraitSrc: string | null;
+  artSrc: string | null;
+}) {
+  const portrait = portraitSrc ? (
+    <img src={portraitSrc} alt="" className="h-8 w-8 shrink-0 rounded object-cover" />
+  ) : (
+    <div className="h-8 w-8 shrink-0 rounded bg-muted" />
+  );
+
+  if (!artSrc) {
+    return portrait;
+  }
+
+  return (
+    <HoverCard.Root openDelay={400} closeDelay={200}>
+      <HoverCard.Trigger asChild>
+        <span className="shrink-0 cursor-default">{portrait}</span>
+      </HoverCard.Trigger>
+      <HoverCard.Portal>
+        <HoverCard.Content
+          side="bottom"
+          align="start"
+          sideOffset={4}
+          avoidCollisions
+          collisionPadding={8}
+          className="z-50 overflow-hidden rounded-md border border-border bg-popover shadow-lg"
+          style={{ width: '240px' }}
+        >
+          <img src={artSrc} alt={name} className="w-full object-contain" />
+        </HoverCard.Content>
+      </HoverCard.Portal>
+    </HoverCard.Root>
   );
 }

--- a/apps/dm-tool/src/features/monsters/monster-art.test.ts
+++ b/apps/dm-tool/src/features/monsters/monster-art.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { resolveMonsterArtAssets } from './monster-art';
+
+describe('resolveMonsterArtAssets', () => {
+  it('uses token as portrait and full art as artSrc when both are present', () => {
+    const result = resolveMonsterArtAssets('token.png', 'art.png');
+    expect(result).toEqual({ portraitSrc: 'token.png', artSrc: 'art.png' });
+  });
+
+  it('uses token as portrait with null artSrc when token exists but no full art', () => {
+    const result = resolveMonsterArtAssets('token.png', null);
+    expect(result).toEqual({ portraitSrc: 'token.png', artSrc: null });
+  });
+
+  it('uses full art for both portrait and artSrc when no token is available', () => {
+    const result = resolveMonsterArtAssets(null, 'art.png');
+    expect(result).toEqual({ portraitSrc: 'art.png', artSrc: 'art.png' });
+  });
+
+  it('returns null for both when neither token nor art is available', () => {
+    const result = resolveMonsterArtAssets(null, null);
+    expect(result).toEqual({ portraitSrc: null, artSrc: null });
+  });
+});

--- a/apps/dm-tool/src/features/monsters/monster-art.ts
+++ b/apps/dm-tool/src/features/monsters/monster-art.ts
@@ -1,0 +1,20 @@
+export interface MonsterArtAssets {
+  /** Small portrait shown inline — token preferred, full art as fallback. */
+  portraitSrc: string | null;
+  /** Full art shown on hover. Null when no imageUrl is available. */
+  artSrc: string | null;
+}
+
+/** Resolve which images to show inline vs on hover.
+ *
+ *  Priority: token → full art → placeholder (both null).
+ */
+export function resolveMonsterArtAssets(tokenUrl: string | null, imageUrl: string | null): MonsterArtAssets {
+  if (tokenUrl) {
+    return { portraitSrc: tokenUrl, artSrc: imageUrl };
+  }
+  if (imageUrl) {
+    return { portraitSrc: imageUrl, artSrc: imageUrl };
+  }
+  return { portraitSrc: null, artSrc: null };
+}


### PR DESCRIPTION
## Summary

Replaces the inline full-art block at the bottom of the monster detail pane with a compact token portrait in the header. Hovering the portrait reveals the full illustration in a HoverCard popover. The token image (`prototypeToken.texture.src`, already surfaced as `tokenUrl` in `MonsterDetail`) is preferred for the inline portrait; falls back to the full art when no token is available, and to a muted placeholder square when neither exists.

Both `imageUrl` and `tokenUrl` were already present in the wire payload — no backend changes needed.

## Changes

- New `resolveMonsterArtAssets(tokenUrl, imageUrl)` helper in `monster-art.ts` encapsulates the fallback logic
- New `ArtHoverCard` component wraps the portrait with a Radix `HoverCard` (same pattern as `SpellChip`)
- `MonsterDetailPane` header now renders the portrait before the monster name
- Removed the full-art `<img>` block that appeared at the bottom of the scroll area

## Test plan

- [ ] `monster-art.test.ts` covers all four asset-resolution cases (token+art, token only, art only, neither)
- [ ] All 320 dm-tool tests pass (`npm run test -w apps/dm-tool`)
- [ ] Typecheck clean (`npm run typecheck -w apps/dm-tool`)