### PR TITLE
fix(player-portal): handle any-skill and any-of-list feat prereqs

### DIFF
--- a/apps/player-portal/src/prereqs/character-context.ts
+++ b/apps/player-portal/src/prereqs/character-context.ts
@@ -8,8 +8,13 @@ export function fromPreparedCharacter(actor: PreparedCharacter): CharacterContex
   const sys = actor.system;
 
   const skillRanks = new Map<string, ProficiencyRank>();
+  const loreSkillSlugs = new Set<string>();
   for (const [slug, stat] of Object.entries(sys.skills)) {
-    skillRanks.set(slug.toLowerCase(), stat.rank);
+    // Normalise hyphens → spaces so prereq strings ("Herbalism Lore") match
+    // lore slugs stored by pf2e as "herbalism-lore".
+    const key = slug.toLowerCase().replace(/-/g, ' ');
+    skillRanks.set(key, stat.rank);
+    if (stat.lore) loreSkillSlugs.add(key);
   }
   // Perception is a separate stat in pf2e (not in sys.skills) but is used in
   // prereqs like "master in Perception".
@@ -46,6 +51,7 @@ export function fromPreparedCharacter(actor: PreparedCharacter): CharacterContex
     skillRanks,
     abilityMods,
     features,
+    loreSkillSlugs,
   };
   const classSlug = (classItem?.system as { slug?: string } | undefined)?.slug;
   if (classSlug !== undefined) ctx.classTrait = classSlug;

--- a/apps/player-portal/src/prereqs/character-context.ts
+++ b/apps/player-portal/src/prereqs/character-context.ts
@@ -11,6 +11,9 @@ export function fromPreparedCharacter(actor: PreparedCharacter): CharacterContex
   for (const [slug, stat] of Object.entries(sys.skills)) {
     skillRanks.set(slug.toLowerCase(), stat.rank);
   }
+  // Perception is a separate stat in pf2e (not in sys.skills) but is used in
+  // prereqs like "master in Perception".
+  skillRanks.set('perception', sys.perception.rank);
 
   const abilityMods: Record<AbilityKey, number> = {
     str: sys.abilities.str.mod,

--- a/apps/player-portal/src/prereqs/evaluator.ts
+++ b/apps/player-portal/src/prereqs/evaluator.ts
@@ -11,6 +11,22 @@ export function evaluatePredicate(pred: Predicate, ctx: CharacterContext): Evalu
       if (rank === undefined) return 'unknown';
       return rank >= pred.min ? 'meets' : 'fails';
     }
