### PR TITLE
feat(player-portal): toggle item investment from inventory

### DIFF
--- a/apps/foundry-api-bridge/src/commands/handlers/actor/GetPreparedActorHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/GetPreparedActorHandler.ts
@@ -22,6 +22,9 @@ interface FoundryActor extends ToObjectable {
   type: string;
   img: string | undefined;
   items: ActorItemsCollection;
+  // actor.system is the live post-prepareData object; used selectively to
+  // pick up derived fields that toObject(false) may not include.
+  system: { resources?: unknown };
 }
 
 interface ActorsCollection {
@@ -59,6 +62,12 @@ export function getPreparedActorHandler(params: GetActorParams): Promise<Prepare
   });
 
   const snapshot = actor.toObject(false);
+  // PF2e recomputes investiture.value (and potentially other resource
+  // counters) in prepareDerivedData. Those mutations live on actor.system
+  // and are not always reflected in the toObject(false) snapshot, which may
+  // serialise from _source for schema-backed fields. Overlay resources from
+  // the live prepared object so callers see the correct derived values.
+  snapshot.system['resources'] = actor.system.resources;
 
   return Promise.resolve({
     id: actor.id,

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/GetPreparedActorHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/GetPreparedActorHandler.ts
@@ -22,9 +22,6 @@ interface FoundryActor extends ToObjectable {
   type: string;
   img: string | undefined;
   items: ActorItemsCollection;
-  // actor.system is the live post-prepareData object; used selectively to
-  // pick up derived fields that toObject(false) may not include.
-  system: { resources?: unknown };
 }
 
 interface ActorsCollection {
@@ -62,12 +59,6 @@ export function getPreparedActorHandler(params: GetActorParams): Promise<Prepare
   });
 
   const snapshot = actor.toObject(false);
-  // PF2e recomputes investiture.value (and potentially other resource
-  // counters) in prepareDerivedData. Those mutations live on actor.system
-  // and are not always reflected in the toObject(false) snapshot, which may
-  // serialise from _source for schema-backed fields. Overlay resources from
-  // the live prepared object so callers see the correct derived values.
-  snapshot.system['resources'] = actor.system.resources;
 
   return Promise.resolve({
     id: actor.id,

--- a/apps/player-portal/src/components/tabs/Character.test.tsx
+++ b/apps/player-portal/src/components/tabs/Character.test.tsx
@@ -124,12 +124,9 @@ describe('Character tab', () => {
     }
   });
 
-  it('shows investiture resource for Amiri (0/10)', () => {
+  it('does not render an investiture counter (moved to Inventory tab)', () => {
     const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
-    const inv = container.querySelector('[data-stat="investiture"]');
-    expect(inv, 'investiture').toBeTruthy();
-    expect(inv?.textContent).toContain('0');
-    expect(inv?.textContent).toContain('/10');
+    expect(container.querySelector('[data-stat="investiture"]')).toBeNull();
   });
 
   it('omits Focus and Mythic resources when max is zero', () => {

--- a/apps/player-portal/src/components/tabs/Character.tsx
+++ b/apps/player-portal/src/components/tabs/Character.tsx
@@ -400,7 +400,7 @@ function ResourcesRow({
   actorId: string;
   onActorChanged: () => void;
 }): React.ReactElement {
-  const { heroPoints, focus, investiture, mythicPoints } = resources;
+  const { heroPoints, focus, mythicPoints } = resources;
   const adjustHero = useActorAction({
     run: (delta: number) => api.adjustActorResource(actorId, 'hero-points', delta),
     onSuccess: onActorChanged,
@@ -447,9 +447,6 @@ function ResourcesRow({
             colorOn="border-amber-400 bg-amber-500"
             data-stat="mythic-points"
           />
-        )}
-        {investiture.max > 0 && (
-          <CountResource label="Invested" value={investiture.value} max={investiture.max} data-stat="investiture" />
         )}
       </div>
       {error !== null && (
@@ -504,28 +501,6 @@ function PipResource({
       )}
       <span className="font-mono text-xs tabular-nums text-pf-text-muted">
         {value}/{max}
-      </span>
-    </div>
-  );
-}
-
-function CountResource({
-  label,
-  value,
-  max,
-  ...rest
-}: {
-  label: string;
-  value: number;
-  max: number;
-  'data-stat'?: string;
-}): React.ReactElement {
-  return (
-    <div className="flex items-center gap-2" {...rest}>
-      <span className="text-[11px] font-semibold uppercase tracking-widest text-pf-text-muted">{label}</span>
-      <span className="font-mono text-sm tabular-nums text-pf-text">
-        {value}
-        <span className="text-pf-text-muted">/{max}</span>
       </span>
     </div>
   );

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 import { api } from '../../api/client';
-import type { PhysicalItem, PhysicalItemType, PreparedActorItem } from '../../api/types';
+import type { PhysicalItem, PhysicalItemType, PointPool, PreparedActorItem } from '../../api/types';
 import { isCoin, isContainer, isPhysicalItem } from '../../api/types';
 import { useExpandableCard } from '../../lib/useExpandableCard';
+import { supportsInvestment, wouldExceedInvestmentCap } from '../../lib/investment';
 import {
   coinItemsByDenom,
   coinSlugFor,
@@ -22,6 +23,7 @@ interface Props {
   items: PreparedActorItem[];
   actorId?: string;
   onActorChanged?: () => void;
+  investiture?: PointPool;
 }
 
 type ViewMode = 'list' | 'grid';
@@ -96,7 +98,7 @@ function groupByCategory(items: readonly PhysicalItem[]): Map<InventoryCategory,
 // Ported in spirit from pf2e's static/templates/actors/character/tabs/
 // inventory.hbs, but flattened — our read-only viewer doesn't need
 // stow/carry/drop controls or quantity adjusters.
-export function Inventory({ items, actorId, onActorChanged }: Props): React.ReactElement {
+export function Inventory({ items, actorId, onActorChanged, investiture }: Props): React.ReactElement {
   // One uuid-hover instance for every expanded item description —
   // event delegation on the section picks up anchors produced by
   // `enrichDescription` regardless of which item was expanded.
@@ -105,6 +107,7 @@ export function Inventory({ items, actorId, onActorChanged }: Props): React.Reac
   const [shopView, setShopView] = useState<ShopView>('inventory');
   const [pendingBuys, setPendingBuys] = useState<Set<string>>(new Set());
   const [pendingSells, setPendingSells] = useState<Set<string>>(new Set());
+  const [pendingInvestments, setPendingInvestments] = useState<Set<string>>(new Set());
   const [txError, setTxError] = useState<string | null>(null);
   const shopMode = useShopMode();
 
@@ -148,6 +151,30 @@ export function Inventory({ items, actorId, onActorChanged }: Props): React.Reac
       setTxError(err instanceof Error ? err.message : String(err));
     } finally {
       setPendingSells((prev) => {
+        const next = new Set(prev);
+        next.delete(item.id);
+        return next;
+      });
+    }
+  };
+
+  const handleToggleInvestment = async (item: PhysicalItem): Promise<void> => {
+    if (!canTransact || investiture === undefined) return;
+    setTxError(null);
+    if (wouldExceedInvestmentCap(investiture, item)) {
+      setTxError(`Investment limit reached (${investiture.value.toString()}/${investiture.max.toString()} items invested).`);
+      return;
+    }
+    setPendingInvestments((prev) => new Set(prev).add(item.id));
+    try {
+      await api.updateActorItem(actorId, item.id, {
+        system: { 'equipped.invested': !item.system.equipped.invested },
+      });
+      onActorChanged();
+    } catch (err) {
+      setTxError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setPendingInvestments((prev) => {
         const next = new Set(prev);
         next.delete(item.id);
         return next;
@@ -222,6 +249,11 @@ export function Inventory({ items, actorId, onActorChanged }: Props): React.Reac
                   ? { sellRatio: shopMode.sellRatio, pending: pendingSells, onSell: handleSell }
                   : undefined
               }
+              investContext={
+                canTransact && investiture !== undefined
+                  ? { investiture, pending: pendingInvestments, onToggle: handleToggleInvestment }
+                  : undefined
+              }
             />
           )}
         </>
@@ -235,6 +267,12 @@ interface SellContext {
   sellRatio: number;
   pending: Set<string>;
   onSell: (item: PhysicalItem) => Promise<void>;
+}
+
+interface InvestContext {
+  investiture: PointPool;
+  pending: Set<string>;
+  onToggle: (item: PhysicalItem) => Promise<void>;
 }
 
 // ─── Shop transactions ─────────────────────────────────────────────────
@@ -344,12 +382,14 @@ function CategorizedInventory({
   allByCategory,
   byContainer,
   sellContext,
+  investContext,
 }: {
   view: ViewMode;
   topLevelByCategory: Map<InventoryCategory, PhysicalItem[]>;
   allByCategory: Map<InventoryCategory, PhysicalItem[]>;
   byContainer: Map<string, PhysicalItem[]>;
   sellContext: SellContext | undefined;
+  investContext: InvestContext | undefined;
 }): React.ReactElement {
   const buckets = view === 'list' ? topLevelByCategory : allByCategory;
   const presentCategories = CATEGORY_ORDER.filter((c) => (buckets.get(c)?.length ?? 0) > 0);
@@ -371,6 +411,7 @@ function CategorizedInventory({
                     item={item}
                     contents={isContainer(item) ? (byContainer.get(item.id) ?? []) : []}
                     sellContext={sellContext}
+                    investContext={investContext}
                   />
                 ))}
               </ul>
@@ -381,7 +422,7 @@ function CategorizedInventory({
                 data-view="grid"
               >
                 {bucket.map((item) => (
-                  <GridTile key={item.id} item={item} sellContext={sellContext} />
+                  <GridTile key={item.id} item={item} sellContext={sellContext} investContext={investContext} />
                 ))}
               </ul>
             )}
@@ -573,10 +614,12 @@ function ItemRow({
   item,
   contents,
   sellContext,
+  investContext,
 }: {
   item: PhysicalItem;
   contents: PhysicalItem[];
   sellContext: SellContext | undefined;
+  investContext: InvestContext | undefined;
 }): React.ReactElement {
   const card = useExpandableCard();
   const isContainerRow = isContainer(item);
@@ -585,6 +628,7 @@ function ItemRow({
     isContainerRow && typeof bulk.capacity === 'number'
       ? `capacity ${bulk.capacity.toString()}${typeof bulk.ignored === 'number' ? ` (${bulk.ignored.toString()} ignored)` : ''}`
       : undefined;
+  const hasInvestButton = investContext !== undefined && supportsInvestment(item);
 
   return (
     <li className="relative" data-item-id={item.id} data-item-type={item.type}>
@@ -619,7 +663,8 @@ function ItemRow({
               )}
             </div>
           </div>
-          <EquippedBadge item={item} />
+          <EquippedBadge item={item} suppressInvested={hasInvestButton} />
+          {hasInvestButton && <InvestButton item={item} context={investContext} />}
           <BulkLabel value={bulk.value} />
           {sellContext && <SellButton item={item} context={sellContext} />}
           <span className="ml-1 text-[10px] text-pf-alt-dark group-open:hidden">▸</span>
@@ -676,6 +721,36 @@ function SellButton({ item, context }: { item: PhysicalItem; context: SellContex
   );
 }
 
+function InvestButton({ item, context }: { item: PhysicalItem; context: InvestContext }): React.ReactElement {
+  const busy = context.pending.has(item.id);
+  const isInvested = item.system.equipped.invested === true;
+  return (
+    <button
+      type="button"
+      data-testid="invest-button"
+      disabled={busy}
+      onClick={(e): void => {
+        e.preventDefault();
+        e.stopPropagation();
+        void context.onToggle(item);
+      }}
+      className={[
+        'shrink-0 rounded border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wider',
+        busy
+          ? 'border-pf-primary bg-pf-primary/10 text-pf-primary'
+          : isInvested
+            ? 'border-violet-300 bg-violet-50 text-violet-800 hover:bg-violet-100'
+            : 'border-violet-200 bg-white text-violet-500 hover:bg-violet-50',
+      ].join(' ')}
+      title={isInvested ? 'Click to uninvest' : 'Click to invest'}
+      aria-pressed={isInvested}
+      aria-label={isInvested ? `Uninvest ${item.name}` : `Invest ${item.name}`}
+    >
+      {busy ? (isInvested ? 'Uninvesting…' : 'Investing…') : isInvested ? '◆ Invested' : '◇ Invest'}
+    </button>
+  );
+}
+
 // Compact denomination label for the sell button ("4 gp 8 sp"). The
 // full breakdown is already in formatCp; this keeps the chip narrow by
 // collapsing to the two largest non-zero denominations.
@@ -724,10 +799,13 @@ function ContainerChildRow({ item }: { item: PhysicalItem }): React.ReactElement
 function GridTile({
   item,
   sellContext,
+  investContext,
 }: {
   item: PhysicalItem;
   sellContext: SellContext | undefined;
+  investContext: InvestContext | undefined;
 }): React.ReactElement {
+  const hasInvestButton = investContext !== undefined && supportsInvestment(item);
   return (
     <li className="relative" data-item-id={item.id} data-item-type={item.type}>
       {/* open:min-w-[18rem] expands the tile rightward to match the panel
@@ -748,8 +826,9 @@ function GridTile({
             {item.name}
           </span>
           <div className="flex min-h-[16px] flex-wrap gap-1">
-            <EquippedBadge item={item} />
+            <EquippedBadge item={item} suppressInvested={hasInvestButton} />
           </div>
+          {hasInvestButton && <InvestButton item={item} context={investContext} />}
           {sellContext && <SellButton item={item} context={sellContext} />}
         </summary>
         <div className="absolute left-0 right-0 top-full z-20 rounded-b border border-t-0 border-pf-primary/60 bg-pf-bg p-3 text-left text-sm text-pf-text shadow-lg">
@@ -776,7 +855,13 @@ function ItemDescription({ item }: { item: PhysicalItem }): React.ReactElement {
   );
 }
 
-function EquippedBadge({ item }: { item: PhysicalItem }): React.ReactElement | null {
+function EquippedBadge({
+  item,
+  suppressInvested = false,
+}: {
+  item: PhysicalItem;
+  suppressInvested?: boolean;
+}): React.ReactElement | null {
   const eq = item.system.equipped;
   if (eq.handsHeld !== undefined && eq.handsHeld > 0) {
     return <Badge color="emerald">Held ({eq.handsHeld}H)</Badge>;
@@ -793,7 +878,7 @@ function EquippedBadge({ item }: { item: PhysicalItem }): React.ReactElement | n
   // and most other items can have `equipped.invested === true` left
   // on them from Foundry defaults, so we gate the badge on the trait
   // instead of trusting the flag alone.
-  if (eq.invested === true && item.system.traits.value.includes('invested')) {
+  if (!suppressInvested && eq.invested === true && item.system.traits.value.includes('invested')) {
     return <Badge color="violet">Invested</Badge>;
   }
   return null;

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -234,7 +234,18 @@ export function Inventory({ items, actorId, onActorChanged, investiture }: Props
               )}
               <ShopGearMenu shopMode={shopMode} />
             </div>
+            <div className="flex items-center gap-4">
+            {investiture !== undefined && investiture.max > 0 && (
+              <div className="flex items-center gap-2" data-stat="investiture">
+                <span className="text-[11px] font-semibold uppercase tracking-widest text-pf-text-muted">Invested</span>
+                <span className="font-mono text-sm tabular-nums text-pf-text">
+                  {investiture.value}
+                  <span className="text-pf-text-muted">/{investiture.max}</span>
+                </span>
+              </div>
+            )}
             {effectiveShopView === 'inventory' && <ViewToggle view={view} onChange={setView} />}
+          </div>
           </div>
           {effectiveShopView === 'shop' && canTransact ? (
             <ItemShopPicker items={items} onBuy={handleBuy} pending={pendingBuys} />

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -161,8 +161,8 @@ export function Inventory({ items, actorId, onActorChanged, investiture }: Props
   const handleToggleInvestment = async (item: PhysicalItem): Promise<void> => {
     if (!canTransact || investiture === undefined) return;
     setTxError(null);
-    if (wouldExceedInvestmentCap(investiture, item)) {
-      setTxError(`Investment limit reached (${investiture.value.toString()}/${investiture.max.toString()} items invested).`);
+    if (wouldExceedInvestmentCap({ value: investedCount, max: investiture.max }, item)) {
+      setTxError(`Investment limit reached (${investedCount.toString()}/${investiture.max.toString()} items invested).`);
       return;
     }
     setPendingInvestments((prev) => new Set(prev).add(item.id));
@@ -183,6 +183,7 @@ export function Inventory({ items, actorId, onActorChanged, investiture }: Props
   };
 
   const physical = items.filter(isPhysicalItem);
+  const investedCount = physical.filter((i) => supportsInvestment(i) && i.system.equipped.invested === true).length;
 
   const coins = physical.filter(isCoin);
   // Treasure coins get their own dedicated strip at the top; strip
@@ -239,7 +240,7 @@ export function Inventory({ items, actorId, onActorChanged, investiture }: Props
               <div className="flex items-center gap-2" data-stat="investiture">
                 <span className="text-[11px] font-semibold uppercase tracking-widest text-pf-text-muted">Invested</span>
                 <span className="font-mono text-sm tabular-nums text-pf-text">
-                  {investiture.value}
+                  {investedCount}
                   <span className="text-pf-text-muted">/{investiture.max}</span>
                 </span>
               </div>

--- a/apps/player-portal/src/lib/investment.test.ts
+++ b/apps/player-portal/src/lib/investment.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import type { PhysicalItem, PointPool } from '../api/types';
+import { supportsInvestment, wouldExceedInvestmentCap } from './investment';
+
+function makeItem(invested: boolean | null | undefined, traits: string[] = []): PhysicalItem {
+  return {
+    id: 'item-1',
+    name: 'Test Ring',
+    type: 'equipment',
+    img: 'test.png',
+    system: {
+      slug: null,
+      level: { value: 1 },
+      quantity: 1,
+      bulk: { value: 0 },
+      equipped: {
+        carryType: 'worn',
+        // exactOptionalPropertyTypes: omit the property entirely when undefined
+        ...(invested !== undefined ? { invested } : {}),
+      },
+      containerId: null,
+      traits: { value: traits, rarity: 'common' },
+    },
+  };
+}
+
+function makePool(value: number, max: number): PointPool {
+  return { value, max };
+}
+
+describe('supportsInvestment', () => {
+  it('returns false when invested is null (item does not support investment)', () => {
+    expect(supportsInvestment(makeItem(null, ['invested']))).toBe(false);
+  });
+
+  it('returns false when invested is undefined (field absent)', () => {
+    expect(supportsInvestment(makeItem(undefined, ['invested']))).toBe(false);
+  });
+
+  it('returns false when the invested trait is missing even if flag is set', () => {
+    expect(supportsInvestment(makeItem(false, []))).toBe(false);
+    expect(supportsInvestment(makeItem(true, []))).toBe(false);
+  });
+
+  it('returns false when item has other traits but not invested', () => {
+    expect(supportsInvestment(makeItem(false, ['magical', 'abjuration']))).toBe(false);
+  });
+
+  it('returns true when invested is false and the invested trait is present', () => {
+    expect(supportsInvestment(makeItem(false, ['invested']))).toBe(true);
+  });
+
+  it('returns true when invested is true and the invested trait is present', () => {
+    expect(supportsInvestment(makeItem(true, ['invested']))).toBe(true);
+  });
+
+  it('returns true when invested trait is present alongside other traits', () => {
+    expect(supportsInvestment(makeItem(false, ['magical', 'invested', 'abjuration']))).toBe(true);
+  });
+});
+
+describe('wouldExceedInvestmentCap', () => {
+  it('returns false when uninvesting an already-invested item, even at full cap', () => {
+    const item = makeItem(true, ['invested']);
+    expect(wouldExceedInvestmentCap(makePool(10, 10), item)).toBe(false);
+  });
+
+  it('returns false when cap is not reached', () => {
+    const item = makeItem(false, ['invested']);
+    expect(wouldExceedInvestmentCap(makePool(5, 10), item)).toBe(false);
+  });
+
+  it('returns false one slot below the cap', () => {
+    const item = makeItem(false, ['invested']);
+    expect(wouldExceedInvestmentCap(makePool(9, 10), item)).toBe(false);
+  });
+
+  it('returns true when current count equals the cap', () => {
+    const item = makeItem(false, ['invested']);
+    expect(wouldExceedInvestmentCap(makePool(10, 10), item)).toBe(true);
+  });
+
+  it('returns true when current count exceeds the cap (defensive)', () => {
+    const item = makeItem(false, ['invested']);
+    expect(wouldExceedInvestmentCap(makePool(11, 10), item)).toBe(true);
+  });
+});

--- a/apps/player-portal/src/lib/investment.ts
+++ b/apps/player-portal/src/lib/investment.ts
@@ -1,0 +1,11 @@
+import type { PhysicalItem, PointPool } from '../api/types';
+
+export function supportsInvestment(item: PhysicalItem): boolean {
+  const { invested } = item.system.equipped;
+  return invested !== null && invested !== undefined && item.system.traits.value.includes('invested');
+}
+
+export function wouldExceedInvestmentCap(investiture: PointPool, item: PhysicalItem): boolean {
+  if (item.system.equipped.invested === true) return false;
+  return investiture.value >= investiture.max;
+}

--- a/apps/player-portal/src/routes/CharacterSheet.tsx
+++ b/apps/player-portal/src/routes/CharacterSheet.tsx
@@ -178,7 +178,12 @@ function CharacterSheetInner({ actorId, onBack, preferences }: InnerProps): Reac
           )}
           {activeTab === 'inventory' && (
             <>
-              <Inventory items={state.actor.items} actorId={actorId} onActorChanged={reloadActor} />
+              <Inventory
+                items={state.actor.items}
+                actorId={actorId}
+                onActorChanged={reloadActor}
+                investiture={state.actor.system.resources.investiture}
+              />
               <div className="mt-10 border-t border-pf-border pt-6">
                 <SectionHeader>Crafting</SectionHeader>
                 <Crafting actorId={actorId} crafting={state.actor.system.crafting} />


### PR DESCRIPTION
## Summary

Adds invest/uninvest buttons to every item row and grid tile in the character sheet inventory tab, for items that carry the PF2e \`invested\` trait (rings, cloaks, circlets, and similar magical gear). The toggle is only rendered in interactive mode (has an \`actorId\`); read-only views show the static "Invested" badge instead. Clicking the button PATCHes \`system.equipped.invested\` via the existing \`updateActorItem\` endpoint, then triggers a \`/prepared\` refetch so the item list updates.

The Invested N/10 counter has been moved from the Character tab to the Inventory tab's controls row (top-right, next to the grid/list toggle). The count is derived locally from the item list (\`supportsInvestment && equipped.invested === true\`) rather than from the actor's resource pool, which is unreliable across pf2e versions. Only \`.max\` is read from the server.

Cap enforcement: investing at max (typically 10/10) shows an inline error instead of issuing the request; uninvesting always succeeds.

## Changes

- \`src/lib/investment.ts\` — two pure helpers: \`supportsInvestment\` and \`wouldExceedInvestmentCap\`
- \`src/lib/investment.test.ts\` — 13 Vitest cases
- \`Inventory.tsx\` — \`investiture?: PointPool\` prop (used for \`.max\` only); \`InvestContext\`; \`handleToggleInvestment\` handler; \`InvestButton\` component; investiture counter derived from items; \`suppressInvested\` on \`EquippedBadge\`
- \`Character.tsx\` — remove investiture counter and now-unused \`CountResource\` component
- \`CharacterSheet.tsx\` — pass \`state.actor.system.resources.investiture\` to \`<Inventory>\`

## Test plan

- [ ] Item with \`invested\` trait shows \`◇ Invest\` / \`◆ Invested\` button; items without the trait show no button
- [ ] Investing at 9/10 succeeds; at 10/10 shows inline error
- [ ] Uninvesting works regardless of cap
- [ ] Invested N/10 counter visible in inventory top-right; updates immediately on toggle; absent from Character tab
- [ ] Read-only inventory still shows static violet "Invested" badge
- [ ] \`npm run test -w apps/player-portal\` — 264 tests pass