### PR TITLE
fix(player-portal): bucket archetype feats separately from class feats

### DIFF
--- a/apps/player-portal/src/components/tabs/Feats.test.tsx
+++ b/apps/player-portal/src/components/tabs/Feats.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { render, cleanup } from '@testing-library/react';
 import amiri from '../../fixtures/amiri-prepared.json';
-import type { PreparedActorItem } from '../../api/types';
+import type { FeatItem, PreparedActorItem } from '../../api/types';
 import { Feats } from './Feats';
+import { resolveFeatCategory } from '../../lib/pf2e-maps';
 
 // Amiri's expected feats grouped by category, from the live fixture.
 // Shape: { category: [featName, featName, ...] }
@@ -76,5 +77,62 @@ describe('Feats tab', () => {
     }
     // PFS Boons stays hidden when empty.
     expect(container.querySelector('[data-feat-category="pfsboon"]')).toBeNull();
+    // Archetype stays hidden when empty (not a canonical always-show category).
+    expect(container.querySelector('[data-feat-category="archetype"]')).toBeNull();
+  });
+
+  it('routes an archetype feat to its own section, not Class Feats', () => {
+    const archetypeFeat: FeatItem = makeFeat({ category: 'class', traits: ['archetype'], name: 'Crafter Dedication' });
+    const classFeat: FeatItem = makeFeat({ category: 'class', traits: [], name: 'Power Attack' });
+    const { container } = render(<Feats items={[archetypeFeat, classFeat]} />);
+
+    const archetypeSection = container.querySelector('[data-feat-category="archetype"]');
+    expect(archetypeSection, 'archetype section exists').toBeTruthy();
+    expect(archetypeSection?.textContent).toContain('Crafter Dedication');
+    expect(archetypeSection?.textContent).not.toContain('Power Attack');
+
+    const classSection = container.querySelector('[data-feat-category="class"]');
+    expect(classSection?.textContent).toContain('Power Attack');
+    expect(classSection?.textContent).not.toContain('Crafter Dedication');
+  });
+});
+
+// ─── resolveFeatCategory predicate ─────────────────────────────────────
+
+function makeFeat({ category, traits, name }: { category: string; traits: string[]; name?: string }): FeatItem {
+  return {
+    id: name ?? category,
+    name: name ?? category,
+    type: 'feat',
+    img: '',
+    system: {
+      slug: null,
+      level: { value: 1 },
+      category,
+      traits: { value: traits, rarity: 'common' },
+      description: { value: '' },
+    },
+  };
+}
+
+describe('resolveFeatCategory', () => {
+  it('routes a pure class feat to "class"', () => {
+    expect(resolveFeatCategory(makeFeat({ category: 'class', traits: ['fighter'] }))).toBe('class');
+  });
+
+  it('routes an archetype feat (category: class, trait: archetype) to "archetype"', () => {
+    expect(resolveFeatCategory(makeFeat({ category: 'class', traits: ['archetype', 'dedication'] }))).toBe('archetype');
+  });
+
+  it('routes an ancestry feat to "ancestry"', () => {
+    expect(resolveFeatCategory(makeFeat({ category: 'ancestry', traits: ['human'] }))).toBe('ancestry');
+  });
+
+  it('routes a general feat to "general"', () => {
+    expect(resolveFeatCategory(makeFeat({ category: 'general', traits: ['general'] }))).toBe('general');
+  });
+
+  it('routes a skill feat to "skill"', () => {
+    expect(resolveFeatCategory(makeFeat({ category: 'skill', traits: ['skill', 'acrobatics'] }))).toBe('skill');
   });
 });

--- a/apps/player-portal/src/components/tabs/Feats.tsx
+++ b/apps/player-portal/src/components/tabs/Feats.tsx
@@ -1,7 +1,7 @@
 import type { FeatCategory, FeatItem, PreparedActorItem } from '../../api/types';
 import { isFeatItem } from '../../api/types';
 import { enrichDescription } from '../../lib/foundry-enrichers';
