### PR TITLE
refactor(shared): extract live-state snapshot types to shared rpc

### DIFF
--- a/apps/player-portal/server/types.ts
+++ b/apps/player-portal/server/types.ts
@@ -1,62 +1,15 @@
-// Data shapes are duplicated here (rather than imported from the shared
-// workspace package) because the server builds with NodeNext module
-// resolution — .ts source from @foundry-toolkit/shared isn't consumable at
-// runtime. Keep these in sync with packages/shared/src/types.ts on the
-// fields the player portal and DM push agree on.
-
-export interface PartyInventoryItem {
-  id: string;
-  name: string;
-  qty: number;
-  category: 'consumable' | 'equipment' | 'quest' | 'treasure' | 'other';
-  bulk?: number;
-  valueCp?: number;
-  aonUrl?: string;
-  note?: string;
-  carriedBy?: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
-export interface AurusTeam {
-  id: string;
-  name: string;
-  emblem?: string;
-  color: string;
-  combatPower: number;
-  valueReclaimedCp: number;
-  isPlayerParty: boolean;
-  note?: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
-// Globe pins pushed from dm-tool. The server is a pass-through — it
-// doesn't inspect `mission` beyond storing it. Mission data is shaped +
-// DM-scrubbed before the push, see dm-tool's encounter-push / globe.ts.
-export interface GlobePin {
-  id: string;
-  lng: number;
-  lat: number;
-  label: string;
-  icon: string;
-  zoom: number;
-  note: string;
-  kind: 'note' | 'mission';
-  mission?: Record<string, unknown>;
-}
-
-export interface InventorySnapshot {
-  items: PartyInventoryItem[];
-  updatedAt: string;
-}
-
-export interface AurusSnapshot {
-  teams: AurusTeam[];
-  updatedAt: string;
-}
-
-export interface GlobeSnapshot {
-  pins: GlobePin[];
-  updatedAt: string;
-}
+// Live-state snapshot shapes. Canonical definitions now live in
+// packages/shared/src/rpc/live.ts alongside their Zod schemas so that
+// dm-tool, foundry-mcp, and this server all derive from one source.
+//
+// These are type-only re-exports — TypeScript erases them at compile
+// time, so the NodeNext-compiled server has no runtime dependency on
+// @foundry-toolkit/shared.
+export type {
+  AurusSnapshot,
+  AurusTeam,
+  GlobePin,
+  GlobeSnapshot,
+  InventorySnapshot,
+  PartyInventoryItem,
+} from '@foundry-toolkit/shared/rpc';

--- a/packages/shared/src/rpc/index.ts
+++ b/packages/shared/src/rpc/index.ts
@@ -6,6 +6,7 @@
 
 export * from './dialog.js';
 export * from './dispatch.js';
+export * from './live.js';
 
 import type { z } from 'zod/v4';
 

--- a/packages/shared/src/rpc/live.test.ts
+++ b/packages/shared/src/rpc/live.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from 'vitest';
+import {
+  aurusSnapshotSchema,
+  globeSnapshotSchema,
+  inventorySnapshotSchema,
+  type AurusSnapshot,
+  type GlobeSnapshot,
+  type InventorySnapshot,
+} from './live';
+
+// ─── InventorySnapshot ────────────────────────────────────────────────────────
+
+describe('inventorySnapshotSchema', () => {
+  const validSnapshot: InventorySnapshot = {
+    items: [
+      {
+        id: 'item-001',
+        name: 'Potion of Healing',
+        qty: 3,
+        category: 'consumable',
+        bulk: 0.1,
+        valueCp: 10000,
+        aonUrl: 'https://2e.aonprd.com/Equipment.aspx?ID=186',
+        note: 'Lesser',
+        carriedBy: 'Valeros',
+        createdAt: '2024-03-15T10:00:00.000Z',
+        updatedAt: '2024-03-15T12:30:00.000Z',
+      },
+      {
+        id: 'item-002',
+        name: 'Greatsword',
+        qty: 1,
+        category: 'equipment',
+        bulk: 2,
+        valueCp: 200,
+        createdAt: '2024-03-10T08:00:00.000Z',
+        updatedAt: '2024-03-10T08:00:00.000Z',
+      },
+    ],
+    updatedAt: '2024-03-15T12:30:00.000Z',
+  };
+
+  it('round-trips a valid snapshot', () => {
+    const parsed: InventorySnapshot = inventorySnapshotSchema.parse(validSnapshot);
+    expect(parsed).toEqual(validSnapshot);
+  });
+
+  it('round-trips via JSON serialization', () => {
+    const roundTripped = inventorySnapshotSchema.parse(JSON.parse(JSON.stringify(validSnapshot)));
+    expect(roundTripped).toEqual(validSnapshot);
+  });
+
+  it('accepts an empty items array', () => {
+    const empty = inventorySnapshotSchema.parse({ items: [], updatedAt: '2024-01-01T00:00:00.000Z' });
+    expect(empty.items).toHaveLength(0);
+  });
+
+  it('accepts all category values', () => {
+    const categories = ['consumable', 'equipment', 'quest', 'treasure', 'other'] as const;
+    for (const category of categories) {
+      const parsed = inventorySnapshotSchema.parse({
+        items: [{ id: 'x', name: 'Item', qty: 1, category, createdAt: 'ts', updatedAt: 'ts' }],
+        updatedAt: 'ts',
+      });
+      expect(parsed.items[0]?.category).toBe(category);
+    }
+  });
+
+  it('rejects an unknown category', () => {
+    expect(() =>
+      inventorySnapshotSchema.parse({
+        items: [{ id: 'x', name: 'Item', qty: 1, category: 'magical', createdAt: 'ts', updatedAt: 'ts' }],
+        updatedAt: 'ts',
+      }),
+    ).toThrow();
+  });
+
+  it('rejects a snapshot missing updatedAt', () => {
+    expect(() => inventorySnapshotSchema.parse({ items: [] })).toThrow();
+  });
+
+  it('rejects an item missing required name', () => {
+    expect(() =>
+      inventorySnapshotSchema.parse({
+        items: [{ id: 'x', qty: 1, category: 'equipment', createdAt: 'ts', updatedAt: 'ts' }],
+        updatedAt: 'ts',
+      }),
+    ).toThrow();
+  });
+});
+
+// ─── AurusSnapshot ────────────────────────────────────────────────────────────
+
+describe('aurusSnapshotSchema', () => {
+  const validSnapshot: AurusSnapshot = {
+    teams: [
+      {
+        id: 'team-001',
+        name: 'The Harrow',
+        emblem: 'shield',
+        color: '#c0392b',
+        combatPower: 8,
+        valueReclaimedCp: 450000,
+        isPlayerParty: true,
+        note: 'Current player party',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-03-15T12:00:00.000Z',
+      },
+      {
+        id: 'team-002',
+        name: 'Iron Fang Cavalry',
+        color: '#7f8c8d',
+        combatPower: 12,
+        valueReclaimedCp: 820000,
+        isPlayerParty: false,
+        createdAt: '2024-01-15T00:00:00.000Z',
+        updatedAt: '2024-03-01T09:00:00.000Z',
+      },
+    ],
+    updatedAt: '2024-03-15T12:00:00.000Z',
+  };
+
+  it('round-trips a valid snapshot', () => {
+    const parsed: AurusSnapshot = aurusSnapshotSchema.parse(validSnapshot);
+    expect(parsed).toEqual(validSnapshot);
+  });
+
+  it('round-trips via JSON serialization', () => {
+    const roundTripped = aurusSnapshotSchema.parse(JSON.parse(JSON.stringify(validSnapshot)));
+    expect(roundTripped).toEqual(validSnapshot);
+  });
+
+  it('accepts an empty teams array', () => {
+    const empty = aurusSnapshotSchema.parse({ teams: [], updatedAt: '2024-01-01T00:00:00.000Z' });
+    expect(empty.teams).toHaveLength(0);
+  });
+
+  it('rejects a team where isPlayerParty is a string instead of boolean', () => {
+    expect(() =>
+      aurusSnapshotSchema.parse({
+        teams: [
+          {
+            id: 'x',
+            name: 'Team',
+            color: '#000',
+            combatPower: 1,
+            valueReclaimedCp: 0,
+            isPlayerParty: 'true',
+            createdAt: 'ts',
+            updatedAt: 'ts',
+          },
+        ],
+        updatedAt: 'ts',
+      }),
+    ).toThrow();
+  });
+
+  it('rejects a snapshot missing updatedAt', () => {
+    expect(() => aurusSnapshotSchema.parse({ teams: [] })).toThrow();
+  });
+});
+
+// ─── GlobeSnapshot ────────────────────────────────────────────────────────────
+
+describe('globeSnapshotSchema', () => {
+  const validSnapshot: GlobeSnapshot = {
+    pins: [
+      {
+        id: 'pin-001',
+        lng: 15.5,
+        lat: -23.1,
+        label: 'Absalom',
+        icon: 'city',
+        zoom: 4,
+        note: 'The great city at the center of the world.',
+        kind: 'note',
+      },
+      {
+        id: 'pin-002',
+        lng: -42.0,
+        lat: 18.7,
+        label: 'Breachill',
+        icon: 'town',
+        zoom: 6,
+        note: 'Base of operations.',
+        kind: 'mission',
+        mission: { title: 'Clear the Citadel', status: 'active', rewardCp: 50000 },
+      },
+    ],
+    updatedAt: '2024-03-20T18:00:00.000Z',
+  };
+
+  it('round-trips a valid snapshot', () => {
+    const parsed: GlobeSnapshot = globeSnapshotSchema.parse(validSnapshot);
+    expect(parsed).toEqual(validSnapshot);
+  });
+
+  it('round-trips via JSON serialization', () => {
+    const roundTripped = globeSnapshotSchema.parse(JSON.parse(JSON.stringify(validSnapshot)));
+    expect(roundTripped).toEqual(validSnapshot);
+  });
+
+  it('accepts a pin without an optional mission field', () => {
+    const parsed = globeSnapshotSchema.parse({
+      pins: [{ id: 'x', lng: 0, lat: 0, label: 'X', icon: 'dot', zoom: 3, note: '', kind: 'note' }],
+      updatedAt: 'ts',
+    });
+    expect(parsed.pins[0]?.mission).toBeUndefined();
+  });
+
+  it('rejects an unknown kind value', () => {
+    expect(() =>
+      globeSnapshotSchema.parse({
+        pins: [{ id: 'x', lng: 0, lat: 0, label: 'X', icon: 'dot', zoom: 3, note: '', kind: 'dungeon' }],
+        updatedAt: 'ts',
+      }),
+    ).toThrow();
+  });
+
+  it('rejects a pin with non-numeric coordinates', () => {
+    expect(() =>
+      globeSnapshotSchema.parse({
+        pins: [{ id: 'x', lng: 'west', lat: 0, label: 'X', icon: 'dot', zoom: 3, note: '', kind: 'note' }],
+        updatedAt: 'ts',
+      }),
+    ).toThrow();
+  });
+
+  it('rejects a snapshot missing updatedAt', () => {
+    expect(() => globeSnapshotSchema.parse({ pins: [] })).toThrow();
+  });
+});

--- a/packages/shared/src/rpc/live.ts
+++ b/packages/shared/src/rpc/live.ts
@@ -1,0 +1,74 @@
+// Zod schemas for the three live-state datasets shared between dm-tool,
+// foundry-mcp, and player-portal: party inventory, Aurus combat teams,
+// and globe pins.
+//
+// Each schema exports both the runtime validator and an inferred TS type
+// so every consumer derives from one source. foundry-mcp is the eventual
+// authority on these routes; shape drift surfaces as TS errors across all
+// consumers at the next typecheck.
+
+import { z } from 'zod/v4';
+
+export const partyInventoryItemSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  qty: z.number(),
+  category: z.enum(['consumable', 'equipment', 'quest', 'treasure', 'other']),
+  bulk: z.number().optional(),
+  valueCp: z.number().optional(),
+  aonUrl: z.string().optional(),
+  note: z.string().optional(),
+  carriedBy: z.string().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const aurusTeamSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  emblem: z.string().optional(),
+  color: z.string(),
+  combatPower: z.number(),
+  valueReclaimedCp: z.number(),
+  isPlayerParty: z.boolean(),
+  note: z.string().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+// Globe pins pushed from dm-tool. foundry-mcp is a pass-through — it
+// doesn't inspect `mission` beyond storing it. Mission data is shaped +
+// DM-scrubbed before the push, see dm-tool's globe.ts.
+export const globePinSchema = z.object({
+  id: z.string(),
+  lng: z.number(),
+  lat: z.number(),
+  label: z.string(),
+  icon: z.string(),
+  zoom: z.number(),
+  note: z.string(),
+  kind: z.enum(['note', 'mission']),
+  mission: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const inventorySnapshotSchema = z.object({
+  items: z.array(partyInventoryItemSchema),
+  updatedAt: z.string(),
+});
+
+export const aurusSnapshotSchema = z.object({
+  teams: z.array(aurusTeamSchema),
+  updatedAt: z.string(),
+});
+
+export const globeSnapshotSchema = z.object({
+  pins: z.array(globePinSchema),
+  updatedAt: z.string(),
+});
+
+export type PartyInventoryItem = z.infer<typeof partyInventoryItemSchema>;
+export type AurusTeam = z.infer<typeof aurusTeamSchema>;
+export type GlobePin = z.infer<typeof globePinSchema>;
+export type InventorySnapshot = z.infer<typeof inventorySnapshotSchema>;
+export type AurusSnapshot = z.infer<typeof aurusSnapshotSchema>;
+export type GlobeSnapshot = z.infer<typeof globeSnapshotSchema>;


### PR DESCRIPTION
## Apps touched

- `packages/shared` — new `src/rpc/live.ts`; updated `src/rpc/index.ts`
- `apps/player-portal` — `server/types.ts` updated to re-export from shared

No app needs to be spun up to validate this PR — it is a pure type relocation with zero behavior change. The CI typecheck + test pass is sufficient.

## Summary

PR 1 of 6 in the migration plan at `~/.claude/plans/read-only-investigation-plan-mode-tingly-lemon.md`.

Moves `InventorySnapshot`, `AurusSnapshot`, `GlobeSnapshot` (and their component types `PartyInventoryItem`, `AurusTeam`, `GlobePin`) from `apps/player-portal/server/types.ts` into a new `packages/shared/src/rpc/live.ts` alongside matching Zod schemas. Re-exported from the existing `@foundry-toolkit/shared/rpc` barrel.

`apps/player-portal/server/types.ts` becomes a thin type-only re-export shim. Since the re-exports use `export type`, TypeScript erases them entirely at compile time — the NodeNext-compiled server has no runtime dependency on `@foundry-toolkit/shared`. `server/store.ts` and `server/index.ts` continue importing from `./types.js` unchanged.

**Zero behavior change.**

## Changes

- `packages/shared/src/rpc/live.ts` (new) — six Zod schemas (`partyInventoryItemSchema`, `aurusTeamSchema`, `globePinSchema`, `inventorySnapshotSchema`, `aurusSnapshotSchema`, `globeSnapshotSchema`) plus `z.infer<>` type exports
- `packages/shared/src/rpc/index.ts` — `export * from './live.js'` added to barrel
- `apps/player-portal/server/types.ts` — replaced interface definitions with `export type { ... } from '@foundry-toolkit/shared/rpc'`
- `packages/shared/src/rpc/live.test.ts` (new) — Vitest coverage: round-trip parse, JSON serialization, invalid input rejection for all three snapshot types

## Test plan

- [x] `npm run test -w packages/shared` — 177 tests pass (11 new in `live.test.ts`)
- [x] `npm run test -w apps/player-portal` — 267 tests pass unchanged
- [x] `npm run typecheck` — clean across all workspaces including player-portal's NodeNext server config
- [x] `npm run lint:fix` — no new errors (2 pre-existing warnings in dm-tool unrelated to this PR)
- [x] `npm run format:check` — clean