### PR TITLE
feat(dm-tool): show player actions and spells in combat detail

### DIFF
--- a/apps/dm-tool/electron/compendium/pc-actor.test.ts
+++ b/apps/dm-tool/electron/compendium/pc-actor.test.ts
@@ -1,0 +1,340 @@
+import { describe, expect, it } from 'vitest';
+import { pcActorToDetail } from './pc-actor.js';
+import type { PreparedActor } from '@foundry-toolkit/shared/foundry-api';
+
+function makeActor(overrides: Partial<PreparedActor> = {}): PreparedActor {
+  return {
+    id: 'actor-1',
+    uuid: 'Actor.actor-1',
+    name: 'Valeros',
+    type: 'character',
+    img: '',
+    system: {},
+    items: [],
+    ...overrides,
+  };
+}
+
+describe('pcActorToDetail', () => {
+  it('maps id and name', () => {
+    const detail = pcActorToDetail(makeActor({ id: 'abc', name: 'Seoni' }));
+    expect(detail.id).toBe('abc');
+    expect(detail.name).toBe('Seoni');
+  });
+
+  it('returns empty arrays for an actor with no items', () => {
+    const detail = pcActorToDetail(makeActor({ items: [] }));
+    expect(detail.actions).toEqual([]);
+    expect(detail.spellGroups).toEqual([]);
+  });
+
+  describe('action extraction', () => {
+    it('extracts a 1-action strike', () => {
+      const actor = makeActor({
+        items: [
+          {
+            id: 'a1',
+            name: 'Strike',
+            type: 'action',
+            img: '',
+            system: {
+              actionType: { value: 'action' },
+              actions: { value: 1 },
+              traits: { value: ['attack'] },
+              description: { value: '<p>Make a strike.</p>' },
+            },
+          },
+        ],
+      });
+      const { actions } = pcActorToDetail(actor);
+      expect(actions).toHaveLength(1);
+      expect(actions[0]).toMatchObject({
+        name: 'Strike',
+        actionType: 'action',
+        actionCost: 1,
+        traits: ['attack'],
+      });
+      expect(actions[0].description).toContain('Make a strike');
+    });
+
+    it('extracts a reaction', () => {
+      const actor = makeActor({
+        items: [
+          {
+            id: 'r1',
+            name: 'Reactive Strike',
+            type: 'action',
+            img: '',
+            system: {
+              actionType: { value: 'reaction' },
+              actions: { value: null },
+              traits: { value: ['attack'] },
+              description: { value: '' },
+            },
+          },
+        ],
+      });
+      const { actions } = pcActorToDetail(actor);
+      expect(actions[0]).toMatchObject({
+        name: 'Reactive Strike',
+        actionType: 'reaction',
+        actionCost: undefined,
+      });
+    });
+
+    it('extracts a free action', () => {
+      const actor = makeActor({
+        items: [
+          {
+            id: 'f1',
+            name: 'Eschew Materials',
+            type: 'action',
+            img: '',
+            system: {
+              actionType: { value: 'free' },
+              actions: { value: null },
+              traits: { value: [] },
+              description: { value: '' },
+            },
+          },
+        ],
+      });
+      const { actions } = pcActorToDetail(actor);
+      expect(actions[0]).toMatchObject({ name: 'Eschew Materials', actionType: 'free' });
+    });
+
+    it('excludes passive abilities', () => {
+      const actor = makeActor({
+        items: [
+          {
+            id: 'p1',
+            name: 'Armor Expertise',
+            type: 'action',
+            img: '',
+            system: {
+              actionType: { value: 'passive' },
+              actions: { value: null },
+              traits: { value: [] },
+              description: { value: '' },
+            },
+          },
+        ],
+      });
+      expect(pcActorToDetail(actor).actions).toHaveLength(0);
+    });
+
+    it('sorts: reactions first, then free, then actions by cost', () => {
+      const actor = makeActor({
+        items: [
+          {
+            id: 'a3',
+            name: 'Slow Burn',
+            type: 'action',
+            img: '',
+            system: {
+              actionType: { value: 'action' },
+              actions: { value: 3 },
+              traits: { value: [] },
+              description: { value: '' },
+            },
+          },
+          {
+            id: 'a1',
+            name: 'Strike',
+            type: 'action',
+            img: '',
+            system: {
+              actionType: { value: 'action' },
+              actions: { value: 1 },
+              traits: { value: [] },
+              description: { value: '' },
+            },
+          },
+          {
+            id: 'r1',
+            name: 'Reactive Strike',
+            type: 'action',
+            img: '',
+            system: {
+              actionType: { value: 'reaction' },
+              actions: { value: null },
+              traits: { value: [] },
+              description: { value: '' },
+            },
+          },
+          {
+            id: 'f1',
+            name: 'Free Action',
+            type: 'action',
+            img: '',
+            system: {
+              actionType: { value: 'free' },
+              actions: { value: null },
+              traits: { value: [] },
+              description: { value: '' },
+            },
+          },
+        ],
+      });
+      const names = pcActorToDetail(actor).actions.map((a) => a.name);
+      expect(names).toEqual(['Reactive Strike', 'Free Action', 'Strike', 'Slow Burn']);
+    });
+
+    it('ignores non-action item types', () => {
+      const actor = makeActor({
+        items: [
+          {
+            id: 'w1',
+            name: 'Longsword',
+            type: 'weapon',
+            img: '',
+            system: {},
+          },
+          {
+            id: 'e1',
+            name: 'Chain Mail',
+            type: 'armor',
+            img: '',
+            system: {},
+          },
+        ],
+      });
+      expect(pcActorToDetail(actor).actions).toHaveLength(0);
+    });
+  });
+
+  describe('spell extraction', () => {
+    it('extracts a prepared spellcasting entry with spells', () => {
+      const actor = makeActor({
+        items: [
+          {
+            id: 'entry-1',
+            name: 'Arcane Prepared Spells',
+            type: 'spellcastingEntry',
+            img: '',
+            system: {
+              tradition: { value: 'arcane' },
+              prepared: { value: 'prepared' },
+              spelldc: { dc: 25, value: 17 },
+            },
+          },
+          {
+            id: 'spell-1',
+            name: 'Fireball',
+            type: 'spell',
+            img: '',
+            system: {
+              level: { value: 3 },
+              location: { value: 'entry-1' },
+              time: { value: '2' },
+              range: { value: '500 feet' },
+              area: { value: 20, type: 'burst' },
+              target: { value: '' },
+              traits: { value: ['fire', 'arcane'] },
+              description: { value: '<p>A ball of fire.</p>' },
+            },
+          },
+        ],
+      });
+
+      const { spellGroups } = pcActorToDetail(actor);
+      expect(spellGroups).toHaveLength(1);
+      const [group] = spellGroups;
+      expect(group.entryName).toBe('Arcane Prepared Spells');
+      expect(group.tradition).toBe('arcane');
+      expect(group.dc).toBe(25);
+      expect(group.attack).toBe(17);
+      expect(group.ranks).toHaveLength(1);
+      expect(group.ranks[0].rank).toBe(3);
+      const [spell] = group.ranks[0].spells;
+      expect(spell.name).toBe('Fireball');
+      expect(spell.castTime).toBe('2');
+      expect(spell.area).toBe('20-foot burst');
+      expect(spell.traits).toContain('fire');
+      expect(spell.traits).toContain('arcane'); // tradition traits are kept
+      // Rarity tags (common/uncommon/rare/unique) would be filtered, but fire/arcane are not rarity tags
+    });
+
+    it('ignores spells without a matching spellcasting entry', () => {
+      const actor = makeActor({
+        items: [
+          {
+            id: 'spell-orphan',
+            name: 'Orphaned Spell',
+            type: 'spell',
+            img: '',
+            system: {
+              level: { value: 1 },
+              location: { value: 'nonexistent-entry' },
+              time: { value: '2' },
+              range: { value: '' },
+              area: {},
+              target: { value: '' },
+              traits: { value: [] },
+              description: { value: '' },
+            },
+          },
+        ],
+      });
+      expect(pcActorToDetail(actor).spellGroups).toHaveLength(0);
+    });
+
+    it('handles innate spells with uses per day', () => {
+      const actor = makeActor({
+        items: [
+          {
+            id: 'entry-innate',
+            name: 'Innate Spells',
+            type: 'spellcastingEntry',
+            img: '',
+            system: {
+              tradition: { value: 'divine' },
+              prepared: { value: 'innate' },
+              spelldc: { dc: 20, value: 12 },
+            },
+          },
+          {
+            id: 'spell-innate',
+            name: 'Darkness',
+            type: 'spell',
+            img: '',
+            system: {
+              level: { value: 2 },
+              location: { value: 'entry-innate', uses: { max: 1 } },
+              time: { value: '3' },
+              range: { value: '' },
+              area: {},
+              target: { value: '' },
+              traits: { value: [] },
+              description: { value: '' },
+            },
+          },
+        ],
+      });
+
+      const { spellGroups } = pcActorToDetail(actor);
+      const spell = spellGroups[0]?.ranks[0]?.spells[0];
+      expect(spell?.name).toBe('Darkness');
+      expect(spell?.usesPerDay).toBe(1);
+    });
+
+    it('skips spellcasting entries with no spells', () => {
+      const actor = makeActor({
+        items: [
+          {
+            id: 'entry-empty',
+            name: 'Empty Entry',
+            type: 'spellcastingEntry',
+            img: '',
+            system: {
+              tradition: { value: 'arcane' },
+              prepared: { value: 'prepared' },
+              spelldc: { dc: 20, value: 12 },
+            },
+          },
+        ],
+      });
+      expect(pcActorToDetail(actor).spellGroups).toHaveLength(0);
+    });
+  });
+});

