### PR TITLE
feat(dispatcher): migrate saves, strikes, damage, and spell casting to pf2e-rules client

### DIFF
--- a/apps/foundry-api-bridge/src/commands/handlers/dispatch/DispatchHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/dispatch/DispatchHandler.ts
@@ -96,7 +96,10 @@ function unmarshalArgs(args: unknown[], gameObj: Record<string, unknown>): unkno
 //
 // The LAST segment is the method name; all prior segments traverse properties.
 
+// Matches 'actions[@slug:my-sword]' — array element lookup by slug.
 const ARRAY_SLUG_RE = /^(.+)\[@slug:(.+)\]$/;
+// Matches 'variants[0]' — array element lookup by numeric index.
+const ARRAY_INDEX_RE = /^(.+)\[(\d+)\]$/;
 
 function resolvePath(target: object, path: string): (...args: unknown[]) => unknown {
   const segments = path.split('.');
@@ -109,12 +112,13 @@ function resolvePath(target: object, path: string): (...args: unknown[]) => unkn
   let current: unknown = target;
 
   for (const segment of segments) {
-    const match = ARRAY_SLUG_RE.exec(segment);
+    const slugMatch = ARRAY_SLUG_RE.exec(segment);
+    const indexMatch = slugMatch === null ? ARRAY_INDEX_RE.exec(segment) : null;
 
-    if (match !== null) {
-      // Array-element lookup: 'actions[@slug:my-sword]'
-      const prop = match[1] as string;
-      const slug = match[2] as string;
+    if (slugMatch !== null) {
+      // Array-element lookup by slug: 'actions[@slug:my-sword]'
+      const prop = slugMatch[1] as string;
+      const slug = slugMatch[2] as string;
 
       const arr = (current as Record<string, unknown>)[prop];
       if (!Array.isArray(arr)) {
@@ -131,6 +135,19 @@ function resolvePath(target: object, path: string): (...args: unknown[]) => unkn
 
       if (current == null) {
         throw new Error(`Dispatcher: no element with slug '${slug}' found in '${prop}'`);
+      }
+    } else if (indexMatch !== null) {
+      // Array-element lookup by numeric index: 'variants[0]'
+      const prop = indexMatch[1] as string;
+      const idx = parseInt(indexMatch[2] as string, 10);
+
+      const arr = (current as Record<string, unknown>)[prop];
+      if (!Array.isArray(arr)) {
+        throw new Error(`Dispatcher: '${prop}' is not an array (segment '${segment}')`);
+      }
+      current = arr[idx];
+      if (current == null) {
+        throw new Error(`Dispatcher: no element at index ${idx.toString()} in '${prop}'`);
       }
     } else {
       // Plain property traversal

--- a/apps/foundry-api-bridge/src/commands/handlers/dispatch/__tests__/DispatchHandler.test.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/dispatch/__tests__/DispatchHandler.test.ts
@@ -6,6 +6,8 @@ const rollSaveMock = jest.fn();
 const applyDamageMock = jest.fn();
 const longswordRollDamageMock = jest.fn();
 const shortswordRollDamageMock = jest.fn();
+// Variant roll mocks: [0] = full attack, [1] = MAP -5, [2] = MAP -10
+const variantRollMocks = [jest.fn(), jest.fn(), jest.fn()];
 
 const mockActor = {
   id: 'actor-001',
@@ -22,11 +24,14 @@ const mockActor = {
         slug: 'longsword',
         item: { slug: 'longsword', name: 'Longsword' },
         rollDamage: longswordRollDamageMock,
+        // PF2e strike variants (full attack, MAP -5, MAP -10)
+        variants: [{ roll: variantRollMocks[0] }, { roll: variantRollMocks[1] }, { roll: variantRollMocks[2] }],
       },
       {
         slug: 'shortsword',
         item: { slug: 'shortsword', name: 'Shortsword' },
         rollDamage: shortswordRollDamageMock,
+        variants: [{ roll: jest.fn() }],
       },
     ],
   },
@@ -55,6 +60,9 @@ describe('dispatchHandler', () => {
     applyDamageMock.mockResolvedValue(undefined);
     longswordRollDamageMock.mockResolvedValue({ formula: '2d6+4', total: 10 });
     shortswordRollDamageMock.mockResolvedValue({ formula: '1d6+4', total: 7 });
+    for (const vm of variantRollMocks) {
+      vm.mockResolvedValue({ total: 15, formula: '1d20+7' });
+    }
   });
 
   // ─── Happy path ────────────────────────────────────────────────────────────
@@ -104,6 +112,30 @@ describe('dispatchHandler', () => {
       expect(longswordRollDamageMock).toHaveBeenCalledWith({});
       expect(shortswordRollDamageMock).not.toHaveBeenCalled();
       expect(result).toEqual({ result: { formula: '2d6+4', total: 10 } });
+    });
+
+    it('resolves array elements by numeric index via [N] convention', async () => {
+      // Simulates: actor.system.actions[@slug:longsword].variants[1].roll({ skipDialog: true })
+      const result = await dispatchHandler({
+        class: 'CharacterPF2e',
+        id: 'actor-001',
+        method: 'system.actions[@slug:longsword].variants[1].roll',
+        args: [{ skipDialog: true }],
+      });
+      expect(variantRollMocks[1]).toHaveBeenCalledWith({ skipDialog: true });
+      expect(variantRollMocks[0]).not.toHaveBeenCalled();
+      expect(variantRollMocks[2]).not.toHaveBeenCalled();
+      expect(result).toEqual({ result: { total: 15, formula: '1d20+7' } });
+    });
+
+    it('throws when numeric index is out of bounds', async () => {
+      await expect(
+        dispatchHandler({
+          class: 'CharacterPF2e',
+          id: 'actor-001',
+          method: 'system.actions[@slug:longsword].variants[99].roll',
+        }),
+      ).rejects.toThrow(/no element at index 99 in 'variants'/i);
     });
 
     it('routes to the Item collection for class=Item', async () => {

--- a/apps/player-portal/src/components/tabs/Actions.test.tsx
+++ b/apps/player-portal/src/components/tabs/Actions.test.tsx
@@ -4,20 +4,16 @@ import { render, cleanup, fireEvent, within } from '@testing-library/react';
 // ─── API mock ─────────────────────────────────────────────────────────────
 // Hoisted so the module resolver sees it before Actions.tsx imports api/client.
 
-const rollStrikeMock = vi.fn().mockResolvedValue({ ok: true });
-const rollStrikeDamageMock = vi.fn().mockResolvedValue({ ok: true });
-const useItemMock = vi.fn().mockResolvedValue({ ok: true, itemId: 'x', itemName: 'x' });
-
 vi.mock('../../api/client', () => ({
   api: {
-    rollStrike: (...args: unknown[]) => rollStrikeMock(...args),
-    rollStrikeDamage: (...args: unknown[]) => rollStrikeDamageMock(...args),
-    useItem: (...args: unknown[]) => useItemMock(...args),
+    dispatch: vi.fn().mockResolvedValue({ result: null }),
+    useItem: vi.fn().mockResolvedValue({ ok: true, itemId: 'x', itemName: 'x' }),
   },
   ApiRequestError: class ApiRequestError extends Error {},
 }));
 import amiri from '../../fixtures/amiri-prepared.json';
 import type { Ability, AbilityKey, PreparedActorItem, Strike } from '../../api/types';
+import { api } from '../../api/client';
 import { Actions } from './Actions';
 
 // Amiri's three strikes with their expected attack modifiers (as per
@@ -178,22 +174,22 @@ describe('Actions tab — action items', () => {
   });
 });
 
-// ─── Attack-button relay path ─────────────────────────────────────────────
+// ─── Attack-button dispatcher path ───────────────────────────────────────────
 // Verifies that clicking a MAP variant button or a Damage/Crit button calls
-// the correct api method with the correct arguments, confirming the player-
-// portal side of the relay path is wired correctly end-to-end.
+// api.dispatch with the expected DispatchRequest, confirming that the
+// pf2e-rules Layer 1 client is wired end-to-end through the Actions tab.
 
-describe('Actions tab — attack-button relay path', () => {
+describe('Actions tab — attack-button dispatcher path', () => {
   beforeEach(() => {
-    rollStrikeMock.mockClear();
-    rollStrikeDamageMock.mockClear();
+    vi.mocked(api.dispatch).mockClear();
+    vi.mocked(api.dispatch).mockResolvedValue({ result: null });
   });
 
   afterEach(() => {
     cleanup();
   });
 
-  it('calls api.rollStrike with variantIndex=0 when the first attack button is clicked', () => {
+  it('dispatches variants[0].roll for the first attack button (full attack)', () => {
     const { container } = render(
       <Actions actorId="test-actor" onItemUsed={() => undefined} actions={actions} items={items} />,
     );
@@ -202,11 +198,15 @@ describe('Actions tab — attack-button relay path', () => {
 
     fireEvent.click(firstBtn);
 
-    // rollStrike is called synchronously inside trigger() before the await.
-    expect(rollStrikeMock).toHaveBeenCalledWith('test-actor', 'bastard-sword', 0);
+    expect(api.dispatch).toHaveBeenCalledWith({
+      class: 'CharacterPF2e',
+      id: 'test-actor',
+      method: 'system.actions[@slug:bastard-sword].variants[0].roll',
+      args: [{ skipDialog: true }],
+    });
   });
 
-  it('calls api.rollStrike with variantIndex=1 for the second attack (MAP −5)', () => {
+  it('dispatches variants[1].roll for the second attack button (MAP −5)', () => {
     const { container } = render(
       <Actions actorId="test-actor" onItemUsed={() => undefined} actions={actions} items={items} />,
     );
@@ -215,10 +215,12 @@ describe('Actions tab — attack-button relay path', () => {
 
     fireEvent.click(secondBtn);
 
-    expect(rollStrikeMock).toHaveBeenCalledWith('test-actor', 'bastard-sword', 1);
+    expect(api.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'system.actions[@slug:bastard-sword].variants[1].roll' }),
+    );
   });
 
-  it('calls api.rollStrike with variantIndex=2 for the third attack (MAP −10)', () => {
+  it('dispatches variants[2].roll for the third attack button (MAP −10)', () => {
     const { container } = render(
       <Actions actorId="test-actor" onItemUsed={() => undefined} actions={actions} items={items} />,
     );
@@ -227,10 +229,12 @@ describe('Actions tab — attack-button relay path', () => {
 
     fireEvent.click(thirdBtn);
 
-    expect(rollStrikeMock).toHaveBeenCalledWith('test-actor', 'bastard-sword', 2);
+    expect(api.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'system.actions[@slug:bastard-sword].variants[2].roll' }),
+    );
   });
 
-  it('calls api.rollStrikeDamage(critical=false) when the Damage button is clicked', () => {
+  it('dispatches .damage() when the Damage button is clicked', () => {
     const { container } = render(
       <Actions actorId="test-actor" onItemUsed={() => undefined} actions={actions} items={items} />,
     );
@@ -239,10 +243,15 @@ describe('Actions tab — attack-button relay path', () => {
 
     fireEvent.click(damageBtn);
 
-    expect(rollStrikeDamageMock).toHaveBeenCalledWith('test-actor', 'bastard-sword', false);
+    expect(api.dispatch).toHaveBeenCalledWith({
+      class: 'CharacterPF2e',
+      id: 'test-actor',
+      method: 'system.actions[@slug:bastard-sword].damage',
+      args: [{}],
+    });
   });
 
-  it('calls api.rollStrikeDamage(critical=true) when the Crit button is clicked', () => {
+  it('dispatches .critical() when the Crit button is clicked', () => {
     const { container } = render(
       <Actions actorId="test-actor" onItemUsed={() => undefined} actions={actions} items={items} />,
     );
@@ -251,19 +260,25 @@ describe('Actions tab — attack-button relay path', () => {
 
     fireEvent.click(critBtn);
 
-    expect(rollStrikeDamageMock).toHaveBeenCalledWith('test-actor', 'bastard-sword', true);
+    expect(api.dispatch).toHaveBeenCalledWith({
+      class: 'CharacterPF2e',
+      id: 'test-actor',
+      method: 'system.actions[@slug:bastard-sword].critical',
+      args: [{}],
+    });
   });
 
-  it('passes the correct strike slug for each weapon', () => {
+  it('uses the correct slug for each weapon', () => {
     const { container } = render(
       <Actions actorId="test-actor" onItemUsed={() => undefined} actions={actions} items={items} />,
     );
-    // Click the javelin's first attack variant.
     const javelinCard = container.querySelector('[data-strike-slug="javelin"]') as HTMLElement;
     const javelinFirst = javelinCard.querySelector('[data-variant-index="0"]') as HTMLElement;
 
     fireEvent.click(javelinFirst);
 
-    expect(rollStrikeMock).toHaveBeenCalledWith('test-actor', 'javelin', 0);
+    expect(api.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'system.actions[@slug:javelin].variants[0].roll' }),
+    );
   });
 });

--- a/apps/player-portal/src/components/tabs/Actions.tsx
+++ b/apps/player-portal/src/components/tabs/Actions.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { createPf2eClient } from '@foundry-toolkit/pf2e-rules';
 import { api } from '../../api/client';
 import type { Ability, AbilityKey, ActionItem, PreparedActorItem, Strike } from '../../api/types';
 import { isActionItem } from '../../api/types';
@@ -74,9 +75,15 @@ function StrikeCard({
   const damageText = formatStrikeDamage(strike, abilities);
   const range = strike.item.system.range;
 
-  const attack = useActorAction({ run: (variantIndex: number) => api.rollStrike(actorId, strike.slug, variantIndex) });
-  const damage = useActorAction({ run: () => api.rollStrikeDamage(actorId, strike.slug, false) });
-  const crit = useActorAction({ run: () => api.rollStrikeDamage(actorId, strike.slug, true) });
+  const attack = useActorAction({
+    run: (variantIndex: number) => createPf2eClient(api.dispatch).weapon(actorId, strike.slug).rollAttack(variantIndex),
+  });
+  const damage = useActorAction({
+    run: () => createPf2eClient(api.dispatch).weapon(actorId, strike.slug).rollDamage(false),
+  });
+  const crit = useActorAction({
+    run: () => createPf2eClient(api.dispatch).weapon(actorId, strike.slug).rollDamage(true),
+  });
   const error = firstError(attack.state, damage.state, crit.state);
 
   return (

--- a/apps/player-portal/src/components/tabs/Character.test.tsx
+++ b/apps/player-portal/src/components/tabs/Character.test.tsx
@@ -238,13 +238,12 @@ describe('Character tab', () => {
   });
 });
 
-// ─── Dispatcher end-to-end: fortitude save button ───────────────────────────
+// ─── Dispatcher end-to-end: all three save buttons ──────────────────────────
 //
-// Verifies that the fortitude save tile calls api.dispatch with the expected
-// DispatchRequest shape.  This is the end-to-end spike test validating that
-// the pf2e-rules Layer 1 client is wired into the Character sheet correctly.
+// Verifies that all three save tiles call api.dispatch with the expected
+// DispatchRequest shapes (saves.fortitude/reflex/will.roll).
 
-describe('Character tab — fortitude save wired through dispatcher', () => {
+describe('Character tab — saves wired through dispatcher', () => {
   beforeEach(() => {
     vi.mocked(api.dispatch).mockClear();
     vi.mocked(api.dispatch).mockResolvedValue({ result: null });
@@ -254,44 +253,42 @@ describe('Character tab — fortitude save wired through dispatcher', () => {
     cleanup();
   });
 
-  it('clicking the Fortitude save tile calls api.dispatch with the right DispatchRequest', async () => {
+  it.each([
+    ['save-fortitude', 'saves.fortitude.roll'],
+    ['save-reflex', 'saves.reflex.roll'],
+    ['save-will', 'saves.will.roll'],
+  ])('clicking the %s tile dispatches method=%s', async (dataStat, expectedMethod) => {
     const { container } = render(
       <Character system={system} actorId="test-actor" onActorChanged={() => undefined} />,
     );
 
-    const fortTile = container.querySelector('[data-stat="save-fortitude"]') as HTMLButtonElement;
-    expect(fortTile, 'fortitude tile should render as a button').toBeTruthy();
+    const tile = container.querySelector(`[data-stat="${dataStat}"]`) as HTMLButtonElement;
+    expect(tile, `${dataStat} tile should render as a button`).toBeTruthy();
 
     await act(async () => {
-      fireEvent.click(fortTile);
+      fireEvent.click(tile);
     });
 
     expect(api.dispatch).toHaveBeenCalledWith({
       class: 'CharacterPF2e',
       id: 'test-actor',
-      method: 'saves.fortitude.roll',
+      method: expectedMethod,
       args: [{}],
     });
   });
 
-  it('reflex and will tiles still call rollActorStatistic (not dispatch)', async () => {
+  it('none of the save tiles call rollActorStatistic', async () => {
     const { container } = render(
       <Character system={system} actorId="test-actor" onActorChanged={() => undefined} />,
     );
 
-    const reflexTile = container.querySelector('[data-stat="save-reflex"]') as HTMLButtonElement;
-    const willTile = container.querySelector('[data-stat="save-will"]') as HTMLButtonElement;
+    for (const stat of ['save-fortitude', 'save-reflex', 'save-will']) {
+      const tile = container.querySelector(`[data-stat="${stat}"]`) as HTMLButtonElement;
+      await act(async () => {
+        fireEvent.click(tile);
+      });
+    }
 
-    await act(async () => {
-      fireEvent.click(reflexTile);
-    });
-    await act(async () => {
-      fireEvent.click(willTile);
-    });
-
-    // Only fortitude goes through dispatch — reflex and will still use rollActorStatistic.
-    expect(api.dispatch).not.toHaveBeenCalled();
-    expect(api.rollActorStatistic).toHaveBeenCalledWith('test-actor', 'reflex');
-    expect(api.rollActorStatistic).toHaveBeenCalledWith('test-actor', 'will');
+    expect(api.rollActorStatistic).not.toHaveBeenCalled();
   });
 });

--- a/apps/player-portal/src/components/tabs/Character.tsx
+++ b/apps/player-portal/src/components/tabs/Character.tsx
@@ -168,18 +168,17 @@ function StatsBlock({
   const rollPerception = useActorAction({
     run: () => api.rollActorStatistic(actorId, 'perception'),
   });
-  // Fortitude is wired through the pf2e-rules Layer 1 client → generic
-  // dispatcher (Layer 0), validating the end-to-end dispatcher round-trip.
-  // createPf2eClient is pure and cheap; recreating per render is intentional
-  // for the spike — follow-up can memoize if profiling shows it matters.
+  // All three saves go through the pf2e-rules Layer 1 client → generic
+  // dispatcher (Layer 0).  createPf2eClient is pure and cheap; recreating
+  // per render is fine for now — memoize if profiling shows it matters.
   const rollFortitude = useActorAction({
     run: () => createPf2eClient(api.dispatch).character(actorId).rollSave('fortitude'),
   });
   const rollReflex = useActorAction({
-    run: () => api.rollActorStatistic(actorId, 'reflex'),
+    run: () => createPf2eClient(api.dispatch).character(actorId).rollSave('reflex'),
   });
   const rollWill = useActorAction({
-    run: () => api.rollActorStatistic(actorId, 'will'),
+    run: () => createPf2eClient(api.dispatch).character(actorId).rollSave('will'),
   });
   const error =
     firstError(rollPerception.state, rollFortitude.state, rollReflex.state, rollWill.state);

--- a/apps/player-portal/src/components/tabs/Spells.test.tsx
+++ b/apps/player-portal/src/components/tabs/Spells.test.tsx
@@ -4,15 +4,15 @@ import type { FocusPool, PreparedActorItem, SpellcastingEntryItem, SpellItem } f
 
 // ─── API mock ─────────────────────────────────────────────────────────────
 
-const castSpellMock = vi.fn().mockResolvedValue({ ok: true });
-
 vi.mock('../../api/client', () => ({
   api: {
-    castSpell: (...args: unknown[]) => castSpellMock(...args),
+    dispatch: vi.fn().mockResolvedValue({ result: null }),
+    invokeActorAction: vi.fn().mockResolvedValue({ ok: true }),
   },
   ApiRequestError: class ApiRequestError extends Error {},
 }));
 
+import { api } from '../../api/client';
 import { Spells } from './Spells';
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────
@@ -75,8 +75,8 @@ function renderSpells(
 
 describe('Spells tab', () => {
   beforeEach(() => {
-    castSpellMock.mockReset();
-    castSpellMock.mockResolvedValue({ ok: true });
+    vi.mocked(api.invokeActorAction).mockReset();
+    vi.mocked(api.invokeActorAction).mockResolvedValue({ ok: true });
   });
 
   afterEach(() => {
@@ -103,7 +103,7 @@ describe('Spells tab', () => {
     expect(castBtn.hasAttribute('disabled')).toBe(false);
   });
 
-  it('calls api.castSpell with correct args when Cast is clicked', async () => {
+  it('routes Cast through pf2eClient.spellEntry().cast() → invokeActorAction', async () => {
     const onCast = vi.fn();
     const items = [makeEntry(), makeSpell()] as PreparedActorItem[];
     renderSpells(items, { onCast });
@@ -112,8 +112,12 @@ describe('Spells tab', () => {
     fireEvent.click(castBtn);
 
     await vi.waitFor(() => {
-      expect(castSpellMock).toHaveBeenCalledOnce();
-      expect(castSpellMock).toHaveBeenCalledWith('actor-1', 'entry-1', 'spell-1', 1);
+      expect(api.invokeActorAction).toHaveBeenCalledOnce();
+      expect(api.invokeActorAction).toHaveBeenCalledWith('actor-1', 'cast-spell', {
+        entryId: 'entry-1',
+        spellId: 'spell-1',
+        rank: 1,
+      });
     });
     await vi.waitFor(() => expect(onCast).toHaveBeenCalledOnce());
   });

--- a/apps/player-portal/src/components/tabs/Spells.tsx
+++ b/apps/player-portal/src/components/tabs/Spells.tsx
@@ -1,3 +1,4 @@
+import { createPf2eClient } from '@foundry-toolkit/pf2e-rules';
 import type { FocusPool, PreparedActorItem, SpellItem, SpellcastingEntryItem } from '../../api/types';
 import { isCantripSpell, isSpellItem, isSpellcastingEntryItem } from '../../api/types';
 import { api } from '../../api/client';
@@ -405,7 +406,7 @@ function SpellCardWithCast({
   const noFocus = !isCantrip && mode === 'focus' && focusPoints.value <= 0;
 
   const { state, trigger } = useActorAction({
-    run: () => api.castSpell(actorId, entry.id, spell.id, rank),
+    run: () => createPf2eClient(api.dispatch, api.invokeActorAction).spellEntry(actorId, entry.id).cast(spell.id, rank),
     onSuccess: onCast,
   });
   const pending = state === 'pending';

--- a/packages/pf2e-rules/src/pf2e-client.test.ts
+++ b/packages/pf2e-rules/src/pf2e-client.test.ts
@@ -139,43 +139,102 @@ describe('createPf2eClient', () => {
     });
   });
 
+  // ─── weapon().rollAttack ─────────────────────────────────────────────────
+
+  describe('weapon().rollAttack', () => {
+    it('dispatches with the variants[N] numeric-index convention', async () => {
+      const { dispatch, spy } = makeDispatch();
+      await createPf2eClient(dispatch).weapon('actor-001', 'longsword').rollAttack(0);
+
+      expect(spy).toHaveBeenCalledWith({
+        class: 'CharacterPF2e',
+        id: 'actor-001',
+        method: 'system.actions[@slug:longsword].variants[0].roll',
+        args: [{ skipDialog: true }],
+      });
+    });
+
+    it('encodes variantIndex 1 (MAP -5) in the method path', async () => {
+      const { dispatch, spy } = makeDispatch();
+      await createPf2eClient(dispatch).weapon('actor-001', 'longsword').rollAttack(1);
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ method: 'system.actions[@slug:longsword].variants[1].roll' }),
+      );
+    });
+
+    it('encodes variantIndex 2 (MAP -10) in the method path', async () => {
+      const { dispatch, spy } = makeDispatch();
+      await createPf2eClient(dispatch).weapon('actor-001', 'longsword').rollAttack(2);
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ method: 'system.actions[@slug:longsword].variants[2].roll' }),
+      );
+    });
+
+    it('always includes skipDialog: true in args', async () => {
+      const { dispatch, spy } = makeDispatch();
+      await createPf2eClient(dispatch).weapon('actor-001', 'longsword').rollAttack(0);
+      const req = (spy.mock.calls[0] as [{ args: unknown[] }])[0];
+      expect((req.args[0] as Record<string, unknown>)['skipDialog']).toBe(true);
+    });
+
+    it('merges additional opts while preserving skipDialog', async () => {
+      const { dispatch, spy } = makeDispatch();
+      await createPf2eClient(dispatch).weapon('actor-001', 'longsword').rollAttack(0, { rollMode: 'gmroll' });
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ args: [{ skipDialog: true, rollMode: 'gmroll' }] }));
+    });
+
+    it('interpolates arbitrary slugs into the method path', async () => {
+      const { dispatch, spy } = makeDispatch();
+      await createPf2eClient(dispatch).weapon('actor-001', 'my-battle-axe').rollAttack(0);
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ method: 'system.actions[@slug:my-battle-axe].variants[0].roll' }),
+      );
+    });
+  });
+
   // ─── weapon().rollDamage ─────────────────────────────────────────────────
 
   describe('weapon().rollDamage', () => {
-    it('dispatches with the @slug array-lookup convention', async () => {
+    it('dispatches to .damage() for normal rolls (critical=false default)', async () => {
       const { dispatch, spy } = makeDispatch();
       await createPf2eClient(dispatch).weapon('actor-001', 'longsword').rollDamage();
 
       expect(spy).toHaveBeenCalledWith({
         class: 'CharacterPF2e',
         id: 'actor-001',
-        method: 'system.actions[@slug:longsword].rollDamage',
+        method: 'system.actions[@slug:longsword].damage',
         args: [{}],
       });
     });
 
-    it('interpolates arbitrary strike slugs into the method path', async () => {
+    it('dispatches to .critical() for critical rolls (critical=true)', async () => {
+      const { dispatch, spy } = makeDispatch();
+      await createPf2eClient(dispatch).weapon('actor-001', 'longsword').rollDamage(true);
+
+      expect(spy).toHaveBeenCalledWith({
+        class: 'CharacterPF2e',
+        id: 'actor-001',
+        method: 'system.actions[@slug:longsword].critical',
+        args: [{}],
+      });
+    });
+
+    it('interpolates arbitrary slugs into the method path', async () => {
       const { dispatch, spy } = makeDispatch();
       await createPf2eClient(dispatch).weapon('actor-001', 'my-battle-axe').rollDamage();
       expect(spy).toHaveBeenCalledWith(
-        expect.objectContaining({ method: 'system.actions[@slug:my-battle-axe].rollDamage' }),
+        expect.objectContaining({ method: 'system.actions[@slug:my-battle-axe].damage' }),
       );
     });
 
     it('passes opts through in args[0]', async () => {
       const { dispatch, spy } = makeDispatch();
-      const opts = { critical: true };
-      await createPf2eClient(dispatch).weapon('actor-001', 'longsword').rollDamage(opts);
+      const opts = { bonus: 2 };
+      await createPf2eClient(dispatch).weapon('actor-001', 'longsword').rollDamage(false, opts);
       expect(spy).toHaveBeenCalledWith(expect.objectContaining({ args: [opts] }));
     });
 
-    it('defaults opts to {} when omitted', async () => {
-      const { dispatch, spy } = makeDispatch();
-      await createPf2eClient(dispatch).weapon('actor-001', 'longsword').rollDamage();
-      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ args: [{}] }));
-    });
-
-    it('uses the actorId supplied to weapon(), not character()', async () => {
+    it('uses the actorId supplied to weapon()', async () => {
       const { dispatch, spy } = makeDispatch();
       await createPf2eClient(dispatch).weapon('specific-actor', 'dagger').rollDamage();
       expect(spy).toHaveBeenCalledWith(expect.objectContaining({ id: 'specific-actor' }));

--- a/packages/pf2e-rules/src/pf2e-client.ts
+++ b/packages/pf2e-rules/src/pf2e-client.ts
@@ -145,30 +145,56 @@ export function createPf2eClient(dispatch: DispatchFn, invokeAction?: InvokeActi
      *
      * @param actorId    - Foundry document id of the actor.
      * @param strikeSlug - slug of the weapon / strike action
-     *   (matched against action.item.slug in actor.system.actions).
+     *   (matched against action.slug in actor.system.actions).
      */
     weapon(actorId: string, strikeSlug: string) {
       return {
         /**
-         * Roll damage for a named strike via the dispatcher.
+         * Roll one MAP variant of a named strike attack via the dispatcher.
          *
-         * Dispatches: `actor.system.actions[@slug:<strikeSlug>].rollDamage(opts)`
+         * Dispatches: `actor.system.actions[@slug:X].variants[N].roll({ skipDialog: true })`
          *
-         * The `[@slug:X]` notation is the dispatcher's array-lookup convention:
-         * it finds the first element in actor.system.actions where
-         * item.slug === strikeSlug (also checks .slug / .item.name).
+         * `[@slug:X]` finds the action by slug; `[N]` is a numeric index into
+         * the `variants` array (0 = full attack, 1 = −5 MAP, 2 = −10 MAP).
+         * `skipDialog: true` suppresses CheckModifiersDialog consistent with
+         * the existing rollStatisticAction behavior; the renderCheckModifiersDialog
+         * hook in prompt-intercept.ts also handles it unconditionally.
          *
-         * @param opts - PF2e DamageRollParams, e.g. `{ critical: true }`.
-         *
-         * Known limitation (spike): if the strikeSlug contains characters that
-         * conflict with the `[@slug:X]` parser (e.g. `]`) the lookup will fail.
-         * Follow-up: sanitize or encode the slug in the dispatcher resolver.
+         * @param variantIndex - 0 (full attack), 1 (−5 MAP), or 2 (−10 MAP).
+         * @param opts         - additional PF2e CheckRollContext options.
          */
-        rollDamage(opts: Record<string, unknown> = {}): Promise<DispatchResponse> {
+        rollAttack(variantIndex: number, opts: Record<string, unknown> = {}): Promise<DispatchResponse> {
           return dispatch({
             class: 'CharacterPF2e',
             id: actorId,
-            method: `system.actions[@slug:${strikeSlug}].rollDamage`,
+            method: `system.actions[@slug:${strikeSlug}].variants[${String(variantIndex)}].roll`,
+            args: [{ skipDialog: true, ...opts }],
+          });
+        },
+
+        /**
+         * Roll damage for a named strike via the dispatcher.
+         *
+         * Dispatches to `actor.system.actions[@slug:X].damage(opts)` for normal
+         * rolls, or `actor.system.actions[@slug:X].critical(opts)` for critical
+         * rolls. These are separate functions on the PF2e CharacterStrike object —
+         * not a single `rollDamage` method.
+         *
+         * DamageModifierDialog is suppressed by the existing renderDamageModifierDialog
+         * hook in prompt-intercept.ts. `skipDialog` is not in DamageRollParams so
+         * passing it would have no effect; the hook handles suppression unconditionally.
+         *
+         * @param critical - true to roll critical damage (default: false).
+         * @param opts     - PF2e DamageRollParams passed through verbatim.
+         */
+        rollDamage(critical = false, opts: Record<string, unknown> = {}): Promise<DispatchResponse> {
+          const method = critical
+            ? `system.actions[@slug:${strikeSlug}].critical`
+            : `system.actions[@slug:${strikeSlug}].damage`;
+          return dispatch({
+            class: 'CharacterPF2e',
+            id: actorId,
+            method,
             args: [opts],
           });
         },


### PR DESCRIPTION
## Summary

Migrates all remaining save rolls, weapon attack rolls (all MAP variants), weapon damage rolls, and spell casting from ad-hoc API calls to the generic dispatcher + pf2e-rules Layer 1 client. The dispatcher spike (#100) validated the pattern with one button; this wires everything else.

## Changes

### `apps/foundry-api-bridge` — numeric index path support

Extended `resolvePath()` in `DispatchHandler.ts` to handle `prop[N]` segments (numeric array index) alongside the existing `[@slug:X]` slug-based lookup:

- `system.actions[@slug:longsword].variants[0].roll` → `actor.system.actions[find by slug].variants[0].roll`

Required because PF2e strike variants are a numeric array, not slug-keyed.

### `packages/pf2e-rules` — new wrappers, corrected damage method

**`weapon().rollAttack(variantIndex, opts?)`** (new):
- Dispatches: `system.actions[@slug:X].variants[N].roll({ skipDialog: true })`
- `skipDialog: true` always included, matching `rollStatisticAction` behaviour

**`weapon().rollDamage(critical, opts?)`** (corrected):
- `critical=false` → `system.actions[@slug:X].damage({})`
- `critical=true` → `system.actions[@slug:X].critical({})`
- Spike had wrong method path (`rollDamage` — not a real method on PF2e's `CharacterStrike`); corrected to `.damage()` / `.critical()`

### `apps/player-portal` — full migration

**`Character.tsx`**: reflex and will saves now use `createPf2eClient(api.dispatch).character(actorId).rollSave(type)` alongside fortitude (already migrated in the spike). `rollActorStatistic` is no longer called for any save.

**`Actions.tsx`**: all three strike button types now go through the dispatcher:
- MAP variant buttons (0/1/2) → `rollAttack(variantIndex)` → `variants[N].roll`
- Damage button → `rollDamage(false)` → `.damage()`
- Crit button → `rollDamage(true)` → `.critical()`

**`Spells.tsx`**: Cast button now routes through `pf2eClient.spellEntry(actorId, entryId).cast(spellId, rank)` instead of calling `api.castSpell` directly. PR #115 added the `spellEntry().cast()` wrapper to the pf2e-rules client but didn't wire the component to it; this closes the gap. Underlying call is identical — `spellEntry.cast` delegates to `invokeActorAction('cast-spell', ...)`.

## Test plan

- [x] `apps/foundry-api-bridge` — 2 new Jest cases for `[N]` numeric index: happy path (`variants[1]`) and out-of-bounds
- [x] `packages/pf2e-rules` — 11 new/updated Vitest cases: 6 for `rollAttack` (index encoding, skipDialog, opts merging), 5 for corrected `rollDamage` (.damage vs .critical dispatch)
- [x] `apps/player-portal` — Character: `it.each` over all 3 saves + assert no `rollActorStatistic` calls; Actions: 6 updated cases asserting `api.dispatch` payloads; Spells: 1 updated case asserting `api.invokeActorAction` called via `spellEntry().cast()`
- [x] All 4 workspace test suites green
- [x] Typecheck clean, lint clean, format clean

Refs #74