### PR TITLE
feat(dm-tool): update combat tracker when a player rolls initiative

### DIFF
--- a/apps/dm-tool/electron/foundry-events.ts
+++ b/apps/dm-tool/electron/foundry-events.ts
@@ -1,0 +1,79 @@
+// Subscribes to foundry-mcp's `combat` SSE channel and forwards
+// `combatant-update` events (initiative changes) to the renderer window
+// via IPC. Reconnects automatically on disconnect.
+
+import type { BrowserWindow } from 'electron';
+import type { CombatantInitiativeEvent } from '@foundry-toolkit/shared/types';
+
+const RECONNECT_DELAY_MS = 3000;
+
+async function consumeCombatStream(url: string, getMainWindow: () => BrowserWindow | null): Promise<void> {
+  const res = await fetch(url);
+  if (!res.ok || !res.body) {
+    console.warn(`foundry-events: combat stream HTTP ${res.status.toString()}`);
+    return;
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buf = '';
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+    const lines = buf.split('\n');
+    buf = lines.pop() ?? '';
+    for (const line of lines) {
+      if (!line.startsWith('data: ')) continue;
+      const json = line.slice(6).trim();
+      if (!json) continue;
+      try {
+        const event = JSON.parse(json) as Record<string, unknown>;
+        if (event['eventType'] !== 'combatant-update') continue;
+        const cb = event['combatant'] as Record<string, unknown> | undefined;
+        if (
+          typeof event['encounterId'] === 'string' &&
+          cb &&
+          typeof cb['actorId'] === 'string' &&
+          typeof cb['initiative'] === 'number'
+        ) {
+          const update: CombatantInitiativeEvent = {
+            encounterId: event['encounterId'],
+            actorId: cb['actorId'],
+            initiative: cb['initiative'],
+          };
+          const win = getMainWindow();
+          if (win && !win.isDestroyed()) {
+            win.webContents.send('combatant-initiative-update', update);
+            console.info(
+              `foundry-events: initiative update — actorId=${update.actorId} value=${update.initiative.toString()}`,
+            );
+          }
+        }
+      } catch {
+        // malformed JSON line — skip
+      }
+    }
+  }
+}
+
+/** Start a background loop that consumes the foundry-mcp combat SSE channel
+ *  and pushes initiative-change events to the main window via IPC.
+ *  Reconnects automatically on error or clean close. Fire-and-forget. */
+export function startCombatEventStream(foundryMcpUrl: string, getMainWindow: () => BrowserWindow | null): void {
+  const url = `${foundryMcpUrl.replace(/\/$/, '')}/api/events/combat/stream`;
+
+  const loop = async (): Promise<void> => {
+    while (true) {
+      try {
+        await consumeCombatStream(url, getMainWindow);
+      } catch (err) {
+        console.debug('foundry-events: combat stream disconnected:', (err as Error).message);
+      }
+      await new Promise<void>((resolve) => setTimeout(resolve, RECONNECT_DELAY_MS));
+    }
+  };
+
+  void loop();
+}

--- a/apps/dm-tool/electron/ipc/combat.ts
+++ b/apps/dm-tool/electron/ipc/combat.ts
@@ -15,8 +15,9 @@ import { deleteEncounter, listEncounters, upsertEncounter } from '@foundry-toolk
 import { getPreparedCompendium } from '../compendium/singleton.js';
 import { tryParseJson } from '../util.js';
 import { pushEncounterActorsToFoundry } from '../encounter-push.js';
+import { startCombatEventStream } from '../foundry-events.js';
 
-export function registerCombatHandlers(cfg: DmToolConfig): void {
+export function registerCombatHandlers(cfg: DmToolConfig, getMainWindow: () => Electron.BrowserWindow | null): void {
   ipcMain.handle('encountersList', (): Encounter[] => listEncounters());
   ipcMain.handle('encountersUpsert', (_e, enc: Encounter): void => upsertEncounter(enc));
   ipcMain.handle('encountersDelete', (_e, id: string): void => deleteEncounter(id));
@@ -126,4 +127,9 @@ export function registerCombatHandlers(cfg: DmToolConfig): void {
     }
     console.info(`pushActorHp: pushed hp=${hp.toString()} for ${actorId}`);
   });
