### PR TITLE
feat(player-portal): click skill chips to roll skill checks

### DIFF
--- a/apps/player-portal/src/components/tabs/Proficiencies.test.tsx
+++ b/apps/player-portal/src/components/tabs/Proficiencies.test.tsx
@@ -29,7 +29,7 @@ describe('Proficiencies', () => {
   });
 
   it('renders every core skill and its value + rank', () => {
-    const { container } = render(<Proficiencies system={system} />);
+    const { container } = render(<Proficiencies system={system} actorId="test-actor" />);
     for (const [slug, { value, rank }] of Object.entries(EXPECTED_SKILLS)) {
       const row = container.querySelector(`[data-statistic="${slug}"]`);
       expect(row, `row for ${slug}`).toBeTruthy();
@@ -41,14 +41,14 @@ describe('Proficiencies', () => {
   });
 
   it('renders the lore skill (Tanning Lore, from Hunter background) as a named row', () => {
-    const { container } = render(<Proficiencies system={system} />);
+    const { container } = render(<Proficiencies system={system} actorId="test-actor" />);
     const row = container.querySelector('[data-statistic="tanning-lore"]');
     expect(row, 'tanning-lore row').toBeTruthy();
     expect(within(row as HTMLElement).getAllByText('Tanning Lore').length).toBeGreaterThan(0);
   });
 
   it('renders martial attack proficiencies', () => {
-    const { container } = render(<Proficiencies system={system} />);
+    const { container } = render(<Proficiencies system={system} actorId="test-actor" />);
     for (const slug of ['simple', 'martial', 'advanced', 'unarmed']) {
       const row = container.querySelector(`[data-slug="${slug}"]`);
       expect(row, `attack row for ${slug}`).toBeTruthy();
@@ -56,7 +56,7 @@ describe('Proficiencies', () => {
   });
 
   it('renders martial defense proficiencies', () => {
-    const { container } = render(<Proficiencies system={system} />);
+    const { container } = render(<Proficiencies system={system} actorId="test-actor" />);
     for (const slug of ['unarmored', 'light', 'medium', 'heavy']) {
       const row = container.querySelector(`[data-slug="${slug}"]`);
       expect(row, `defense row for ${slug}`).toBeTruthy();
@@ -64,7 +64,7 @@ describe('Proficiencies', () => {
   });
 
   it('renders the class DC — Barbarian at DC 17', () => {
-    const { container } = render(<Proficiencies system={system} />);
+    const { container } = render(<Proficiencies system={system} actorId="test-actor" />);
     // The ClassDC row has no data-slug attribute yet; query by unique content.
     const dcRows = Array.from(container.querySelectorAll('li')).filter((li) => li.textContent?.includes('17'));
     expect(dcRows.length).toBeGreaterThan(0);
@@ -73,7 +73,7 @@ describe('Proficiencies', () => {
   });
 
   it('omits spellcasting when rank is 0', () => {
-    const { container } = render(<Proficiencies system={system} />);
+    const { container } = render(<Proficiencies system={system} actorId="test-actor" />);
     // Amiri has spellcasting rank 0; the Spells header key shouldn't render.
     const headers = Array.from(container.querySelectorAll('h2')).map((h) => h.textContent);
     expect(headers.some((h) => h?.includes('Spells'))).toBe(false);

--- a/apps/player-portal/src/components/tabs/Proficiencies.tsx
+++ b/apps/player-portal/src/components/tabs/Proficiencies.tsx
@@ -1,3 +1,4 @@
+import { createPf2eClient } from '@foundry-toolkit/pf2e-rules';
 import type {
   CharacterSystem,
   ClassDC,
@@ -6,15 +7,18 @@ import type {
   ProficiencyRank,
   SkillStatistic,
 } from '../../api/types';
+import { api } from '../../api/client';
 import { t } from '../../i18n/t';
 import { formatSignedInt } from '../../lib/format';
 import { ATTACK_LABEL_KEY, DEFENSE_LABEL_KEY } from '../../lib/pf2e-maps';
+import { useActorAction } from '../../lib/useActorAction';
 import { ModifierTooltip } from '../common/ModifierTooltip';
 import { RankChip } from '../common/RankChip';
 import { SectionHeader } from '../common/SectionHeader';
 
 interface Props {
   system: CharacterSystem;
+  actorId: string;
 }
 
 // Proficiencies tab — a direct port of the data shape consumed by
@@ -26,7 +30,7 @@ interface Props {
 //   4. Defense proficiencies (unarmored/light/medium/heavy/barding)
 //   5. Spellcasting (omitted when rank is 0)
 //   6. Class DCs (one per class; most characters have exactly one)
-export function Proficiencies({ system }: Props): React.ReactElement {
+export function Proficiencies({ system, actorId }: Props): React.ReactElement {
   const skills = Object.values(system.skills);
   const coreSkills = skills.filter((s) => !s.lore);
   const loreSkills = skills.filter((s) => s.lore);
@@ -41,7 +45,7 @@ export function Proficiencies({ system }: Props): React.ReactElement {
       <SectionHeader>{t('PF2E.CoreSkillsHeader')}</SectionHeader>
       <ProficiencyGrid>
         {coreSkills.map((skill) => (
-          <SkillRow key={skill.slug} skill={skill} />
+          <SkillRow key={skill.slug} skill={skill} actorId={actorId} />
         ))}
       </ProficiencyGrid>
 
@@ -50,7 +54,7 @@ export function Proficiencies({ system }: Props): React.ReactElement {
           <SectionHeader>{t('PF2E.LoreSkillsHeader')}</SectionHeader>
           <ProficiencyGrid>
             {loreSkills.map((skill) => (
-              <SkillRow key={skill.slug} skill={skill} spanFull />
+              <SkillRow key={skill.slug} skill={skill} actorId={actorId} spanFull />
             ))}
           </ProficiencyGrid>
         </>
@@ -120,18 +124,41 @@ function ProficiencyGrid({ children }: { children: React.ReactNode }): React.Rea
 
 // ─── Row renderers ─────────────────────────────────────────────────────
 
-function SkillRow({ skill, spanFull }: { skill: SkillStatistic; spanFull?: boolean }): React.ReactElement {
+function SkillRow({
+  skill,
+  actorId,
+  spanFull,
+}: {
+  skill: SkillStatistic;
+  actorId: string;
+  spanFull?: boolean;
+}): React.ReactElement {
+  const roll = useActorAction({
+    run: () => createPf2eClient(api.dispatch).character(actorId).rollSkill(skill.slug),
+  });
+
   return (
     <li
       className={[
-        'group relative flex items-center gap-3 rounded border border-pf-border bg-pf-bg px-3 py-2',
+        'group relative rounded border border-pf-border bg-pf-bg',
         spanFull === true ? 'sm:col-span-2' : '',
-      ].join(' ')}
+      ]
+        .filter(Boolean)
+        .join(' ')}
       data-statistic={skill.slug}
     >
-      <Modifier value={skill.value} />
-      <span className="flex-1 truncate text-sm text-pf-text">{renderLabel(skill.label, skill.lore === true)}</span>
-      <RankChip rank={skill.rank} />
+      <button
+        type="button"
+        className="flex w-full items-center gap-3 px-3 py-2 hover:bg-pf-bg-dark disabled:opacity-50"
+        onClick={() => {
+          roll.trigger();
+        }}
+        disabled={roll.state === 'pending'}
+      >
+        <Modifier value={skill.value} />
+        <span className="flex-1 truncate text-sm text-pf-text">{renderLabel(skill.label, skill.lore === true)}</span>
+        <RankChip rank={skill.rank} />
+      </button>
       <ModifierTooltip title={skill.label} breakdown={skill.breakdown} modifiers={skill.modifiers} />
     </li>
   );

--- a/apps/player-portal/src/routes/CharacterSheet.tsx
+++ b/apps/player-portal/src/routes/CharacterSheet.tsx
@@ -186,7 +186,7 @@ function CharacterSheetInner({ actorId, onBack, preferences }: InnerProps): Reac
             </>
           )}
           {activeTab === 'feats' && <Feats items={state.actor.items} />}
-          {activeTab === 'proficiencies' && <Proficiencies system={state.actor.system} />}
+          {activeTab === 'proficiencies' && <Proficiencies system={state.actor.system} actorId={actorId} />}
           {activeTab === 'progression' && (
             <Progression
               characterLevel={state.actor.system.details.level.value}

--- a/packages/pf2e-rules/src/pf2e-client.test.ts
+++ b/packages/pf2e-rules/src/pf2e-client.test.ts
@@ -88,6 +88,57 @@ describe('createPf2eClient', () => {
     });
   });
 
+  // ─── character().rollSkill ──────────────────────────────────────────────
+
+  describe('character().rollSkill', () => {
+    it('dispatches class=CharacterPF2e, method=skills.<slug>.roll', async () => {
+      const { dispatch, spy } = makeDispatch();
+      await createPf2eClient(dispatch).character('actor-001').rollSkill('acrobatics');
+
+      expect(spy).toHaveBeenCalledOnce();
+      expect(spy).toHaveBeenCalledWith({
+        class: 'CharacterPF2e',
+        id: 'actor-001',
+        method: 'skills.acrobatics.roll',
+        args: [{}],
+      });
+    });
+
+    it('interpolates arbitrary skill slugs including lore skills', async () => {
+      const { dispatch, spy } = makeDispatch();
+      await createPf2eClient(dispatch).character('actor-001').rollSkill('tanning-lore');
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ method: 'skills.tanning-lore.roll' }));
+    });
+
+    it('passes opts through in args[0]', async () => {
+      const { dispatch, spy } = makeDispatch();
+      const opts = { skipDialog: true };
+      await createPf2eClient(dispatch).character('actor-001').rollSkill('athletics', opts);
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ args: [opts] }));
+    });
+
+    it('defaults opts to {} when omitted', async () => {
+      const { dispatch, spy } = makeDispatch();
+      await createPf2eClient(dispatch).character('actor-001').rollSkill('stealth');
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ args: [{}] }));
+    });
+
+    it('uses the actorId supplied to character()', async () => {
+      const { dispatch, spy } = makeDispatch();
+      await createPf2eClient(dispatch).character('specific-actor').rollSkill('arcana');
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ id: 'specific-actor' }));
+    });
+
+    it('returns the DispatchResponse from the dispatch function', async () => {
+      const { dispatch } = makeDispatch();
+      const expected: DispatchResponse = { result: { total: 14, formula: '1d20+3' } };
+      vi.mocked(dispatch).mockResolvedValueOnce(expected);
+
+      const resp = await createPf2eClient(dispatch).character('actor-001').rollSkill('deception');
+      expect(resp).toEqual(expected);
+    });
+  });
+
   // ─── weapon().rollDamage ─────────────────────────────────────────────────
 
   describe('weapon().rollDamage', () => {

--- a/packages/pf2e-rules/src/pf2e-client.ts
+++ b/packages/pf2e-rules/src/pf2e-client.ts
@@ -91,6 +91,27 @@ export function createPf2eClient(dispatch: DispatchFn) {
         },
 
         /**
+         * Roll a skill check via the dispatcher.
+         *
+         * Dispatches: `actor.skills[slug].roll(opts)`
+         *
+         * Works for both core skills (acrobatics, arcana, …) and lore skills
+         * (custom slugs like "tanning-lore") — any slug present on the actor.
+         *
+         * @param slug - PF2e skill slug, e.g. 'acrobatics' or 'tanning-lore'.
+         * @param opts - PF2e CheckRollContext options, e.g. `{ skipDialog, rollMode }`.
+         *   Passed through to Foundry's roll method verbatim.
+         */
+        rollSkill(slug: string, opts: Record<string, unknown> = {}): Promise<DispatchResponse> {
+          return dispatch({
+            class: 'CharacterPF2e',
+            id: actorId,
+            method: `skills.${slug}.roll`,
+            args: [opts],
+          });
+        },
+
+        /**
          * Apply damage to the actor via the dispatcher.
          *
          * Dispatches: `actor.applyDamage(amount, opts)`


### PR DESCRIPTION
## Summary

Skill chips in the character sheet Proficiencies tab are now clickable buttons that roll a PF2e skill check against the bound actor. Clicking any skill (including custom lore skills) fires the standard `actor.skills[slug].roll()` call via the Layer 1 dispatcher client; the existing `CheckPF2e` dialog relay from PR #98 surfaces the dialog to the player automatically.

## Changes

- **`packages/pf2e-rules`** — adds `character(id).rollSkill(slug, opts?)` to `createPf2eClient`, dispatching `skills.<slug>.roll` via the generic dispatcher (Layer 0). Works for all PF2e skill slugs including lore skills with arbitrary slugs.
- **`apps/player-portal`** — `SkillRow` in `Proficiencies.tsx` is now a `<button>` (wrapped inside the list item) using `useActorAction` for the pending guard; hover affordance via `hover:bg-pf-bg-dark disabled:opacity-50`. `Proficiencies` gains a required `actorId` prop threaded from `CharacterSheet`.
- **Tests** — 6 new `pf2e-client` tests covering `rollSkill` dispatch shape (slug interpolation, opts passthrough, lore slugs, return value). Existing `Proficiencies.test.tsx` updated to pass `actorId`.

## Test plan

- [ ] Open character sheet → Proficiencies tab → click any core skill → Foundry rolls a check and posts a chat card
- [ ] Click a lore skill (e.g. Tanning Lore) — same flow
- [ ] Double-click while pending does nothing (button is disabled)
- [ ] Modifier tooltip still appears on hover

Refs #74