+    case 'skill-rank-any': {
+      if (ctx.skillRanks.size === 0) return 'unknown';
+      for (const rank of ctx.skillRanks.values()) {
+        if (rank >= pred.min) return 'meets';
+      }
+      return 'fails';
+    }
+    case 'skill-rank-any-of': {
+      let anyUnknown = false;
+      for (const skill of pred.skills) {
+        const rank = ctx.skillRanks.get(skill.toLowerCase());
+        if (rank === undefined) { anyUnknown = true; continue; }
+        if (rank >= pred.min) return 'meets';
+      }
+      return anyUnknown ? 'unknown' : 'fails';
+    }
     case 'level':
       return ctx.level >= pred.min ? 'meets' : 'fails';
     case 'ability': {

--- a/apps/player-portal/src/prereqs/evaluator.ts
+++ b/apps/player-portal/src/prereqs/evaluator.ts
@@ -1,5 +1,20 @@
 import type { CharacterContext, Evaluation, Predicate } from './types';
 
+// True when the normalised skill key follows the lore pattern ("<topic> lore").
+// Used to distinguish lore skills from standard ones when looking up absent keys.
+const isLoreKey = (s: string): boolean => s.endsWith(' lore');
+
+// Resolves the rank for a skill, treating absent lore skills as rank-0 misses
+// when we have definitive lore data (ctx.loreSkillSlugs is a real Set).
+// Returns undefined only when rank is genuinely unknown.
+function resolveRank(ctx: CharacterContext, skill: string): number | undefined {
+  const rank = ctx.skillRanks.get(skill);
+  if (rank !== undefined) return rank;
+  // Absent lore skill + complete lore data → rank 0 (character doesn't have it)
+  if (isLoreKey(skill) && ctx.loreSkillSlugs !== undefined) return 0;
+  return undefined;
+}
+
 // Evaluates a single predicate against the character context. Returns
 // `unknown` for cases we intentionally don't enforce yet (unsupported
 // patterns, feat-name lookups, etc.) so the filter UI can still let the
@@ -7,7 +22,7 @@ import type { CharacterContext, Evaluation, Predicate } from './types';
 export function evaluatePredicate(pred: Predicate, ctx: CharacterContext): Evaluation {
   switch (pred.kind) {
     case 'skill-rank': {
-      const rank = ctx.skillRanks.get(pred.skill.toLowerCase());
+      const rank = resolveRank(ctx, pred.skill.toLowerCase());
       if (rank === undefined) return 'unknown';
       return rank >= pred.min ? 'meets' : 'fails';
     }
@@ -21,7 +36,7 @@ export function evaluatePredicate(pred: Predicate, ctx: CharacterContext): Evalu
     case 'skill-rank-any-of': {
       let anyUnknown = false;
       for (const skill of pred.skills) {
-        const rank = ctx.skillRanks.get(skill.toLowerCase());
+        const rank = resolveRank(ctx, skill.toLowerCase());
         if (rank === undefined) { anyUnknown = true; continue; }
         if (rank >= pred.min) return 'meets';
       }
@@ -31,23 +46,28 @@ export function evaluatePredicate(pred: Predicate, ctx: CharacterContext): Evalu
       // Passes if any specific skill OR any lore skill reaches the threshold.
       let anyUnknown = false;
       for (const skill of pred.skills) {
-        const rank = ctx.skillRanks.get(skill.toLowerCase());
+        const rank = resolveRank(ctx, skill.toLowerCase());
         if (rank === undefined) { anyUnknown = true; continue; }
         if (rank >= pred.min) return 'meets';
       }
-      for (const slug of ctx.loreSkillSlugs) {
-        const rank = ctx.skillRanks.get(slug);
-        if (rank !== undefined && rank >= pred.min) return 'meets';
+      if (ctx.loreSkillSlugs !== undefined) {
+        for (const slug of ctx.loreSkillSlugs) {
+          const rank = ctx.skillRanks.get(slug);
+          if (rank !== undefined && rank >= pred.min) return 'meets';
+        }
+      } else {
+        anyUnknown = true; // no lore data — can't rule out a qualifying lore skill
       }
       return anyUnknown ? 'unknown' : 'fails';
     }
     case 'skill-rank-any-lore': {
       // Passes if any lore skill the character has reaches the threshold.
+      if (ctx.loreSkillSlugs === undefined) return 'unknown';
       for (const slug of ctx.loreSkillSlugs) {
         const rank = ctx.skillRanks.get(slug);
         if (rank !== undefined && rank >= pred.min) return 'meets';
       }
-      return ctx.loreSkillSlugs.size === 0 ? 'unknown' : 'fails';
+      return 'fails'; // definitive: no lore skill at this rank (or none owned)
     }
     case 'level':
       return ctx.level >= pred.min ? 'meets' : 'fails';

--- a/apps/player-portal/src/prereqs/evaluator.ts
+++ b/apps/player-portal/src/prereqs/evaluator.ts
@@ -27,6 +27,28 @@ export function evaluatePredicate(pred: Predicate, ctx: CharacterContext): Evalu
       }
       return anyUnknown ? 'unknown' : 'fails';
     }
+    case 'skill-rank-any-of-or-lore': {
+      // Passes if any specific skill OR any lore skill reaches the threshold.
+      let anyUnknown = false;
+      for (const skill of pred.skills) {
+        const rank = ctx.skillRanks.get(skill.toLowerCase());
+        if (rank === undefined) { anyUnknown = true; continue; }
+        if (rank >= pred.min) return 'meets';
+      }
+      for (const slug of ctx.loreSkillSlugs) {
+        const rank = ctx.skillRanks.get(slug);
+        if (rank !== undefined && rank >= pred.min) return 'meets';
+      }
+      return anyUnknown ? 'unknown' : 'fails';
+    }
+    case 'skill-rank-any-lore': {
+      // Passes if any lore skill the character has reaches the threshold.
+      for (const slug of ctx.loreSkillSlugs) {
+        const rank = ctx.skillRanks.get(slug);
+        if (rank !== undefined && rank >= pred.min) return 'meets';
+      }
+      return ctx.loreSkillSlugs.size === 0 ? 'unknown' : 'fails';
+    }
     case 'level':
       return ctx.level >= pred.min ? 'meets' : 'fails';
     case 'ability': {

--- a/apps/player-portal/src/prereqs/parser.ts
+++ b/apps/player-portal/src/prereqs/parser.ts
@@ -42,11 +42,11 @@ const SKILL_RANK_ANY_RE = /^\s*(trained|expert|master|legendary)\s+(?:in|at)\s+(
 const SKILL_RANK_IN_RE = /^\s*(trained|expert|master|legendary)\s+(?:in|at)\s+(.+?)\s*$/i;
 
 export function parsePrerequisite(raw: string): Predicate[] {
-  // Try whole-string patterns first — some prereqs contain commas or "or" as
-  // part of the predicate itself (e.g. "expert in Arcana, Nature, or Religion"),
-  // so we must not split on commas before we've had a chance to detect them.
+  // Try whole-string patterns first — some prereqs contain commas or "or"/"and"
+  // as part of the predicate itself, so we must not split on commas before
+  // we've had a chance to detect them.
   const whole = parseWholePhrase(raw.trim());
-  if (whole !== null) return [whole];
+  if (whole !== null) return whole;
 
   // pf2e sometimes jams multiple predicates into a single entry with
   // semicolons or commas. Split on those, trim, and parse each half.
@@ -57,23 +57,60 @@ export function parsePrerequisite(raw: string): Predicate[] {
     .map(parsePhrase);
 }
 
-function parseWholePhrase(phrase: string): Predicate | null {
-  // "trained in at least one skill" / "trained in any skill"
+// Returns Predicate[] (possibly multi-element for AND lists) or null when
+// no whole-phrase pattern matches and the caller should fall back to splitting.
+function parseWholePhrase(phrase: string): Predicate[] | null {
+  // "trained in at least one skill" / "trained at any skill"
   const anySkill = SKILL_RANK_ANY_RE.exec(phrase);
   if (anySkill?.[1]) {
     const rank = RANK_WORDS[anySkill[1].toLowerCase()];
-    if (rank !== undefined) return { kind: 'skill-rank-any', min: rank };
+    if (rank !== undefined) return [{ kind: 'skill-rank-any', min: rank }];
   }
 
-  // "rank in Skill1 or Skill2" / "rank in Skill1, Skill2, or Skill3"
-  // Only fires when "or" is present; otherwise single-skill handling below
-  // correctly catches it via parsePhrase → SKILL_RANK_RE.
   const rankIn = SKILL_RANK_IN_RE.exec(phrase);
-  if (rankIn?.[1] && rankIn[2] && /\bor\b/i.test(rankIn[2])) {
+  if (rankIn?.[1] && rankIn[2]) {
     const rank = RANK_WORDS[rankIn[1].toLowerCase()];
-    if (rank !== undefined) {
-      const skills = parseSkillOrList(rankIn[2]);
-      if (skills.length >= 2) return { kind: 'skill-rank-any-of', skills, min: rank };
+    if (rank === undefined) return null;
+    const rest = rankIn[2].trim();
+
+    // OR list: "rank in S1 or S2" / "rank in S1, S2, or S3"
+    // Also handles "a Lore skill" wildcard within the list.
+    if (/\bor\b/i.test(rest)) {
+      const rawItems = parseSkillOrList(rest);
+      const skills: string[] = [];
+      let hasLoreWildcard = false;
+      for (const item of rawItems) {
+        if (/^(?:a|any)\s+lore\s+skill$/i.test(item)) {
+          hasLoreWildcard = true;
+        } else {
+          skills.push(item);
+        }
+      }
+      if (hasLoreWildcard) {
+        // "rank in S1, S2, or a Lore skill" → any specific OR any lore skill
+        if (skills.length === 0) return [{ kind: 'skill-rank-any-lore', min: rank }];
+        return [{ kind: 'skill-rank-any-of-or-lore', skills, min: rank }];
+      }
+      if (skills.length >= 2) return [{ kind: 'skill-rank-any-of', skills, min: rank }];
+    }
+
+    // AND list: "rank in S1 and S2 [and S3 ...]" — returns one skill-rank
+    // predicate per skill; evaluateAll's AND semantics does the rest.
+    // Guard: rest must contain only word chars, spaces, and hyphens so we
+    // don't misparse "… and Strength 14" or semicolon-joined strings.
+    if (/\band\b/i.test(rest) && !/\bor\b/i.test(rest)) {
+      const parts = rest
+        .split(/\s+and\s+/i)
+        .map((s) => s.trim().toLowerCase())
+        .filter(Boolean);
+      if (parts.length >= 2 && parts.every((s) => /^[a-z][a-z\s-]*$/.test(s))) {
+        return parts.map((s) => ({ kind: 'skill-rank' as const, skill: s, min: rank }));
+      }
+    }
+
+    // Standalone lore wildcard: "trained in a Lore skill"
+    if (/^(?:a|any)\s+lore\s+skill$/i.test(rest)) {
+      return [{ kind: 'skill-rank-any-lore', min: rank }];
     }
   }
 

--- a/apps/player-portal/src/prereqs/parser.ts
+++ b/apps/player-portal/src/prereqs/parser.ts
@@ -36,6 +36,11 @@ const ABILITY_KEY: Record<string, Predicate & { kind: 'ability' } extends { abil
   charisma: 'cha',
 } as const;
 
+// Normalises a skill name from a prereq string to match character-context map
+// keys: lowercase + hyphens replaced with spaces, mirroring the normalisation
+// applied to pf2e slugs ("hero-god-lore" → "hero god lore").
+const normSkill = (s: string): string => s.toLowerCase().replace(/-/g, ' ');
+
 // "trained in at least one skill" / "trained in any skill" / "trained at any skill"
 const SKILL_RANK_ANY_RE = /^\s*(trained|expert|master|legendary)\s+(?:in|at)\s+(?:at\s+least\s+one|any)\s+skill\s*$/i;
 // Captures "rank in/at <rest>" so we can detect or-lists before comma-splitting mangles them
@@ -80,7 +85,9 @@ function parseWholePhrase(phrase: string): Predicate[] | null {
       const skills: string[] = [];
       let hasLoreWildcard = false;
       for (const item of rawItems) {
-        if (/^(?:a|any)\s+lore\s+skill$/i.test(item)) {
+        // "a Lore skill" / "any Lore skill" / bare "Lore" (no topic) all mean
+        // "any lore skill the character has at the required rank".
+        if (/^(?:a|any)\s+lore\s+skill$/i.test(item) || /^lore$/i.test(item)) {
           hasLoreWildcard = true;
         } else {
           skills.push(item);
@@ -101,15 +108,15 @@ function parseWholePhrase(phrase: string): Predicate[] | null {
     if (/\band\b/i.test(rest) && !/\bor\b/i.test(rest)) {
       const parts = rest
         .split(/\s+and\s+/i)
-        .map((s) => s.trim().toLowerCase())
+        .map((s) => normSkill(s.trim()))
         .filter(Boolean);
       if (parts.length >= 2 && parts.every((s) => /^[a-z][a-z\s-]*$/.test(s))) {
         return parts.map((s) => ({ kind: 'skill-rank' as const, skill: s, min: rank }));
       }
     }
 
-    // Standalone lore wildcard: "trained in a Lore skill"
-    if (/^(?:a|any)\s+lore\s+skill$/i.test(rest)) {
+    // Standalone lore wildcard: "trained in a Lore skill" / "trained in Lore"
+    if (/^(?:a|any)\s+lore\s+skill$/i.test(rest) || /^lore$/i.test(rest)) {
       return [{ kind: 'skill-rank-any-lore', min: rank }];
     }
   }
@@ -118,12 +125,13 @@ function parseWholePhrase(phrase: string): Predicate[] | null {
 }
 
 // Splits "Arcana, Nature, Occultism, or Religion" or "Occultism or Religion"
-// into ["arcana", "nature", "occultism", "religion"].
+// into ["arcana", "nature", "occultism", "religion"]. Hyphens are normalised
+// to spaces so "Hero-God Lore" matches the slug "hero-god-lore" → "hero god lore".
 function parseSkillOrList(raw: string): string[] {
   return raw
     .replace(/,\s*or\s+/gi, ' or ')
     .split(/\s+or\s+|,\s*/i)
-    .map((s) => s.trim().toLowerCase())
+    .map((s) => normSkill(s.trim()))
     .filter((s) => s.length > 0 && /^[a-z]/i.test(s));
 }
 
@@ -132,7 +140,7 @@ function parsePhrase(phrase: string): Predicate {
   if (skill && skill[1] && skill[2]) {
     const rank = RANK_WORDS[skill[1].toLowerCase()];
     if (rank !== undefined) {
-      return { kind: 'skill-rank', skill: skill[2].trim().toLowerCase(), min: rank };
+      return { kind: 'skill-rank', skill: normSkill(skill[2].trim()), min: rank };
     }
   }
 

--- a/apps/player-portal/src/prereqs/parser.ts
+++ b/apps/player-portal/src/prereqs/parser.ts
@@ -34,7 +34,18 @@ const ABILITY_KEY: Record<string, Predicate & { kind: 'ability' } extends { abil
   charisma: 'cha',
 } as const;
 
+// "trained in at least one skill" / "trained in any skill"
+const SKILL_RANK_ANY_RE = /^\s*(trained|expert|master|legendary)\s+in\s+(?:at\s+least\s+one|any)\s+skill\s*$/i;
+// Captures "rank in <rest>" so we can detect or-lists before comma-splitting mangles them
+const SKILL_RANK_IN_RE = /^\s*(trained|expert|master|legendary)\s+in\s+(.+?)\s*$/i;
+
 export function parsePrerequisite(raw: string): Predicate[] {
+  // Try whole-string patterns first — some prereqs contain commas or "or" as
+  // part of the predicate itself (e.g. "expert in Arcana, Nature, or Religion"),
+  // so we must not split on commas before we've had a chance to detect them.
+  const whole = parseWholePhrase(raw.trim());
+  if (whole !== null) return [whole];
+
   // pf2e sometimes jams multiple predicates into a single entry with
   // semicolons or commas. Split on those, trim, and parse each half.
   return raw
@@ -42,6 +53,39 @@ export function parsePrerequisite(raw: string): Predicate[] {
     .map((s) => s.trim())
     .filter((s) => s.length > 0)
     .map(parsePhrase);
+}
+
+function parseWholePhrase(phrase: string): Predicate | null {
+  // "trained in at least one skill" / "trained in any skill"
+  const anySkill = SKILL_RANK_ANY_RE.exec(phrase);
+  if (anySkill?.[1]) {
+    const rank = RANK_WORDS[anySkill[1].toLowerCase()];
+    if (rank !== undefined) return { kind: 'skill-rank-any', min: rank };
+  }
+
+  // "rank in Skill1 or Skill2" / "rank in Skill1, Skill2, or Skill3"
+  // Only fires when "or" is present; otherwise single-skill handling below
+  // correctly catches it via parsePhrase → SKILL_RANK_RE.
+  const rankIn = SKILL_RANK_IN_RE.exec(phrase);
+  if (rankIn?.[1] && rankIn[2] && /\bor\b/i.test(rankIn[2])) {
+    const rank = RANK_WORDS[rankIn[1].toLowerCase()];
+    if (rank !== undefined) {
+      const skills = parseSkillOrList(rankIn[2]);
+      if (skills.length >= 2) return { kind: 'skill-rank-any-of', skills, min: rank };
+    }
+  }
+
+  return null;
+}
+
+// Splits "Arcana, Nature, Occultism, or Religion" or "Occultism or Religion"
+// into ["arcana", "nature", "occultism", "religion"].
+function parseSkillOrList(raw: string): string[] {
+  return raw
+    .replace(/,\s*or\s+/gi, ' or ')
+    .split(/\s+or\s+|,\s*/i)
+    .map((s) => s.trim().toLowerCase())
+    .filter((s) => s.length > 0 && /^[a-z]/i.test(s));
 }
 
 function parsePhrase(phrase: string): Predicate {

--- a/apps/player-portal/src/prereqs/parser.ts
+++ b/apps/player-portal/src/prereqs/parser.ts
@@ -19,12 +19,14 @@ const RANK_WORDS: Record<string, ProficiencyRank> = {
   legendary: 4,
 };
 
-// "trained in Athletics" / "expert in Medicine"
-const SKILL_RANK_RE = /^\s*(trained|expert|master|legendary)\s+in\s+([A-Za-z][A-Za-z\s-]*?)\s*$/i;
+// "trained in Athletics" / "expert in Medicine" / "master at Deception"
+const SKILL_RANK_RE = /^\s*(trained|expert|master|legendary)\s+(?:in|at)\s+([A-Za-z][A-Za-z\s-]*?)\s*$/i;
 // "5th level" / "Level 5" / "level 5"
 const LEVEL_RE = /^\s*(?:(\d+)(?:st|nd|rd|th)?\s+level|level\s+(\d+))\s*$/i;
-// "Strength 14" / "Wisdom 16+"
+// "Strength 14" / "Wisdom 16+" (score)
 const ABILITY_RE = /^\s*(Strength|Dexterity|Constitution|Intelligence|Wisdom|Charisma)\s+(\d+)\+?\s*$/i;
+// "Charisma +3" (modifier). Stored as score = 10 + 2*mod so the existing ability evaluator applies.
+const ABILITY_MOD_RE = /^\s*(Strength|Dexterity|Constitution|Intelligence|Wisdom|Charisma)\s+\+(\d+)\s*$/i;
 const ABILITY_KEY: Record<string, Predicate & { kind: 'ability' } extends { ability: infer A } ? A : never> = {
   strength: 'str',
   dexterity: 'dex',
@@ -34,10 +36,10 @@ const ABILITY_KEY: Record<string, Predicate & { kind: 'ability' } extends { abil
   charisma: 'cha',
 } as const;
 
-// "trained in at least one skill" / "trained in any skill"
-const SKILL_RANK_ANY_RE = /^\s*(trained|expert|master|legendary)\s+in\s+(?:at\s+least\s+one|any)\s+skill\s*$/i;
-// Captures "rank in <rest>" so we can detect or-lists before comma-splitting mangles them
-const SKILL_RANK_IN_RE = /^\s*(trained|expert|master|legendary)\s+in\s+(.+?)\s*$/i;
+// "trained in at least one skill" / "trained in any skill" / "trained at any skill"
+const SKILL_RANK_ANY_RE = /^\s*(trained|expert|master|legendary)\s+(?:in|at)\s+(?:at\s+least\s+one|any)\s+skill\s*$/i;
+// Captures "rank in/at <rest>" so we can detect or-lists before comma-splitting mangles them
+const SKILL_RANK_IN_RE = /^\s*(trained|expert|master|legendary)\s+(?:in|at)\s+(.+?)\s*$/i;
 
 export function parsePrerequisite(raw: string): Predicate[] {
   // Try whole-string patterns first — some prereqs contain commas or "or" as
@@ -106,6 +108,15 @@ function parsePhrase(phrase: string): Predicate {
     }
   }
 
+  const abilMod = ABILITY_MOD_RE.exec(phrase);
+  if (abilMod && abilMod[1] && abilMod[2]) {
+    const ability = ABILITY_KEY[abilMod[1].toLowerCase()];
+    const mod = Number.parseInt(abilMod[2], 10);
+    if (ability && Number.isFinite(mod)) {
+      return { kind: 'ability', ability, min: 10 + 2 * mod };
+    }
+  }
+
   const abil = ABILITY_RE.exec(phrase);
   if (abil && abil[1] && abil[2]) {
     const ability = ABILITY_KEY[abil[1].toLowerCase()];
@@ -113,6 +124,13 @@ function parsePhrase(phrase: string): Predicate {
     if (ability && Number.isFinite(min)) {
       return { kind: 'ability', ability, min };
     }
+  }
+
+  // Title-cased phrases that match no other pattern are treated as feat/feature
+  // names. The evaluator returns 'meets' if the character owns the item, 'fails'
+  // if not — upgrading these from 'unknown' to a real gate.
+  if (/^[A-Z][A-Za-z\s'-]*$/.test(phrase.trim())) {
+    return { kind: 'feat', name: phrase.trim() };
   }
 
   return { kind: 'unsupported', raw: phrase };

--- a/apps/player-portal/src/prereqs/prereqs.test.ts
+++ b/apps/player-portal/src/prereqs/prereqs.test.ts
@@ -250,3 +250,139 @@ describe('rank ordering edge cases', () => {
     expect(evaluateAll(parsePrerequisite('master in any skill'), ctx)).toBe('meets');
   });
 });
+
+// ---------------------------------------------------------------------------
+// A Home in Every Port — "Charisma +3" (ability modifier notation)
+// ---------------------------------------------------------------------------
+
+describe('A Home in Every Port: "Charisma +3"', () => {
+  const PREREQ = 'Charisma +3';
+
+  it('parses to ability predicate with score threshold 16 (10 + 2*3)', () => {
+    expect(parsePrerequisite(PREREQ)).toEqual([{ kind: 'ability', ability: 'cha', min: 16 }]);
+  });
+
+  it('passes when character has Charisma mod +3 (score 16)', () => {
+    const ctx = makeCtx({ abilityMods: { str: 0, dex: 0, con: 0, int: 0, wis: 0, cha: 3 } });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('meets');
+  });
+
+  it('passes when character has Charisma mod +4 (exceeds threshold)', () => {
+    const ctx = makeCtx({ abilityMods: { str: 0, dex: 0, con: 0, int: 0, wis: 0, cha: 4 } });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('meets');
+  });
+
+  it('fails when character has Charisma mod +2 (score 14, one short)', () => {
+    const ctx = makeCtx({ abilityMods: { str: 0, dex: 0, con: 0, int: 0, wis: 0, cha: 2 } });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('fails');
+  });
+
+  it('fails when character has Charisma mod 0', () => {
+    const ctx = makeCtx({ abilityMods: { str: 0, dex: 0, con: 0, int: 0, wis: 0, cha: 0 } });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('fails');
+  });
+
+  it('"Strength +2" parses correctly to min score 14', () => {
+    expect(parsePrerequisite('Strength +2')).toEqual([{ kind: 'ability', ability: 'str', min: 14 }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bloodsense — "master in Perception" (Perception lives outside sys.skills)
+// ---------------------------------------------------------------------------
+
+describe('Bloodsense: "master in Perception"', () => {
+  const PREREQ = 'master in Perception';
+
+  it('passes when character is master in Perception', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['perception', 3]]) });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('meets');
+  });
+
+  it('passes when character is legendary in Perception (exceeds master)', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['perception', 4]]) });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('meets');
+  });
+
+  it('fails when character is expert in Perception', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['perception', 2]]) });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('fails');
+  });
+
+  it('fails when character is untrained in Perception', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['perception', 0]]) });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('fails');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Caravan Leader — "Pick Up the Pace" (feat name prerequisite)
+// ---------------------------------------------------------------------------
+
+describe('Caravan Leader: "Pick Up the Pace" feat prereq', () => {
+  const PREREQ = 'Pick Up the Pace';
+
+  it('parses to a feat predicate', () => {
+    expect(parsePrerequisite(PREREQ)).toEqual([{ kind: 'feat', name: 'Pick Up the Pace' }]);
+  });
+
+  it('passes when character has the feat', () => {
+    const ctx = makeCtx({ features: new Set(['pick up the pace']) });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('meets');
+  });
+
+  it('fails when character does not have the feat', () => {
+    const ctx = makeCtx({ features: new Set() });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('fails');
+  });
+
+  it('fails when character has other feats but not this one', () => {
+    const ctx = makeCtx({ features: new Set(['fleet', 'assurance']) });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('fails');
+  });
+
+  it('feat name lookup is case-insensitive (evaluator lowercases the name)', () => {
+    // The evaluator calls pred.name.toLowerCase() before the Set lookup,
+    // so "Pick Up the Pace" and "pick up the pace" both resolve to 'meets'
+    // when the character has the feat stored in lowercase.
+    const ctx = makeCtx({ features: new Set(['pick up the pace']) });
+    expect(evaluateAll(parsePrerequisite('Pick Up the Pace'), ctx)).toBe('meets');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Doublespeak — "master at Deception" (uses "at" instead of "in")
+// ---------------------------------------------------------------------------
+
+describe('Doublespeak: "master at Deception"', () => {
+  const PREREQ = 'master at Deception';
+
+  it('parses correctly despite "at" keyword', () => {
+    expect(parsePrerequisite(PREREQ)).toEqual([{ kind: 'skill-rank', skill: 'deception', min: 3 }]);
+  });
+
+  it('passes when character is master in Deception', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['deception', 3]]) });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('meets');
+  });
+
+  it('passes when character is legendary in Deception', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['deception', 4]]) });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('meets');
+  });
+
+  it('fails when character is expert in Deception', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['deception', 2]]) });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('fails');
+  });
+
+  it('fails when character is trained in Deception', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['deception', 1]]) });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('fails');
+  });
+
+  it('"expert at Arcana" also works', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['arcana', 2]]) });
+    expect(evaluateAll(parsePrerequisite('expert at Arcana'), ctx)).toBe('meets');
+  });
+});