+
+  if (cfg.foundryMcpUrl) {
+    startCombatEventStream(cfg.foundryMcpUrl, getMainWindow);
+    console.info('foundry-events: started combat SSE stream');
+  }
 }

--- a/apps/dm-tool/electron/ipc/index.ts
+++ b/apps/dm-tool/electron/ipc/index.ts
@@ -44,5 +44,5 @@ export function registerIpcHandlers(
   registerGlobeHandlers(cfg, getMainWindow);
   registerInventoryHandlers(cfg);
   registerAurusHandlers(cfg);
-  registerCombatHandlers(cfg);
+  registerCombatHandlers(cfg, getMainWindow);
 }

--- a/apps/dm-tool/electron/preload.ts
+++ b/apps/dm-tool/electron/preload.ts
@@ -12,6 +12,7 @@ import type {
   ActorUpdate,
   AonPreviewData,
   AurusTeam,
+  CombatantInitiativeEvent,
   Encounter,
   LootItem,
   PartyMember,
@@ -194,6 +195,11 @@ const api: ElectronAPI = {
   listPartyMembers: (): Promise<PartyMember[]> => ipcRenderer.invoke('listPartyMembers'),
   getActorSpellcasting: (actorId: string): Promise<ActorSpellcasting | null> =>
     ipcRenderer.invoke('getActorSpellcasting', actorId),
+  onCombatantInitiativeUpdate: (callback: (event: CombatantInitiativeEvent) => void): (() => void) => {
+    const handler = (_event: unknown, update: CombatantInitiativeEvent) => callback(update);
+    ipcRenderer.on('combatant-initiative-update', handler);
+    return () => ipcRenderer.removeListener('combatant-initiative-update', handler);
+  },
 
   // Auto-Wall
   autoWallAvailable: (): Promise<boolean> => ipcRenderer.invoke('autoWallAvailable'),

--- a/apps/dm-tool/src/features/combat/CombatTab.tsx
+++ b/apps/dm-tool/src/features/combat/CombatTab.tsx
@@ -15,7 +15,7 @@ import { EncounterList } from './EncounterList';
 import { InitiativeTracker } from './InitiativeTracker';
 import { CombatantStatBlock } from './CombatantStatBlock';
 import { LootPanel } from './LootPanel';
-import { sortedCombatants } from './util';
+import { applyFoundryInitiativeUpdate, sortedCombatants } from './util';
 import { useFoundryHpSync } from './useFoundryHpSync';
 
 interface CombatTabProps {
@@ -40,6 +40,30 @@ export function CombatTab({ partyLevel, anthropicApiKey }: CombatTabProps) {
       .catch((e) => console.error('encountersList failed:', e))
       .finally(() => setLoading(false));
   }, [refresh]);
+
+  // Subscribe to Foundry initiative-change events pushed from the main
+  // process. When a combatant's initiative is updated in Foundry (e.g. a
+  // player rolls initiative), find the matching combatant by foundryActorId,
+  // stamp the new value, and persist to SQLite — no manual refresh needed.
+  useEffect(() => {
+    return api.onCombatantInitiativeUpdate((event) => {
+      setEncounters((prev) => {
+        const next = applyFoundryInitiativeUpdate(prev, event.actorId, event.initiative);
+        if (next === prev) return prev;
+        for (const enc of next) {
+          const orig = prev.find((e) => e.id === enc.id);
+          if (orig !== enc) {
+            void api
+              .encountersUpsert(enc)
+              .catch((e) =>
+                console.error(`encountersUpsert failed after initiative update for actor ${event.actorId}:`, e),
+              );
+          }
+        }
+        return next;
+      });
+    });
+  }, []);
 
   const saveEncounter = useCallback(
     async (next: Encounter): Promise<void> => {

--- a/apps/dm-tool/src/features/combat/InitiativeTracker.tsx
+++ b/apps/dm-tool/src/features/combat/InitiativeTracker.tsx
@@ -135,15 +135,7 @@ export function InitiativeTracker({ encounter, onChange }: Props) {
    *  foundryActorId, then displayName) so a UI bug or double-click can't
    *  add a duplicate. */
   const addPcs = useCallback(
-    (
-      pcs: ReadonlyArray<{
-        name: string;
-        initiativeMod: number;
-        hp?: number;
-        maxHp: number;
-        foundryActorId?: string;
-      }>,
-    ) => {
+    (pcs: ReadonlyArray<PcInput>) => {
       const fresh = pcs.filter(
         (pc) => !isAlreadyInEncounter(encounter.combatants, { id: pc.foundryActorId ?? '', name: pc.name }),
       );
@@ -156,7 +148,7 @@ export function InitiativeTracker({ encounter, onChange }: Props) {
         initiative: null,
         hp: pc.hp ?? pc.maxHp,
         maxHp: pc.maxHp,
-        ...(pc.foundryActorId !== undefined ? { foundryActorId: pc.foundryActorId } : {}),
+        foundryActorId: pc.foundryActorId,
       }));
       return update({ combatants: [...encounter.combatants, ...newCombatants] });
     },

--- a/apps/dm-tool/src/features/combat/util.test.ts
+++ b/apps/dm-tool/src/features/combat/util.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import { applyFoundryInitiativeUpdate, sortedCombatants } from './util';
+import type { Combatant, Encounter } from '@foundry-toolkit/shared/types';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeCombatant(overrides: Partial<Combatant> & { id: string }): Combatant {
+  return {
+    kind: 'pc',
+    displayName: 'Test PC',
+    initiativeMod: 0,
+    initiative: null,
+    hp: 20,
+    maxHp: 20,
+    ...overrides,
+  };
+}
+
+function makeEncounter(overrides: Partial<Encounter> & { id: string }): Encounter {
+  return {
+    name: 'Test Encounter',
+    combatants: [],
+    turnIndex: 0,
+    round: 1,
+    loot: [],
+    allowInventedItems: false,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+// ─── sortedCombatants ─────────────────────────────────────────────────────────
+
+describe('sortedCombatants', () => {
+  it('sorts by initiative descending', () => {
+    const combatants = [
+      makeCombatant({ id: 'a', initiative: 10 }),
+      makeCombatant({ id: 'b', initiative: 20 }),
+      makeCombatant({ id: 'c', initiative: 5 }),
+    ];
+    const sorted = sortedCombatants(combatants);
+    expect(sorted.map((c) => c.id)).toEqual(['b', 'a', 'c']);
+  });
+
+  it('places unrolled combatants (null initiative) at the end', () => {
+    const combatants = [makeCombatant({ id: 'a', initiative: null }), makeCombatant({ id: 'b', initiative: 15 })];
+    const sorted = sortedCombatants(combatants);
+    expect(sorted[0].id).toBe('b');
+    expect(sorted[1].id).toBe('a');
+  });
+
+  it('breaks ties by initiativeMod descending', () => {
+    const combatants = [
+      makeCombatant({ id: 'a', initiative: 15, initiativeMod: 2 }),
+      makeCombatant({ id: 'b', initiative: 15, initiativeMod: 5 }),
+    ];
+    const sorted = sortedCombatants(combatants);
+    expect(sorted[0].id).toBe('b');
+  });
+
+  it('does not mutate the original array', () => {
+    const combatants = [makeCombatant({ id: 'a', initiative: 5 }), makeCombatant({ id: 'b', initiative: 20 })];
+    const original = [...combatants];
+    sortedCombatants(combatants);
+    expect(combatants[0].id).toBe(original[0].id);
+  });
+});
+
+// ─── applyFoundryInitiativeUpdate ────────────────────────────────────────────
+
+describe('applyFoundryInitiativeUpdate', () => {
+  it('updates initiative for a combatant matching foundryActorId', () => {
+    const enc = makeEncounter({
+      id: 'enc-1',
+      combatants: [
+        makeCombatant({ id: 'c1', foundryActorId: 'actor-xyz', initiative: null }),
+        makeCombatant({ id: 'c2', foundryActorId: 'actor-abc', initiative: null }),
+      ],
+    });
+
+    const result = applyFoundryInitiativeUpdate([enc], 'actor-xyz', 18);
+
+    expect(result[0].combatants.find((c) => c.id === 'c1')?.initiative).toBe(18);
+    expect(result[0].combatants.find((c) => c.id === 'c2')?.initiative).toBeNull();
+  });
+
+  it('stamps updatedAt on changed encounters', () => {
+    const enc = makeEncounter({
+      id: 'enc-1',
+      combatants: [makeCombatant({ id: 'c1', foundryActorId: 'actor-xyz', initiative: null })],
+    });
+    const before = enc.updatedAt;
+
+    const result = applyFoundryInitiativeUpdate([enc], 'actor-xyz', 12);
+
+    expect(result[0].updatedAt).not.toBe(before);
+  });
+
+  it('returns the same array reference when no combatant matches', () => {
+    const enc = makeEncounter({
+      id: 'enc-1',
+      combatants: [makeCombatant({ id: 'c1', foundryActorId: 'actor-xyz' })],
+    });
+    const encounters = [enc];
+
+    const result = applyFoundryInitiativeUpdate(encounters, 'actor-unknown', 10);
+
+    expect(result).toBe(encounters);
+  });
+
+  it('does not touch encounters that have no matching combatant', () => {
+    const enc1 = makeEncounter({
+      id: 'enc-1',
+      combatants: [makeCombatant({ id: 'c1', foundryActorId: 'actor-xyz' })],
+    });
+    const enc2 = makeEncounter({
+      id: 'enc-2',
+      combatants: [makeCombatant({ id: 'c2', foundryActorId: 'actor-abc' })],
+    });
+
+    const result = applyFoundryInitiativeUpdate([enc1, enc2], 'actor-xyz', 14);
+
+    expect(result[0]).not.toBe(enc1);
+    expect(result[1]).toBe(enc2);
+  });
+
+  it('causes the tracker to re-sort when initiative updates', () => {
+    // Verifies that sortedCombatants re-orders after applyFoundryInitiativeUpdate.
+    const enc = makeEncounter({
+      id: 'enc-1',
+      combatants: [
+        makeCombatant({ id: 'monster', kind: 'monster', displayName: 'Goblin', initiative: 8, initiativeMod: 2 }),
+        makeCombatant({ id: 'pc', kind: 'pc', displayName: 'Serafine', foundryActorId: 'actor-pc', initiative: null }),
+      ],
+    });
+
+    // Before: monster goes first (only one with a roll), PC is unrolled
+    const beforeOrder = sortedCombatants(enc.combatants);
+    expect(beforeOrder[0].id).toBe('monster');
+    expect(beforeOrder[1].id).toBe('pc');
+
+    // Player rolls initiative 20 in Foundry → event arrives
+    const [updated] = applyFoundryInitiativeUpdate([enc], 'actor-pc', 20);
+    const afterOrder = sortedCombatants(updated.combatants);
+
+    // After: PC with 20 should be first, monster with 8 second
+    expect(afterOrder[0].id).toBe('pc');
+    expect(afterOrder[0].initiative).toBe(20);
+    expect(afterOrder[1].id).toBe('monster');
+  });
+});

--- a/apps/dm-tool/src/features/combat/util.ts
+++ b/apps/dm-tool/src/features/combat/util.ts
@@ -1,4 +1,4 @@
-import type { Combatant } from '@foundry-toolkit/shared/types';
+import type { Combatant, Encounter } from '@foundry-toolkit/shared/types';
 
 /** Sort combatants by initiative descending, tiebreaking on initiativeMod
  *  (PF2e houserules vary — mod is a reasonable default). Unrolled combatants
@@ -45,4 +45,29 @@ export function reserveMonsterName(combatants: Combatant[], baseName: string): {
 
 function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Apply a Foundry `updateCombatant` initiative-change event to a list of
+ *  encounters.  Finds every combatant whose `foundryActorId` matches and
+ *  stamps the new initiative value.  Returns the same array reference when
+ *  nothing matched — callers can identity-check to skip unnecessary re-renders
+ *  or persistence writes. */
+export function applyFoundryInitiativeUpdate(
+  encounters: Encounter[],
+  actorId: string,
+  initiative: number,
+): Encounter[] {
+  let changed = false;
+  const now = new Date().toISOString();
+  const next = encounters.map((enc) => {
+    const hasMatch = enc.combatants.some((c) => c.foundryActorId === actorId);
+    if (!hasMatch) return enc;
+    changed = true;
+    return {
+      ...enc,
+      combatants: enc.combatants.map((c) => (c.foundryActorId === actorId ? { ...c, initiative } : c)),
+      updatedAt: now,
+    };
+  });
+  return changed ? next : encounters;
 }

--- a/apps/foundry-api-bridge/src/events/EventChannelController.ts
+++ b/apps/foundry-api-bridge/src/events/EventChannelController.ts
@@ -61,6 +61,16 @@ interface CombatantWithParent extends CombatantForEvent {
   combat: { id: string } | null;
 }
 
+// Used for updateCombatant — includes actorId so dm-tool can match
+// the Foundry combatant back to its local Combatant by foundryActorId.
+interface CombatantUpdateForEvent {
+  id: string;
+  actorId: string;
+  initiative: number | null;
+  defeated: boolean;
+  combat: { id: string } | null;
+}
+
 interface CombatForEvent {
   id: string;
   round: number;
@@ -226,6 +236,25 @@ export class EventChannelController {
             this.publisher.pushEvent('combat', { eventType: 'end', encounterId: raw.id });
           }),
         );
+        handles.push(
+          this.reg('updateCombatant', (...args: unknown[]) => {
+            const [rawCombatant, rawChanges] = args;
+            if (!isCombatantUpdateForEvent(rawCombatant) || !rawCombatant.combat) return;
+            // Only push when initiative was explicitly set (not cleared to null).
+            const changes = rawChanges as Record<string, unknown>;
+            if (typeof changes['initiative'] !== 'number') return;
+            this.publisher.pushEvent('combat', {
+              eventType: 'combatant-update',
+              encounterId: rawCombatant.combat.id,
+              combatant: {
+                id: rawCombatant.id,
+                actorId: rawCombatant.actorId,
+                initiative: rawCombatant.initiative,
+                defeated: rawCombatant.defeated,
+              },
+            });
+          }),
+        );
         break;
       }
     }
@@ -384,6 +413,17 @@ function isCombatantWithParent(value: unknown): value is CombatantWithParent {
   // `combat` may be null for a combatant mid-creation; the caller
   // checks before pushing.
   return true;
+}
+
+function isCombatantUpdateForEvent(value: unknown): value is CombatantUpdateForEvent {
+  if (typeof value !== 'object' || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj['id'] === 'string' &&
+    typeof obj['actorId'] === 'string' &&
+    (typeof obj['initiative'] === 'number' || obj['initiative'] === null) &&
+    typeof obj['defeated'] === 'boolean'
+  );
 }
 
 function isFoundryActorForEvent(value: unknown): value is FoundryActorForEvent {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -816,6 +816,10 @@ export interface ElectronAPI {
   encountersList(): Promise<Encounter[]>;
   encountersUpsert(encounter: Encounter): Promise<void>;
   encountersDelete(id: string): Promise<void>;
+  /** Subscribe to live initiative updates pushed from Foundry via the
+   *  combat SSE channel. Fires when a combatant's initiative changes in
+   *  Foundry (e.g. a player rolls initiative). Returns an unsubscribe fn. */
+  onCombatantInitiativeUpdate(callback: (event: CombatantInitiativeEvent) => void): () => void;
   /** Generate loot for an encounter via Anthropic. Returns the new loot
    *  list; the renderer is responsible for persisting it onto the
    *  encounter via encountersUpsert. */
@@ -957,8 +961,10 @@ export interface Combatant {
   notes?: string;
   /** Foundry actor document id. Set only when the PC was added from the party
    *  picker (where we have the live actor id). Absent for manually-entered PCs
-   *  and monsters. Required by the spell cast + slot display features and the
-   *  live HP sync via the `actors` SSE channel. */
+   *  and monsters. Required by the spell cast + slot display features, the
+   *  live HP sync via the `actors` SSE channel, and to match incoming
+   *  `updateCombatant` SSE events so the tracker updates automatically when
+   *  a player rolls initiative in Foundry. */
   foundryActorId?: string;
 }
 
@@ -971,6 +977,18 @@ export interface ActorUpdate {
   actorId: string;
   changedPaths: string[];
   system: Record<string, unknown>;
+}
+
+/** Payload pushed over IPC when Foundry fires an updateCombatant hook that
+ *  sets a new initiative value. The dm-tool main process subscribes to the
+ *  foundry-mcp `combat` SSE channel and forwards these to the renderer. */
+export interface CombatantInitiativeEvent {
+  /** Foundry combat encounter id (for debugging/logging). */
+  encounterId: string;
+  /** Foundry actor id — matches `Combatant.foundryActorId`. */
+  actorId: string;
+  /** The newly-rolled initiative total. */
+  initiative: number;
 }
 
 /** One monster combatant successfully turned into a Foundry actor. */


### PR DESCRIPTION
## Summary

Subscribes the dm-tool main process to the foundry-mcp `combat` SSE channel so the initiative tracker updates automatically when a player rolls initiative in Foundry — no manual refresh. When Foundry fires `updateCombatant` with a new initiative value, the event travels: Foundry hook → foundry-mcp SSE → dm-tool main process → IPC → React state → re-sorted combatant list → SQLite persist.

## Changes

- **`EventChannelController`** (`foundry-api-bridge`) — adds `updateCombatant` hook to the `combat` channel; only fires when `initiative` is a number in the change diff (ignores non-initiative updates and null clears)
- **`Combatant` type** (`shared`) — adds optional `foundryActorId` so PCs added via the party picker carry the Foundry actor id for event matching
- **`ElectronAPI`** (`shared`) — adds `onCombatantInitiativeUpdate` subscription method and `CombatantInitiativeEvent` type
- **`foundry-events.ts`** (`dm-tool`) — new SSE consumer with 3 s auto-reconnect; intentionally generic so the companion HP-tracking PR can reuse the same pattern without a second channel
- **`IPC / preload`** — wires the new push event through the contextBridge
- **`InitiativeTracker`** — `PartyPickerPanel` now passes `foundryActorId: m.id` when constructing PC combatants from the party roster
- **`CombatTab`** — subscribes to initiative-update events; applies `applyFoundryInitiativeUpdate` to state, then persists changed encounters to SQLite fire-and-forget
- **`util.ts`** — extracts `applyFoundryInitiativeUpdate` as a pure function; tested independently

## How it composes with `feat/combat-track-player-hp`

The HP-tracking PR needs actor-update events, not combatant-update events. It can either:
- Subscribe to the existing `actors` channel (`updateActor` hook, already implemented) using the same `foundry-events.ts` SSE consumer pattern — just add a second `startXxxEventStream` call with the `actors` channel URL; or
- Reuse this PR's `foundryActorId` field on `Combatant` (already there) to match actor events back to combatants.

Whichever shape HP tracking lands in, `foundryActorId` and the SSE plumbing are already in place.

## Test plan

- [ ] Add PCs from the party picker; confirm combatants now carry a `foundryActorId` (check SQLite / devtools state)
- [ ] Roll initiative for a PC in Foundry's combat tracker — dm-tool should re-sort without refresh
- [ ] Kill foundry-mcp and restart — stream should reconnect within ~3 s
- [ ] Manually-added PCs (no `foundryActorId`) are unaffected by Foundry events
- [ ] `npm run test -w apps/dm-tool` — 9 new tests for `applyFoundryInitiativeUpdate` and `sortedCombatants`