-import { FEAT_CATEGORY_LABEL, FEAT_CATEGORY_ORDER } from '../../lib/pf2e-maps';
+import { FEAT_CATEGORY_LABEL, FEAT_CATEGORY_ORDER, resolveFeatCategory } from '../../lib/pf2e-maps';
 import { useUuidHover } from '../../lib/useUuidHover';
 import { SectionHeader } from '../common/SectionHeader';
 
@@ -132,9 +132,10 @@ function TraitChips({ traits }: { traits: string[] }): React.ReactElement {
 function groupByCategory(feats: FeatItem[]): Map<string, FeatItem[]> {
   const out = new Map<string, FeatItem[]>();
   for (const feat of feats) {
-    const arr = out.get(feat.system.category) ?? [];
+    const key = resolveFeatCategory(feat);
+    const arr = out.get(key) ?? [];
     arr.push(feat);
-    out.set(feat.system.category, arr);
+    out.set(key, arr);
   }
   // Sort within each group by level asc, then name.
   for (const [, arr] of out) {

--- a/apps/player-portal/src/lib/pf2e-maps.ts
+++ b/apps/player-portal/src/lib/pf2e-maps.ts
@@ -1,4 +1,4 @@
-import type { FeatCategory, ProficiencyRank } from '../api/types';
+import type { FeatCategory, FeatItem, ProficiencyRank } from '../api/types';
 
 // PF2e proficiency-rank labels and palette.
 // Labels match the en.json `PF2E.ProficiencyLevel{0..4}` keys; we duplicate
@@ -63,6 +63,7 @@ export const DEFENSE_LABEL_KEY: Record<string, string> = {
 export const FEAT_CATEGORY_ORDER: readonly FeatCategory[] = [
   'ancestry',
   'class',
+  'archetype',
   'classfeature',
   'skill',
   'general',
@@ -73,9 +74,18 @@ export const FEAT_CATEGORY_ORDER: readonly FeatCategory[] = [
 export const FEAT_CATEGORY_LABEL: Record<string, string> = {
   ancestry: 'Ancestry Feats',
   class: 'Class Feats',
+  archetype: 'Archetype Feats',
   classfeature: 'Class Features',
   skill: 'Skill Feats',
   general: 'General Feats',
   bonus: 'Bonus Feats',
   pfsboon: 'PFS Boons',
 };
+
+// Archetype feats carry `category: 'class'` in the PF2e system but also
+// have the `archetype` trait. Check the trait first so they land in their
+// own section rather than being lumped with class feats.
+export function resolveFeatCategory(feat: FeatItem): string {
+  if (feat.system.traits.value.includes('archetype')) return 'archetype';
+  return feat.system.category;
+}


### PR DESCRIPTION
## Summary

Archetype feats in PF2e carry `system.category: 'class'` but also have the `archetype` trait in `system.traits.value`. Previously, `groupByCategory` bucketed purely by `system.category`, so archetype feats appeared under "Class Feats". They now land in a dedicated "Archetype Feats" section rendered between Class Feats and Class Features.

## Changes

- `pf2e-maps.ts`: add `resolveFeatCategory(feat)` — checks `archetype` trait before falling through to `system.category`; add `'archetype'` to `FEAT_CATEGORY_ORDER` (after `'class'`) and `FEAT_CATEGORY_LABEL`
- `Feats.tsx`: `groupByCategory` now calls `resolveFeatCategory` instead of reading `system.category` directly
- `Feats.test.tsx`: add `resolveFeatCategory` predicate matrix (pure class, archetype, ancestry, general, skill) and a render test confirming archetype feats appear in their own section

## Test plan

- [ ] `npm run test -w apps/player-portal` — 258 tests pass
- [ ] Open Jackstone Mannlyn's character sheet in player-portal; archetype feats should appear under "Archetype Feats", not "Class Feats"