### PR TITLE
fix(api-bridge): set scene background.src directly, not via levels array

### DIFF
--- a/apps/dm-tool/electron/foundry-push.ts
+++ b/apps/dm-tool/electron/foundry-push.ts
@@ -76,11 +76,9 @@ export async function pushSceneToFoundry(opts: PushSceneOptions): Promise<PushSc
   });
 
   // 2. Create the scene. We always go through `create_scene_from_uvtt` even for
-  //    wall-less maps, because foundry-mcp's plain `create_scene` handler only
-  //    sets `scene.background.src` — which Foundry v14 ignores in favor of
-  //    `levels[0].background.src`. The uvtt handler sets the Level correctly, so
-  //    the image actually renders. When we don't have a real .uvtt file we
-  //    synthesize a minimal blob sized to the image with no walls or portals.
+  //    wall-less maps so that we get the correct scene dimensions from the uvtt
+  //    resolution block. When we don't have a real .uvtt file we synthesize a
+  //    minimal blob sized to the image with no walls or portals.
   const uvttData: UvttData = opts.uvttData ?? {
     resolution: {
       pixels_per_grid: DEFAULT_PIXELS_PER_GRID,

--- a/apps/foundry-api-bridge/src/commands/handlers/scene/CreateSceneFromUvttHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/scene/CreateSceneFromUvttHandler.ts
@@ -49,17 +49,11 @@ export async function createSceneFromUvttHandler(
     },
   };
 
-  // Foundry v14: background images live on Level documents, not the Scene itself.
-  // Include a default level with the background in the creation data so the
-  // scene.background shim getter has a firstLevel to read from.
+  // Foundry v12+: the background image lives on `background.src` on the scene
+  // document itself. (The "levels" approach used here previously was specific to
+  // the third-party Levels module and had no effect on vanilla Foundry.)
   if (params.img) {
-    sceneData['levels'] = [
-      {
-        name: 'Ground',
-        elevation: { bottom: 0, top: 20 },
-        background: { src: params.img },
-      },
-    ];
+    sceneData['background'] = { src: params.img };
   }
 
   const scene = await game.scenes.documentClass.create(sceneData);

--- a/apps/foundry-api-bridge/src/commands/handlers/scene/CreateSceneFromUvttHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/scene/CreateSceneFromUvttHandler.ts
@@ -49,11 +49,20 @@ export async function createSceneFromUvttHandler(
     },
   };
 
-  // Foundry v12+: the background image lives on `background.src` on the scene
-  // document itself. (The "levels" approach used here previously was specific to
-  // the third-party Levels module and had no effect on vanilla Foundry.)
+  // Foundry v14: Scene#background is a deprecated shim getter that reads from
+  // scene.firstLevel.background.src. The scene's background image must be set
+  // on a Level embedded document — not on the scene itself. Passing a levels
+  // array at create time overrides the auto-created defaultLevel0000.
+  // (These are Foundry's native Level documents, distinct from the third-party
+  // Levels module.)
   if (params.img) {
-    sceneData['background'] = { src: params.img };
+    sceneData['levels'] = [
+      {
+        name: 'Ground',
+        elevation: { bottom: 0, top: 20 },
+        background: { src: params.img },
+      },
+    ];
   }
 
   const scene = await game.scenes.documentClass.create(sceneData);

--- a/apps/foundry-api-bridge/src/commands/handlers/scene/__tests__/CreateSceneFromUvttHandler.test.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/scene/__tests__/CreateSceneFromUvttHandler.test.ts
@@ -70,11 +70,12 @@ describe('createSceneFromUvttHandler', () => {
     mockGame.scenes.documentClass.create.mockResolvedValue(mockScene);
   });
 
