### PR TITLE
chore: require PRs to declare which apps they touched

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,13 @@ Lint in this monorepo is slow — TypeScript-aware rules type-check across works
 - Push frequently — at minimum after every logical unit of work, and always before ending a session.
 - Run `npm run lint` + `npm run format:check` before committing; fix warnings before pushing.
 - Commit only when explicitly asked.
+- **PR descriptions must declare which apps were touched.** List the affected apps and their dev commands near the top so the reviewer knows what to spin up in the worktree. Example:
+
+  **Apps touched**
+  - `apps/dm-tool` — `npm run dev:dm-tool`
+  - `apps/foundry-mcp` — `npm run dev:mcp`
+
+  If only `packages/*` changed, name which app(s) consume the changed package so the reviewer can pick a representative one to validate. If no app needs to be spun up (pure docs / config / CI), say so explicitly.
 
 ## Key gotchas
 


### PR DESCRIPTION
## Summary

Adds a PR-discipline rule to the root `CLAUDE.md`: every PR description must declare which apps were touched and list the corresponding `npm run dev:*` commands so the reviewer knows what to spin up in the worktree when validating.

**Apps touched**

None — this is a `CLAUDE.md`-only change. No app code was modified; no dev server needs to be started to validate this PR. CI passing is sufficient.

## Changes

- Added bullet to the "Git workflow" section of `CLAUDE.md` requiring PR descriptions to list affected apps and their dev commands (or explicitly state that no app needs to be started).

## Test plan

- [ ] CI green