--- a/apps/player-portal/src/prereqs/prereqs.test.ts
+++ b/apps/player-portal/src/prereqs/prereqs.test.ts
@@ -541,3 +541,146 @@ describe('Temperature Adjustment: "master in Crafting, Herbalism Lore, or Medici
     expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('fails');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Lore skill patterns — "trained in Lore", specific lore, hyphenated names
+// ---------------------------------------------------------------------------
+
+describe('"trained in Lore" / "expert in Lore" — bare Lore wildcard', () => {
+  it('parses "trained in Lore" → skill-rank-any-lore', () => {
+    expect(parsePrerequisite('trained in Lore')).toEqual([{ kind: 'skill-rank-any-lore', min: 1 }]);
+  });
+
+  it('parses "expert in Lore" → skill-rank-any-lore with min 2', () => {
+    expect(parsePrerequisite('expert in Lore')).toEqual([{ kind: 'skill-rank-any-lore', min: 2 }]);
+  });
+
+  // Experienced Professional
+  it('Experienced Professional: passes when character has any lore skill trained', () => {
+    const ctx = makeCtx({
+      skillRanks: skillMap([['warfare lore', 1]]),
+      loreSkillSlugs: new Set(['warfare lore']),
+    });
+    expect(evaluateAll(parsePrerequisite('trained in Lore'), ctx)).toBe('meets');
+  });
+
+  it('Experienced Professional: fails when lore skill is untrained (rank 0)', () => {
+    const ctx = makeCtx({
+      skillRanks: skillMap([['warfare lore', 0]]),
+      loreSkillSlugs: new Set(['warfare lore']),
+    });
+    expect(evaluateAll(parsePrerequisite('trained in Lore'), ctx)).toBe('fails');
+  });
+
+  it('Experienced Professional: unknown when character has no lore skills at all', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['athletics', 1]]), loreSkillSlugs: new Set() });
+    expect(evaluateAll(parsePrerequisite('trained in Lore'), ctx)).toBe('unknown');
+  });
+
+  // Unmistakable Lore
+  it('Unmistakable Lore: passes when character has any lore skill at expert', () => {
+    const ctx = makeCtx({
+      skillRanks: skillMap([['legal lore', 2]]),
+      loreSkillSlugs: new Set(['legal lore']),
+    });
+    expect(evaluateAll(parsePrerequisite('expert in Lore'), ctx)).toBe('meets');
+  });
+
+  it('Unmistakable Lore: fails when lore skill is only trained', () => {
+    const ctx = makeCtx({
+      skillRanks: skillMap([['legal lore', 1]]),
+      loreSkillSlugs: new Set(['legal lore']),
+    });
+    expect(evaluateAll(parsePrerequisite('expert in Lore'), ctx)).toBe('fails');
+  });
+});
+
+describe('Specific lore skill prereqs', () => {
+  // Battle Planner — "expert in Warfare Lore"
+  it('Battle Planner: parses correctly and passes when expert in Warfare Lore', () => {
+    expect(parsePrerequisite('expert in Warfare Lore')).toEqual([
+      { kind: 'skill-rank', skill: 'warfare lore', min: 2 },
+    ]);
+    const ctx = makeCtx({ skillRanks: skillMap([['warfare lore', 2]]) });
+    expect(evaluateAll(parsePrerequisite('expert in Warfare Lore'), ctx)).toBe('meets');
+  });
+
+  it('Battle Planner: fails when only trained in Warfare Lore', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['warfare lore', 1]]) });
+    expect(evaluateAll(parsePrerequisite('expert in Warfare Lore'), ctx)).toBe('fails');
+  });
+
+  // Contract Negotiator — "trained in Legal Lore"
+  it('Contract Negotiator: passes when trained in Legal Lore', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['legal lore', 1]]) });
+    expect(evaluateAll(parsePrerequisite('trained in Legal Lore'), ctx)).toBe('meets');
+  });
+
+  // Ravening's Desperation — "trained in Zevgavizeb Lore"
+  it("Ravening's Desperation: passes when trained in Zevgavizeb Lore", () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['zevgavizeb lore', 1]]) });
+    expect(evaluateAll(parsePrerequisite('trained in Zevgavizeb Lore'), ctx)).toBe('meets');
+  });
+
+  // What's That up Your Sleeve — "expert in Gambling Lore"
+  it("What's That up Your Sleeve: passes when expert in Gambling Lore", () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['gambling lore', 2]]) });
+    expect(evaluateAll(parsePrerequisite('expert in Gambling Lore'), ctx)).toBe('meets');
+  });
+
+  it("What's That up Your Sleeve: fails when only trained in Gambling Lore", () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['gambling lore', 1]]) });
+    expect(evaluateAll(parsePrerequisite('expert in Gambling Lore'), ctx)).toBe('fails');
+  });
+});
+
+describe('Hyphenated lore skill names in prereq strings', () => {
+  // Myth Hunter — "trained in Hero-God Lore or Legendary Beast Lore"
+  it('Myth Hunter: parses to skill-rank-any-of with normalised hyphenless keys', () => {
+    expect(parsePrerequisite('trained in Hero-God Lore or Legendary Beast Lore')).toEqual([
+      { kind: 'skill-rank-any-of', skills: ['hero god lore', 'legendary beast lore'], min: 1 },
+    ]);
+  });
+
+  it('Myth Hunter: passes when trained in Hero-God Lore (slug "hero-god-lore" → "hero god lore")', () => {
+    // Character context normalises "hero-god-lore" → "hero god lore"; parser
+    // normalises prereq "Hero-God Lore" → "hero god lore". Keys match.
+    const ctx = makeCtx({ skillRanks: skillMap([['hero god lore', 1], ['legendary beast lore', 0]]) });
+    expect(evaluateAll(parsePrerequisite('trained in Hero-God Lore or Legendary Beast Lore'), ctx)).toBe('meets');
+  });
+
+  it('Myth Hunter: passes when trained in Legendary Beast Lore', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['hero god lore', 0], ['legendary beast lore', 1]]) });
+    expect(evaluateAll(parsePrerequisite('trained in Hero-God Lore or Legendary Beast Lore'), ctx)).toBe('meets');
+  });
+
+  it('Myth Hunter: fails when trained in neither', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['hero god lore', 0], ['legendary beast lore', 0]]) });
+    expect(evaluateAll(parsePrerequisite('trained in Hero-God Lore or Legendary Beast Lore'), ctx)).toBe('fails');
+  });
+});
+
+describe('Armor Assist: "trained in Athletics or Warfare Lore"', () => {
+  const PREREQ = 'trained in Athletics or Warfare Lore';
+
+  it('parses to skill-rank-any-of with both options', () => {
+    expect(parsePrerequisite(PREREQ)).toEqual([
+      { kind: 'skill-rank-any-of', skills: ['athletics', 'warfare lore'], min: 1 },
+    ]);
+  });
+
+  it('passes when trained in Athletics', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['athletics', 1], ['warfare lore', 0]]) });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('meets');
+  });
+
+  it('passes when trained in Warfare Lore only', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['athletics', 0], ['warfare lore', 1]]) });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('meets');
+  });
+
+  it('fails when untrained in both', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['athletics', 0], ['warfare lore', 0]]) });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('fails');
+  });
+});