-  // Regression: background image was being passed as `levels[0].background.src`
-  // (the third-party Levels module schema) instead of the vanilla Foundry
-  // `background.src` field. Scenes created via the "Create scene" button in the
-  // dm-tool map browser appeared with no background image.
-  it('puts the background image on background.src, not in a levels array', async () => {
+  // Regression: In Foundry v14, Scene#background is a deprecated shim getter
+  // that reads from scene.firstLevel.background.src. Setting background.src
+  // directly on the scene creation data is silently ignored — the field is not
+  // in the v14 Scene schema. The background must be passed via a Level embedded
+  // document in the levels array, which Foundry uses to populate firstLevel.
+  it('puts the background image in levels[0].background.src for Foundry v14', async () => {
     await createSceneFromUvttHandler({
       name: 'My Map',
       img: 'maps/dungeon.jpg',
@@ -84,14 +85,16 @@ describe('createSceneFromUvttHandler', () => {
     expect(mockGame.scenes.documentClass.create).toHaveBeenCalledTimes(1);
     const sceneData = mockGame.scenes.documentClass.create.mock.calls[0][0] as Record<string, unknown>;
 
-    // Must carry background.src
-    expect(sceneData['background']).toEqual({ src: 'maps/dungeon.jpg' });
+    // Must carry the image on the Level document, not directly on the scene.
+    const levels = sceneData['levels'] as Array<Record<string, unknown>>;
+    expect(levels).toHaveLength(1);
+    expect((levels[0]!['background'] as Record<string, unknown>)['src']).toBe('maps/dungeon.jpg');
 
-    // Must NOT carry a levels array (that was the wrong fix)
-    expect(sceneData['levels']).toBeUndefined();
+    // Must NOT set background.src directly on the scene (Foundry v14 ignores it).
+    expect(sceneData['background']).toBeUndefined();
   });
 
-  it('omits background entirely when img is not provided', async () => {
+  it('omits the levels array when img is not provided', async () => {
     await createSceneFromUvttHandler({
       name: 'No Image',
       uvtt: baseUvtt,

--- a/apps/foundry-api-bridge/src/commands/handlers/scene/__tests__/CreateSceneFromUvttHandler.test.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/scene/__tests__/CreateSceneFromUvttHandler.test.ts
@@ -1,0 +1,209 @@
+import { createSceneFromUvttHandler } from '@/commands/handlers/scene/CreateSceneFromUvttHandler';
+
+// ---------------------------------------------------------------------------
+// Minimal mock of the Foundry globals used by the handler
+// ---------------------------------------------------------------------------
+
+interface MockCreatedScene {
+  id: string;
+  name: string;
+  img: string;
+  width: number;
+  height: number;
+  active: boolean;
+  grid: { size: number };
+  update: jest.Mock;
+  createEmbeddedDocuments: jest.Mock;
+}
+
+const mockScene: MockCreatedScene = {
+  id: 'scene-abc',
+  name: 'Test Map',
+  img: 'maps/test.jpg',
+  width: 2000,
+  height: 1500,
+  active: false,
+  grid: { size: 100 },
+  update: jest.fn().mockResolvedValue(undefined),
+  createEmbeddedDocuments: jest.fn().mockResolvedValue([]),
+};
+
+const mockGame = {
+  scenes: {
+    documentClass: {
+      create: jest.fn().mockResolvedValue(mockScene),
+    },
+  },
+};
+
+// Foundry CONST values used to set wall sense/move types
+const mockCONST: Record<string, Record<string, number>> = {
+  WALL_MOVEMENT_TYPES: { NORMAL: 20 },
+  WALL_SENSE_TYPES: { NORMAL: 20 },
+  WALL_DOOR_TYPES: { DOOR: 1 },
+};
+
+(global as Record<string, unknown>)['game'] = mockGame;
+(global as Record<string, unknown>)['CONST'] = mockCONST;
+
+// ---------------------------------------------------------------------------
+// Shared UVTT fixture
+// ---------------------------------------------------------------------------
+
+const baseUvtt = {
+  resolution: {
+    pixels_per_grid: 100,
+    map_size: { x: 20, y: 15 },
+  },
+  line_of_sight: [],
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createSceneFromUvttHandler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockScene.update.mockResolvedValue(undefined);
+    mockScene.createEmbeddedDocuments.mockResolvedValue([]);
+    mockGame.scenes.documentClass.create.mockResolvedValue(mockScene);
+  });
+
+  // Regression: background image was being passed as `levels[0].background.src`
+  // (the third-party Levels module schema) instead of the vanilla Foundry
+  // `background.src` field. Scenes created via the "Create scene" button in the
+  // dm-tool map browser appeared with no background image.
+  it('puts the background image on background.src, not in a levels array', async () => {
+    await createSceneFromUvttHandler({
+      name: 'My Map',
+      img: 'maps/dungeon.jpg',
+      uvtt: baseUvtt,
+    });
+
+    expect(mockGame.scenes.documentClass.create).toHaveBeenCalledTimes(1);
+    const sceneData = mockGame.scenes.documentClass.create.mock.calls[0][0] as Record<string, unknown>;
+
+    // Must carry background.src
+    expect(sceneData['background']).toEqual({ src: 'maps/dungeon.jpg' });
+
+    // Must NOT carry a levels array (that was the wrong fix)
+    expect(sceneData['levels']).toBeUndefined();
+  });
+
+  it('omits background entirely when img is not provided', async () => {
+    await createSceneFromUvttHandler({
+      name: 'No Image',
+      uvtt: baseUvtt,
+    });
+
+    const sceneData = mockGame.scenes.documentClass.create.mock.calls[0][0] as Record<string, unknown>;
+
+    expect(sceneData['background']).toBeUndefined();
+    expect(sceneData['levels']).toBeUndefined();
+  });
+
+  it('derives scene dimensions from uvtt resolution', async () => {
+    await createSceneFromUvttHandler({
+      name: 'Sized Map',
+      uvtt: {
+        resolution: { pixels_per_grid: 50, map_size: { x: 30, y: 20 } },
+        line_of_sight: [],
+      },
+    });
+
+    const sceneData = mockGame.scenes.documentClass.create.mock.calls[0][0] as Record<string, unknown>;
+
+    // 30 grid cells × 50 px/cell = 1500 px wide; 20 × 50 = 1000 px tall
+    expect(sceneData['width']).toBe(1500);
+    expect(sceneData['height']).toBe(1000);
+  });
+
+  it('activates the scene when activate=true', async () => {
+    await createSceneFromUvttHandler({
+      name: 'Active Map',
+      uvtt: baseUvtt,
+      activate: true,
+    });
+
+    expect(mockScene.update).toHaveBeenCalledWith({ active: true });
+  });
+
+  it('does not activate the scene when activate is omitted', async () => {
+    await createSceneFromUvttHandler({
+      name: 'Inactive Map',
+      uvtt: baseUvtt,
+    });
+
+    expect(mockScene.update).not.toHaveBeenCalled();
+  });
+
+  it('creates walls from line_of_sight segments', async () => {
+    mockScene.createEmbeddedDocuments.mockResolvedValue([{ id: 'w1' }, { id: 'w2' }]);
+
+    const result = await createSceneFromUvttHandler({
+      name: 'Walled Map',
+      uvtt: {
+        resolution: { pixels_per_grid: 100, map_size: { x: 10, y: 10 } },
+        line_of_sight: [
+          [
+            { x: 1, y: 1 },
+            { x: 3, y: 1 },
+          ],
+          [
+            { x: 3, y: 1 },
+            { x: 3, y: 3 },
+          ],
+        ],
+      },
+    });
+
+    expect(mockScene.createEmbeddedDocuments).toHaveBeenCalledWith('Wall', expect.any(Array));
+    // 2 wall segments, no doors → wallsCreated=2, doorsCreated=0
+    expect(result.wallsCreated).toBe(2);
+    expect(result.doorsCreated).toBe(0);
+  });
+
+  it('converts portals to door walls', async () => {
+    // 1 wall + 1 door; createEmbeddedDocuments receives both
+    mockScene.createEmbeddedDocuments.mockResolvedValue([{ id: 'w1' }, { id: 'd1' }]);
+
+    const result = await createSceneFromUvttHandler({
+      name: 'Door Map',
+      uvtt: {
+        resolution: { pixels_per_grid: 100, map_size: { x: 10, y: 10 } },
+        line_of_sight: [[{ x: 0, y: 0 }, { x: 1, y: 0 }]],
+        portals: [
+          {
+            position: { x: 2, y: 0 },
+            bounds: [
+              { x: 2, y: 0 },
+              { x: 3, y: 0 },
+            ],
+            closed: false,
+          },
+        ],
+      },
+    });
+
+    expect(result.wallsCreated).toBe(1);
+    expect(result.doorsCreated).toBe(1);
+  });
+
+  it('returns correct scene metadata', async () => {
+    const result = await createSceneFromUvttHandler({
+      name: 'Meta Map',
+      img: 'maps/meta.png',
+      uvtt: baseUvtt,
+    });
+
+    expect(result.id).toBe('scene-abc');
+    expect(result.name).toBe('Test Map');
+    expect(result.img).toBe('maps/test.jpg');
+    expect(result.width).toBe(2000);
+    expect(result.height).toBe(1500);
+    expect(result.gridSize).toBe(100);
+    expect(result.gridCols).toBe(20);
+    expect(result.gridRows).toBe(15);
+  });
+});

--- a/apps/foundry-mcp/src/config.ts
+++ b/apps/foundry-mcp/src/config.ts
@@ -4,7 +4,12 @@ import { homedir } from 'node:os';
 export const PORT = parseInt(process.env.PORT ?? '8765', 10);
 export const HOST = process.env.HOST ?? '0.0.0.0';
 export const COMMAND_TIMEOUT_MS = 30_000;
-export const FOUNDRY_DATA_DIR = process.env.FOUNDRY_DATA_DIR ?? resolve(homedir(), 'foundrydata', 'Data');
+// FOUNDRY_DATA_DIR: explicit path to Foundry's Data directory (e.g. /data/Data).
+// FOUNDRY_DATA: path to the Foundry data root (e.g. /data); Data/ is appended.
+// Falls back to ~/foundrydata/Data if neither is set.
+export const FOUNDRY_DATA_DIR =
+  process.env.FOUNDRY_DATA_DIR ??
+  (process.env.FOUNDRY_DATA ? resolve(process.env.FOUNDRY_DATA, 'Data') : resolve(homedir(), 'foundrydata', 'Data'));
 
 // Gates POST /api/eval. When off (the default), the route isn't registered
 // at all — a request returns 404 with our envelope, indistinguishable from


### PR DESCRIPTION
## Summary

Two bugs, both causing scenes created via the dm-tool \"Create Scene\" button to have no background image.

**Bug 1 — wrong Foundry v14 background API** (this PR's original commit introduced this): In Foundry v14, \`Scene#background\` is a deprecated compatibility shim that reads from \`scene.firstLevel.background.src\`. The scene document schema has no \`background\` field — passing \`background: { src }\` at create time is silently discarded. The background image must be set on a Level embedded document in the \`levels\` array. The previous commit replaced the working \`levels\` approach with the silently-ignored \`background.src\` approach, based on a misdiagnosis. This commit reverts that change and corrects the comment (Foundry's native v14 Level documents, not the third-party Levels module).

**Bug 2 — upload goes to wrong directory**: \`foundry-mcp\`'s \`config.ts\` reads \`FOUNDRY_DATA_DIR\` but \`.env\` only sets \`FOUNDRY_DATA\` (the root data path, without the \`/Data\` subdirectory). \`upload_asset\` was writing images to \`~/foundrydata/Data/maps/\` instead of the configured Foundry data directory. Config now derives the data dir from \`FOUNDRY_DATA + /Data\` when \`FOUNDRY_DATA_DIR\` is not explicitly set.

Root cause confirmed via \`/api/eval\`: \`await game.scenes.documentClass.create({ background: { src: \"...\" } })\` always returns \`background.src = null\` in Foundry v14.360. Creating with \`levels: [{ background: { src: \"...\" } }]\` correctly sets the background on the resulting scene.

## Changes
- \`CreateSceneFromUvttHandler.ts\`: revert to \`levels[]\` approach; fix code comment
- \`CreateSceneFromUvttHandler.test.ts\`: regression test now asserts \`levels[0].background.src\` is set and \`background\` is absent from the top-level create data
- \`foundry-mcp/config.ts\`: fall back to \`FOUNDRY_DATA + /Data\` when \`FOUNDRY_DATA_DIR\` is not set

## Test plan
- [ ] Regression test asserts \`levels[0].background.src\` is set; fails if the \`background.src\` approach is used instead
- [ ] \`npm run test -w apps/foundry-api-bridge\` — 812 tests pass
- [ ] \`npm run type-check -w apps/foundry-api-bridge\` — clean