--- a/apps/dm-tool/electron/compendium/pc-actor.ts
+++ b/apps/dm-tool/electron/compendium/pc-actor.ts
@@ -1,0 +1,188 @@
+// Project a PreparedActor (fetched live from Foundry) into the
+// PlayerActorDetail shape consumed by CombatantStatBlock's PC detail pane.
+//
+// Extracts combat-relevant actions (non-passive) and spell groups,
+// mirroring the monsterSpells + action extraction in projection.ts but
+// operating on PreparedActorItem[] instead of CompendiumEmbeddedItem[].
+
+import type { PreparedActor } from '@foundry-toolkit/shared/foundry-api';
+import type {
+  MonsterSpellGroup,
+  MonsterSpellInfo,
+  MonsterSpellRank,
+  PlayerAction,
+  PlayerActorDetail,
+} from '@foundry-toolkit/shared/types';
+import { cleanDescription } from './projection.js';
+
+// ---------------------------------------------------------------------------
+// Narrow readers (mirrors the unexported helpers in projection.ts)
+// ---------------------------------------------------------------------------
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function readPath(obj: Record<string, unknown>, path: string[]): unknown {
+  let cur: unknown = obj;
+  for (const key of path) {
+    if (!isRecord(cur)) return undefined;
+    cur = cur[key];
+  }
+  return cur;
+}
+
+function readString(v: unknown, fallback = ''): string {
+  return typeof v === 'string' ? v : fallback;
+}
+
+function readNumber(v: unknown, fallback = 0): number {
+  return typeof v === 'number' && Number.isFinite(v) ? v : fallback;
+}
+
+function readStringArray(v: unknown): string[] {
+  return Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : [];
+}
+
+// ---------------------------------------------------------------------------
+// Spell extraction
+// ---------------------------------------------------------------------------
+
+const RARITY_SPELL_TRAITS = new Set(['common', 'uncommon', 'rare', 'unique']);
+
+function extractSpellGroups(items: PreparedActor['items']): MonsterSpellGroup[] {
+  interface EntryInfo {
+    name: string;
+    tradition: string;
+    castingType: string;
+    dc?: number;
+    attack?: number;
+  }
+
+  const entries = new Map<string, EntryInfo>();
+  for (const item of items) {
+    if (item.type !== 'spellcastingEntry') continue;
+    const sys = item.system;
+    entries.set(item.id, {
+      name: item.name,
+      tradition: readString(readPath(sys, ['tradition', 'value'])),
+      castingType: readString(readPath(sys, ['prepared', 'value'])),
+      dc: (() => {
+        const v = readPath(sys, ['spelldc', 'dc']);
+        return typeof v === 'number' && v > 0 ? v : undefined;
+      })(),
+      attack: (() => {
+        const v = readPath(sys, ['spelldc', 'value']);
+        return typeof v === 'number' && v !== 0 ? v : undefined;
+      })(),
+    });
+  }
+  if (entries.size === 0) return [];
+
+  const spellsByEntry: Record<string, Map<number, MonsterSpellInfo[]>> = {};
+
+  for (const item of items) {
+    if (item.type !== 'spell') continue;
+    const sys = item.system;
+    const entryId = readString(readPath(sys, ['location', 'value']));
+    if (!entryId || !entries.has(entryId)) continue;
+
+    const baseLevel = readNumber(readPath(sys, ['level', 'value']));
+    const heightened = readPath(sys, ['location', 'heightenedLevel']);
+    const rank = typeof heightened === 'number' ? heightened : baseLevel;
+
+    const usesMax = readPath(sys, ['location', 'uses', 'max']);
+    const usesPerDay = typeof usesMax === 'number' && usesMax > 0 ? usesMax : undefined;
+
+    const castTime = readString(readPath(sys, ['time', 'value']));
+    const range = readString(readPath(sys, ['range', 'value']));
+
+    const areaValue = readPath(sys, ['area', 'value']);
+    const areaType = readPath(sys, ['area', 'type']);
+    const area =
+      typeof areaValue === 'number' && typeof areaType === 'string' && areaType.length > 0
+        ? `${areaValue.toString()}-foot ${areaType}`
+        : '';
+
+    const target = readString(readPath(sys, ['target', 'value']));
+    const allTraits = readStringArray(readPath(sys, ['traits', 'value']));
+    const traits = allTraits.filter((t) => !RARITY_SPELL_TRAITS.has(t.toLowerCase()));
+    const description = cleanDescription(readString(readPath(sys, ['description', 'value'])));
+
+    if (!spellsByEntry[entryId]) spellsByEntry[entryId] = new Map();
+    const byRank = spellsByEntry[entryId];
+    if (!byRank.has(rank)) byRank.set(rank, []);
+    byRank.get(rank)!.push({ name: item.name, rank, usesPerDay, castTime, range, area, target, traits, description });
+  }
+
+  const groups: MonsterSpellGroup[] = [];
+  for (const [entryId, entry] of entries) {
+    const byRank = spellsByEntry[entryId];
+    if (!byRank || byRank.size === 0) continue;
+
+    const ranks: MonsterSpellRank[] = [...byRank.keys()]
+      .sort((a, b) => a - b)
+      .map((rank) => ({ rank, spells: byRank.get(rank)! }));
+
+    groups.push({
+      entryName: entry.name,
+      tradition: entry.tradition,
+      castingType: entry.castingType,
+      dc: entry.dc,
+      attack: entry.attack,
+      ranks,
+    });
+  }
+
+  return groups;
+}
+
+// ---------------------------------------------------------------------------
+// Action extraction
+// ---------------------------------------------------------------------------
+
+const ACTION_TYPE_ORDER: Record<string, number> = {
+  reaction: 0,
+  free: 1,
+  action: 2,
+};
+
+function sortActions(a: PlayerAction, b: PlayerAction): number {
+  const ao = ACTION_TYPE_ORDER[a.actionType] ?? 3;
+  const bo = ACTION_TYPE_ORDER[b.actionType] ?? 3;
+  if (ao !== bo) return ao - bo;
+  return (a.actionCost ?? 1) - (b.actionCost ?? 1);
+}
+
+function extractActions(items: PreparedActor['items']): PlayerAction[] {
+  const actions: PlayerAction[] = [];
+
+  for (const item of items) {
+    if (item.type !== 'action') continue;
+    const sys = item.system;
+    const actionType = readString(readPath(sys, ['actionType', 'value']));
+    if (!actionType || actionType === 'passive') continue;
+
+    const rawCost = readPath(sys, ['actions', 'value']);
+    const actionCost = actionType === 'action' && typeof rawCost === 'number' && rawCost > 0 ? rawCost : undefined;
+    const traits = readStringArray(readPath(sys, ['traits', 'value']));
+    const description = cleanDescription(readString(readPath(sys, ['description', 'value'])));
+
+    actions.push({ name: item.name, actionType, actionCost, traits, description });
+  }
+
+  return actions.sort(sortActions);
+}
+
+// ---------------------------------------------------------------------------
+// Public projection
+// ---------------------------------------------------------------------------
+
+export function pcActorToDetail(actor: PreparedActor): PlayerActorDetail {
+  return {
+    id: actor.id,
+    name: actor.name,
+    actions: extractActions(actor.items ?? []),
+    spellGroups: extractSpellGroups(actor.items ?? []),
+  };
+}