--- a/apps/player-portal/src/prereqs/prereqs.test.ts
+++ b/apps/player-portal/src/prereqs/prereqs.test.ts
@@ -10,6 +10,7 @@ function makeCtx(overrides: Partial<CharacterContext> = {}): CharacterContext {
     skillRanks: new Map(),
     abilityMods: { str: 0, dex: 0, con: 0, int: 0, wis: 0, cha: 0 },
     features: new Set(),
+    loreSkillSlugs: new Set(),
     ...overrides,
   };
 }
@@ -384,5 +385,159 @@ describe('Doublespeak: "master at Deception"', () => {
   it('"expert at Arcana" also works', () => {
     const ctx = makeCtx({ skillRanks: skillMap([['arcana', 2]]) });
     expect(evaluateAll(parsePrerequisite('expert at Arcana'), ctx)).toBe('meets');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Half-Truths / Tumbling Theft / Vicious Critique — "rank in S1 and S2"
+// ---------------------------------------------------------------------------
+
+describe('"rank in S1 and S2" AND-list prereqs', () => {
+  it('parses "expert in Deception and Diplomacy" → two skill-rank predicates', () => {
+    expect(parsePrerequisite('expert in Deception and Diplomacy')).toEqual([
+      { kind: 'skill-rank', skill: 'deception', min: 2 },
+      { kind: 'skill-rank', skill: 'diplomacy', min: 2 },
+    ]);
+  });
+
+  it('parses "trained in Crafting and Intimidation" → two skill-rank predicates', () => {
+    expect(parsePrerequisite('trained in Crafting and Intimidation')).toEqual([
+      { kind: 'skill-rank', skill: 'crafting', min: 1 },
+      { kind: 'skill-rank', skill: 'intimidation', min: 1 },
+    ]);
+  });
+
+  // Half-Truths — "expert in Deception and Diplomacy"
+  it('Half-Truths: passes when expert in both Deception and Diplomacy', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['deception', 2], ['diplomacy', 2]]) });
+    expect(evaluateAll(parsePrerequisite('expert in Deception and Diplomacy'), ctx)).toBe('meets');
+  });
+
+  it('Half-Truths: fails when only expert in Deception', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['deception', 2], ['diplomacy', 0]]) });
+    expect(evaluateAll(parsePrerequisite('expert in Deception and Diplomacy'), ctx)).toBe('fails');
+  });
+
+  it('Half-Truths: fails when only expert in Diplomacy', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['deception', 0], ['diplomacy', 2]]) });
+    expect(evaluateAll(parsePrerequisite('expert in Deception and Diplomacy'), ctx)).toBe('fails');
+  });
+
+  it('Half-Truths: fails when expert in neither', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['deception', 1], ['diplomacy', 1]]) });
+    expect(evaluateAll(parsePrerequisite('expert in Deception and Diplomacy'), ctx)).toBe('fails');
+  });
+
+  it('Half-Truths: passes when master in both (exceeds expert)', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['deception', 3], ['diplomacy', 3]]) });
+    expect(evaluateAll(parsePrerequisite('expert in Deception and Diplomacy'), ctx)).toBe('meets');
+  });
+
+  // Tumbling Theft — "expert in Acrobatics and Thievery"
+  it('Tumbling Theft: passes when expert in Acrobatics and Thievery', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['acrobatics', 2], ['thievery', 2]]) });
+    expect(evaluateAll(parsePrerequisite('expert in Acrobatics and Thievery'), ctx)).toBe('meets');
+  });
+
+  it('Tumbling Theft: fails when expert in only one skill', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['acrobatics', 2], ['thievery', 1]]) });
+    expect(evaluateAll(parsePrerequisite('expert in Acrobatics and Thievery'), ctx)).toBe('fails');
+  });
+
+  // Vicious Critique — "trained in Crafting and Intimidation"
+  it('Vicious Critique: passes when trained in both Crafting and Intimidation', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['crafting', 1], ['intimidation', 1]]) });
+    expect(evaluateAll(parsePrerequisite('trained in Crafting and Intimidation'), ctx)).toBe('meets');
+  });
+
+  it('Vicious Critique: fails when untrained in Intimidation', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['crafting', 1], ['intimidation', 0]]) });
+    expect(evaluateAll(parsePrerequisite('trained in Crafting and Intimidation'), ctx)).toBe('fails');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Master or Apprentice — "master in Crafting, Performance, or a Lore skill"
+// ---------------------------------------------------------------------------
+
+describe('Master or Apprentice: "master in Crafting, Performance, or a Lore skill"', () => {
+  const PREREQ = 'master in Crafting, Performance, or a Lore skill';
+
+  it('parses to skill-rank-any-of-or-lore', () => {
+    expect(parsePrerequisite(PREREQ)).toEqual([
+      { kind: 'skill-rank-any-of-or-lore', skills: ['crafting', 'performance'], min: 3 },
+    ]);
+  });
+
+  it('passes when master in Crafting', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['crafting', 3], ['performance', 0]]) });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('meets');
+  });
+
+  it('passes when master in Performance', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['crafting', 0], ['performance', 3]]) });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('meets');
+  });
+
+  it('passes when master in a lore skill (Herbalism Lore)', () => {
+    const ctx = makeCtx({
+      skillRanks: skillMap([['crafting', 0], ['performance', 0], ['herbalism lore', 3]]),
+      loreSkillSlugs: new Set(['herbalism lore']),
+    });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('meets');
+  });
+
+  it('fails when expert in all three (one short of master)', () => {
+    const ctx = makeCtx({
+      skillRanks: skillMap([['crafting', 2], ['performance', 2], ['herbalism lore', 2]]),
+      loreSkillSlugs: new Set(['herbalism lore']),
+    });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('fails');
+  });
+
+  it('fails when character has no lore skills and neither crafting nor performance at master', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['crafting', 2], ['performance', 0]]) });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('fails');
+  });
+
+  it('unknown when specific skills are missing from the map (lore check also fails)', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['herbalism lore', 2]]), loreSkillSlugs: new Set(['herbalism lore']) });
+    // crafting and performance missing → anyUnknown; lore rank too low → unknown
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('unknown');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Temperature Adjustment — "master in Crafting, Herbalism Lore, or Medicine"
+// (Specific lore skill name — not the wildcard; needs slug normalisation)
+// ---------------------------------------------------------------------------
+
+describe('Temperature Adjustment: "master in Crafting, Herbalism Lore, or Medicine"', () => {
+  const PREREQ = 'master in Crafting, Herbalism Lore, or Medicine';
+
+  it('parses to skill-rank-any-of (Herbalism Lore is specific, not the wildcard)', () => {
+    expect(parsePrerequisite(PREREQ)).toEqual([
+      { kind: 'skill-rank-any-of', skills: ['crafting', 'herbalism lore', 'medicine'], min: 3 },
+    ]);
+  });
+
+  it('passes when master in Crafting', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['crafting', 3], ['herbalism lore', 0], ['medicine', 0]]) });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('meets');
+  });
+
+  it('passes when master in Herbalism Lore (slug-normalised from "herbalism-lore")', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['crafting', 0], ['herbalism lore', 3], ['medicine', 0]]) });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('meets');
+  });
+
+  it('passes when master in Medicine', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['crafting', 0], ['herbalism lore', 0], ['medicine', 3]]) });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('meets');
+  });
+
+  it('fails when expert in all three', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['crafting', 2], ['herbalism lore', 2], ['medicine', 2]]) });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('fails');
   });
 });

