### PR TITLE
feat(dm-tool): show Foundry item icon in browser chip and detail window

### DIFF
--- a/apps/dm-tool/electron/compendium/projection.test.ts
+++ b/apps/dm-tool/electron/compendium/projection.test.ts
@@ -709,6 +709,20 @@ describe('itemDocToBrowserRow', () => {
     expect(row.isRemastered).toBe(true);
     // Rarity trait should not leak into the public traits array
     expect(row.traits).not.toContain('UNCOMMON');
+    // img is passed through from doc.img (raw path; IPC layer rewrites to proxy URL)
+    expect(row.img).toBe('systems/pf2e/icons/equipment/consumables/potions/potion-minor.webp');
+  });
+
+  it('returns null img for a default-icon placeholder', () => {
+    const doc = potionOfHealingDoc();
+    doc.img = 'systems/pf2e/icons/default-icons/consumable.svg';
+    expect(itemDocToBrowserRow(doc).img).toBeNull();
+  });
+
+  it('returns null img when img is absent', () => {
+    const doc = potionOfHealingDoc();
+    doc.img = '';
+    expect(itemDocToBrowserRow(doc).img).toBeNull();
   });
 });
 
@@ -756,6 +770,20 @@ describe('itemMatchToBrowserRow', () => {
     expect(row.rarity).toBe('UNCOMMON');
     expect(row.price).toBe('4 gp');
     expect(row.isMagical).toBe(true);
+  });
+
+  it('passes through a non-default img path', () => {
+    const m = { ...itemMatch(), img: 'systems/pf2e/icons/equipment/consumables/potions/potion-minor.webp' };
+    expect(itemMatchToBrowserRow(m).img).toBe('systems/pf2e/icons/equipment/consumables/potions/potion-minor.webp');
+  });
+
+  it('returns null img for an empty string (the fixture default)', () => {
+    expect(itemMatchToBrowserRow(itemMatch()).img).toBeNull();
+  });
+
+  it('returns null img for a default-icon path', () => {
+    const m = { ...itemMatch(), img: 'systems/pf2e/icons/default-icons/consumable.svg' };
+    expect(itemMatchToBrowserRow(m).img).toBeNull();
   });
 });
 

--- a/apps/dm-tool/electron/compendium/projection.ts
+++ b/apps/dm-tool/electron/compendium/projection.ts
@@ -1016,6 +1016,7 @@ export function itemDocToBrowserRow(doc: CompendiumDocument): ItemBrowserRow {
     isMagical: isMagical(system),
     hasVariants: variants.length > 0,
     isRemastered: isRemastered(system),
+    img: pickPortraitUrl(doc),
   };
 }
 
@@ -1051,6 +1052,7 @@ export function itemMatchToBrowserRow(m: CompendiumMatch): ItemBrowserRow {
     isMagical: allTraits.includes('magical') || allTraits.includes('invested'),
     hasVariants: false,
     isRemastered: null,
+    img: m.img && !isDefaultIcon(m.img) ? m.img : null,
   };
 }
 