--- a/apps/dm-tool/electron/ipc/combat.ts
+++ b/apps/dm-tool/electron/ipc/combat.ts
@@ -2,13 +2,21 @@
 // only; players aren't meant to see the stat blocks or HP totals in here.
 
 import { ipcMain } from 'electron';
-import type { Encounter, LootItem, PartyMember, PushEncounterResult } from '@foundry-toolkit/shared/types';
+import type {
+  Encounter,
+  LootItem,
+  PartyMember,
+  PlayerActorDetail,
+  PushEncounterResult,
+} from '@foundry-toolkit/shared/types';
+import type { PreparedActor } from '@foundry-toolkit/shared/foundry-api';
 import { generateEncounterLoot, type LootMonster } from '@foundry-toolkit/ai/loot';
 import type { DmToolConfig } from '../config.js';
 import { deleteEncounter, listEncounters, upsertEncounter } from '@foundry-toolkit/db/pf2e';
 import { getPreparedCompendium } from '../compendium/singleton.js';
 import { tryParseJson } from '../util.js';
 import { pushEncounterActorsToFoundry } from '../encounter-push.js';
+import { pcActorToDetail } from '../compendium/pc-actor.js';
 
 export function registerCombatHandlers(cfg: DmToolConfig): void {
   ipcMain.handle('encountersList', (): Encounter[] => listEncounters());
@@ -79,5 +87,20 @@ export function registerCombatHandlers(cfg: DmToolConfig): void {
       throw new Error(`Party fetch failed: HTTP ${res.status.toString()}`);
     }
     return res.json() as Promise<PartyMember[]>;
+  });
+
+  ipcMain.handle('getPlayerActorDetail', async (_e, actorId: string): Promise<PlayerActorDetail | null> => {
+    if (!cfg.foundryMcpUrl) {
+      console.info('getPlayerActorDetail: foundryMcpUrl not configured', { actorId });
+      return null;
+    }
+    const base = cfg.foundryMcpUrl.replace(/\/$/, '');
+    const res = await fetch(`${base}/api/actors/${encodeURIComponent(actorId)}/prepared`);
+    if (!res.ok) {
+      console.warn('getPlayerActorDetail: fetch failed', { actorId, status: res.status });
+      return null;
+    }
+    const actor = (await res.json()) as PreparedActor;
+    return pcActorToDetail(actor);
   });
 }