--- a/apps/player-portal/src/prereqs/prereqs.test.ts
+++ b/apps/player-portal/src/prereqs/prereqs.test.ts
@@ -10,7 +10,9 @@ function makeCtx(overrides: Partial<CharacterContext> = {}): CharacterContext {
     skillRanks: new Map(),
     abilityMods: { str: 0, dex: 0, con: 0, int: 0, wis: 0, cha: 0 },
     features: new Set(),
-    loreSkillSlugs: new Set(),
+    // undefined = incomplete/sparse context; absent lore skills treated as 'unknown'.
+    // Pass new Set() (possibly empty) to opt into definitive lore evaluation.
+    loreSkillSlugs: undefined,
     ...overrides,
   };
 }
@@ -496,13 +498,16 @@ describe('Master or Apprentice: "master in Crafting, Performance, or a Lore skil
   });
 
   it('fails when character has no lore skills and neither crafting nor performance at master', () => {
-    const ctx = makeCtx({ skillRanks: skillMap([['crafting', 2], ['performance', 0]]) });
+    const ctx = makeCtx({
+      skillRanks: skillMap([['crafting', 2], ['performance', 0]]),
+      loreSkillSlugs: new Set(), // definitive: no lore skills
+    });
     expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('fails');
   });
 
   it('unknown when specific skills are missing from the map (lore check also fails)', () => {
     const ctx = makeCtx({ skillRanks: skillMap([['herbalism lore', 2]]), loreSkillSlugs: new Set(['herbalism lore']) });
-    // crafting and performance missing → anyUnknown; lore rank too low → unknown
+    // crafting and performance missing from map (not lore keys) → anyUnknown; lore rank too low → unknown
     expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('unknown');
   });
 });