--- a/apps/dm-tool/electron/ipc/index.ts
+++ b/apps/dm-tool/electron/ipc/index.ts
@@ -34,7 +34,7 @@ export function registerIpcHandlers(
   registerBookHandlers(bookDb, cfg, getMainWindow);
   registerChatHandlers(getMainWindow);
   registerMonsterHandlers(cfg.foundryMcpUrl);
-  registerItemHandlers();
+  registerItemHandlers(cfg.foundryMcpUrl);
   registerCompendiumHandlers();
   registerTaggerHandlers(cfg, getMainWindow);
   registerAutoWallHandlers(cfg);

--- a/apps/dm-tool/electron/ipc/items.test.ts
+++ b/apps/dm-tool/electron/ipc/items.test.ts
@@ -1,0 +1,57 @@
+// Tests for item icon URL resolution via the asset-proxy helper.
+// The same toMonsterFileUrl function used for monster portraits also handles
+// item icons — confirmed by the identical path prefixes (icons/, systems/).
+
+import { describe, expect, it } from 'vitest';
+import { toMonsterFileUrl } from '../compendium/image-url';
+
+const MCP = 'http://server.ad:8765';
+
+describe('item icon → asset proxy URL (foundryMcpUrl provided)', () => {
+  it('prefixes an icons/ path with the mcp base URL', () => {
+    expect(toMonsterFileUrl('icons/equipment/weapons/sword-longsword.webp', MCP)).toBe(
+      'http://server.ad:8765/icons/equipment/weapons/sword-longsword.webp',
+    );
+  });
+
+  it('prefixes a systems/pf2e/icons/ equipment path with the mcp base URL', () => {
+    expect(toMonsterFileUrl('systems/pf2e/icons/equipment/consumables/potions/potion-minor.webp', MCP)).toBe(
+      'http://server.ad:8765/systems/pf2e/icons/equipment/consumables/potions/potion-minor.webp',
+    );
+  });
+
+  it('strips trailing slash from the base URL before joining', () => {
+    expect(toMonsterFileUrl('icons/equipment/armor/plate.webp', 'http://server.ad:8765/')).toBe(
+      'http://server.ad:8765/icons/equipment/armor/plate.webp',
+    );
+  });
+
+  it('leaves an already-absolute http URL untouched', () => {
+    const url = 'http://localhost:30000/icons/equipment/weapons/sword.webp';
+    expect(toMonsterFileUrl(url, MCP)).toBe(url);
+  });
+});
+
+describe('item icon → local fallback (no foundryMcpUrl)', () => {
+  it('converts a Foundry-relative icons/ path to a monster-file URL', () => {
+    expect(toMonsterFileUrl('icons/equipment/weapons/sword-longsword.webp')).toBe(
+      'monster-file://img/icons/equipment/weapons/sword-longsword.webp',
+    );
+  });
+
+  it('converts a systems/pf2e path to a monster-file URL', () => {
+    expect(toMonsterFileUrl('systems/pf2e/icons/equipment/consumables/potions/potion-minor.webp')).toBe(
+      'monster-file://img/systems/pf2e/icons/equipment/consumables/potions/potion-minor.webp',
+    );
+  });
+});
+
+describe('item icon — null / empty inputs', () => {
+  it('returns null for null (missing img field)', () => {
+    expect(toMonsterFileUrl(null)).toBeNull();
+  });
+
+  it('returns null for empty string (default placeholder that projection filtered to null)', () => {
+    expect(toMonsterFileUrl('')).toBeNull();
+  });
+});

--- a/apps/dm-tool/electron/ipc/items.ts
+++ b/apps/dm-tool/electron/ipc/items.ts
@@ -1,18 +1,27 @@
 import { ipcMain } from 'electron';
 import type { ItemBrowserDetail, ItemBrowserRow, ItemFacets, ItemSearchParams } from '@foundry-toolkit/shared/types';
 import { getPreparedCompendium } from '../compendium/singleton.js';
+import { toMonsterFileUrl } from '../compendium/image-url.js';
+
+function rewriteImg<T extends { img?: string | null }>(item: T, mcpBaseUrl: string | undefined): T {
+  return { ...item, img: toMonsterFileUrl(item.img, mcpBaseUrl) };
+}
 
 // Every item IPC now routes through the foundry-mcp-backed prepared
 // compendium. `getItemBrowserDetail` reads the full document + parses
 // `variants[]` from `system.variants` via the projection layer in
 // projection.ts.
-export function registerItemHandlers(): void {
+export function registerItemHandlers(foundryMcpUrl?: string): void {
   ipcMain.handle('searchItemsBrowser', (_e, params: ItemSearchParams): Promise<ItemBrowserRow[]> => {
-    return getPreparedCompendium().searchItemsBrowser(params ?? {});
+    return getPreparedCompendium()
+      .searchItemsBrowser(params ?? {})
+      .then((rows) => rows.map((row) => rewriteImg(row, foundryMcpUrl)));
   });
 
   ipcMain.handle('getItemBrowserDetail', (_e, id: string): Promise<ItemBrowserDetail | null> => {
-    return getPreparedCompendium().getItemBrowserDetail(id);
+    return getPreparedCompendium()
+      .getItemBrowserDetail(id)
+      .then((d) => (d ? rewriteImg(d, foundryMcpUrl) : null));
   });
 
   ipcMain.handle('getItemFacets', (): Promise<ItemFacets> => {

--- a/apps/dm-tool/src/features/item-browser/ItemCardGrid.tsx
+++ b/apps/dm-tool/src/features/item-browser/ItemCardGrid.tsx
@@ -112,11 +112,24 @@ export function ItemCardGrid({ groups, selectedId, onSelect, loading }: Props) {
                         )}
                         style={{ height: CARD_H }}
                       >
-                        {/* Name + group count */}
+                        {/* Name + icon + group count */}
                         <div className="flex items-start justify-between gap-1">
-                          <span className="min-w-0 truncate font-medium leading-tight">
-                            {isGroup ? displayName(item.name) : item.name}
-                          </span>
+                          <div className="flex min-w-0 items-center gap-1.5">
+                            {item.img && (
+                              <img
+                                src={item.img}
+                                alt=""
+                                className="h-7 w-7 shrink-0 rounded object-contain"
+                                loading="lazy"
+                                onError={(e) => {
+                                  e.currentTarget.style.display = 'none';
+                                }}
+                              />
+                            )}
+                            <span className="min-w-0 truncate font-medium leading-tight">
+                              {isGroup ? displayName(item.name) : item.name}
+                            </span>
+                          </div>
                           {isGroup && (
                             <span className="shrink-0 rounded-full bg-primary/15 px-1.5 py-0.5 text-[9px] font-semibold tabular-nums leading-none text-primary">
                               {group.siblings.length}

--- a/apps/dm-tool/src/features/item-browser/ItemDetailPane.tsx
+++ b/apps/dm-tool/src/features/item-browser/ItemDetailPane.tsx
@@ -48,6 +48,21 @@ export function ItemDetailPane({ itemId, siblings, onSelectSibling, onClose }: I
       {detail && (
         <ScrollArea className="min-h-0 flex-1">
           <div className="space-y-4 p-4">
+            {/* Item icon */}
+            {detail.img && (
+              <div className="flex justify-center">
+                <img
+                  src={detail.img}
+                  alt=""
+                  className="h-24 w-24 rounded-md object-contain"
+                  loading="lazy"
+                  onError={(e) => {
+                    e.currentTarget.parentElement!.style.display = 'none';
+                  }}
+                />
+              </div>
+            )}
+
             {/* Level + type + rarity row */}
             <div className="flex flex-wrap items-center gap-2">
               <div className="flex items-baseline gap-1.5">

--- a/apps/dm-tool/src/features/item-browser/ItemDetailPane.tsx
+++ b/apps/dm-tool/src/features/item-browser/ItemDetailPane.tsx
@@ -48,52 +48,50 @@ export function ItemDetailPane({ itemId, siblings, onSelectSibling, onClose }: I
       {detail && (
         <ScrollArea className="min-h-0 flex-1">
           <div className="space-y-4 p-4">
-            {/* Item icon */}
-            {detail.img && (
-              <div className="flex justify-center">
+            {/* Icon (left) + stacked metadata (right) */}
+            <div className="flex items-start gap-3">
+              {detail.img && (
                 <img
                   src={detail.img}
                   alt=""
-                  className="h-24 w-24 rounded-md object-contain"
+                  className="h-24 w-24 shrink-0 rounded-md object-contain"
                   loading="lazy"
                   onError={(e) => {
-                    e.currentTarget.parentElement!.style.display = 'none';
+                    e.currentTarget.style.display = 'none';
                   }}
                 />
-              </div>
-            )}
-
-            {/* Level + type + rarity row */}
-            <div className="flex flex-wrap items-center gap-2">
-              <div className="flex items-baseline gap-1.5">
-                <span className="text-lg font-bold tabular-nums text-foreground">
-                  {detail.level != null ? `Level ${detail.level}` : 'Level —'}
+              )}
+              <div className="flex flex-col gap-1.5">
+                <div className="flex items-baseline gap-1.5">
+                  <span className="text-lg font-bold tabular-nums text-foreground">
+                    {detail.level != null ? `Level ${detail.level}` : 'Level —'}
+                  </span>
+                  {detail.itemType && (
+                    <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                      {formatItemType(detail.itemType)}
+                    </span>
+                  )}
+                </div>
+                <span
+                  className={cn(
+                    'self-start rounded border px-1.5 py-0.5 text-[10px] font-medium capitalize leading-none',
+                    RARITY_CHIP[detail.rarity] || RARITY_CHIP.COMMON,
+                  )}
+                >
+                  {detail.rarity.toLowerCase()}
                 </span>
-                {detail.itemType && (
-                  <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-                    {formatItemType(detail.itemType)}
+                {detail.isMagical && (
+                  <span className="flex items-center gap-0.5 text-[10px] text-amber-400">
+                    <Sparkles className="h-3 w-3" />
+                    Magical
+                  </span>
+                )}
+                {detail.isRemastered === false && (
+                  <span className="self-start rounded border border-yellow-700/40 bg-yellow-950/30 px-1.5 py-0.5 text-[10px] font-medium leading-none text-yellow-400">
+                    Legacy
                   </span>
                 )}
               </div>
-              <span
-                className={cn(
-                  'rounded border px-1.5 py-0.5 text-[10px] font-medium capitalize leading-none',
-                  RARITY_CHIP[detail.rarity] || RARITY_CHIP.COMMON,
-                )}
-              >
-                {detail.rarity.toLowerCase()}
-              </span>
-              {detail.isMagical && (
-                <span className="flex items-center gap-0.5 text-[10px] text-amber-400">
-                  <Sparkles className="h-3 w-3" />
-                  Magical
-                </span>
-              )}
-              {detail.isRemastered === false && (
-                <span className="rounded border border-yellow-700/40 bg-yellow-950/30 px-1.5 py-0.5 text-[10px] font-medium leading-none text-yellow-400">
-                  Legacy
-                </span>
-              )}
             </div>
 
             {/* Traits */}

--- a/apps/dm-tool/src/features/item-browser/ItemDetailPane.tsx
+++ b/apps/dm-tool/src/features/item-browser/ItemDetailPane.tsx
@@ -94,20 +94,6 @@ export function ItemDetailPane({ itemId, siblings, onSelectSibling, onClose }: I
               )}
             </div>
 
-            {/* Traits */}
-            {detail.traits.length > 0 && (
-              <div className="flex flex-wrap gap-1">
-                {detail.traits.map((t) => (
-                  <span
-                    key={t}
-                    className="rounded border border-border bg-accent/60 px-1.5 py-0.5 text-[10px] leading-none text-foreground/80"
-                  >
-                    {t.toLowerCase()}
-                  </span>
-                ))}
-              </div>
-            )}
-
             <Separator />
 
             {/* Stats — single-column, label left / value right */}
@@ -208,6 +194,23 @@ export function ItemDetailPane({ itemId, siblings, onSelectSibling, onClose }: I
                   <ExternalLink className="h-3 w-3" />
                   View on Archives of Nethys
                 </button>
+              </>
+            )}
+
+            {/* Traits */}
+            {detail.traits.length > 0 && (
+              <>
+                <Separator />
+                <div className="flex flex-wrap gap-1">
+                  {detail.traits.map((t) => (
+                    <span
+                      key={t}
+                      className="rounded border border-border bg-accent/60 px-1.5 py-0.5 text-[10px] leading-none text-foreground/80"
+                    >
+                      {t.toLowerCase()}
+                    </span>
+                  ))}
+                </div>
               </>
             )}
           </div>

--- a/apps/dm-tool/src/features/item-browser/ItemDetailPane.tsx
+++ b/apps/dm-tool/src/features/item-browser/ItemDetailPane.tsx
@@ -48,20 +48,9 @@ export function ItemDetailPane({ itemId, siblings, onSelectSibling, onClose }: I
       {detail && (
         <ScrollArea className="min-h-0 flex-1">
           <div className="space-y-4 p-4">
-            {/* Icon (left) + stacked metadata (right) */}
+            {/* Stacked metadata (left) + icon (right) */}
             <div className="flex items-start gap-3">
-              {detail.img && (
-                <img
-                  src={detail.img}
-                  alt=""
-                  className="h-24 w-24 shrink-0 rounded-md object-contain"
-                  loading="lazy"
-                  onError={(e) => {
-                    e.currentTarget.style.display = 'none';
-                  }}
-                />
-              )}
-              <div className="flex flex-col gap-1.5">
+              <div className="flex flex-1 flex-col gap-1.5">
                 <div className="flex items-baseline gap-1.5">
                   <span className="text-lg font-bold tabular-nums text-foreground">
                     {detail.level != null ? `Level ${detail.level}` : 'Level —'}
@@ -92,6 +81,17 @@ export function ItemDetailPane({ itemId, siblings, onSelectSibling, onClose }: I
                   </span>
                 )}
               </div>
+              {detail.img && (
+                <img
+                  src={detail.img}
+                  alt=""
+                  className="h-24 w-24 shrink-0 rounded-md object-contain"
+                  loading="lazy"
+                  onError={(e) => {
+                    e.currentTarget.style.display = 'none';
+                  }}
+                />
+              )}
             </div>
 
             {/* Traits */}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -173,6 +173,10 @@ export interface ItemBrowserRow {
   hasVariants: boolean;
   /** true = ORC/remastered, false = OGL/legacy, null = unknown. */
   isRemastered: boolean | null;
+  /** Renderer-ready URL for the item's Foundry icon (already routed through
+   *  the asset proxy or monster-file:// protocol by the IPC layer). Null
+   *  when the icon is missing or is a default-icon placeholder. */
+  img?: string | null;
 }
 
 export interface ItemVariant {


### PR DESCRIPTION
## Summary

PF2e items have an `img` field (e.g. `systems/pf2e/icons/equipment/...`) that the item browser was silently discarding. This PR surfaces that icon in two places: a 28px thumbnail at the top-left of each card in the grid, and a 96px centred portrait at the top of the detail pane. Both use `loading="lazy"` so they don't block list render, and fall back gracefully (the image hides itself via `onError`) when the path is missing or fails to load.

The icon path is rewritten through the same `toMonsterFileUrl` asset-proxy helper used by monster portraits — routing through foundry-mcp's `/icons/*` and `/systems/*` proxy when `foundryMcpUrl` is configured, or falling back to the `monster-file://` Electron protocol for local-only installs.

## Changes

- `packages/shared/src/types.ts` — add `img?: string | null` to `ItemBrowserRow` (inherited by `ItemBrowserDetail`)
- `electron/compendium/projection.ts` — `itemDocToBrowserRow` extracts `img` via the existing `pickPortraitUrl` helper (filters default-icon placeholders); `itemMatchToBrowserRow` reads `m.img` with the same default-icon filter
- `electron/ipc/items.ts` — accepts `foundryMcpUrl` parameter; rewrites `img` on every row via `toMonsterFileUrl` before sending over IPC (both search results and detail)
- `electron/ipc/index.ts` — passes `cfg.foundryMcpUrl` to `registerItemHandlers` (mirrors the monster handler pattern)
- `ItemCardGrid.tsx` — 28px lazy thumbnail left of the item name; hidden via `onError` if load fails
- `ItemDetailPane.tsx` — 96px centred portrait block at the top of the detail scroll area; container hidden via `onError`
- New `electron/ipc/items.test.ts` — tests that `icons/` and `systems/pf2e/icons/equipment/` paths resolve correctly through the proxy and local fallback
- Updated `projection.test.ts` — asserts `img` is extracted for real paths, null for empty strings and default-icon placeholders

## Test plan

- [ ] Item grid cards show the PF2e icon thumbnail (28px) when connected to foundry-mcp
- [ ] Item detail pane shows the 96px icon portrait
- [ ] No icon element rendered when `img` is null (missing/placeholder)
- [ ] Icon fails gracefully on load error (element hidden, layout unchanged)
- [ ] `npm run test -w apps/dm-tool` passes (329 tests)
- [ ] `npm run typecheck -w apps/dm-tool` clean