### PR TITLE
fix(player-portal): expand inventory detail in place, drop duplicate image

### DIFF
--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -735,7 +735,7 @@ function GridTile({
           right-0 (spans exactly the <details> width) rather than a
           fixed pixel value so it always tracks the tile. */}
       <details className="group relative rounded border border-pf-border bg-pf-bg open:z-10 open:min-w-[18rem] open:rounded-b-none open:border-pf-primary/60 open:shadow-lg">
-        <summary className="flex cursor-pointer list-none flex-col items-center gap-1 p-2 text-center hover:bg-pf-bg-dark/40">
+        <summary className="flex cursor-pointer list-none flex-col items-start gap-1 p-2 hover:bg-pf-bg-dark/40">
           <div className="relative">
             <img src={item.img} alt="" className="h-14 w-14 rounded border border-pf-border bg-pf-bg-dark" />
             {item.system.quantity > 1 && (
@@ -747,7 +747,7 @@ function GridTile({
           <span className="line-clamp-2 text-[11px] font-medium leading-tight text-pf-text" title={item.name}>
             {item.name}
           </span>
-          <div className="flex min-h-[16px] flex-wrap justify-center gap-1">
+          <div className="flex min-h-[16px] flex-wrap gap-1">
             <EquippedBadge item={item} />
           </div>
           {sellContext && <SellButton item={item} context={sellContext} />}

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -730,9 +730,11 @@ function GridTile({
 }): React.ReactElement {
   return (
     <li className="relative" data-item-id={item.id} data-item-type={item.type}>
-      {/* Border lives on <details> (not <summary>) so open:rounded-b-none
-          + panel border-t-0 form one continuous card shape. */}
-      <details className="group relative rounded border border-pf-border bg-pf-bg open:rounded-b-none open:border-pf-primary/60 open:shadow-lg">
+      {/* open:min-w-[18rem] expands the tile rightward to match the panel
+          so both share the same right border edge. Panel uses left-0
+          right-0 (spans exactly the <details> width) rather than a
+          fixed pixel value so it always tracks the tile. */}
+      <details className="group relative rounded border border-pf-border bg-pf-bg open:min-w-[18rem] open:rounded-b-none open:border-pf-primary/60 open:shadow-lg">
         <summary className="flex cursor-pointer list-none flex-col items-center gap-1 p-2 text-center hover:bg-pf-bg-dark/40">
           <div className="relative">
             <img src={item.img} alt="" className="h-14 w-14 rounded border border-pf-border bg-pf-bg-dark" />
@@ -750,10 +752,7 @@ function GridTile({
           </div>
           {sellContext && <SellButton item={item} context={sellContext} />}
         </summary>
-        {/* min-w-[18rem] keeps descriptions readable on narrow tiles;
-            the panel may overhang to the right which is fine. No mt-1 —
-            border-t-0 seals directly against the <details> bottom edge. */}
-        <div className="absolute left-0 top-full z-20 min-w-[18rem] rounded-b border border-t-0 border-pf-primary/60 bg-pf-bg p-3 text-left text-sm text-pf-text shadow-lg">
+        <div className="absolute left-0 right-0 top-full z-20 rounded-b border border-t-0 border-pf-primary/60 bg-pf-bg p-3 text-left text-sm text-pf-text shadow-lg">
           <ItemDescription item={item} />
         </div>
       </details>

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -734,7 +734,7 @@ function GridTile({
           so both share the same right border edge. Panel uses left-0
           right-0 (spans exactly the <details> width) rather than a
           fixed pixel value so it always tracks the tile. */}
-      <details className="group relative rounded border border-pf-border bg-pf-bg open:min-w-[18rem] open:rounded-b-none open:border-pf-primary/60 open:shadow-lg">
+      <details className="group relative rounded border border-pf-border bg-pf-bg open:z-10 open:min-w-[18rem] open:rounded-b-none open:border-pf-primary/60 open:shadow-lg">
         <summary className="flex cursor-pointer list-none flex-col items-center gap-1 p-2 text-center hover:bg-pf-bg-dark/40">
           <div className="relative">
             <img src={item.img} alt="" className="h-14 w-14 rounded border border-pf-border bg-pf-bg-dark" />

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -730,8 +730,10 @@ function GridTile({
 }): React.ReactElement {
   return (
     <li className="relative" data-item-id={item.id} data-item-type={item.type}>
-      <details className="group">
-        <summary className="flex cursor-pointer list-none flex-col items-center gap-1 rounded border border-pf-border bg-pf-bg p-2 text-center hover:bg-pf-bg-dark/40 group-open:border-pf-primary/60 group-open:shadow-lg">
+      {/* Border lives on <details> (not <summary>) so open:rounded-b-none
+          + panel border-t-0 form one continuous card shape. */}
+      <details className="group relative rounded border border-pf-border bg-pf-bg open:rounded-b-none open:border-pf-primary/60 open:shadow-lg">
+        <summary className="flex cursor-pointer list-none flex-col items-center gap-1 p-2 text-center hover:bg-pf-bg-dark/40">
           <div className="relative">
             <img src={item.img} alt="" className="h-14 w-14 rounded border border-pf-border bg-pf-bg-dark" />
             {item.system.quantity > 1 && (
@@ -748,13 +750,10 @@ function GridTile({
           </div>
           {sellContext && <SellButton item={item} context={sellContext} />}
         </summary>
-        {/* Floating detail card below the tile. Fixed 18rem width so
-            descriptions stay readable even when the tile itself is
-            narrow; overlaps neighbouring tiles rather than pushing
-            the grid around. z-20 keeps it above nearby tiles but
-            below the tab bar / popovers. Image stays in the summary
-            above — no duplicate here. */}
-        <div className="absolute left-0 top-full z-20 mt-1 w-72 rounded border border-pf-primary/60 bg-pf-bg p-3 text-left text-sm text-pf-text shadow-lg">
+        {/* min-w-[18rem] keeps descriptions readable on narrow tiles;
+            the panel may overhang to the right which is fine. No mt-1 —
+            border-t-0 seals directly against the <details> bottom edge. */}
+        <div className="absolute left-0 top-full z-20 min-w-[18rem] rounded-b border border-t-0 border-pf-primary/60 bg-pf-bg p-3 text-left text-sm text-pf-text shadow-lg">
           <ItemDescription item={item} />
         </div>
       </details>

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { api } from '../../api/client';
 import type { PhysicalItem, PhysicalItemType, PreparedActorItem } from '../../api/types';
 import { isCoin, isContainer, isPhysicalItem } from '../../api/types';
+import { useExpandableCard } from '../../lib/useExpandableCard';
 import {
   coinItemsByDenom,
   coinSlugFor,
@@ -577,6 +578,7 @@ function ItemRow({
   contents: PhysicalItem[];
   sellContext: SellContext | undefined;
 }): React.ReactElement {
+  const card = useExpandableCard();
   const isContainerRow = isContainer(item);
   const bulk = item.system.bulk;
   const capacityText =
@@ -585,9 +587,15 @@ function ItemRow({
       : undefined;
 
   return (
-    <li className="rounded border border-pf-border bg-pf-bg" data-item-id={item.id} data-item-type={item.type}>
-      <details className="group">
-        <summary className="flex cursor-pointer list-none items-center gap-3 px-3 py-2 hover:bg-pf-bg-dark/40">
+    <li className="relative rounded border border-pf-border bg-pf-bg" data-item-id={item.id} data-item-type={item.type}>
+      <details className="group" open={card.isOpen}>
+        <summary
+          className="flex cursor-pointer list-none items-center gap-3 px-3 py-2 hover:bg-pf-bg-dark/40"
+          onClick={(e): void => {
+            e.preventDefault();
+            card.toggle();
+          }}
+        >
           <img src={item.img} alt="" className="h-8 w-8 flex-shrink-0 rounded border border-pf-border bg-pf-bg-dark" />
           <div className="min-w-0 flex-1">
             <div className="flex items-baseline gap-2">
@@ -608,7 +616,12 @@ function ItemRow({
           <span className="ml-1 text-[10px] text-pf-alt-dark group-open:hidden">▸</span>
           <span className="ml-1 hidden text-[10px] text-pf-alt-dark group-open:inline">▾</span>
         </summary>
-        <ItemDetailBody item={item} />
+        {/* Absolute-positioned panel — overlays rows below instead of
+            pushing them down. Containing block is the <li> (relative);
+            left/right span the full card width. */}
+        <div className="absolute left-0 right-0 top-full z-20 rounded-b border border-t-0 border-pf-primary/60 bg-pf-bg px-3 py-2 text-sm text-pf-text shadow-lg">
+          <ItemDescription item={item} />
+        </div>
       </details>
       {isContainerRow && contents.length > 0 && (
         <ul className="divide-y divide-neutral-100 border-t border-neutral-100 pl-6" data-container-contents={item.id}>
@@ -665,10 +678,17 @@ function formatShortCp(cp: number): string {
 }
 
 function ContainerChildRow({ item }: { item: PhysicalItem }): React.ReactElement {
+  const card = useExpandableCard();
   return (
-    <li data-item-id={item.id} data-item-type={item.type}>
-      <details className="group">
-        <summary className="flex cursor-pointer list-none items-center gap-3 px-3 py-1.5 hover:bg-pf-bg-dark/40">
+    <li className="relative" data-item-id={item.id} data-item-type={item.type}>
+      <details className="group" open={card.isOpen}>
+        <summary
+          className="flex cursor-pointer list-none items-center gap-3 px-3 py-1.5 hover:bg-pf-bg-dark/40"
+          onClick={(e): void => {
+            e.preventDefault();
+            card.toggle();
+          }}
+        >
           <img src={item.img} alt="" className="h-6 w-6 flex-shrink-0 rounded border border-pf-border bg-pf-bg-dark" />
           <div className="min-w-0 flex-1">
             <span className="truncate text-sm text-neutral-800">{item.name}</span>
@@ -678,7 +698,9 @@ function ContainerChildRow({ item }: { item: PhysicalItem }): React.ReactElement
           <span className="ml-1 text-[10px] text-pf-alt-dark group-open:hidden">▸</span>
           <span className="ml-1 hidden text-[10px] text-pf-alt-dark group-open:inline">▾</span>
         </summary>
-        <ItemDetailBody item={item} />
+        <div className="absolute left-0 right-0 top-full z-20 rounded-b border border-t-0 border-pf-primary/60 bg-pf-bg px-3 py-2 text-sm text-pf-text shadow-lg">
+          <ItemDescription item={item} />
+        </div>
       </details>
     </li>
   );
@@ -715,22 +737,9 @@ function GridTile({
             descriptions stay readable even when the tile itself is
             narrow; overlaps neighbouring tiles rather than pushing
             the grid around. z-20 keeps it above nearby tiles but
-            below the tab bar / popovers. */}
+            below the tab bar / popovers. Image stays in the summary
+            above — no duplicate here. */}
         <div className="absolute left-0 top-full z-20 mt-1 w-72 rounded border border-pf-primary/60 bg-pf-bg p-3 text-left text-sm text-pf-text shadow-lg">
-          <div className="mb-2 flex items-center gap-2">
-            <img
-              src={item.img}
-              alt=""
-              className="h-8 w-8 flex-shrink-0 rounded border border-pf-border bg-pf-bg-dark"
-            />
-            <div className="min-w-0 flex-1">
-              <p className="truncate font-serif text-sm font-semibold text-pf-text">{item.name}</p>
-              <p className="text-[10px] uppercase tracking-widest text-pf-alt-dark">
-                {item.type}
-                {item.system.quantity > 1 && ` · ×${item.system.quantity.toString()}`}
-              </p>
-            </div>
-          </div>
           <ItemDescription item={item} />
         </div>
       </details>
@@ -738,17 +747,8 @@ function GridTile({
   );
 }
 
-function ItemDetailBody({ item }: { item: PhysicalItem }): React.ReactElement {
-  return (
-    <div className="border-t border-pf-border bg-pf-bg/60 px-3 py-2 text-sm text-pf-text">
-      <ItemDescription item={item} />
-    </div>
-  );
-}
-
-// Bare description block without wrapper chrome — used inside the
-// list-mode row (wrapped with its own border) and the grid-mode
-// floating card (which brings its own container styling).
+// Bare description block — used inside the list-mode absolute panel
+// and the grid-mode floating card (each brings its own container styling).
 function ItemDescription({ item }: { item: PhysicalItem }): React.ReactElement {
   const description = (item.system.description as { value?: unknown } | undefined)?.value;
   const enriched = typeof description === 'string' && description.length > 0 ? enrichDescription(description) : '';

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -587,8 +587,17 @@ function ItemRow({
       : undefined;
 
   return (
-    <li className="relative rounded border border-pf-border bg-pf-bg" data-item-id={item.id} data-item-type={item.type}>
-      <details className="group" open={card.isOpen}>
+    <li className="relative" data-item-id={item.id} data-item-type={item.type}>
+      {/* <details> is the visual card (owns the border). Making it
+          relative means the absolute panel positions from the bottom of
+          the summary rather than from the bottom of the <li>, so it
+          appears directly below the row even on container items whose
+          <li> is taller due to nested contents.
+          open:rounded-b-none seals the seam with the panel's rounded-b. */}
+      <details
+        className="group relative rounded border border-pf-border bg-pf-bg open:rounded-b-none open:border-pf-primary/60 open:shadow-lg"
+        open={card.isOpen}
+      >
         <summary
           className="flex cursor-pointer list-none items-center gap-3 px-3 py-2 hover:bg-pf-bg-dark/40"
           onClick={(e): void => {
@@ -616,15 +625,18 @@ function ItemRow({
           <span className="ml-1 text-[10px] text-pf-alt-dark group-open:hidden">▸</span>
           <span className="ml-1 hidden text-[10px] text-pf-alt-dark group-open:inline">▾</span>
         </summary>
-        {/* Absolute-positioned panel — overlays rows below instead of
-            pushing them down. Containing block is the <li> (relative);
-            left/right span the full card width. */}
+        {/* Absolute panel shares border color with the open <details>,
+            drops the top border (seam is the <details> bottom edge),
+            and gets the bottom rounding that <details> gives up. */}
         <div className="absolute left-0 right-0 top-full z-20 rounded-b border border-t-0 border-pf-primary/60 bg-pf-bg px-3 py-2 text-sm text-pf-text shadow-lg">
           <ItemDescription item={item} />
         </div>
       </details>
       {isContainerRow && contents.length > 0 && (
-        <ul className="divide-y divide-neutral-100 border-t border-neutral-100 pl-6" data-container-contents={item.id}>
+        <ul
+          className="rounded-b border-x border-b border-pf-border divide-y divide-neutral-100 pl-6"
+          data-container-contents={item.id}
+        >
           {contents.map((child) => (
             <ContainerChildRow key={child.id} item={child} />
           ))}
@@ -681,7 +693,10 @@ function ContainerChildRow({ item }: { item: PhysicalItem }): React.ReactElement
   const card = useExpandableCard();
   return (
     <li className="relative" data-item-id={item.id} data-item-type={item.type}>
-      <details className="group" open={card.isOpen}>
+      <details
+        className="group relative rounded border border-pf-border bg-pf-bg open:rounded-b-none open:border-pf-primary/60 open:shadow-lg"
+        open={card.isOpen}
+      >
         <summary
           className="flex cursor-pointer list-none items-center gap-3 px-3 py-1.5 hover:bg-pf-bg-dark/40"
           onClick={(e): void => {

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -744,7 +744,7 @@ function GridTile({
               </span>
             )}
           </div>
-          <span className="line-clamp-2 text-[11px] font-medium leading-tight text-pf-text" title={item.name}>
+          <span className="line-clamp-2 min-h-[2.5em] text-[11px] font-medium leading-tight text-pf-text" title={item.name}>
             {item.name}
           </span>
           <div className="flex min-h-[16px] flex-wrap gap-1">

--- a/apps/player-portal/src/lib/useExpandableCard.test.ts
+++ b/apps/player-portal/src/lib/useExpandableCard.test.ts
@@ -1,0 +1,64 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import { useExpandableCard } from './useExpandableCard';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('useExpandableCard', () => {
+  it('starts collapsed by default', () => {
+    const { result } = renderHook(() => useExpandableCard());
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('can start expanded', () => {
+    const { result } = renderHook(() => useExpandableCard(true));
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it('toggle: collapsed → expanded → collapsed', () => {
+    const { result } = renderHook(() => useExpandableCard());
+    act(() => {
+      result.current.toggle();
+    });
+    expect(result.current.isOpen).toBe(true);
+    act(() => {
+      result.current.toggle();
+    });
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('open moves to expanded state', () => {
+    const { result } = renderHook(() => useExpandableCard());
+    act(() => {
+      result.current.open();
+    });
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it('close moves to collapsed state', () => {
+    const { result } = renderHook(() => useExpandableCard(true));
+    act(() => {
+      result.current.close();
+    });
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('open is idempotent', () => {
+    const { result } = renderHook(() => useExpandableCard(true));
+    act(() => {
+      result.current.open();
+    });
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it('close is idempotent', () => {
+    const { result } = renderHook(() => useExpandableCard(false));
+    act(() => {
+      result.current.close();
+    });
+    expect(result.current.isOpen).toBe(false);
+  });
+});

--- a/apps/player-portal/src/lib/useExpandableCard.ts
+++ b/apps/player-portal/src/lib/useExpandableCard.ts
@@ -1,0 +1,21 @@
+import { useState } from 'react';
+
+export interface ExpandableCardHandle {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+}
+
+/** Controlled open/closed state for an expandable card. Drive a
+ *  <details open={card.isOpen}> with onClick={(e) => { e.preventDefault(); card.toggle(); }}
+ *  on the <summary>. The actions tab and any other expandable row can adopt this same hook. */
+export function useExpandableCard(initialOpen = false): ExpandableCardHandle {
+  const [isOpen, setIsOpen] = useState(initialOpen);
+  return {
+    isOpen,
+    open: (): void => { setIsOpen(true); },
+    close: (): void => { setIsOpen(false); },
+    toggle: (): void => { setIsOpen((prev) => !prev); },
+  };
+}


### PR DESCRIPTION
## Summary

Clicking an inventory item in list view expanded the detail as an inline block, pushing subsequent rows down instead of overlaying them. In grid view, the floating detail card showed a second copy of the item image (one in the tile summary, one in the card header). Both are fixed to match the in-place expansion pattern already used by the Feats tab.

Extracts `useExpandableCard` — a small controlled-open hook — as the shared abstraction for this branch and the parallel `fix/actions-card-full-click-expand` work.

## Changes
- `ItemRow` / `ContainerChildRow`: convert inline `<ItemDetailBody>` to an absolutely-positioned overlay panel (same pattern as `FeatCard` in Feats.tsx); add `relative` to the `<li>`; drive with `useExpandableCard`
- `GridTile`: remove the duplicate image/name header from the floating detail card — the tile summary already shows the image
- `ItemDetailBody`: removed (unused after the above)
- `useExpandableCard`: new hook — controlled open/closed state with `open`, `close`, `toggle`; 7 Vitest tests covering state transitions

## Test plan
- [ ] 259 existing tests pass (`npm run test -w apps/player-portal`)
- [ ] Manual: list view — expanding an item overlays rows below, does not push them; collapsing restores layout
- [ ] Manual: grid view — expanding a tile shows description only, no second image
- [ ] Manual: feats tab unaffected (no changes there)