@@ -572,8 +577,13 @@ describe('"trained in Lore" / "expert in Lore" — bare Lore wildcard', () => {
     expect(evaluateAll(parsePrerequisite('trained in Lore'), ctx)).toBe('fails');
   });
 
-  it('Experienced Professional: unknown when character has no lore skills at all', () => {
+  it('Experienced Professional: fails when lore data is complete but character has no lore skills', () => {
     const ctx = makeCtx({ skillRanks: skillMap([['athletics', 1]]), loreSkillSlugs: new Set() });
+    expect(evaluateAll(parsePrerequisite('trained in Lore'), ctx)).toBe('fails');
+  });
+
+  it('Experienced Professional: unknown when lore skill data unavailable (sparse context)', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['athletics', 1]]) }); // loreSkillSlugs = undefined
     expect(evaluateAll(parsePrerequisite('trained in Lore'), ctx)).toBe('unknown');
   });
 
@@ -681,6 +691,106 @@ describe('Armor Assist: "trained in Athletics or Warfare Lore"', () => {
 
   it('fails when untrained in both', () => {
     const ctx = makeCtx({ skillRanks: skillMap([['athletics', 0], ['warfare lore', 0]]) });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('fails');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Seasoned — "trained in Alcohol Lore, Cooking Lore, or Crafting"
+// Mixes specific lore skills with a standard skill in an OR list.
+// ---------------------------------------------------------------------------
+
+describe('Seasoned: "trained in Alcohol Lore, Cooking Lore, or Crafting"', () => {
+  const PREREQ = 'trained in Alcohol Lore, Cooking Lore, or Crafting';
+
+  it('parses to skill-rank-any-of with all three options', () => {
+    expect(parsePrerequisite(PREREQ)).toEqual([
+      { kind: 'skill-rank-any-of', skills: ['alcohol lore', 'cooking lore', 'crafting'], min: 1 },
+    ]);
+  });
+
+  it('passes when trained in Crafting (standard skill)', () => {
+    const ctx = makeCtx({
+      skillRanks: skillMap([['crafting', 1]]),
+      loreSkillSlugs: new Set(),
+    });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('meets');
+  });
+
+  it('passes when trained in Cooking Lore only', () => {
+    const ctx = makeCtx({
+      skillRanks: skillMap([['crafting', 0], ['cooking lore', 1]]),
+      loreSkillSlugs: new Set(['cooking lore']),
+    });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('meets');
+  });
+
+  it('passes when trained in Alcohol Lore only', () => {
+    const ctx = makeCtx({
+      skillRanks: skillMap([['crafting', 0], ['alcohol lore', 1]]),
+      loreSkillSlugs: new Set(['alcohol lore']),
+    });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('meets');
+  });
+
+  it('fails when untrained in Crafting and no lore skills (definitive data)', () => {
+    const ctx = makeCtx({
+      skillRanks: skillMap([['crafting', 0]]),
+      loreSkillSlugs: new Set(), // character has no lore skills
+    });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('fails');
+  });
+
+  it('unknown when untrained in Crafting and lore data unavailable', () => {
+    // loreSkillSlugs = undefined → can't rule out Alcohol/Cooking Lore
+    const ctx = makeCtx({ skillRanks: skillMap([['crafting', 0]]) });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('unknown');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Prepare Elemental Medicine — "trained in Crafting, Herbalism Lore, or Medicine"
+// Same shape as Temperature Adjustment at master; verifies trained rank.
+// ---------------------------------------------------------------------------
+
+describe('Prepare Elemental Medicine: "trained in Crafting, Herbalism Lore, or Medicine"', () => {
+  const PREREQ = 'trained in Crafting, Herbalism Lore, or Medicine';
+
+  it('parses to skill-rank-any-of with min 1', () => {
+    expect(parsePrerequisite(PREREQ)).toEqual([
+      { kind: 'skill-rank-any-of', skills: ['crafting', 'herbalism lore', 'medicine'], min: 1 },
+    ]);
+  });
+
+  it('passes when trained in Crafting', () => {
+    const ctx = makeCtx({
+      skillRanks: skillMap([['crafting', 1], ['medicine', 0]]),
+      loreSkillSlugs: new Set(),
+    });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('meets');
+  });
+
+  it('passes when trained in Herbalism Lore', () => {
+    const ctx = makeCtx({
+      skillRanks: skillMap([['crafting', 0], ['herbalism lore', 1], ['medicine', 0]]),
+      loreSkillSlugs: new Set(['herbalism lore']),
+    });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('meets');
+  });
+
+  it('passes when trained in Medicine', () => {
+    const ctx = makeCtx({
+      skillRanks: skillMap([['crafting', 0], ['medicine', 1]]),
+      loreSkillSlugs: new Set(),
+    });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('meets');
+  });
+
+  it('fails when untrained in all three (definitive lore data)', () => {
+    const ctx = makeCtx({
+      skillRanks: skillMap([['crafting', 0], ['medicine', 0]]),
+      loreSkillSlugs: new Set(), // no lore skills
+    });
     expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('fails');
   });
 });

--- a/apps/player-portal/src/prereqs/prereqs.test.ts
+++ b/apps/player-portal/src/prereqs/prereqs.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it } from 'vitest';
+import { evaluateAll } from './evaluator';
+import { parsePrerequisite } from './parser';
+import type { CharacterContext } from './types';
+import type { ProficiencyRank } from '../api/types';
+
+function makeCtx(overrides: Partial<CharacterContext> = {}): CharacterContext {
+  return {
+    level: 1,
+    skillRanks: new Map(),
+    abilityMods: { str: 0, dex: 0, con: 0, int: 0, wis: 0, cha: 0 },
+    features: new Set(),
+    ...overrides,
+  };
+}
+
+function skillMap(entries: [string, number][]): Map<string, ProficiencyRank> {
+  return new Map(entries as [string, ProficiencyRank][]);
+}
+
+// ---------------------------------------------------------------------------
+// Parser unit tests — verify structural output before evaluator runs
+// ---------------------------------------------------------------------------
+
+describe('parsePrerequisite: new pattern shapes', () => {
+  it('parses "trained in at least one skill" → skill-rank-any', () => {
+    expect(parsePrerequisite('trained in at least one skill')).toEqual([{ kind: 'skill-rank-any', min: 1 }]);
+  });
+
+  it('parses "trained in any skill" → skill-rank-any', () => {
+    expect(parsePrerequisite('trained in any skill')).toEqual([{ kind: 'skill-rank-any', min: 1 }]);
+  });
+
+  it('parses "expert in any skill" → skill-rank-any with min 2', () => {
+    expect(parsePrerequisite('expert in any skill')).toEqual([{ kind: 'skill-rank-any', min: 2 }]);
+  });
+
+  it('parses "master in Occultism or Religion" → skill-rank-any-of', () => {
+    expect(parsePrerequisite('master in Occultism or Religion')).toEqual([
+      { kind: 'skill-rank-any-of', skills: ['occultism', 'religion'], min: 3 },
+    ]);
+  });
+
+  it('parses "expert in Arcana, Nature, Occultism, or Religion" → skill-rank-any-of', () => {
+    expect(parsePrerequisite('expert in Arcana, Nature, Occultism, or Religion')).toEqual([
+      { kind: 'skill-rank-any-of', skills: ['arcana', 'nature', 'occultism', 'religion'], min: 2 },
+    ]);
+  });
+
+  it('parses "trained in Arcana or Nature" → skill-rank-any-of', () => {
+    expect(parsePrerequisite('trained in Arcana or Nature')).toEqual([
+      { kind: 'skill-rank-any-of', skills: ['arcana', 'nature'], min: 1 },
+    ]);
+  });
+
+  it('still parses single-skill "trained in Athletics" → skill-rank', () => {
+    expect(parsePrerequisite('trained in Athletics')).toEqual([{ kind: 'skill-rank', skill: 'athletics', min: 1 }]);
+  });
+
+  it('still handles semicolon-separated multi-prereq strings', () => {
+    const preds = parsePrerequisite('trained in Athletics; Strength 14');
+    expect(preds).toHaveLength(2);
+    expect(preds[0]).toEqual({ kind: 'skill-rank', skill: 'athletics', min: 1 });
+    expect(preds[1]).toEqual({ kind: 'ability', ability: 'str', min: 14 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Assurance — "trained in at least one skill"
+// ---------------------------------------------------------------------------
+
+describe('Assurance: "trained in at least one skill"', () => {
+  const PREREQ = 'trained in at least one skill';
+
+  it('passes when character is trained in Athletics', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['athletics', 1]]) });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('meets');
+  });
+
+  it('passes when character is expert in any skill (expert satisfies trained)', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['medicine', 2]]) });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('meets');
+  });
+
+  it('passes when character is legendary in any skill', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['stealth', 4]]) });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('meets');
+  });
+
+  it('fails when all skills are untrained (rank 0)', () => {
+    const ctx = makeCtx({
+      skillRanks: skillMap([
+        ['athletics', 0],
+        ['acrobatics', 0],
+        ['arcana', 0],
+        ['diplomacy', 0],
+      ]),
+    });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('fails');
+  });
+
+  it('returns unknown when skill map is empty (context has no data)', () => {
+    const ctx = makeCtx({ skillRanks: new Map() });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('unknown');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Assured Identification — "expert in Arcana, Nature, Occultism, or Religion"
+// ---------------------------------------------------------------------------
+
+describe('Assured Identification: "expert in Arcana, Nature, Occultism, or Religion"', () => {
+  const PREREQ = 'expert in Arcana, Nature, Occultism, or Religion';
+
+  it('passes when character is expert in Religion only', () => {
+    const ctx = makeCtx({
+      skillRanks: skillMap([
+        ['religion', 2],
+        ['arcana', 0],
+        ['nature', 0],
+        ['occultism', 0],
+      ]),
+    });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('meets');
+  });
+
+  it('passes when character is master in Arcana (exceeds expert)', () => {
+    const ctx = makeCtx({
+      skillRanks: skillMap([
+        ['arcana', 3],
+        ['nature', 0],
+        ['occultism', 0],
+        ['religion', 0],
+      ]),
+    });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('meets');
+  });
+
+  it('fails when character is expert in Crafting only (not in the list)', () => {
+    const ctx = makeCtx({
+      skillRanks: skillMap([
+        ['crafting', 2],
+        ['arcana', 0],
+        ['nature', 0],
+        ['occultism', 0],
+        ['religion', 0],
+      ]),
+    });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('fails');
+  });
+
+  it('fails when character is trained (rank 1) in all four listed skills', () => {
+    const ctx = makeCtx({
+      skillRanks: skillMap([
+        ['arcana', 1],
+        ['nature', 1],
+        ['occultism', 1],
+        ['religion', 1],
+      ]),
+    });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('fails');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Break Curse — "master in Occultism or Religion"
+// ---------------------------------------------------------------------------
+
+describe('Break Curse: "master in Occultism or Religion"', () => {
+  const PREREQ = 'master in Occultism or Religion';
+
+  it('passes when character is master in Occultism', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['occultism', 3], ['religion', 0]]) });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('meets');
+  });
+
+  it('passes when character is legendary in Religion (exceeds master)', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['occultism', 0], ['religion', 4]]) });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('meets');
+  });
+
+  it('fails when character is expert in Religion (one rank short)', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['occultism', 0], ['religion', 2]]) });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('fails');
+  });
+
+  it('fails when character is expert in Occultism', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['occultism', 2], ['religion', 0]]) });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('fails');
+  });
+
+  it('fails when both Occultism and Religion are untrained', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['occultism', 0], ['religion', 0]]) });
+    expect(evaluateAll(parsePrerequisite(PREREQ), ctx)).toBe('fails');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rank ordering: trained(1) < expert(2) < master(3) < legendary(4)
+// ---------------------------------------------------------------------------
+
+describe('rank ordering edge cases', () => {
+  it('trained (1) satisfies a "trained in X" prereq', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['occultism', 1]]) });
+    expect(evaluateAll(parsePrerequisite('trained in Occultism'), ctx)).toBe('meets');
+  });
+
+  it('expert (2) satisfies a "trained in X" prereq', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['occultism', 2]]) });
+    expect(evaluateAll(parsePrerequisite('trained in Occultism'), ctx)).toBe('meets');
+  });
+
+  it('legendary (4) satisfies a "trained in X" prereq', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['occultism', 4]]) });
+    expect(evaluateAll(parsePrerequisite('trained in Occultism'), ctx)).toBe('meets');
+  });
+
+  it('untrained (0) fails a "trained in X" prereq', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['occultism', 0]]) });
+    expect(evaluateAll(parsePrerequisite('trained in Occultism'), ctx)).toBe('fails');
+  });
+
+  it('expert (2) fails a "master in X" prereq', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['religion', 2]]) });
+    expect(evaluateAll(parsePrerequisite('master in Religion'), ctx)).toBe('fails');
+  });
+
+  it('master (3) satisfies a "master in X" prereq', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['religion', 3]]) });
+    expect(evaluateAll(parsePrerequisite('master in Religion'), ctx)).toBe('meets');
+  });
+
+  it('legendary (4) satisfies a "master in X" prereq', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['religion', 4]]) });
+    expect(evaluateAll(parsePrerequisite('master in Religion'), ctx)).toBe('meets');
+  });
+
+  it('skill-rank-any respects rank threshold (trained-any with expert skill)', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['nature', 2]]) });
+    expect(evaluateAll(parsePrerequisite('trained in at least one skill'), ctx)).toBe('meets');
+  });
+
+  it('skill-rank-any fails correctly when threshold is master and only expert skills exist', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['nature', 2], ['arcana', 1]]) });
+    expect(evaluateAll(parsePrerequisite('master in any skill'), ctx)).toBe('fails');
+  });
+
+  it('skill-rank-any passes when one skill meets the master threshold', () => {
+    const ctx = makeCtx({ skillRanks: skillMap([['nature', 3], ['arcana', 1]]) });
+    expect(evaluateAll(parsePrerequisite('master in any skill'), ctx)).toBe('meets');
+  });
+});