--- a/apps/dm-tool/electron/preload.ts
+++ b/apps/dm-tool/electron/preload.ts
@@ -13,6 +13,7 @@ import type {
   Encounter,
   LootItem,
   PartyMember,
+  PlayerActorDetail,
   PushEncounterResult,
   Book,
   BookClassifyProgress,
@@ -183,6 +184,8 @@ const api: ElectronAPI = {
   pushEncounterToFoundry: (encounterId: string): Promise<PushEncounterResult> =>
     ipcRenderer.invoke('pushEncounterToFoundry', encounterId),
   listPartyMembers: (): Promise<PartyMember[]> => ipcRenderer.invoke('listPartyMembers'),
+  getPlayerActorDetail: (actorId: string): Promise<PlayerActorDetail | null> =>
+    ipcRenderer.invoke('getPlayerActorDetail', actorId),
 
   // Auto-Wall
   autoWallAvailable: (): Promise<boolean> => ipcRenderer.invoke('autoWallAvailable'),

--- a/apps/dm-tool/src/features/combat/CombatantStatBlock.tsx
+++ b/apps/dm-tool/src/features/combat/CombatantStatBlock.tsx
@@ -1,7 +1,6 @@
 // Compact stat block pinned to the right of the combat tab. Always renders
 // the current actor — monsters pull their full detail from the DB; PCs show
-// just name + HP (no stat block available). Kept visually close to
-// MonsterDetailPane but without the header bar / close button.
+// their live actions and spells fetched from Foundry.
 
 import { useEffect, useState } from 'react';
 import { ExternalLink, Heart, ShieldAlert } from 'lucide-react';
@@ -10,7 +9,13 @@ import { cn } from '@/lib/utils';
 import { cleanFoundryMarkup } from '@/lib/foundry-markup';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Separator } from '@/components/ui/separator';
-import type { Combatant, MonsterDetail } from '@foundry-toolkit/shared/types';
+import type {
+  Combatant,
+  MonsterDetail,
+  MonsterSpellGroup,
+  PlayerAction,
+  PlayerActorDetail,
+} from '@foundry-toolkit/shared/types';
 
 const RARITY_BADGE: Record<string, string> = {
   common: 'bg-zinc-600 text-zinc-100',
@@ -27,6 +32,8 @@ interface Props {
 export function CombatantStatBlock({ combatant, round }: Props) {
   const [detail, setDetail] = useState<MonsterDetail | null>(null);
   const [loading, setLoading] = useState(false);
+  const [playerDetail, setPlayerDetail] = useState<PlayerActorDetail | null>(null);
+  const [playerLoading, setPlayerLoading] = useState(false);
 
   useEffect(() => {
     if (!combatant || combatant.kind !== 'monster' || !combatant.monsterName) {
@@ -43,6 +50,27 @@ export function CombatantStatBlock({ combatant, round }: Props) {
       .catch((e) => console.error('monstersGetDetail failed:', e))
       .finally(() => {
         if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [combatant]);
+
+  useEffect(() => {
+    if (!combatant || combatant.kind !== 'pc' || !combatant.actorId) {
+      setPlayerDetail(null);
+      return;
+    }
+    let cancelled = false;
+    setPlayerLoading(true);
+    api
+      .getPlayerActorDetail(combatant.actorId)
+      .then((d) => {
+        if (!cancelled) setPlayerDetail(d);
+      })
+      .catch((e) => console.error('getPlayerActorDetail failed:', e))
+      .finally(() => {
+        if (!cancelled) setPlayerLoading(false);
       });
     return () => {
       cancelled = true;
@@ -77,7 +105,7 @@ export function CombatantStatBlock({ combatant, round }: Props) {
       </div>
 
       {combatant.kind === 'pc' ? (
-        <PcBody combatant={combatant} />
+        <PcBody combatant={combatant} detail={playerDetail} loading={playerLoading} />
       ) : loading ? (
         <div className="flex flex-1 items-center justify-center text-xs text-muted-foreground">Loading stat block…</div>
       ) : detail ? (
@@ -128,26 +156,71 @@ function HpBar({ hp, maxHp }: { hp: number; maxHp: number }) {
   );
 }
 
-function PcBody({ combatant }: { combatant: Combatant }) {
+function PcBody({
+  combatant,
+  detail,
+  loading,
+}: {
+  combatant: Combatant;
+  detail: PlayerActorDetail | null;
+  loading: boolean;
+}) {
   return (
-    <div className="flex flex-1 flex-col gap-3 p-4 text-xs text-muted-foreground">
-      <div className="flex items-center gap-2">
-        <ShieldAlert className="h-3.5 w-3.5" />
-        <span>
-          Initiative mod {combatant.initiativeMod >= 0 ? '+' : ''}
-          {combatant.initiativeMod}
-          {combatant.initiative != null && (
-            <>
-              {' · rolled '}
-              <span className="font-medium text-foreground">{combatant.initiative}</span>
-            </>
-          )}
-        </span>
+    <ScrollArea className="min-h-0 flex-1">
+      <div style={{ padding: 12, display: 'flex', flexDirection: 'column', gap: 12 }}>
+        {/* Initiative summary */}
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <ShieldAlert className="h-3.5 w-3.5 shrink-0" />
+          <span>
+            Initiative mod {combatant.initiativeMod >= 0 ? '+' : ''}
+            {combatant.initiativeMod}
+            {combatant.initiative != null && (
+              <>
+                {' · rolled '}
+                <span className="font-medium text-foreground">{combatant.initiative}</span>
+              </>
+            )}
+          </span>
+        </div>
+
+        {/* No Foundry actor linked — manually added PC */}
+        {!combatant.actorId && (
+          <p className="text-[11px] italic text-muted-foreground">
+            Added manually — connect via the party picker for actions and spells.
+          </p>
+        )}
+
+        {/* Loading actor detail */}
+        {combatant.actorId && loading && <p className="text-xs text-muted-foreground">Loading character data…</p>}
+
+        {/* Failed to load */}
+        {combatant.actorId && !loading && !detail && (
+          <p className="text-[11px] italic text-muted-foreground">Could not load character data from Foundry.</p>
+        )}
+
+        {/* Actions */}
+        {detail && detail.actions.length > 0 && (
+          <>
+            <Separator />
+            <section>
+              <SectionLabel>Actions</SectionLabel>
+              <PcActionsSection actions={detail.actions} />
+            </section>
+          </>
+        )}
+
+        {/* Spells */}
+        {detail && detail.spellGroups.length > 0 && (
+          <>
+            <Separator />
+            <section>
+              <SectionLabel>Spells</SectionLabel>
+              <PcSpellsSection groups={detail.spellGroups} />
+            </section>
+          </>
+        )}
       </div>
-      <p className="text-[11px] italic">
-        PCs don&rsquo;t have a stored stat block — consult the player&rsquo;s character sheet.
-      </p>
-    </div>
+    </ScrollArea>
   );
 }
 
@@ -329,6 +402,91 @@ function StatCell({ label, value }: { label: string; value: string }) {
     >
       <span className="text-[9px] font-semibold uppercase text-muted-foreground">{label}</span>
       <span className="mt-0.5 text-xs font-medium tabular-nums">{value}</span>
+    </div>
+  );
+}
+
+/** Map PF2e action-type + cost to Unicode glyphs for the PC action list. */
+const ACTION_GLYPH: Record<string, string> = {
+  '1': '◆',
+  '2': '◆◆',
+  '3': '◆◆◆',
+  reaction: '↺',
+  free: '◇',
+};
+
+function pcActionGlyph(action: PlayerAction): string {
+  if (action.actionType === 'reaction') return '↺';
+  if (action.actionType === 'free') return '◇';
+  return ACTION_GLYPH[String(action.actionCost ?? 1)] ?? '◆';
+}
+
+function PcActionsSection({ actions }: { actions: PlayerAction[] }) {
+  return (
+    <div className="space-y-1 text-xs">
+      {actions.map((a, i) => (
+        <div key={i} className="flex items-baseline gap-1.5">
+          <span className="shrink-0 w-6 text-center text-muted-foreground">{pcActionGlyph(a)}</span>
+          <span className="font-medium text-foreground/90">{a.name}</span>
+          {a.traits.length > 0 && (
+            <span className="text-[10px] text-muted-foreground">({a.traits.slice(0, 3).join(', ')})</span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const CAST_GLYPH: Record<string, string> = {
+  '1': '◆',
+  '2': '◆◆',
+  '3': '◆◆◆',
+  reaction: '↺',
+  free: '◇',
+};
+
+function castGlyph(castTime: string): string {
+  return CAST_GLYPH[castTime] ?? castTime;
+}
+
+function PcSpellsSection({ groups }: { groups: MonsterSpellGroup[] }) {
+  return (
+    <div className="space-y-3 text-xs">
+      {groups.map((group, gi) => {
+        const parts: string[] = [];
+        if (group.tradition) parts.push(group.tradition);
+        if (group.dc) parts.push(`DC ${group.dc.toString()}`);
+        if (group.attack !== undefined) parts.push(`+${group.attack.toString()} attack`);
+        const subtitle = parts.join(' · ');
+
+        return (
+          <div key={gi}>
+            <p className="font-semibold text-foreground/90">
+              {group.entryName}
+              {subtitle && <span className="ml-1 font-normal text-muted-foreground">({subtitle})</span>}
+            </p>
+            <div className="mt-1 space-y-1">
+              {group.ranks.map((rankRow) => {
+                const rankLabel = rankRow.rank === 0 ? 'Cantrips' : `Rank ${rankRow.rank.toString()}`;
+                return (
+                  <div key={rankRow.rank} className="flex flex-wrap items-baseline gap-1 pl-3">
+                    <span className="shrink-0 text-muted-foreground">{rankLabel}:</span>
+                    {rankRow.spells.map((spell, si) => (
+                      <span
+                        key={si}
+                        className="rounded border border-border/60 bg-muted/40 px-1.5 py-0.5 text-[11px] text-foreground/90"
+                      >
+                        {castGlyph(spell.castTime)} {spell.name}
+                        {spell.usesPerDay !== undefined && ` (${spell.usesPerDay.toString()}/day)`}
+                      </span>
+                    ))}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/apps/dm-tool/src/features/combat/InitiativeTracker.tsx
+++ b/apps/dm-tool/src/features/combat/InitiativeTracker.tsx
@@ -131,7 +131,7 @@ export function InitiativeTracker({ encounter, onChange }: Props) {
    *  combatants array — calling this in a loop would lose all but the
    *  last because each call closes over the same stale snapshot. */
   const addPcs = useCallback(
-    (pcs: ReadonlyArray<{ name: string; initiativeMod: number; maxHp: number }>) => {
+    (pcs: ReadonlyArray<{ name: string; initiativeMod: number; maxHp: number; actorId?: string }>) => {
       const newCombatants: Combatant[] = pcs.map((pc) => ({
         id: crypto.randomUUID(),
         kind: 'pc',
@@ -140,6 +140,7 @@ export function InitiativeTracker({ encounter, onChange }: Props) {
         initiative: null,
         hp: pc.maxHp,
         maxHp: pc.maxHp,
+        actorId: pc.actorId,
       }));
       return update({ combatants: [...encounter.combatants, ...newCombatants] });
     },
@@ -536,7 +537,7 @@ function AddMonsterPanel({
   );
 }
 
-type PcInput = { name: string; initiativeMod: number; maxHp: number };
+type PcInput = { name: string; initiativeMod: number; maxHp: number; actorId?: string };
 
 /** Party picker: fetches characters from the PF2e party actor and
  *  presents them as a multi-select list.  Falls back to the manual
@@ -579,6 +580,7 @@ function PartyPickerPanel({
     name: m.name,
     initiativeMod: m.initiativeMod,
     maxHp: m.maxHp,
+    actorId: m.id,
   });
 
   const handleAddSelected = () => {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -344,6 +344,25 @@ export interface MonsterSpellGroup {
   ranks: MonsterSpellRank[];
 }
 
+export interface PlayerAction {
+  name: string;
+  /** "action" | "reaction" | "free" */
+  actionType: string;
+  /** Number of actions (1, 2, 3) — only set when actionType === "action". */
+  actionCost?: number;
+  traits: string[];
+  description: string;
+}
+
+/** Actions and spells for a player character fetched live from Foundry.
+ *  Passive abilities are excluded — only combat-relevant actions. */
+export interface PlayerActorDetail {
+  id: string;
+  name: string;
+  actions: PlayerAction[];
+  spellGroups: MonsterSpellGroup[];
+}
+
 export interface MonsterDetail {
   name: string;
   level: number;
@@ -828,6 +847,10 @@ export interface ElectronAPI {
    *  The folder name defaults to "The Party" and can be overridden by
    *  passing `?folder=` on the HTTP side. */
   listPartyMembers(): Promise<PartyMember[]>;
+  /** Fetch combat-relevant actions and spells for a specific Foundry actor
+   *  (identified by its ID). Returns null when foundryMcpUrl is not
+   *  configured or the actor cannot be reached. */
+  getPlayerActorDetail(actorId: string): Promise<PlayerActorDetail | null>;
 }
 
 // --- Party inventory ---------------------------------------------------------
@@ -920,6 +943,10 @@ export interface Combatant {
   /** Exact monster name from pf2e-db. Only present for kind='monster' — used
    *  to refetch the full stat block on demand. */
   monsterName?: string;
+  /** Foundry actor ID for PC combatants added from the party picker. Used to
+   *  fetch actions and spells from the live Foundry session on demand.
+   *  Absent for PCs added manually (no Foundry actor linked). */
+  actorId?: string;
   /** Rendered name. Auto-numbered ("Goblin 1", "Goblin 2") when multiple of
    *  the same monster are added, but freely editable by the DM. */
   displayName: string;


### PR DESCRIPTION
## Summary

When a PC is added to the combat tracker from the party picker, the right-column detail pane now shows their combat-relevant actions and spells fetched live from Foundry, rather than just \"consult the character sheet\". Manually-added PCs (no Foundry actor ID) get a prompt to use the party picker instead.

## Changes

- **`packages/shared`**: add `PlayerAction` + `PlayerActorDetail` types; add `actorId?` to `Combatant`; add `getPlayerActorDetail` to `ElectronAPI`
- **`electron/compendium/pc-actor.ts`** (new): projects a `PreparedActor` fetched from `/api/actors/:id/prepared` into `PlayerActorDetail` — extracts non-passive actions sorted (reaction → free → 1/2/3-action) and spell groups keyed by spellcasting entry
- **`electron/ipc/combat.ts`**: `getPlayerActorDetail` IPC handler; fetches prepared actor and calls `pcActorToDetail`; returns `null` gracefully when foundryMcpUrl is unset or Foundry is unreachable
- **`electron/preload.ts`**: exposes `getPlayerActorDetail` on the contextBridge
- **`InitiativeTracker`**: `toPcInput` now passes `actorId: m.id` from `PartyMember` through to the new `Combatant.actorId` field
- **`CombatantStatBlock`**: `PcBody` fetches actor detail on mount (cancel-safe), then renders Actions and Spells sections using the same glyph + spell-chip pattern as `MonsterDetailPane`

## Test plan

- [ ] 12 Vitest cases in `pc-actor.test.ts` cover: id/name mapping, 1/2/3-action extraction, reaction, free action, passive exclusion, sort order, non-action item types, prepared spell entries, orphaned spells, innate spells with uses/day, empty entries
- [ ] `npm run typecheck -w apps/dm-tool` passes (both tsconfig.node + tsconfig.web)
- [ ] Add a PC from the party picker → combat detail pane shows Actions + Spells sections
- [ ] Add a PC manually → pane shows initiative mod + "connect via party picker" note
- [ ] Switch turns between monsters and PCs → each re-fetches its own data correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)