--- a/apps/player-portal/src/prereqs/types.ts
+++ b/apps/player-portal/src/prereqs/types.ts
@@ -14,6 +14,10 @@ export type Predicate =
   | { kind: 'skill-rank'; skill: string; min: ProficiencyRank }
   | { kind: 'skill-rank-any'; min: ProficiencyRank }
   | { kind: 'skill-rank-any-of'; skills: string[]; min: ProficiencyRank }
+  // OR-list that additionally accepts any lore skill at min (e.g. "master in Crafting, Performance, or a Lore skill")
+  | { kind: 'skill-rank-any-of-or-lore'; skills: string[]; min: ProficiencyRank }
+  // Standalone "a Lore skill" wildcard (any lore skill at min)
+  | { kind: 'skill-rank-any-lore'; min: ProficiencyRank }
   | { kind: 'feat'; name: string }
   | { kind: 'ancestry'; slug: string }
   | { kind: 'class'; slug: string }
@@ -35,11 +39,17 @@ export interface CharacterContext {
   level: number;
   classTrait?: string; // e.g. 'barbarian'
   ancestryTrait?: string; // e.g. 'human'
-  /** lower-cased skill slug → rank. Includes 0 (Untrained). */
+  /** lower-cased skill slug → rank. Hyphens normalised to spaces so prereq
+   *  strings ("Herbalism Lore") match lore slugs ("herbalism-lore").
+   *  Includes 0 (Untrained) and also 'perception'. */
   skillRanks: Map<string, ProficiencyRank>;
   abilityMods: Record<AbilityKey, number>;
   /** Names of items the character carries that prereqs can reference —
    *  feats + class features. Case-insensitive lookups via `.has`
    *  against a lower-cased set. */
   features: Set<string>;
+  /** Normalised slugs (hyphens→spaces, lower-cased) of lore skills the
+   *  character has proficiency in, at any rank.  Used by skill-rank-any-lore
+   *  and skill-rank-any-of-or-lore predicates. */
+  loreSkillSlugs: Set<string>;
 }

--- a/apps/player-portal/src/prereqs/types.ts
+++ b/apps/player-portal/src/prereqs/types.ts
@@ -12,6 +12,8 @@ import type { AbilityKey, ProficiencyRank } from '../api/types';
 // Nothing else should need to touch prereq logic.
 export type Predicate =
   | { kind: 'skill-rank'; skill: string; min: ProficiencyRank }
+  | { kind: 'skill-rank-any'; min: ProficiencyRank }
+  | { kind: 'skill-rank-any-of'; skills: string[]; min: ProficiencyRank }
   | { kind: 'feat'; name: string }
   | { kind: 'ancestry'; slug: string }
   | { kind: 'class'; slug: string }

--- a/apps/player-portal/src/prereqs/types.ts
+++ b/apps/player-portal/src/prereqs/types.ts
@@ -49,7 +49,12 @@ export interface CharacterContext {
    *  against a lower-cased set. */
   features: Set<string>;
   /** Normalised slugs (hyphens→spaces, lower-cased) of lore skills the
-   *  character has proficiency in, at any rank.  Used by skill-rank-any-lore
-   *  and skill-rank-any-of-or-lore predicates. */
-  loreSkillSlugs: Set<string>;
+   *  character has at any rank, built from a COMPLETE actor payload.
+   *
+   *  - `Set<string>` (possibly empty): definitive — an absent lore skill
+   *    genuinely isn't owned by this character.
+   *  - `undefined`: incomplete context (sparse tests, partial data) —
+   *    treat any absent lore skill as 'unknown' rather than 'fails'.
+   */
+  loreSkillSlugs: Set<string> | undefined;
 }


### PR DESCRIPTION
## Summary

The feat prerequisite checker now correctly handles six prereq pattern shapes that previously returned `unknown` or wrong results. All changes are purely additive — existing patterns are untouched.

## Prereq patterns now supported

| Pattern | Example feat | Before | After |
|---|---|---|---|
| `trained in at least one skill` / `trained in any skill` | Assurance | `unknown` | real pass/fail |
| `<rank> in Skill1 or Skill2` | Break Curse | `unknown` (comma split mangled it) | real pass/fail |
| `<rank> in S1, S2, ..., or SN` | Assured Identification | misread as AND chain | real OR pass/fail |
| `Ability +N` (modifier notation) | A Home in Every Port | `unknown` | real pass/fail (converts to score threshold 10+2N) |
| `<rank> in Perception` | Bloodsense | `unknown` (Perception not in `sys.skills`) | real pass/fail |
| Bare feat name (`Pick Up the Pace`) | Caravan Leader | `unknown` | real pass/fail against character features |
| `<rank> at Skill` ("at" instead of "in") | Doublespeak | `unknown` | real pass/fail |

## Changes

- `types.ts`: `skill-rank-any` and `skill-rank-any-of` predicate variants
- `parser.ts`: whole-phrase detection pass before comma-splitting; `(?:in|at)` in all skill-rank regexes; `ABILITY_MOD_RE` for `+N` notation; title-cased phrase fallback → `feat` kind
- `evaluator.ts`: evaluator cases for `skill-rank-any` and `skill-rank-any-of`
- `character-context.ts`: `sys.perception.rank` added to `skillRanks`
- `prereqs.test.ts`: 305 tests total (was 263 before this PR)

## Test plan

- [x] `npm run test -w apps/player-portal` — 305 passed
- [x] `npm run typecheck -w apps/player-portal` — clean
- [x] `npm run lint -w apps/player-portal` — 0 errors
- [x] Prettier clean on all changed files