### PR TITLE
feat(player-portal): character sheet design pass — layout, themes, grid views

### DIFF
--- a/apps/player-portal/src/components/Nav.tsx
+++ b/apps/player-portal/src/components/Nav.tsx
@@ -15,7 +15,7 @@ interface Props {
 
 export function Nav({ theme, onToggleTheme }: Props) {
   return (
-    <nav className="flex flex-shrink-0 items-center border-b border-portal-border bg-portal-surface">
+    <nav className="flex flex-shrink-0 items-center border-b border-portal-border bg-portal-surface shadow-sm">
       {tabs.map((tab) => (
         <NavLink
           key={tab.to}

--- a/apps/player-portal/src/components/common/RankChip.tsx
+++ b/apps/player-portal/src/components/common/RankChip.tsx
@@ -4,25 +4,31 @@ import { RANK_BG, RANK_I18N_KEY } from '../../lib/pf2e-maps';
 
 interface Props {
   rank: ProficiencyRank;
+  /** Show single-letter abbreviation (U/T/E/M/L) in a narrow chip. */
+  condensed?: boolean;
   className?: string;
 }
 
+const RANK_ABBREV: Record<number, string> = { 0: 'U', 1: 'T', 2: 'E', 3: 'M', 4: 'L' };
+
 // Fixed-width label chip in the pf2e rank palette. Used in every proficiency
 // row (skill, save, martial, class DC).
-export function RankChip({ rank, className }: Props): React.ReactElement {
+export function RankChip({ rank, condensed = false, className }: Props): React.ReactElement {
   const bg = RANK_BG[rank];
   return (
     <span
       className={[
-        'inline-flex h-5 w-20 shrink-0 items-center justify-center',
-        'rounded-sm text-[10px] font-medium uppercase tracking-wider text-white',
+        'inline-flex shrink-0 items-center justify-center rounded-sm',
+        condensed ? 'h-5 w-6' : 'h-5 w-20',
+        'text-[10px] font-medium uppercase tracking-wider text-white',
         'shadow-[inset_0_0_0_1px_rgba(255,255,255,0.15)] border border-black/50',
         bg,
         className ?? '',
       ].join(' ')}
       data-rank={rank}
+      title={condensed ? t(RANK_I18N_KEY[rank]) : undefined}
     >
-      {t(RANK_I18N_KEY[rank])}
+      {condensed ? (RANK_ABBREV[rank as number] ?? '?') : t(RANK_I18N_KEY[rank])}
     </span>
   );
 }

--- a/apps/player-portal/src/components/common/SectionHeader.tsx
+++ b/apps/player-portal/src/components/common/SectionHeader.tsx
@@ -1,10 +1,19 @@
 interface Props {
   children: React.ReactNode;
+  /** When true, renders as a filled accent band spanning the top of a `p-4
+   *  rounded-lg` card. Uses negative margins to break out of the card's
+   *  padding so the band sits flush against all three top edges. */
+  band?: boolean;
 }
 
-// Display-serif section header used across every tab. The family + colour
-// come from the pf2e-derived design tokens (src/styles/pf2e/tokens.css).
-export function SectionHeader({ children }: Props): React.ReactElement {
+export function SectionHeader({ children, band = false }: Props): React.ReactElement {
+  if (band) {
+    return (
+      <h2 className="-mx-4 -mt-4 mb-3 rounded-t-lg border-b border-pf-border bg-pf-bg px-4 pb-2.5 pt-3 font-serif text-sm font-bold uppercase tracking-wider text-pf-alt-dark">
+        {children}
+      </h2>
+    );
+  }
   return (
     <h2 className="mb-3 border-l-2 border-pf-primary pl-3 font-serif text-sm font-bold uppercase tracking-wider text-pf-alt-dark">
       {children}

--- a/apps/player-portal/src/components/common/SectionHeader.tsx
+++ b/apps/player-portal/src/components/common/SectionHeader.tsx
@@ -6,7 +6,7 @@ interface Props {
 // come from the pf2e-derived design tokens (src/styles/pf2e/tokens.css).
 export function SectionHeader({ children }: Props): React.ReactElement {
   return (
-    <h2 className="mb-2 border-b border-pf-border pb-1 font-serif text-base font-semibold uppercase tracking-wide text-pf-alt-dark">
+    <h2 className="mb-3 border-l-2 border-pf-primary pl-3 font-serif text-sm font-bold uppercase tracking-wider text-pf-alt-dark">
       {children}
     </h2>
   );

--- a/apps/player-portal/src/components/settings/SettingsDialog.tsx
+++ b/apps/player-portal/src/components/settings/SettingsDialog.tsx
@@ -157,7 +157,7 @@ export function SettingsDialog({
                 );
               })}
             </div>
-            <p className="text-[11px] text-pf-alt">Recolors the primary/secondary/tertiary palette used across the sheet.</p>
+            <p className="text-[11px] text-pf-alt">Controls the sheet's surface and accent palette. The nav dark mode toggle is independent.</p>
           </section>
 
           <section className="flex flex-col gap-2 border-t border-pf-border/60 pt-4">

--- a/apps/player-portal/src/components/settings/SettingsDialog.tsx
+++ b/apps/player-portal/src/components/settings/SettingsDialog.tsx
@@ -129,6 +129,9 @@ export function SettingsDialog({
               {COLOR_SCHEMES.map((s) => {
                 const active = s.id === colorScheme;
                 return (
+                  // data-color-scheme scopes this button's CSS variables to its
+                  // own palette, so the swatch and active-state colours are live
+                  // and always correct — no hardcoded hex needed.
                   <button
                     key={s.id}
                     type="button"
@@ -136,18 +139,18 @@ export function SettingsDialog({
                       onColorSchemeChange(s.id);
                     }}
                     aria-pressed={active}
-                    data-scheme={s.id}
+                    data-color-scheme={s.id}
                     className={[
                       'flex items-center gap-2 rounded border px-2.5 py-1.5 text-sm transition-colors',
                       active
                         ? 'border-pf-primary bg-pf-primary/10 text-pf-primary'
-                        : 'border-pf-border bg-white text-pf-text hover:bg-pf-bg-dark/40',
+                        : 'border-pf-border bg-pf-bg text-pf-text hover:bg-pf-bg-dark/40',
                     ].join(' ')}
                   >
                     <span
                       aria-hidden
-                      className="inline-block h-3.5 w-3.5 rounded-full border border-pf-border"
-                      style={{ background: s.swatch }}
+                      className="inline-block h-3.5 w-3.5 rounded-full border border-pf-primary-dark/40"
+                      style={{ background: 'var(--color-pf-primary)' }}
                     />
                     {s.label}
                   </button>
@@ -160,7 +163,7 @@ export function SettingsDialog({
           <section className="flex flex-col gap-2 border-t border-pf-border/60 pt-4">
             <p className="text-xs font-semibold uppercase tracking-widest text-pf-alt-dark">Sheet Background</p>
             {backgroundPath && (
-              <div className="flex items-center gap-2 rounded border border-pf-border bg-white/60 p-2">
+              <div className="flex items-center gap-2 rounded border border-pf-border bg-pf-bg p-2">
                 <div
                   aria-hidden
                   className="h-10 w-16 rounded border border-pf-border bg-cover bg-center"
@@ -204,7 +207,7 @@ export function SettingsDialog({
                     void handleClear();
                   }}
                   data-testid="background-clear"
-                  className="rounded border border-pf-border bg-white px-3 py-1.5 text-xs text-pf-text hover:bg-pf-bg-dark disabled:opacity-50"
+                  className="rounded border border-pf-border bg-pf-bg px-3 py-1.5 text-xs text-pf-text hover:bg-pf-bg-dark disabled:opacity-50"
                 >
                   Remove
                 </button>

--- a/apps/player-portal/src/components/sheet/QuickActionPicker.tsx
+++ b/apps/player-portal/src/components/sheet/QuickActionPicker.tsx
@@ -41,7 +41,7 @@ export function QuickActionPicker({ options, selectedIds, onSelectionChange, onC
   const toggle = (id: string): void => {
     if (selectedIds.includes(id)) {
       onSelectionChange(selectedIds.filter((x) => x !== id));
-    } else if (selectedIds.length < 5) {
+    } else {
       onSelectionChange([...selectedIds, id]);
     }
   };
@@ -61,7 +61,7 @@ export function QuickActionPicker({ options, selectedIds, onSelectionChange, onC
               Quick Actions
             </h2>
             <p className="mt-0.5 pl-3 text-[10px] text-pf-text-muted">
-              {selectedIds.length} / 5 selected
+              {selectedIds.length} selected
             </p>
           </div>
           <button
@@ -109,20 +109,17 @@ function PickerGroup({
       <ul className="space-y-1">
         {options.map((opt) => {
           const selected = selectedIds.includes(opt.id);
-          const disabled = !selected && selectedIds.length >= 5;
           const imgSrc = opt.img ? (opt.img.startsWith('/') ? opt.img : `/${opt.img}`) : '';
           return (
             <li key={opt.id}>
               <button
                 type="button"
                 onClick={() => { onToggle(opt.id); }}
-                disabled={disabled}
                 className={[
                   'flex w-full items-center gap-2 rounded border px-2 py-1.5 text-left transition-colors',
                   selected
                     ? 'border-pf-primary bg-pf-primary/5 text-pf-text'
                     : 'border-pf-border bg-pf-bg text-pf-text hover:bg-pf-bg-dark',
-                  disabled ? 'cursor-not-allowed opacity-40' : '',
                 ].join(' ')}
               >
                 {imgSrc && (

--- a/apps/player-portal/src/components/sheet/QuickActionPicker.tsx
+++ b/apps/player-portal/src/components/sheet/QuickActionPicker.tsx
@@ -1,0 +1,149 @@
+import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+
+export type QAStrike = {
+  kind: 'strike';
+  id: string;
+  slug: string;
+  label: string;
+  img: string;
+  variants: { label: string }[];
+};
+export type QAItem = { kind: 'item'; id: string; itemId: string; label: string; img: string };
+export type QASpell = {
+  kind: 'spell';
+  id: string;
+  spellId: string;
+  label: string;
+  img: string;
+  entryId: string;
+  rank: number;
+  isCantrip: boolean;
+};
+export type QuickActionOption = QAStrike | QAItem | QASpell;
+
+interface Props {
+  options: QuickActionOption[];
+  selectedIds: string[];
+  onSelectionChange: (ids: string[]) => void;
+  onClose: () => void;
+}
+
+export function QuickActionPicker({ options, selectedIds, onSelectionChange, onClose }: Props): React.ReactElement {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handler);
+    return (): void => { document.removeEventListener('keydown', handler); };
+  }, [onClose]);
+
+  const toggle = (id: string): void => {
+    if (selectedIds.includes(id)) {
+      onSelectionChange(selectedIds.filter((x) => x !== id));
+    } else if (selectedIds.length < 5) {
+      onSelectionChange([...selectedIds, id]);
+    }
+  };
+
+  const strikes = options.filter((o): o is QAStrike => o.kind === 'strike');
+  const items = options.filter((o): o is QAItem => o.kind === 'item');
+  const spells = options.filter((o): o is QASpell => o.kind === 'spell');
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-start justify-end">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} aria-hidden />
+      <div className="relative flex h-full w-72 flex-col overflow-hidden border-l border-pf-border bg-pf-bg shadow-2xl">
+        {/* Header */}
+        <div className="flex items-start justify-between border-b border-pf-border bg-pf-bg px-4 py-3">
+          <div>
+            <h2 className="border-l-2 border-pf-primary pl-3 font-serif text-sm font-bold uppercase tracking-wider text-pf-alt-dark">
+              Quick Actions
+            </h2>
+            <p className="mt-0.5 pl-3 text-[10px] text-pf-text-muted">
+              {selectedIds.length} / 5 selected
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="mt-0.5 rounded border border-pf-border bg-pf-bg px-2 py-1 text-xs text-pf-text-muted hover:bg-pf-bg-dark"
+          >
+            Done
+          </button>
+        </div>
+
+        {/* Option list */}
+        <div className="flex-1 overflow-y-auto p-3 space-y-5">
+          {strikes.length > 0 && (
+            <PickerGroup label="Strikes" options={strikes} selectedIds={selectedIds} onToggle={toggle} />
+          )}
+          {items.length > 0 && (
+            <PickerGroup label="Actions" options={items} selectedIds={selectedIds} onToggle={toggle} />
+          )}
+          {spells.length > 0 && (
+            <PickerGroup label="Spells" options={spells} selectedIds={selectedIds} onToggle={toggle} />
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+function PickerGroup({
+  label,
+  options,
+  selectedIds,
+  onToggle,
+}: {
+  label: string;
+  options: QuickActionOption[];
+  selectedIds: string[];
+  onToggle: (id: string) => void;
+}): React.ReactElement {
+  return (
+    <div>
+      <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-widest text-pf-text-muted">{label}</p>
+      <ul className="space-y-1">
+        {options.map((opt) => {
+          const selected = selectedIds.includes(opt.id);
+          const disabled = !selected && selectedIds.length >= 5;
+          const imgSrc = opt.img ? (opt.img.startsWith('/') ? opt.img : `/${opt.img}`) : '';
+          return (
+            <li key={opt.id}>
+              <button
+                type="button"
+                onClick={() => { onToggle(opt.id); }}
+                disabled={disabled}
+                className={[
+                  'flex w-full items-center gap-2 rounded border px-2 py-1.5 text-left transition-colors',
+                  selected
+                    ? 'border-pf-primary bg-pf-primary/5 text-pf-text'
+                    : 'border-pf-border bg-pf-bg text-pf-text hover:bg-pf-bg-dark',
+                  disabled ? 'cursor-not-allowed opacity-40' : '',
+                ].join(' ')}
+              >
+                {imgSrc && (
+                  <img src={imgSrc} alt="" className="h-6 w-6 shrink-0 rounded border border-pf-border/50 bg-pf-bg-dark object-cover" />
+                )}
+                <span className="flex-1 truncate text-xs">{opt.label}</span>
+                <span
+                  className={[
+                    'flex h-4 w-4 shrink-0 items-center justify-center rounded-full border text-[10px]',
+                    selected
+                      ? 'border-pf-primary bg-pf-primary text-white'
+                      : 'border-pf-border',
+                  ].join(' ')}
+                >
+                  {selected && '✓'}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/apps/player-portal/src/components/sheet/SheetHeader.test.tsx
+++ b/apps/player-portal/src/components/sheet/SheetHeader.test.tsx
@@ -12,7 +12,7 @@ describe('SheetHeader', () => {
   });
 
   it('renders name, level, class, background, and ancestry', () => {
-    const { container } = render(<SheetHeader character={character} />);
+    const { container } = render(<SheetHeader character={character} actorId="test-actor" onActorChanged={() => undefined} />);
     expect(container.textContent).toContain('Amiri');
     const identity = container.querySelector('[data-section="identity"]');
     expect(identity, 'identity line').toBeTruthy();
@@ -28,19 +28,19 @@ describe('SheetHeader', () => {
       ...character,
       items: character.items.filter((i) => i.type !== 'background'),
     };
-    const { container } = render(<SheetHeader character={withoutBg} />);
+    const { container } = render(<SheetHeader character={withoutBg} actorId="test-actor" onActorChanged={() => undefined} />);
     expect(container.querySelector('[data-section="identity"]')?.textContent).not.toContain('Hunter');
   });
 
   it('renders rarity badge when non-common (Amiri is unique)', () => {
-    const { container } = render(<SheetHeader character={character} />);
+    const { container } = render(<SheetHeader character={character} actorId="test-actor" onActorChanged={() => undefined} />);
     const badge = container.querySelector('[data-badge="rarity"]');
     expect(badge, 'rarity badge').toBeTruthy();
     expect(badge?.textContent).toBe('Unique');
   });
 
   it('renders alliance badge for party members', () => {
-    const { container } = render(<SheetHeader character={character} />);
+    const { container } = render(<SheetHeader character={character} actorId="test-actor" onActorChanged={() => undefined} />);
     const badge = container.querySelector('[data-badge="alliance"]');
     expect(badge, 'alliance badge').toBeTruthy();
     expect(badge?.textContent).toBe('Party');
@@ -54,7 +54,7 @@ describe('SheetHeader', () => {
         traits: { ...character.system.traits, rarity: 'common' },
       },
     };
-    const { container } = render(<SheetHeader character={common} />);
+    const { container } = render(<SheetHeader character={common} actorId="test-actor" onActorChanged={() => undefined} />);
     expect(container.querySelector('[data-badge="rarity"]')).toBeNull();
   });
 
@@ -66,7 +66,7 @@ describe('SheetHeader', () => {
         details: { ...character.system.details, alliance: null },
       },
     };
-    const { container } = render(<SheetHeader character={neutral} />);
+    const { container } = render(<SheetHeader character={neutral} actorId="test-actor" onActorChanged={() => undefined} />);
     expect(container.querySelector('[data-badge="alliance"]')).toBeNull();
   });
 
@@ -84,14 +84,14 @@ describe('SheetHeader', () => {
         },
       },
     };
-    const { container } = render(<SheetHeader character={vishkanya} />);
+    const { container } = render(<SheetHeader character={vishkanya} actorId="test-actor" onActorChanged={() => undefined} />);
     const identity = container.querySelector('[data-section="identity"]');
     expect(identity?.textContent).toContain('Venom-Resistant Vishkanya');
     expect(identity?.textContent).not.toContain('Venom-Resistant Vishkanya Vishkanya');
   });
 
   it('renders portrait img with a leading-slash asset path', () => {
-    const { container } = render(<SheetHeader character={character} />);
+    const { container } = render(<SheetHeader character={character} actorId="test-actor" onActorChanged={() => undefined} />);
     const img = container.querySelector('[data-testid="character-portrait"]') as HTMLImageElement | null;
     expect(img, 'portrait img element').toBeTruthy();
     // Amiri fixture: "systems/pf2e/icons/iconics/portraits/amiri.webp"
@@ -100,7 +100,7 @@ describe('SheetHeader', () => {
 
   it('renders portrait placeholder when img is empty', () => {
     const noImg: PreparedCharacter = { ...character, img: '' };
-    const { container } = render(<SheetHeader character={noImg} />);
+    const { container } = render(<SheetHeader character={noImg} actorId="test-actor" onActorChanged={() => undefined} />);
     expect(container.querySelector('[data-testid="character-portrait"]')).toBeNull();
     expect(container.querySelector('[data-testid="character-portrait-placeholder"]')).toBeTruthy();
   });

--- a/apps/player-portal/src/components/sheet/SheetHeader.tsx
+++ b/apps/player-portal/src/components/sheet/SheetHeader.tsx
@@ -199,7 +199,7 @@ function LongRestButton({ actorId, onRested }: { actorId: string; onRested: () =
           type="button"
           onClick={() => { trigger(); }}
           disabled={state === 'pending'}
-          className="rounded border border-pf-tertiary-dark bg-pf-tertiary px-3 py-1.5 text-sm font-semibold text-pf-alt-dark hover:bg-pf-tertiary-dark hover:text-white disabled:opacity-50"
+          className="rounded border border-pf-border bg-pf-bg px-3 py-1.5 text-sm font-semibold text-pf-text hover:border-pf-tertiary-dark hover:bg-pf-tertiary/40 disabled:opacity-50"
         >
           {state === 'pending' ? 'Resting…' : 'Long Rest'}
         </button>

--- a/apps/player-portal/src/components/sheet/SheetHeader.tsx
+++ b/apps/player-portal/src/components/sheet/SheetHeader.tsx
@@ -1,22 +1,21 @@
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import type { PreparedCharacter } from '../../api/types';
+import { api } from '../../api/client';
 import { formatAncestryLine } from '../../lib/format';
+import { useActorAction } from '../../lib/useActorAction';
+import { ConfirmDialog } from '../dialog/ConfirmDialog';
 
 interface Props {
   character: PreparedCharacter;
-  /** When provided, renders a "← Actors" link to the right of the
-   *  name row. Lets the character sheet reclaim the row the button
-   *  used to occupy above the header. */
+  actorId: string;
+  onActorChanged: () => void;
+  /** When provided, renders a "← Actors" link in the action cluster. */
   onBack?: () => void;
-  /** When provided, renders a gear button in the right-side action
-   *  cluster that opens the sheet settings dialog. */
+  /** When provided, renders a gear button in the action cluster. */
   onSettingsOpen?: () => void;
 }
 
-// Rarity pill colours borrowed from pf2e's _colors.scss rarity palette
-// (`--color-rarity-*`). Background/foreground tuned for contrast on the
-// cream sheet surface.
 const RARITY_CLASSES: Record<string, string> = {
   uncommon: 'border-pf-rarity-uncommon bg-pf-rarity-uncommon/10 text-pf-rarity-uncommon',
   rare: 'border-pf-rarity-rare bg-pf-rarity-rare/10 text-pf-rarity-rare',
@@ -28,78 +27,210 @@ const ALLIANCE_CLASSES: Record<string, string> = {
   opposition: 'border-pf-primary bg-pf-primary/10 text-pf-primary',
 };
 
-// Identity band at the top of the character sheet: name + level +
-// ancestry/heritage/class/background, plus rarity/alliance badges.
-// Ported in spirit from pf2e's
-// static/templates/actors/character/partials/header.hbs but
-// render-only (no name/level inputs, no XP bar).
-export function SheetHeader({ character, onBack, onSettingsOpen }: Props): React.ReactElement {
+export function SheetHeader({
+  character,
+  actorId,
+  onActorChanged,
+  onBack,
+  onSettingsOpen,
+}: Props): React.ReactElement {
   const { name, system, items } = character;
   const level = system.details.level.value;
   const ancestry = system.details.ancestry?.name;
   const heritage = system.details.heritage?.name;
   const cls = system.details.class?.name;
-  // Background lives as an item (type='background'); pf2e doesn't
-  // surface it under system.details.
   const background = items.find((i) => i.type === 'background')?.name;
   const rarity = system.traits.rarity;
   const alliance = system.details.alliance;
+  const xp = system.details.xp;
+  const heroPoints = system.resources.heroPoints;
 
   const identity = formatAncestryLine(heritage, ancestry);
   const subtitle = [`Level ${level.toString()}`, cls, background, identity].filter(Boolean).join(' · ');
 
-  // Foundry asset paths are relative (e.g. "systems/pf2e/icons/...") — prepend
-  // "/" so they resolve through the Vite/Fastify asset proxy.
   const portraitSrc = !character.img ? '' : character.img.startsWith('/') ? character.img : `/${character.img}`;
 
   return (
     <header className="mb-4 flex items-start gap-3">
       <CharacterPortrait src={portraitSrc} name={name} />
       <div className="min-w-0 flex-1">
-        <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-          <h1 className="font-serif text-2xl font-semibold text-pf-text">{name}</h1>
-          {rarity && rarity !== 'common' && (
-            <Badge data-badge="rarity" label={capitalise(rarity)} className={RARITY_CLASSES[rarity] ?? ''} />
-          )}
-          {alliance && (
-            <Badge data-badge="alliance" label={capitalise(alliance)} className={ALLIANCE_CLASSES[alliance] ?? ''} />
-          )}
-          {(onSettingsOpen || onBack) && (
-            <div className="ml-auto flex items-center gap-2 self-center">
-              {onSettingsOpen && (
-                <button
-                  type="button"
-                  onClick={onSettingsOpen}
-                  data-testid="open-settings"
-                  aria-label="Settings"
-                  title="Settings"
-                  className="flex h-7 w-7 items-center justify-center rounded border border-pf-border bg-pf-bg text-pf-text hover:bg-pf-bg"
-                >
-                  <GearIcon />
-                </button>
+        <div className="flex items-start gap-3">
+          {/* Left: name, subtitle, XP + hero points */}
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+              <h1 className="font-serif text-2xl font-bold text-pf-text">{name}</h1>
+              {rarity && rarity !== 'common' && (
+                <Badge data-badge="rarity" label={capitalise(rarity)} className={RARITY_CLASSES[rarity] ?? ''} />
               )}
-              {onBack && (
-                <button
-                  type="button"
-                  onClick={onBack}
-                  data-testid="back-to-actors"
-                  className="rounded border border-pf-border bg-pf-bg px-2 py-1 text-xs text-pf-text hover:bg-pf-bg"
-                >
-                  ← Actors
-                </button>
+              {alliance && (
+                <Badge
+                  data-badge="alliance"
+                  label={capitalise(alliance)}
+                  className={ALLIANCE_CLASSES[alliance] ?? ''}
+                />
               )}
             </div>
-          )}
+            {subtitle && (
+              <p className="mt-0.5 font-sans text-sm text-pf-alt" data-section="identity">
+                {subtitle}
+              </p>
+            )}
+            <div className="mt-2 flex flex-wrap items-center gap-x-5 gap-y-1.5">
+              <XPDisplay xp={xp} />
+              <HeroPointsControl heroPoints={heroPoints} actorId={actorId} onActorChanged={onActorChanged} />
+            </div>
+          </div>
+
+          {/* Right: gear + back, then long rest below */}
+          <div className="flex shrink-0 flex-col items-end gap-2">
+            {(onSettingsOpen !== undefined || onBack !== undefined) && (
+              <div className="flex items-center gap-2">
+                {onSettingsOpen && (
+                  <button
+                    type="button"
+                    onClick={onSettingsOpen}
+                    data-testid="open-settings"
+                    aria-label="Settings"
+                    title="Settings"
+                    className="flex h-7 w-7 items-center justify-center rounded border border-pf-border bg-pf-bg text-pf-text hover:bg-pf-bg-dark"
+                  >
+                    <GearIcon />
+                  </button>
+                )}
+                {onBack && (
+                  <button
+                    type="button"
+                    onClick={onBack}
+                    data-testid="back-to-actors"
+                    className="rounded border border-pf-border bg-pf-bg px-2 py-1 text-xs text-pf-text hover:bg-pf-bg-dark"
+                  >
+                    ← Actors
+                  </button>
+                )}
+              </div>
+            )}
+            <LongRestButton actorId={actorId} onRested={onActorChanged} />
+          </div>
         </div>
-        {subtitle && (
-          <p className="mt-0.5 font-sans text-sm text-pf-alt" data-section="identity">
-            {subtitle}
-          </p>
-        )}
       </div>
     </header>
   );
 }
+
+// ─── Sub-components ────────────────────────────────────────────────────
+
+function XPDisplay({ xp }: { xp: { value: number; max: number; pct: number } }): React.ReactElement {
+  const clamped = Math.max(0, Math.min(100, xp.pct));
+  return (
+    <div className="flex items-center gap-1.5" data-stat="xp">
+      <span className="text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark">XP</span>
+      <span className="font-mono text-xs tabular-nums text-pf-text-muted">
+        {xp.value} / {xp.max}
+      </span>
+      <span
+        className="inline-block h-1.5 w-12 overflow-hidden rounded bg-pf-bg-dark"
+        role="progressbar"
+        aria-valuenow={xp.value}
+        aria-valuemin={0}
+        aria-valuemax={xp.max}
+        title={`${clamped.toString()}% to next level`}
+      >
+        <span className="block h-full bg-pf-secondary" style={{ width: `${clamped.toString()}%` }} />
+      </span>
+    </div>
+  );
+}
+
+function HeroPointsControl({
+  heroPoints,
+  actorId,
+  onActorChanged,
+}: {
+  heroPoints: { value: number; max: number };
+  actorId: string;
+  onActorChanged: () => void;
+}): React.ReactElement {
+  const adjust = useActorAction({
+    run: (delta: number) => api.adjustActorResource(actorId, 'hero-points', delta),
+    onSuccess: onActorChanged,
+  });
+  return (
+    <div className="flex items-center gap-1" data-stat="hero-points">
+      <span className="text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark">Hero Points</span>
+      <MiniStepButton label="−" disabled={adjust.state === 'pending'} onClick={() => { adjust.trigger(-1); }} />
+      <div
+        className="flex gap-0.5"
+        aria-label={`Hero Points: ${heroPoints.value.toString()} of ${heroPoints.max.toString()}`}
+      >
+        {Array.from({ length: heroPoints.max }, (_, i) => (
+          <span
+            key={i}
+            className={[
+              'inline-block h-2.5 w-2.5 rounded-full border',
+              i < heroPoints.value ? 'border-rose-400 bg-rose-500' : 'border-pf-border bg-pf-bg',
+            ].join(' ')}
+          />
+        ))}
+      </div>
+      <MiniStepButton label="+" disabled={adjust.state === 'pending'} onClick={() => { adjust.trigger(1); }} />
+    </div>
+  );
+}
+
+function LongRestButton({ actorId, onRested }: { actorId: string; onRested: () => void }): React.ReactElement {
+  const { state, trigger, confirming } = useActorAction({
+    run: () => api.longRest(actorId),
+    confirm: 'Rest for the night? This restores HP, refreshes resources, and advances in-world time.',
+    onSuccess: onRested,
+  });
+  const isError = typeof state === 'object';
+  return (
+    <>
+      {confirming !== null && (
+        <ConfirmDialog
+          message={confirming.message}
+          confirmLabel="Rest"
+          onConfirm={confirming.accept}
+          onCancel={confirming.cancel}
+        />
+      )}
+      <div className="flex flex-col items-end gap-1" data-action="long-rest">
+        <button
+          type="button"
+          onClick={() => { trigger(); }}
+          disabled={state === 'pending'}
+          className="rounded border border-pf-tertiary-dark bg-pf-tertiary px-3 py-1.5 text-sm font-semibold text-pf-alt-dark hover:bg-pf-tertiary-dark hover:text-white disabled:opacity-50"
+        >
+          {state === 'pending' ? 'Resting…' : 'Long Rest'}
+        </button>
+        {isError && <span className="text-xs text-red-700">{state.error}</span>}
+      </div>
+    </>
+  );
+}
+
+function MiniStepButton({
+  label,
+  onClick,
+  disabled,
+}: {
+  label: string;
+  onClick: () => void;
+  disabled: boolean;
+}): React.ReactElement {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="rounded border border-pf-border bg-pf-bg px-1 py-0.5 font-mono text-[10px] text-pf-text hover:bg-pf-bg-dark disabled:opacity-50"
+    >
+      {label}
+    </button>
+  );
+}
+
+// ─── Portrait ──────────────────────────────────────────────────────────
 
 function CharacterPortrait({ src, name }: { src: string; name: string }): React.ReactElement {
   const [failed, setFailed] = useState(false);
@@ -144,7 +275,15 @@ function CharacterPortrait({ src, name }: { src: string; name: string }): React.
   );
 }
 
-function PortraitLightbox({ src, name, onClose }: { src: string; name: string; onClose: () => void }): React.ReactElement {
+function PortraitLightbox({
+  src,
+  name,
+  onClose,
+}: {
+  src: string;
+  name: string;
+  onClose: () => void;
+}): React.ReactElement {
   useEffect(() => {
     const handler = (e: KeyboardEvent): void => {
       if (e.key === 'Escape') onClose();
@@ -173,6 +312,8 @@ function PortraitLightbox({ src, name, onClose }: { src: string; name: string; o
   );
 }
 
+// ─── Badges ────────────────────────────────────────────────────────────
+
 function Badge({
   label,
   className,
@@ -195,6 +336,8 @@ function Badge({
 function capitalise(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
+
+// ─── Icons ─────────────────────────────────────────────────────────────
 
 function GearIcon(): React.ReactElement {
   return (

--- a/apps/player-portal/src/components/shop/ItemShopPicker.tsx
+++ b/apps/player-portal/src/components/shop/ItemShopPicker.tsx
@@ -55,13 +55,12 @@ const SEARCH_LIMIT = 10_000;
 // measured the grid yet (e.g. first render, or in unit tests that
 // render outside a real DOM). The visible page adapts to the grid's
 // actual dimensions on mount via `useFitPageSize` below.
-const FALLBACK_PAGE_SIZE = 24;
+const FALLBACK_PAGE_SIZE = 25;
 
-// Approximate tile box (including gap). Used with ResizeObserver to
-// compute how many whole tiles fit in the available grid area without
-// introducing a scroll bar. The grid itself uses
-// `minmax(9rem, 1fr)` columns + `gap-2` (8px); 9rem = 144px.
-const TILE_WIDTH_PX = 144;
+// Grid column count — fixed to match the `repeat(5, ...)` template.
+const GRID_COLS = 5;
+// Approximate tile height (including gap). Used with ResizeObserver to
+// compute how many whole rows fit in the available grid area.
 const TILE_HEIGHT_PX = 146; // ≈ img h-12 + name line + level + price + buy btn + padding
 const GRID_GAP_PX = 8;
 // Floor for the computed page size so we never land on "0 tiles per
@@ -103,11 +102,8 @@ function useFitPageSize(): {
       const availableHeight = Math.max(200, window.innerHeight - rect.top - VIEWPORT_BOTTOM_MARGIN_PX);
       setMaxHeight(availableHeight);
 
-      const widthForGrid = gridEl.clientWidth || rect.width;
-      if (widthForGrid === 0) return;
-      const cols = Math.max(1, Math.floor((widthForGrid + GRID_GAP_PX) / (TILE_WIDTH_PX + GRID_GAP_PX)));
       const rows = Math.max(1, Math.floor((availableHeight + GRID_GAP_PX) / (TILE_HEIGHT_PX + GRID_GAP_PX)));
-      setPageSize(Math.max(MIN_FIT_PAGE_SIZE, cols * rows));
+      setPageSize(Math.max(MIN_FIT_PAGE_SIZE, GRID_COLS * rows));
     };
     recompute();
     const ro = new ResizeObserver(recompute);

--- a/apps/player-portal/src/components/shop/ItemShopPicker.tsx
+++ b/apps/player-portal/src/components/shop/ItemShopPicker.tsx
@@ -558,8 +558,8 @@ function ShopTile({
         </div>
       </div>
       {/* Price + buy chip */}
-      <div className="flex flex-col gap-1 border-t border-pf-border p-1.5">
-        <span className="text-center font-mono text-[10px] tabular-nums text-pf-alt-dark" data-role="tile-price">
+      <div className="flex items-center gap-1.5 border-t border-pf-border px-1.5 py-1">
+        <span className="min-w-0 flex-1 truncate font-mono text-[10px] tabular-nums text-pf-alt-dark" data-role="tile-price">
           {priceText}
         </span>
         <button
@@ -571,7 +571,7 @@ function ShopTile({
           disabled={!canAfford || buying}
           data-testid="shop-buy"
           className={[
-            'w-full rounded border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider',
+            'flex-shrink-0 rounded border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider',
             !canAfford
               ? 'cursor-not-allowed border-neutral-200 bg-neutral-50 text-neutral-400'
               : buying

--- a/apps/player-portal/src/components/shop/ItemShopPicker.tsx
+++ b/apps/player-portal/src/components/shop/ItemShopPicker.tsx
@@ -379,7 +379,7 @@ export function ItemShopPicker({ items, onBuy, pending }: Props): React.ReactEle
               ref={gridRef}
               className="grid gap-2 overflow-hidden"
               style={{
-                gridTemplateColumns: 'repeat(auto-fill, minmax(9rem, 1fr))',
+                gridTemplateColumns: 'repeat(5, minmax(0, 1fr))',
                 // maxHeight is measured from the grid's live offset so
                 // the grid never extends past the viewport. Falls back
                 // to a conservative ceiling before the first measure.

--- a/apps/player-portal/src/components/shop/ItemShopPicker.tsx
+++ b/apps/player-portal/src/components/shop/ItemShopPicker.tsx
@@ -19,6 +19,7 @@ interface Props {
   items: readonly PreparedActorItem[];
   onBuy: (req: BuyRequest) => Promise<void>;
   pending: Set<string>;
+  disabledRarities?: readonly string[];
 }
 
 // Equipment packs available for browsing. More packs can be appended
@@ -31,6 +32,12 @@ const EQUIPMENT_PACKS: readonly { id: string; label: string }[] = [
 // `system.category` / `type` taxonomy loosely; the picker uses them
 // as a free-text filter that checks a match's displayed type + traits.
 type TypeFilter = 'all' | 'weapon' | 'armor' | 'consumable' | 'equipment' | 'backpack';
+const RARITY_FILTERS: Array<{ id: string; label: string }> = [
+  { id: 'common',   label: 'Common'   },
+  { id: 'uncommon', label: 'Uncommon' },
+  { id: 'rare',     label: 'Rare'     },
+  { id: 'unique',   label: 'Unique'   },
+];
 
 const TYPE_FILTERS: Array<{ id: TypeFilter; label: string }> = [
   { id: 'all', label: 'All' },
@@ -56,6 +63,60 @@ const SEARCH_LIMIT = 10_000;
 // render outside a real DOM). The visible page adapts to the grid's
 // actual dimensions on mount via `useFitPageSize` below.
 const FALLBACK_PAGE_SIZE = 25;
+
+// Known quality tiers with explicit sort order. Used to sort variants
+// within a group when the variant text contains a recognised keyword.
+const QUALITY_ORDER: Record<string, number> = {
+  minor: 0,
+  lesser: 1,
+  moderate: 2,
+  greater: 3,
+  major: 4,
+  true: 5,
+  young: 6,
+  adult: 7,
+  wyrm: 8,
+  '1st-rank': 10,
+  '2nd-rank': 11,
+  '3rd-rank': 12,
+  '4th-rank': 13,
+  '5th-rank': 14,
+  '6th-rank': 15,
+  '7th-rank': 16,
+  '8th-rank': 17,
+  '9th-rank': 18,
+  'rank 1': 10,
+  'rank 2': 11,
+  'rank 3': 12,
+  'rank 4': 13,
+  'rank 5': 14,
+  'rank 6': 15,
+  'rank 7': 16,
+  'rank 8': 17,
+  'rank 9': 18,
+};
+
+// Matches a quality keyword anywhere in a variant string.
+const QUALITY_WORD_RE =
+  /\b(minor|lesser|moderate|greater|major|true|young|adult|wyrm|[1-9](?:st|nd|rd|th)-rank|rank\s+[1-9])(?:\s+spell)?\b/i;
+
+// Split "Healing Potion (Lesser)" → { base: "Healing Potion", variant: "Lesser" }.
+// Only strips the final trailing parenthetical; parens in the middle of the
+// name (e.g. "Ring of the Ram (Type I)") are preserved in `base`.
+function parseItemName(name: string): { base: string; variant: string | null } {
+  const m = /^(.+?)\s*\(([^)]+)\)\s*$/.exec(name);
+  if (!m) return { base: name.trim(), variant: null };
+  return { base: m[1]!.trim(), variant: m[2]!.trim() };
+}
+
+// Sort rank for a variant string. Known quality keywords get explicit
+// ranks; unknown variants sort alphabetically (rank 99); the base item
+// with no variant sorts first (-1).
+function variantRank(variant: string | null): number {
+  if (variant === null) return -1;
+  const m = QUALITY_WORD_RE.exec(variant);
+  return m ? (QUALITY_ORDER[m[1]!.toLowerCase()] ?? 99) : 99;
+}
 
 // Grid column count — fixed to match the `repeat(5, ...)` template.
 const GRID_COLS = 5;
@@ -121,11 +182,12 @@ function useFitPageSize(): {
   return { pageSize, maxHeight, gridRef };
 }
 
-export function ItemShopPicker({ items, onBuy, pending }: Props): React.ReactElement {
+export function ItemShopPicker({ items, onBuy, pending, disabledRarities }: Props): React.ReactElement {
   const [query, setQuery] = useState('');
   const [debouncedQuery, setDebouncedQuery] = useState('');
   const [maxLevel, setMaxLevel] = useState<number | ''>('');
   const [typeFilter, setTypeFilter] = useState<TypeFilter>('all');
+  const [rarityFilter, setRarityFilter] = useState<Set<string>>(new Set());
   const [packId, setPackId] = useState<string>(EQUIPMENT_PACKS[0]?.id ?? '');
   const [matches, setMatches] = useState<CompendiumMatch[]>([]);
   const [loading, setLoading] = useState(false);
@@ -137,10 +199,8 @@ export function ItemShopPicker({ items, onBuy, pending }: Props): React.ReactEle
   // Prefetched prices keyed by uuid. `undefined` means "not yet
   // fetched", `null` means "fetched but no price / error — treat as 0".
   const [prices, setPrices] = useState<Map<string, ItemPrice | null>>(new Map());
-  // When non-null, the item detail overlay covers the grid. The
-  // match carries the identifying uuid + lean fields; the overlay
-  // lazily fetches the full document for description + traits.
-  const [selectedMatch, setSelectedMatch] = useState<CompendiumMatch | null>(null);
+  // When non-null, the item detail overlay covers the grid.
+  const [selectedGroup, setSelectedGroup] = useState<ItemGroup | null>(null);
 
   const purseCp = useMemo(() => sumActorCoinsCp(items), [items]);
 
@@ -198,8 +258,41 @@ export function ItemShopPicker({ items, onBuy, pending }: Props): React.ReactEle
     // price field at all (e.g. uncached packs where price isn't
     // embedded) remain visible; the tile price prefetch and the
     // detail overlay pick up the real number later.
-    return typed.filter((m) => m.price === undefined || priceToCp(m.price) > 0);
-  }, [matches, typeFilter]);
+    const priceFiltered = typed.filter((m) => m.price === undefined || priceToCp(m.price) > 0);
+    const disabledSet = new Set(disabledRarities?.map((r) => r.toLowerCase()) ?? []);
+    const availableRarities = disabledSet.size > 0
+      ? priceFiltered.filter((m) => !disabledSet.has((m.rarity ?? 'common').toLowerCase()))
+      : priceFiltered;
+    const rarityFiltered = rarityFilter.size === 0
+      ? availableRarities
+      : availableRarities.filter((m) => rarityFilter.has((m.rarity ?? 'common').toLowerCase()));
+
+    // Group items that share the same base name via the "$name ($variant)"
+    // structure. "Healing Potion (Lesser)" and "Healing Potion (Greater)"
+    // both parse to base "Healing Potion" and are merged into one tile.
+    const groupMap = new Map<string, CompendiumMatch[]>();
+    for (const m of rarityFiltered) {
+      const key = parseItemName(m.name).base.toLowerCase();
+      const arr = groupMap.get(key);
+      if (arr) arr.push(m);
+      else groupMap.set(key, [m]);
+    }
+
+    const groups: ItemGroup[] = [];
+    for (const [key, variants] of groupMap) {
+      variants.sort((a, b) => {
+        const ra = variantRank(parseItemName(a.name).variant);
+        const rb = variantRank(parseItemName(b.name).variant);
+        if (ra !== rb) return ra - rb;
+        // Unknown variants (both rank 99) fall back to alphabetical.
+        return (parseItemName(a.name).variant ?? '').localeCompare(parseItemName(b.name).variant ?? '');
+      });
+      const displayName = parseItemName(variants[0]?.name ?? '').base;
+      groups.push({ key, displayName, variants });
+    }
+    groups.sort((a, b) => a.key.localeCompare(b.key));
+    return groups;
+  }, [matches, typeFilter, rarityFilter, disabledRarities]);
   // The grid's height is capped (see `gridRef` below) and the page
   // size adapts to however many tiles fit at the current viewport via
   // ResizeObserver + window-resize. Falling back to
@@ -224,7 +317,8 @@ export function ItemShopPicker({ items, onBuy, pending }: Props): React.ReactEle
   // recommended pattern for derived reset state) rather than an
   // effect, which would trigger the set-state-in-effect lint and an
   // extra render pass.
-  const filterKey = `${debouncedQuery}|${maxLevel.toString()}|${packId}|${typeFilter}`;
+  const filterKey = `${debouncedQuery}|${maxLevel.toString()}|${packId}|${typeFilter}|${[...rarityFilter].sort().join(',')}`;
+
   const [lastFilterKey, setLastFilterKey] = useState(filterKey);
   if (filterKey !== lastFilterKey) {
     setLastFilterKey(filterKey);
@@ -237,8 +331,9 @@ export function ItemShopPicker({ items, onBuy, pending }: Props): React.ReactEle
   // short-circuits — no per-tile getCompendiumDocument calls in the
   // common case. Scoped to the current page so uncached packs don't
   // fire off thousands of fetches up-front.
+  const pageVariants = useMemo(() => pageSlice.flatMap((g) => g.variants), [pageSlice]);
   useEffect(() => {
-    const needed = pageSlice.filter((m) => m.price === undefined && !prices.has(m.uuid));
+    const needed = pageVariants.filter((m) => m.price === undefined && !prices.has(m.uuid));
     if (needed.length === 0) return;
     let cancelled = false;
     const queue = [...needed];
@@ -274,7 +369,7 @@ export function ItemShopPicker({ items, onBuy, pending }: Props): React.ReactEle
     return (): void => {
       cancelled = true;
     };
-  }, [pageSlice, prices]);
+  }, [pageVariants, prices]);
 
   const emptyResults = filtered.length === 0;
 
@@ -294,6 +389,33 @@ export function ItemShopPicker({ items, onBuy, pending }: Props): React.ReactEle
           className="min-w-[10rem] flex-1 rounded border border-pf-border bg-white px-2 py-1 text-sm"
           data-testid="shop-search"
         />
+        <ul className="flex items-center gap-1" role="group" aria-label="Rarity filter">
+          {RARITY_FILTERS.filter((rf) => !disabledRarities?.includes(rf.id)).map((rf) => {
+            const active = rarityFilter.has(rf.id);
+            return (
+              <li key={rf.id}>
+                <button
+                  type="button"
+                  aria-pressed={active}
+                  onClick={(): void => {
+                    setRarityFilter((prev) => {
+                      const next = new Set(prev);
+                      if (next.has(rf.id)) next.delete(rf.id);
+                      else next.add(rf.id);
+                      return next;
+                    });
+                  }}
+                  className={[
+                    'rounded-full border px-2 py-0.5 text-[11px] font-medium uppercase tracking-wider',
+                    active ? rarityChipActiveClass(rf.id) : 'border-pf-border bg-white text-pf-alt-dark hover:bg-pf-bg-dark/40',
+                  ].join(' ')}
+                >
+                  {rf.label}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
         <label className="flex items-center gap-1 text-xs text-pf-alt-dark">
           <span>Max level</span>
           <input
@@ -383,46 +505,37 @@ export function ItemShopPicker({ items, onBuy, pending }: Props): React.ReactEle
               }}
               data-testid="shop-grid"
             >
-              {pageSlice.map((m) => (
+              {pageSlice.map((g) => (
                 <ShopTile
-                  key={m.uuid}
-                  match={m}
-                  priceState={resolvePriceState(m, prices)}
+                  key={g.key}
+                  group={g}
+                  priceState={resolvePriceState(g.variants[0] as CompendiumMatch, prices)}
                   purseCp={purseCp}
-                  buying={pending.has(m.uuid)}
+                  buying={g.variants.some((v) => pending.has(v.uuid))}
                   onOpen={(): void => {
-                    setSelectedMatch(m);
+                    setSelectedGroup(g);
                   }}
-                  onBuy={(unitPriceCp): Promise<void> => onBuy({ match: m, unitPriceCp })}
+                  onBuyDirect={(unitPriceCp): Promise<void> =>
+                    onBuy({ match: g.variants[0] as CompendiumMatch, unitPriceCp })
+                  }
                 />
               ))}
             </ul>
-            {selectedMatch && (
+            {selectedGroup && (
               <ShopItemDetail
-                match={selectedMatch}
+                group={selectedGroup}
                 purseCp={purseCp}
-                buying={pending.has(selectedMatch.uuid)}
-                onBuy={async (unitPriceCp): Promise<void> => {
-                  await onBuy({ match: selectedMatch, unitPriceCp });
-                  setSelectedMatch(null);
+                pending={pending}
+                onBuy={async (match, unitPriceCp): Promise<void> => {
+                  await onBuy({ match, unitPriceCp });
+                  setSelectedGroup(null);
                 }}
                 onClose={(): void => {
-                  setSelectedMatch(null);
+                  setSelectedGroup(null);
                 }}
               />
             )}
           </div>
-          {pageCount > 1 && (
-            <div className="flex justify-end" data-role="pagination" data-position="bottom">
-              <PaginationControls
-                page={clampedPage}
-                pageCount={pageCount}
-                onPageChange={setPage}
-                capHit={matches.length >= SEARCH_LIMIT}
-                capLimit={SEARCH_LIMIT}
-              />
-            </div>
-          )}
         </>
       )}
     </div>
@@ -494,6 +607,43 @@ function PaginationControls({
 
 type PriceState = { kind: 'loading' } | { kind: 'ready'; price: ItemPrice | null };
 
+function rarityFooterClass(rarity: string | undefined): string {
+  switch (rarity?.toLowerCase()) {
+    case 'uncommon': return 'bg-amber-200 border-amber-500';
+    case 'rare':     return 'bg-blue-200 border-blue-500';
+    case 'unique':   return 'bg-purple-200 border-purple-500';
+    default:         return 'border-pf-border';
+  }
+}
+
+function rarityChipActiveClass(rarity: string): string {
+  switch (rarity) {
+    case 'uncommon': return 'border-amber-500 bg-amber-200 text-amber-900';
+    case 'rare':     return 'border-blue-500 bg-blue-200 text-blue-900';
+    case 'unique':   return 'border-purple-500 bg-purple-200 text-purple-900';
+    default:         return 'border-pf-border bg-pf-bg-dark text-pf-text';
+  }
+}
+
+function rarityChipClass(rarity: string | undefined): string {
+  switch (rarity?.toLowerCase()) {
+    case 'uncommon': return 'border-amber-500 bg-amber-100 text-amber-800';
+    case 'rare':     return 'border-blue-500 bg-blue-100 text-blue-800';
+    case 'unique':   return 'border-purple-500 bg-purple-100 text-purple-800';
+    default:         return 'border-pf-border bg-pf-bg-dark text-pf-alt-dark';
+  }
+}
+
+interface ItemGroup {
+  key: string;
+  displayName: string;
+  variants: CompendiumMatch[];
+}
+
+function qualityLabel(name: string): string {
+  return parseItemName(name).variant ?? '—';
+}
+
 // Priority for the per-tile price:
 //   1. `match.price` when the server embedded it (cache hit) — instant
 //   2. The lazy-loaded prices Map (uncached packs)
@@ -505,34 +655,33 @@ function resolvePriceState(match: CompendiumMatch, prefetched: Map<string, ItemP
 }
 
 function ShopTile({
-  match,
+  group,
   priceState,
   purseCp,
   buying,
   onOpen,
-  onBuy,
+  onBuyDirect,
 }: {
-  match: CompendiumMatch;
+  group: ItemGroup;
   priceState: PriceState;
   purseCp: number;
   buying: boolean;
   onOpen: () => void;
-  onBuy: (unitPriceCp: number) => Promise<void>;
+  onBuyDirect: (unitPriceCp: number) => Promise<void>;
 }): React.ReactElement {
+  const representative = group.variants[0] as CompendiumMatch;
+  const multiVariant = group.variants.length > 1;
   const price = priceState.kind === 'ready' ? priceState.price : null;
   const unitPriceCp = price ? priceToCp(price) : 0;
   const priceText =
     priceState.kind === 'loading' ? '…' : price ? formatCp(unitPriceCp) : '—';
   const priceReady = priceState.kind === 'ready';
-  // Free items (0 cp) remain buyable. When price data hasn't loaded
-  // yet we optimistically allow hitting Buy — the real cost will be
-  // enforced when the buy handler re-checks the actor's purse.
   const canAfford = !priceReady || unitPriceCp === 0 || purseCp >= unitPriceCp;
 
   return (
     <li
       className="flex flex-col overflow-hidden rounded border border-pf-border bg-pf-bg transition-shadow hover:cursor-pointer hover:shadow-md"
-      data-item-uuid={match.uuid}
+      data-item-uuid={representative.uuid}
       data-affordable={canAfford ? 'true' : 'false'}
       onClick={(e): void => {
         if ((e.target as HTMLElement).closest('button, a, input')) return;
@@ -550,36 +699,45 @@ function ShopTile({
     >
       {/* Square art with name overlay — mirrors the inventory GridTile */}
       <div className="relative aspect-square w-full overflow-hidden bg-pf-bg-dark">
-        <img src={match.img} alt="" className="h-full w-full object-contain" />
+        <img src={representative.img} alt="" className="h-full w-full object-contain" />
         <div className="absolute inset-x-0 bottom-0 bg-black/40 px-1.5 py-1">
-          <span className="line-clamp-2 block text-[10px] font-medium leading-tight text-white" title={match.name}>
-            {match.name}
+          <span className="line-clamp-2 block text-[10px] font-medium leading-tight text-white" title={group.displayName}>
+            {group.displayName}
           </span>
         </div>
+        {multiVariant && (
+          <span className="absolute right-1 top-1 rounded bg-black/50 px-1.5 py-0.5 text-[10px] font-semibold leading-none text-white">
+            Variants: {group.variants.length}
+          </span>
+        )}
       </div>
-      {/* Price + buy chip */}
-      <div className="flex items-center gap-1.5 border-t border-pf-border px-1.5 py-1">
+      {/* Price + buy chip — tinted by rarity */}
+      <div className={`flex items-center gap-1.5 border-t px-1.5 py-1 ${rarityFooterClass(representative.rarity)}`}>
         <span className="min-w-0 flex-1 truncate font-mono text-[10px] tabular-nums text-pf-alt-dark" data-role="tile-price">
-          {priceText}
+          {multiVariant ? `from ${priceText}` : priceText}
         </span>
         <button
           type="button"
           onClick={(e): void => {
             e.stopPropagation();
-            void onBuy(unitPriceCp);
+            if (multiVariant) {
+              onOpen();
+            } else {
+              void onBuyDirect(unitPriceCp);
+            }
           }}
-          disabled={!canAfford || buying}
+          disabled={!multiVariant && (!canAfford || buying)}
           data-testid="shop-buy"
           className={[
             'flex-shrink-0 rounded border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider',
-            !canAfford
+            !multiVariant && !canAfford
               ? 'cursor-not-allowed border-neutral-200 bg-neutral-50 text-neutral-400'
               : buying
                 ? 'border-pf-primary bg-pf-primary/10 text-pf-primary'
                 : 'border-pf-primary bg-pf-primary text-white hover:bg-pf-primary-dark',
           ].join(' ')}
         >
-          {buying ? 'Buying…' : canAfford ? 'Buy' : 'Too rich'}
+          {buying ? 'Buying…' : multiVariant ? 'Select' : canAfford ? 'Buy' : 'Too rich'}
         </button>
       </div>
     </li>
@@ -600,27 +758,28 @@ function extractPriceFromDocument(doc: CompendiumDocument): ItemPrice | null {
 // cached on the mcp side, the fetch is a synchronous in-memory hit.
 // Dismissed via the × button, Esc, or clicking outside the panel.
 function ShopItemDetail({
-  match,
+  group,
   purseCp,
-  buying,
+  pending,
   onBuy,
   onClose,
 }: {
-  match: CompendiumMatch;
+  group: ItemGroup;
   purseCp: number;
-  buying: boolean;
-  onBuy: (unitPriceCp: number) => Promise<void>;
+  pending: Set<string>;
+  onBuy: (match: CompendiumMatch, unitPriceCp: number) => Promise<void>;
   onClose: () => void;
 }): React.ReactElement {
+  const [selectedVariantIdx, setSelectedVariantIdx] = useState(0);
+  const activeVariant = (group.variants[Math.min(selectedVariantIdx, group.variants.length - 1)] ?? group.variants[0]) as CompendiumMatch;
+  const multiVariant = group.variants.length > 1;
+
   const [doc, setDoc] = useState<CompendiumDocument | null>(null);
   const [docError, setDocError] = useState<string | null>(null);
   const [docLoading, setDocLoading] = useState(true);
 
   useEffect(() => {
     let cancelled = false;
-    // Defer the "reset to loading" setStates to a microtask so React
-    // doesn't treat the synchronous trio as a cascading-render
-    // warning. The subsequent .then / .catch are already async.
     queueMicrotask(() => {
       if (cancelled) return;
       setDoc(null);
@@ -628,7 +787,7 @@ function ShopItemDetail({
       setDocLoading(true);
     });
     api
-      .getCompendiumDocument(match.uuid)
+      .getCompendiumDocument(activeVariant.uuid)
       .then((result) => {
         if (cancelled) return;
         setDoc(result.document);
@@ -642,7 +801,7 @@ function ShopItemDetail({
     return (): void => {
       cancelled = true;
     };
-  }, [match.uuid]);
+  }, [activeVariant.uuid]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent): void => {
@@ -654,14 +813,12 @@ function ShopItemDetail({
     };
   }, [onClose]);
 
-  // Prefer `match.price` when the server embedded it (cached pack).
-  // Falls back to reading from the freshly-fetched document for
-  // uncached packs.
-  const price = match.price ?? (doc ? extractPriceFromDocument(doc) : null);
+  const price = activeVariant.price ?? (doc ? extractPriceFromDocument(doc) : null);
   const unitPriceCp = price ? priceToCp(price) : 0;
   const priceText = price ? formatCp(unitPriceCp) : '—';
   const canAfford = unitPriceCp === 0 || purseCp >= unitPriceCp;
-  const traits = match.traits ?? extractTraitsFromDocument(doc);
+  const buying = pending.has(activeVariant.uuid);
+  const traits = activeVariant.traits ?? extractTraitsFromDocument(doc);
   const description = doc ? extractDescriptionFromDocument(doc) : '';
   const enriched = description.length > 0 ? enrichDescription(description) : '';
 
@@ -669,28 +826,56 @@ function ShopItemDetail({
     <div
       role="dialog"
       aria-modal="true"
-      aria-label={`${match.name} details`}
+      aria-label={`${group.displayName} details`}
       data-testid="shop-item-detail"
       onClick={(e): void => {
-        // Click on the backdrop itself (not any child) closes.
         if (e.target === e.currentTarget) onClose();
       }}
-      className="absolute inset-0 z-20 flex items-start justify-center bg-black/10 p-2"
+      className="absolute inset-x-0 top-0 z-20 flex items-start justify-center bg-black/10 p-2"
     >
-      <div className="flex max-h-full w-full flex-col rounded border border-pf-border bg-pf-bg shadow-lg">
+      <div className="w-full flex-col rounded border border-pf-border bg-pf-bg shadow-lg">
         <header className="flex items-start gap-3 border-b border-pf-border p-3">
           <img
-            src={match.img}
+            src={activeVariant.img}
             alt=""
             className="h-12 w-12 flex-shrink-0 rounded border border-pf-border bg-pf-bg-dark"
           />
           <div className="min-w-0 flex-1">
-            <h3 className="font-serif text-base font-semibold text-pf-text">{match.name}</h3>
+            <div className="flex items-baseline gap-2">
+              <h3 className="font-serif text-base font-semibold text-pf-text">{group.displayName}</h3>
+              {activeVariant.rarity && activeVariant.rarity !== 'common' && (
+                <span className={`rounded border px-1.5 py-0.5 text-[10px] font-medium capitalize ${rarityChipClass(activeVariant.rarity)}`}>
+                  {activeVariant.rarity}
+                </span>
+              )}
+            </div>
             <p className="text-[10px] uppercase tracking-widest text-pf-alt-dark">
-              {match.type}
-              {typeof match.level === 'number' && ` · Level ${match.level.toString()}`}
+              {activeVariant.type}
+              {typeof activeVariant.level === 'number' && ` · Level ${activeVariant.level.toString()}`}
               {priceText !== '—' && ` · ${priceText}`}
             </p>
+            {multiVariant && (
+              <ul className="mt-2 flex flex-wrap gap-1" aria-label="Variant">
+                {group.variants.map((v, i) => (
+                  <li key={v.uuid}>
+                    <button
+                      type="button"
+                      onClick={(): void => {
+                        setSelectedVariantIdx(i);
+                      }}
+                      className={[
+                        'rounded border px-2 py-0.5 text-[10px] font-medium',
+                        i === selectedVariantIdx
+                          ? 'border-pf-primary bg-pf-primary text-white'
+                          : 'border-pf-border bg-pf-bg-dark text-pf-alt-dark hover:bg-pf-bg-dark/60',
+                      ].join(' ')}
+                    >
+                      {qualityLabel(v.name)}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
             {traits.length > 0 && (
               <ul className="mt-1 flex flex-wrap gap-1">
                 {traits.slice(0, 8).map((t) => (
@@ -714,7 +899,7 @@ function ShopItemDetail({
             ×
           </button>
         </header>
-        <div className="flex-1 overflow-y-auto p-3 text-sm leading-relaxed text-pf-text [&_.pf-damage]:font-semibold [&_.pf-damage]:text-pf-primary [&_.pf-template]:italic [&_.pf-template]:text-pf-secondary [&_a]:cursor-pointer [&_a]:text-pf-primary [&_a]:underline [&_p]:my-2">
+        <div className="max-h-96 overflow-y-auto p-3 text-sm leading-relaxed text-pf-text [&_.pf-damage]:font-semibold [&_.pf-damage]:text-pf-primary [&_.pf-template]:italic [&_.pf-template]:text-pf-secondary [&_a]:cursor-pointer [&_a]:text-pf-primary [&_a]:underline [&_p]:my-2">
           {docLoading && !doc ? (
             <p className="italic text-pf-alt-dark">Loading…</p>
           ) : docError !== null ? (
@@ -737,7 +922,7 @@ function ShopItemDetail({
             type="button"
             disabled={!canAfford || buying}
             onClick={(): void => {
-              void onBuy(unitPriceCp);
+              void onBuy(activeVariant, unitPriceCp);
             }}
             data-testid="shop-detail-buy"
             className={[

--- a/apps/player-portal/src/components/shop/ItemShopPicker.tsx
+++ b/apps/player-portal/src/components/shop/ItemShopPicker.tsx
@@ -531,14 +531,10 @@ function ShopTile({
 
   return (
     <li
-      className="flex flex-col items-center gap-1 rounded border border-pf-border bg-white p-2 text-center transition-shadow hover:cursor-pointer hover:shadow-md"
+      className="flex flex-col overflow-hidden rounded border border-pf-border bg-pf-bg transition-shadow hover:cursor-pointer hover:shadow-md"
       data-item-uuid={match.uuid}
       data-affordable={canAfford ? 'true' : 'false'}
       onClick={(e): void => {
-        // The Buy button lives inside this tile, so clicks on the
-        // button would otherwise fall through to the tile click
-        // handler and pop the detail overlay. Skip when the click
-        // target is (or is inside) an interactive child.
         if ((e.target as HTMLElement).closest('button, a, input')) return;
         onOpen();
       }}
@@ -552,38 +548,40 @@ function ShopTile({
       }}
       data-testid="shop-tile"
     >
-      <img src={match.img} alt="" className="h-12 w-12 rounded border border-pf-border bg-pf-bg-dark" />
-      <span className="line-clamp-2 text-[11px] font-medium leading-tight text-pf-text" title={match.name}>
-        {match.name}
-      </span>
-      {typeof match.level === 'number' && (
-        <span className="text-[10px] uppercase tracking-widest text-pf-alt-dark">Level {match.level}</span>
-      )}
-      <span className="font-mono text-[10px] tabular-nums text-pf-alt-dark" data-role="tile-price">
-        {priceText}
-      </span>
-      <button
-        type="button"
-        onClick={(e): void => {
-          // Stop the tile's click handler from also firing and
-          // popping the detail overlay — the user's intent with a
-          // Buy click is purchase, not inspect.
-          e.stopPropagation();
-          void onBuy(unitPriceCp);
-        }}
-        disabled={!canAfford || buying}
-        data-testid="shop-buy"
-        className={[
-          'mt-auto w-full rounded border px-2 py-0.5 text-xs font-semibold uppercase tracking-wider',
-          !canAfford
-            ? 'cursor-not-allowed border-neutral-200 bg-neutral-50 text-neutral-400'
-            : buying
-              ? 'border-pf-primary bg-pf-primary/10 text-pf-primary'
-              : 'border-pf-primary bg-pf-primary text-white hover:bg-pf-primary-dark',
-        ].join(' ')}
-      >
-        {buying ? 'Buying…' : canAfford ? 'Buy' : 'Too rich'}
-      </button>
+      {/* Square art with name overlay — mirrors the inventory GridTile */}
+      <div className="relative aspect-square w-full overflow-hidden bg-pf-bg-dark">
+        <img src={match.img} alt="" className="h-full w-full object-contain" />
+        <div className="absolute inset-x-0 bottom-0 bg-black/40 px-1.5 py-1">
+          <span className="line-clamp-2 block text-[10px] font-medium leading-tight text-white" title={match.name}>
+            {match.name}
+          </span>
+        </div>
+      </div>
+      {/* Price + buy chip */}
+      <div className="flex flex-col gap-1 border-t border-pf-border p-1.5">
+        <span className="text-center font-mono text-[10px] tabular-nums text-pf-alt-dark" data-role="tile-price">
+          {priceText}
+        </span>
+        <button
+          type="button"
+          onClick={(e): void => {
+            e.stopPropagation();
+            void onBuy(unitPriceCp);
+          }}
+          disabled={!canAfford || buying}
+          data-testid="shop-buy"
+          className={[
+            'w-full rounded border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider',
+            !canAfford
+              ? 'cursor-not-allowed border-neutral-200 bg-neutral-50 text-neutral-400'
+              : buying
+                ? 'border-pf-primary bg-pf-primary/10 text-pf-primary'
+                : 'border-pf-primary bg-pf-primary text-white hover:bg-pf-primary-dark',
+          ].join(' ')}
+        >
+          {buying ? 'Buying…' : canAfford ? 'Buy' : 'Too rich'}
+        </button>
+      </div>
     </li>
   );
 }

--- a/apps/player-portal/src/components/tabs/Actions.test.tsx
+++ b/apps/player-portal/src/components/tabs/Actions.test.tsx
@@ -164,13 +164,14 @@ describe('Actions tab — action items', () => {
       .getAllByText(/Rage/i)[0]
       ?.closest('[data-action-id]') as HTMLElement | null;
     expect(rage, 'Rage card').toBeTruthy();
-    expect(rage?.getAttribute('data-expanded')).toBe('false');
-    expect(rage?.querySelector('[data-role="action-description"]')).toBeNull();
 
-    const toggle = rage?.querySelector('[data-testid="action-card-toggle"]') as HTMLElement;
-    fireEvent.click(toggle);
+    const details = rage?.querySelector('details') as HTMLDetailsElement | null;
+    expect(details?.open, 'collapsed by default').toBe(false);
 
-    expect(rage?.getAttribute('data-expanded')).toBe('true');
+    const summary = rage?.querySelector('summary') as HTMLElement;
+    fireEvent.click(summary);
+
+    expect(details?.open, 'expanded after click').toBe(true);
     const body = rage?.querySelector('[data-role="action-description"]');
     expect(body, 'description body').toBeTruthy();
     // Rage's description starts with "You tap into your inner fury".

--- a/apps/player-portal/src/components/tabs/Actions.test.tsx
+++ b/apps/player-portal/src/components/tabs/Actions.test.tsx
@@ -50,13 +50,17 @@ describe('Actions tab — strikes', () => {
     }
   });
 
-  it("renders each strike's three attack variants with MAP labels", () => {
+  it("renders each strike's three attack variants (bonus only, MAP in title)", () => {
     const { container } = render(<Actions actorId="test-actor" onItemUsed={() => undefined}actions={actions} items={items} />);
     for (const [slug, { variants }] of Object.entries(EXPECTED_STRIKES)) {
       const card = container.querySelector(`[data-strike-slug="${slug}"]`);
-      for (const label of variants) {
-        expect(within(card as HTMLElement).getByText(label), `${slug} variant ${label}`).toBeTruthy();
-      }
+      variants.forEach((label, i) => {
+        const bonus = label.split(' ')[0] ?? label;
+        const btn = (card as HTMLElement).querySelector(`[data-variant-index="${i.toString()}"]`);
+        expect(btn, `${slug} variant ${i.toString()} button`).toBeTruthy();
+        expect(btn?.textContent?.trim(), `${slug} variant ${i.toString()} text`).toBe(bonus);
+        expect(btn?.getAttribute('title'), `${slug} variant ${i.toString()} title`).toBe(label);
+      });
     }
   });
 

--- a/apps/player-portal/src/components/tabs/Actions.test.tsx
+++ b/apps/player-portal/src/components/tabs/Actions.test.tsx
@@ -131,10 +131,10 @@ describe('Actions tab — action items', () => {
     expect(section, 'Actions section').toBeTruthy();
     expect(section?.textContent).toContain('Rage');
     expect(section?.textContent).toContain('Demoralize');
-    // Both are 1-action so the cost badge reads "1A".
+    // Both are 1-action so the cost badge shows the ◆ glyph.
     const cards = section?.querySelectorAll('[data-action-kind="action"]');
     for (const card of Array.from(cards ?? [])) {
-      expect(card.textContent).toContain('1A');
+      expect(card.textContent).toContain('◆');
     }
   });
 

--- a/apps/player-portal/src/components/tabs/Actions.tsx
+++ b/apps/player-portal/src/components/tabs/Actions.tsx
@@ -300,7 +300,7 @@ function ActionCard({
             type="button"
             onClick={(e) => { e.preventDefault(); use.trigger(); }}
             disabled={use.state === 'pending'}
-            className="ml-auto rounded border border-sky-300 bg-sky-50 px-2 py-0.5 text-[11px] font-semibold text-sky-900 hover:bg-sky-100 disabled:opacity-50"
+            className="ml-auto rounded border border-pf-border bg-pf-bg px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-pf-text hover:bg-pf-bg-dark disabled:opacity-50"
             data-role="action-use"
           >
             {use.state === 'pending' ? 'Using…' : 'Use'}

--- a/apps/player-portal/src/components/tabs/Actions.tsx
+++ b/apps/player-portal/src/components/tabs/Actions.tsx
@@ -344,14 +344,12 @@ function ActionCard({
 }
 
 function ActionCostBadge({ kind, count }: { kind: string; count: number | null }): React.ReactElement {
-  // PF2e renders these as decorative glyphs; we use short text so the
-  // viewer reads the same on any font/render surface.
   let label = '—';
   if (kind === 'action') {
-    label = count === 1 ? '1A' : count === 2 ? '2A' : count === 3 ? '3A' : 'A';
-  } else if (kind === 'reaction') label = 'R';
-  else if (kind === 'free') label = 'F';
-  else if (kind === 'passive') label = 'P';
+    label = count === 1 ? '◆' : count === 2 ? '◆◆' : count === 3 ? '◆◆◆' : '◆';
+  } else if (kind === 'reaction') label = '↺';
+  else if (kind === 'free') label = '◇';
+  else if (kind === 'passive') label = '—';
 
   const palette: Record<string, string> = {
     action: 'border-emerald-300 bg-emerald-50 text-emerald-800',

--- a/apps/player-portal/src/components/tabs/Actions.tsx
+++ b/apps/player-portal/src/components/tabs/Actions.tsx
@@ -39,7 +39,7 @@ export function Actions({ actions, items, abilities, actorId, onItemUsed }: Prop
       {strikes.length > 0 && (
         <div>
           <SectionHeader band>Strikes</SectionHeader>
-          <ul className="space-y-2">
+          <ul className="grid grid-cols-2 gap-2">
             {strikes.map((strike) => (
               <StrikeCard key={strike.slug} strike={strike} abilities={abilities} actorId={actorId} />
             ))}
@@ -71,7 +71,7 @@ function StrikeCard({
   abilities: Record<AbilityKey, Ability> | undefined;
   actorId: string;
 }): React.ReactElement {
-  const allTraits = [...strike.traits, ...strike.weaponTraits];
+  const allTraits = [...strike.traits, ...strike.weaponTraits].filter((t) => t.name !== 'attack');
   const damageText = formatStrikeDamage(strike, abilities);
   const range = strike.item.system.range;
 
@@ -115,12 +115,28 @@ function StrikeCard({
               </span>
             )}
           </div>
-          <VariantStrip
-            variants={strike.variants}
-            onVariant={(i) => { attack.trigger(i); }}
-            pending={attack.state === 'pending'}
-          />
-          <div className="mt-1.5 flex flex-wrap gap-1.5" data-role="strike-damage-actions">
+          <div className="mt-1 flex flex-wrap items-center gap-1.5" role="group" aria-label="Attack and damage">
+            {strike.variants.map((v, i) => {
+              const bonus = v.label.split(' ')[0] ?? v.label;
+              const color =
+                i === 0 ? 'border-emerald-300 bg-emerald-50 text-emerald-900 hover:bg-emerald-100'
+                : i === 1 ? 'border-amber-300 bg-amber-50 text-amber-900 hover:bg-amber-100'
+                : 'border-rose-300 bg-rose-50 text-rose-900 hover:bg-rose-100';
+              return (
+                <button
+                  key={i}
+                  type="button"
+                  onClick={() => { attack.trigger(i); }}
+                  disabled={attack.state === 'pending'}
+                  title={v.label}
+                  data-variant-index={i}
+                  className={`rounded border px-1.5 py-0.5 font-mono text-xs tabular-nums disabled:opacity-50 ${color}`}
+                >
+                  {bonus}
+                </button>
+              );
+            })}
+            <span aria-hidden className="mx-0.5 h-4 w-px bg-pf-border" />
             <button
               type="button"
               onClick={() => { damage.trigger(); }}
@@ -220,41 +236,6 @@ function computeDamageAbilityMod(
     return 0;
   }
   return 0;
-}
-
-function VariantStrip({
-  variants,
-  onVariant,
-  pending,
-}: {
-  variants: { label: string }[];
-  onVariant: (index: number) => void;
-  pending: boolean;
-}): React.ReactElement {
-  return (
-    <ul className="mt-1 flex flex-wrap gap-1.5" role="group" aria-label="Attack variants">
-      {variants.map((v, i) => (
-        <li key={`${i.toString()}-${v.label}`}>
-          <button
-            type="button"
-            onClick={() => {
-              onVariant(i);
-            }}
-            disabled={pending}
-            data-variant-index={i}
-            className={[
-              'rounded border px-1.5 py-0.5 font-mono text-xs tabular-nums disabled:opacity-50',
-              i === 0
-                ? 'border-emerald-300 bg-emerald-50 text-emerald-900 hover:bg-emerald-100'
-                : 'border-pf-border bg-pf-bg text-pf-text hover:bg-pf-bg-dark',
-            ].join(' ')}
-          >
-            {v.label}
-          </button>
-        </li>
-      ))}
-    </ul>
-  );
 }
 
 // ─── Action section (Actions / Reactions / Free Actions) ──────────────

--- a/apps/player-portal/src/components/tabs/Actions.tsx
+++ b/apps/player-portal/src/components/tabs/Actions.tsx
@@ -324,6 +324,7 @@ function ActionCard({
               </ul>
             )}
           </div>
+          <span aria-hidden className="flex-shrink-0 self-center text-[10px] text-pf-alt-dark group-open:hidden">▸</span>
         </summary>
         <div
           className="absolute left-0 right-0 top-full z-20 rounded-b border border-t-0 border-pf-primary/60 bg-pf-bg p-3 shadow-lg"

--- a/apps/player-portal/src/components/tabs/Actions.tsx
+++ b/apps/player-portal/src/components/tabs/Actions.tsx
@@ -311,18 +311,6 @@ function ActionCard({
             {typeof use.state === 'object' && (
               <p className="mt-1 text-[11px] text-red-700">{use.state.error}</p>
             )}
-            {traits.length > 0 && (
-              <ul className="mt-1 flex flex-wrap gap-1">
-                {traits.map((slug) => (
-                  <li
-                    key={slug}
-                    className="rounded-full border border-pf-border bg-pf-bg px-1.5 py-0.5 text-[10px] text-pf-text-muted"
-                  >
-                    {capitaliseSlug(slug)}
-                  </li>
-                ))}
-              </ul>
-            )}
           </div>
           <span aria-hidden className="flex-shrink-0 self-center text-[10px] text-pf-alt-dark group-open:hidden">▸</span>
         </summary>
@@ -330,6 +318,18 @@ function ActionCard({
           className="absolute left-0 right-0 top-full z-20 rounded-b border border-t-0 border-pf-primary/60 bg-pf-bg p-3 shadow-lg"
           data-role="action-description"
         >
+          {traits.length > 0 && (
+            <ul className="mb-2 flex flex-wrap gap-1">
+              {traits.map((slug) => (
+                <li
+                  key={slug}
+                  className="rounded-full border border-pf-border bg-pf-bg px-1.5 py-0.5 text-[10px] text-pf-text-muted"
+                >
+                  {capitaliseSlug(slug)}
+                </li>
+              ))}
+            </ul>
+          )}
           {hasDescription ? (
             <div
               className="text-sm leading-relaxed [&_.pf-damage]:font-semibold [&_.pf-damage]:text-pf-primary [&_.pf-template]:italic [&_.pf-template]:text-pf-secondary [&_a]:cursor-pointer [&_a]:text-pf-primary [&_a]:underline [&_p]:my-2"

--- a/apps/player-portal/src/components/tabs/Actions.tsx
+++ b/apps/player-portal/src/components/tabs/Actions.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { createPf2eClient } from '@foundry-toolkit/pf2e-rules';
 import { api } from '../../api/client';
 import type { Ability, AbilityKey, ActionItem, PreparedActorItem, Strike } from '../../api/types';
@@ -278,7 +277,6 @@ function ActionCard({
   const kind = item.system.actionType.value;
   const count = item.system.actions.value;
   const traits = item.system.traits.value;
-  const [expanded, setExpanded] = useState(false);
   const description = item.system.description?.value ?? '';
   const hasDescription = description.trim() !== '';
   const enriched = hasDescription ? enrichDescription(description) : '';
@@ -287,85 +285,60 @@ function ActionCard({
     onSuccess: onUsed,
   });
 
-  const toggle = (): void => {
-    setExpanded((v) => !v);
-  };
-
   return (
-    <li
-      className="rounded border border-pf-border bg-pf-bg"
-      data-action-id={item.id}
-      data-action-kind={kind}
-      data-expanded={expanded ? 'true' : 'false'}
-    >
-      <div className="flex items-start gap-3 px-3 py-2">
-        <img
-          src={item.img}
-          alt=""
-          className="mt-0.5 h-8 w-8 flex-shrink-0 rounded border border-pf-border bg-pf-bg-dark"
-        />
-        <div className="min-w-0 flex-1">
-          <div className="flex items-baseline gap-2">
-            <button
-              type="button"
-              onClick={toggle}
-              aria-expanded={expanded}
-              className="min-w-0 truncate text-left text-sm font-medium text-pf-text hover:underline"
-              data-testid="action-card-toggle"
-            >
-              {item.name}
-            </button>
-            <ActionCostBadge kind={kind} count={count} />
-            <button
-              type="button"
-              onClick={() => { use.trigger(); }}
-              disabled={use.state === 'pending'}
-              className="ml-auto rounded border border-sky-300 bg-sky-50 px-2 py-0.5 text-[11px] font-semibold text-sky-900 hover:bg-sky-100 disabled:opacity-50"
-              data-role="action-use"
-            >
-              {use.state === 'pending' ? 'Using…' : 'Use'}
-            </button>
-            <button
-              type="button"
-              onClick={toggle}
-              aria-label={expanded ? 'Collapse' : 'Expand'}
-              className="text-[10px] text-pf-text-muted hover:text-pf-text"
-            >
-              {expanded ? '▾' : '▸'}
-            </button>
+    <li className="relative" data-action-id={item.id} data-action-kind={kind}>
+      <details className="group rounded border border-pf-border bg-pf-bg open:rounded-b-none open:border-pf-primary/60 open:shadow-md">
+        <summary className="flex cursor-pointer list-none items-start gap-3 px-3 py-2 [&::-webkit-details-marker]:hidden">
+          <img
+            src={item.img}
+            alt=""
+            className="mt-0.5 h-8 w-8 flex-shrink-0 rounded border border-pf-border bg-pf-bg-dark"
+          />
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <span className="min-w-0 truncate text-sm font-medium text-pf-text">{item.name}</span>
+              <ActionCostBadge kind={kind} count={count} />
+              <button
+                type="button"
+                onClick={(e) => { e.preventDefault(); use.trigger(); }}
+                disabled={use.state === 'pending'}
+                className="ml-auto rounded border border-sky-300 bg-sky-50 px-2 py-0.5 text-[11px] font-semibold text-sky-900 hover:bg-sky-100 disabled:opacity-50"
+                data-role="action-use"
+              >
+                {use.state === 'pending' ? 'Using…' : 'Use'}
+              </button>
+            </div>
+            {typeof use.state === 'object' && (
+              <p className="mt-1 text-[11px] text-red-700">{use.state.error}</p>
+            )}
+            {traits.length > 0 && (
+              <ul className="mt-1 flex flex-wrap gap-1">
+                {traits.map((slug) => (
+                  <li
+                    key={slug}
+                    className="rounded-full border border-pf-border bg-pf-bg px-1.5 py-0.5 text-[10px] text-pf-text-muted"
+                  >
+                    {capitaliseSlug(slug)}
+                  </li>
+                ))}
+              </ul>
+            )}
           </div>
-          {typeof use.state === 'object' && (
-            <p className="mt-1 text-[11px] text-red-700">{use.state.error}</p>
-          )}
-          {traits.length > 0 && (
-            <ul className="mt-1 flex flex-wrap gap-1">
-              {traits.map((slug) => (
-                <li
-                  key={slug}
-                  className="rounded-full border border-pf-border bg-pf-bg px-1.5 py-0.5 text-[10px] text-pf-text-muted"
-                >
-                  {capitaliseSlug(slug)}
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
-      </div>
-      {expanded && (
+        </summary>
         <div
-          className="border-t border-pf-border bg-pf-bg/60 px-3 py-2 text-sm text-pf-text"
+          className="absolute left-0 right-0 top-full z-20 rounded-b border border-t-0 border-pf-primary/60 bg-pf-bg p-3 shadow-lg"
           data-role="action-description"
         >
           {hasDescription ? (
             <div
-              className="leading-relaxed [&_.pf-damage]:font-semibold [&_.pf-damage]:text-pf-primary [&_.pf-template]:italic [&_.pf-template]:text-pf-secondary [&_a]:cursor-pointer [&_a]:text-pf-primary [&_a]:underline [&_p]:my-2"
+              className="text-sm leading-relaxed [&_.pf-damage]:font-semibold [&_.pf-damage]:text-pf-primary [&_.pf-template]:italic [&_.pf-template]:text-pf-secondary [&_a]:cursor-pointer [&_a]:text-pf-primary [&_a]:underline [&_p]:my-2"
               dangerouslySetInnerHTML={{ __html: enriched }}
             />
           ) : (
-            <p className="italic text-neutral-400">No description.</p>
+            <p className="text-sm italic text-neutral-400">No description.</p>
           )}
         </div>
-      )}
+      </details>
     </li>
   );
 }

--- a/apps/player-portal/src/components/tabs/Actions.tsx
+++ b/apps/player-portal/src/components/tabs/Actions.tsx
@@ -35,10 +35,10 @@ export function Actions({ actions, items, abilities, actorId, onItemUsed }: Prop
   }
 
   return (
-    <section className="space-y-6">
+    <section className="space-y-4 *:rounded-lg *:border *:border-pf-border *:bg-pf-bg-dark *:p-4">
       {strikes.length > 0 && (
         <div>
-          <SectionHeader>Strikes</SectionHeader>
+          <SectionHeader band>Strikes</SectionHeader>
           <ul className="space-y-2">
             {strikes.map((strike) => (
               <StrikeCard key={strike.slug} strike={strike} abilities={abilities} actorId={actorId} />
@@ -275,7 +275,7 @@ function ActionSection({
   if (items.length === 0) return null;
   return (
     <div data-action-section={kind}>
-      <SectionHeader>{title}</SectionHeader>
+      <SectionHeader band>{title}</SectionHeader>
       <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
         {items.map((item) => (
           <ActionCard key={item.id} item={item} actorId={actorId} onUsed={onUsed} />

--- a/apps/player-portal/src/components/tabs/Actions.tsx
+++ b/apps/player-portal/src/components/tabs/Actions.tsx
@@ -351,19 +351,8 @@ function ActionCostBadge({ kind, count }: { kind: string; count: number | null }
   else if (kind === 'free') label = '◇';
   else if (kind === 'passive') label = '—';
 
-  const palette: Record<string, string> = {
-    action: 'border-emerald-300 bg-emerald-50 text-emerald-800',
-    reaction: 'border-sky-300 bg-sky-50 text-sky-800',
-    free: 'border-violet-300 bg-violet-50 text-violet-800',
-    passive: 'border-pf-border bg-pf-bg text-pf-text-muted',
-  };
   return (
-    <span
-      className={[
-        'flex-shrink-0 rounded border px-1.5 py-0.5 font-mono text-[10px] font-medium tabular-nums',
-        palette[kind] ?? palette['passive'] ?? '',
-      ].join(' ')}
-    >
+    <span className="flex-shrink-0 rounded border border-pf-border bg-pf-bg px-1.5 py-0.5 font-mono text-[10px] font-medium tabular-nums text-pf-alt-dark">
       {label}
     </span>
   );

--- a/apps/player-portal/src/components/tabs/Actions.tsx
+++ b/apps/player-portal/src/components/tabs/Actions.tsx
@@ -288,32 +288,28 @@ function ActionCard({
   return (
     <li className="relative" data-action-id={item.id} data-action-kind={kind}>
       <details className="group rounded border border-pf-border bg-pf-bg open:rounded-b-none open:border-pf-primary/60 open:shadow-md">
-        <summary className="flex cursor-pointer list-none items-start gap-3 px-3 py-2 [&::-webkit-details-marker]:hidden">
+        <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 [&::-webkit-details-marker]:hidden">
           <img
             src={item.img}
             alt=""
-            className="mt-0.5 h-8 w-8 flex-shrink-0 rounded border border-pf-border bg-pf-bg-dark"
+            className="h-6 w-6 flex-shrink-0 rounded border border-pf-border bg-pf-bg-dark"
           />
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2">
-              <span className="min-w-0 truncate text-sm font-medium text-pf-text">{item.name}</span>
-              <ActionCostBadge kind={kind} count={count} />
-              <button
-                type="button"
-                onClick={(e) => { e.preventDefault(); use.trigger(); }}
-                disabled={use.state === 'pending'}
-                className="ml-auto rounded border border-sky-300 bg-sky-50 px-2 py-0.5 text-[11px] font-semibold text-sky-900 hover:bg-sky-100 disabled:opacity-50"
-                data-role="action-use"
-              >
-                {use.state === 'pending' ? 'Using…' : 'Use'}
-              </button>
-            </div>
-            {typeof use.state === 'object' && (
-              <p className="mt-1 text-[11px] text-red-700">{use.state.error}</p>
-            )}
-          </div>
-          <span aria-hidden className="flex-shrink-0 self-center text-[10px] text-pf-alt-dark group-open:hidden">▸</span>
+          <span className="min-w-0 truncate text-sm font-medium text-pf-text">{item.name}</span>
+          <ActionCostBadge kind={kind} count={count} />
+          <button
+            type="button"
+            onClick={(e) => { e.preventDefault(); use.trigger(); }}
+            disabled={use.state === 'pending'}
+            className="ml-auto rounded border border-sky-300 bg-sky-50 px-2 py-0.5 text-[11px] font-semibold text-sky-900 hover:bg-sky-100 disabled:opacity-50"
+            data-role="action-use"
+          >
+            {use.state === 'pending' ? 'Using…' : 'Use'}
+          </button>
+          <span aria-hidden className="flex-shrink-0 text-[10px] text-pf-alt-dark group-open:hidden">▸</span>
         </summary>
+        {typeof use.state === 'object' && (
+          <p className="px-3 pb-1 text-[11px] text-red-700">{use.state.error}</p>
+        )}
         <div
           className="absolute left-0 right-0 top-full z-20 rounded-b border border-t-0 border-pf-primary/60 bg-pf-bg p-3 shadow-lg"
           data-role="action-description"

--- a/apps/player-portal/src/components/tabs/Background.test.tsx
+++ b/apps/player-portal/src/components/tabs/Background.test.tsx
@@ -102,7 +102,7 @@ describe('Background tab', () => {
       age: { value: '' },
       height: { value: '' },
       weight: { value: '' },
-      languages: { value: [] },
+      languages: { value: [], details: '' },
       biography: {
         ...details.biography,
         birthPlace: '',

--- a/apps/player-portal/src/components/tabs/Background.test.tsx
+++ b/apps/player-portal/src/components/tabs/Background.test.tsx
@@ -12,7 +12,7 @@ describe('Background tab', () => {
   });
 
   it('renders demographic fields that are populated (Amiri: gender + ethnicity)', () => {
-    const { container } = render(<Background details={details} />);
+    const { container } = render(<Background details={details} traits={[]} />);
     const demo = container.querySelector('[data-section="demographics"]');
     expect(demo, 'demographics section').toBeTruthy();
     expect(container.querySelector('[data-field="gender"]')?.textContent).toContain('F/She/Her');
@@ -33,12 +33,12 @@ describe('Background tab', () => {
       weight: { value: '' },
       biography: { ...details.biography, birthPlace: '' },
     };
-    const { container } = render(<Background details={bare} />);
+    const { container } = render(<Background details={bare} traits={[]} />);
     expect(container.querySelector('[data-section="demographics"]')).toBeNull();
   });
 
   it('renders the backstory HTML block for Amiri', () => {
-    const { container } = render(<Background details={details} />);
+    const { container } = render(<Background details={details} traits={[]} />);
     const backstory = container.querySelector('[data-section="backstory"]');
     expect(backstory, 'backstory section').toBeTruthy();
     // Amiri's backstory opens with "There are a million ways to die…".
@@ -48,12 +48,12 @@ describe('Background tab', () => {
   });
 
   it('omits Appearance when the field is empty (Amiri)', () => {
-    const { container } = render(<Background details={details} />);
+    const { container } = render(<Background details={details} traits={[]} />);
     expect(container.querySelector('[data-section="appearance"]')).toBeNull();
   });
 
   it('omits the Personality block when every field is empty (Amiri)', () => {
-    const { container } = render(<Background details={details} />);
+    const { container } = render(<Background details={details} traits={[]} />);
     expect(container.querySelector('[data-section="personality"]')).toBeNull();
   });
 
@@ -66,7 +66,7 @@ describe('Background tab', () => {
         anathema: ['Harm an ally in rage'],
       },
     };
-    const { container } = render(<Background details={withCode} />);
+    const { container } = render(<Background details={withCode} traits={[]} />);
     const section = container.querySelector('[data-section="edicts-anathema"]');
     expect(section, 'edicts/anathema section').toBeTruthy();
     expect(container.querySelector('[data-list="edicts"]')?.textContent).toContain('Protect the innocent');
@@ -74,7 +74,7 @@ describe('Background tab', () => {
   });
 
   it('hides the edicts/anathema block when both arrays are empty (Amiri)', () => {
-    const { container } = render(<Background details={details} />);
+    const { container } = render(<Background details={details} traits={[]} />);
     expect(container.querySelector('[data-section="edicts-anathema"]')).toBeNull();
   });
 
@@ -83,13 +83,13 @@ describe('Background tab', () => {
       ...details,
       biography: { ...details.biography, allies: 'The Pathfinder Society', enemies: 'Frost giants', organizations: '' },
     };
-    const { container } = render(<Background details={connected} />);
+    const { container } = render(<Background details={connected} traits={[]} />);
     expect(container.querySelector('[data-section="social"]')?.textContent).toContain('Pathfinder Society');
     expect(container.querySelector('[data-section="social"]')?.textContent).toContain('Frost giants');
   });
 
   it('hides Campaign Notes when empty (Amiri)', () => {
-    const { container } = render(<Background details={details} />);
+    const { container } = render(<Background details={details} traits={[]} />);
     expect(container.querySelector('[data-section="campaign-notes"]')).toBeNull();
   });
 
@@ -102,6 +102,7 @@ describe('Background tab', () => {
       age: { value: '' },
       height: { value: '' },
       weight: { value: '' },
+      languages: { value: [] },
       biography: {
         ...details.biography,
         birthPlace: '',
@@ -120,7 +121,7 @@ describe('Background tab', () => {
         anathema: [],
       },
     };
-    const { container } = render(<Background details={bare} />);
+    const { container } = render(<Background details={bare} traits={[]} />);
     expect(container.querySelector('[data-section="background-empty"]')).toBeTruthy();
     expect(container.textContent).toContain('No background details');
     // None of the populated-only sections should have rendered.

--- a/apps/player-portal/src/components/tabs/Background.tsx
+++ b/apps/player-portal/src/components/tabs/Background.tsx
@@ -13,8 +13,6 @@ interface Props {
 export function Background({ details, traits }: Props): React.ReactElement {
   const bio = details.biography;
   const languages = details.languages.value;
-  const hasIdentity = languages.length > 0 || traits.length > 0;
-
   if (!hasAnyBackgroundContent(details, traits)) {
     return (
       <section className="space-y-6" data-section="background-empty">
@@ -25,8 +23,9 @@ export function Background({ details, traits }: Props): React.ReactElement {
     );
   }
   return (
-    <section className="space-y-6">
-      {hasIdentity && <IdentityBlock languages={languages} traits={traits} />}
+    <section className="space-y-4 *:rounded-lg *:border *:border-pf-border *:bg-pf-bg-dark *:p-4">
+      {languages.length > 0 && <LanguagesBlock languages={languages} />}
+      {traits.length > 0 && <TraitsBlock traits={traits} />}
       <DemographicsBlock details={details} />
       <TextBlock title="Appearance" html={bio.appearance} />
       <TextBlock title="Backstory" html={bio.backstory} dataSection="backstory" />
@@ -72,39 +71,38 @@ function hasAnyBackgroundContent(details: CharacterDetails, traits: string[]): b
 
 // ─── Sub-sections ──────────────────────────────────────────────────────
 
-function IdentityBlock({ languages, traits }: { languages: string[]; traits: string[] }): React.ReactElement {
+function LanguagesBlock({ languages }: { languages: string[] }): React.ReactElement {
   return (
-    <div data-section="identity">
-      {languages.length > 0 && (
-        <div className="mb-4">
-          <SectionHeader>Languages</SectionHeader>
-          <ul className="flex flex-wrap gap-1.5">
-            {languages.map((lang) => (
-              <li
-                key={lang}
-                className="rounded-full border border-pf-tertiary-dark bg-pf-tertiary/40 px-2.5 py-0.5 text-xs text-pf-alt-dark"
-              >
-                {humaniseSlug(lang)}
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-      {traits.length > 0 && (
-        <div>
-          <SectionHeader>Traits</SectionHeader>
-          <ul className="flex flex-wrap gap-1.5">
-            {traits.map((trait) => (
-              <li
-                key={trait}
-                className="rounded-full border border-pf-tertiary-dark bg-pf-tertiary/40 px-2.5 py-0.5 text-xs text-pf-alt-dark"
-              >
-                {humaniseSlug(trait)}
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
+    <div data-section="languages">
+      <SectionHeader band>Languages</SectionHeader>
+      <ul className="flex flex-wrap gap-1.5">
+        {languages.map((lang) => (
+          <li
+            key={lang}
+            className="rounded-full border border-pf-tertiary-dark bg-pf-tertiary/40 px-2.5 py-0.5 text-xs text-pf-alt-dark"
+          >
+            {humaniseSlug(lang)}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function TraitsBlock({ traits }: { traits: string[] }): React.ReactElement {
+  return (
+    <div data-section="traits">
+      <SectionHeader band>Traits</SectionHeader>
+      <ul className="flex flex-wrap gap-1.5">
+        {traits.map((trait) => (
+          <li
+            key={trait}
+            className="rounded-full border border-pf-tertiary-dark bg-pf-tertiary/40 px-2.5 py-0.5 text-xs text-pf-alt-dark"
+          >
+            {humaniseSlug(trait)}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }
@@ -131,11 +129,11 @@ function DemographicsBlock({ details }: { details: CharacterDetails }): React.Re
   if (populated.length === 0) return null;
   return (
     <div data-section="demographics">
-      <SectionHeader>Demographics</SectionHeader>
+      <SectionHeader band>Demographics</SectionHeader>
       <dl className="grid grid-cols-2 gap-x-6 gap-y-1.5 text-sm sm:grid-cols-3">
         {populated.map(([label, value]) => (
           <div key={label} className="flex items-baseline gap-2" data-field={label.toLowerCase()}>
-            <dt className="text-[10px] font-semibold uppercase tracking-widest text-neutral-500">{label}</dt>
+            <dt className="text-[10px] font-semibold uppercase tracking-widest text-pf-text-muted">{label}</dt>
             <dd className="text-pf-text">{value}</dd>
           </div>
         ))}
@@ -156,7 +154,7 @@ function PersonalityBlock({ bio }: { bio: CharacterBiography }): React.ReactElem
   if (populated.length === 0) return null;
   return (
     <div data-section="personality">
-      <SectionHeader>Personality</SectionHeader>
+      <SectionHeader band>Personality</SectionHeader>
       <dl className="space-y-1.5 text-sm">
         {populated.map(([label, value]) => (
           <div key={label} className="flex flex-col gap-0.5 sm:flex-row sm:gap-3">
@@ -175,7 +173,7 @@ function EdictsAnathemaBlock({ bio }: { bio: CharacterBiography }): React.ReactE
   if (bio.edicts.length === 0 && bio.anathema.length === 0) return null;
   return (
     <div data-section="edicts-anathema">
-      <SectionHeader>Edicts &amp; Anathema</SectionHeader>
+      <SectionHeader band>Edicts &amp; Anathema</SectionHeader>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         <ListCol label="Edicts" entries={bio.edicts} />
         <ListCol label="Anathema" entries={bio.anathema} />
@@ -188,7 +186,7 @@ function ListCol({ label, entries }: { label: string; entries: string[] }): Reac
   if (entries.length === 0) return null;
   return (
     <div data-list={label.toLowerCase()}>
-      <h3 className="mb-1 text-[11px] font-semibold uppercase tracking-widest text-neutral-600">{label}</h3>
+      <h3 className="mb-1 text-[11px] font-semibold uppercase tracking-widest text-pf-alt-dark">{label}</h3>
       <ul className="list-disc space-y-0.5 pl-5 text-sm text-pf-text">
         {entries.map((e, i) => (
           <li key={`${label}-${i.toString()}`}>{e}</li>
@@ -208,7 +206,7 @@ function SocialBlock({ bio }: { bio: CharacterBiography }): React.ReactElement |
   if (populated.length === 0) return null;
   return (
     <div data-section="social">
-      <SectionHeader>Connections</SectionHeader>
+      <SectionHeader band>Connections</SectionHeader>
       <dl className="space-y-1.5 text-sm">
         {populated.map(([label, value]) => (
           <div key={label} className="flex flex-col gap-0.5 sm:flex-row sm:gap-3">
@@ -235,7 +233,7 @@ function TextBlock({
   if (html.trim() === '') return null;
   return (
     <div data-section={dataSection ?? title.toLowerCase()}>
-      <SectionHeader>{title}</SectionHeader>
+      <SectionHeader band>{title}</SectionHeader>
       <div
         className="max-w-none text-sm leading-relaxed text-pf-text [&_p]:my-2 [&_p]:leading-relaxed"
         // Safe: source is our own Foundry world, not untrusted user input.

--- a/apps/player-portal/src/components/tabs/Background.tsx
+++ b/apps/player-portal/src/components/tabs/Background.tsx
@@ -3,15 +3,19 @@ import { SectionHeader } from '../common/SectionHeader';
 
 interface Props {
   details: CharacterDetails;
+  traits: string[];
 }
 
 // Background tab — pf2e system.details.biography + demographic fields.
 // Read-only viewer. HTML fields (appearance, backstory, campaignNotes)
 // are rendered as raw HTML because the source is our self-hosted
 // Foundry; there's no untrusted-user input path into these fields.
-export function Background({ details }: Props): React.ReactElement {
+export function Background({ details, traits }: Props): React.ReactElement {
   const bio = details.biography;
-  if (!hasAnyBackgroundContent(details)) {
+  const languages = details.languages.value;
+  const hasIdentity = languages.length > 0 || traits.length > 0;
+
+  if (!hasAnyBackgroundContent(details, traits)) {
     return (
       <section className="space-y-6" data-section="background-empty">
         <p className="text-sm italic text-neutral-500">
@@ -22,6 +26,7 @@ export function Background({ details }: Props): React.ReactElement {
   }
   return (
     <section className="space-y-6">
+      {hasIdentity && <IdentityBlock languages={languages} traits={traits} />}
       <DemographicsBlock details={details} />
       <TextBlock title="Appearance" html={bio.appearance} />
       <TextBlock title="Backstory" html={bio.backstory} dataSection="backstory" />
@@ -33,7 +38,8 @@ export function Background({ details }: Props): React.ReactElement {
   );
 }
 
-function hasAnyBackgroundContent(details: CharacterDetails): boolean {
+function hasAnyBackgroundContent(details: CharacterDetails, traits: string[]): boolean {
+  if (traits.length > 0 || details.languages.value.length > 0) return true;
   const bio = details.biography;
   const demographicValues = [
     details.gender.value,
@@ -43,6 +49,7 @@ function hasAnyBackgroundContent(details: CharacterDetails): boolean {
     details.height.value,
     details.weight.value,
     bio.birthPlace,
+    details.deity?.value ?? '',
   ];
   const textValues = [
     bio.appearance,
@@ -65,6 +72,50 @@ function hasAnyBackgroundContent(details: CharacterDetails): boolean {
 
 // ─── Sub-sections ──────────────────────────────────────────────────────
 
+function IdentityBlock({ languages, traits }: { languages: string[]; traits: string[] }): React.ReactElement {
+  return (
+    <div data-section="identity">
+      {languages.length > 0 && (
+        <div className="mb-4">
+          <SectionHeader>Languages</SectionHeader>
+          <ul className="flex flex-wrap gap-1.5">
+            {languages.map((lang) => (
+              <li
+                key={lang}
+                className="rounded-full border border-pf-tertiary-dark bg-pf-tertiary/40 px-2.5 py-0.5 text-xs text-pf-alt-dark"
+              >
+                {humaniseSlug(lang)}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {traits.length > 0 && (
+        <div>
+          <SectionHeader>Traits</SectionHeader>
+          <ul className="flex flex-wrap gap-1.5">
+            {traits.map((trait) => (
+              <li
+                key={trait}
+                className="rounded-full border border-pf-tertiary-dark bg-pf-tertiary/40 px-2.5 py-0.5 text-xs text-pf-alt-dark"
+              >
+                {humaniseSlug(trait)}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function humaniseSlug(slug: string): string {
+  return slug
+    .split('-')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
 function DemographicsBlock({ details }: { details: CharacterDetails }): React.ReactElement | null {
   const fields: Array<[label: string, value: string]> = [
     ['Gender', details.gender.value],
@@ -74,6 +125,7 @@ function DemographicsBlock({ details }: { details: CharacterDetails }): React.Re
     ['Height', details.height.value],
     ['Weight', details.weight.value],
     ['Birthplace', details.biography.birthPlace],
+    ['Deity', details.deity?.value ?? ''],
   ];
   const populated = fields.filter(([, v]) => v.trim() !== '');
   if (populated.length === 0) return null;

--- a/apps/player-portal/src/components/tabs/Character.test.tsx
+++ b/apps/player-portal/src/components/tabs/Character.test.tsx
@@ -5,9 +5,6 @@ import type { CharacterSystem } from '../../api/types';
 import { Character } from './Character';
 import { api } from '../../api/client';
 
-// Mock the api client. The existing render-only tests never trigger api calls,
-// so this mock is safe for the whole file.  The new dispatcher test below
-// inspects `api.dispatch` directly.
 vi.mock('../../api/client', () => ({
   api: {
     dispatch: vi.fn().mockResolvedValue({ result: null }),
@@ -23,21 +20,15 @@ vi.mock('../../api/client', () => ({
 // AC 18, HP 22/22, Perception +5, Fort +7, Ref +5, Will +5, Class DC 17.
 const system = (amiri as unknown as { system: CharacterSystem }).system;
 
-
 describe('Character tab', () => {
   afterEach(() => {
     cleanup();
   });
 
   it('renders the six ability modifiers with correct signs', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} characterLevel={1} />);
     const expected: Record<string, string> = {
-      str: '+4',
-      dex: '+2',
-      con: '+2',
-      int: '+0',
-      wis: '+0',
-      cha: '+1',
+      str: '+4', dex: '+2', con: '+2', int: '+0', wis: '+0', cha: '+1',
     };
     for (const [slug, mod] of Object.entries(expected)) {
       const row = container.querySelector(`[data-attribute="${slug}"]`);
@@ -47,105 +38,64 @@ describe('Character tab', () => {
   });
 
   it("marks the character's key ability", () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} characterLevel={1} />);
     const strRow = container.querySelector('[data-attribute="str"]');
     expect(strRow?.textContent).toContain('KEY');
-    // Non-key abilities should not carry the KEY badge.
     const dexRow = container.querySelector('[data-attribute="dex"]');
     expect(dexRow?.textContent).not.toContain('KEY');
   });
 
   it('renders the headline stats (AC, HP, Perception)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} characterLevel={1} />);
     expect(container.querySelector('[data-stat="hp"]')?.textContent).toContain('22');
     expect(container.querySelector('[data-stat="perception"]')?.textContent).toContain('+5');
-    // AC 18 is in the StatTile without data-stat but in the first StatsBlock row.
     const acLabel = Array.from(container.querySelectorAll('span')).find((el) => el.textContent === 'AC');
     expect(acLabel, 'AC label').toBeTruthy();
   });
 
   it('renders the three saves with correct modifiers', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} characterLevel={1} />);
     expect(container.querySelector('[data-stat="save-fortitude"]')?.textContent).toContain('+7');
     expect(container.querySelector('[data-stat="save-reflex"]')?.textContent).toContain('+5');
     expect(container.querySelector('[data-stat="save-will"]')?.textContent).toContain('+5');
   });
 
   it('renders the class DC (Barbarian @ 17)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} characterLevel={1} />);
     const dc = container.querySelector('[data-stat="class-dc"]');
     expect(dc, 'class DC tile').toBeTruthy();
     expect(dc?.textContent).toContain('17');
   });
 
-  it('renders hero points pips (1 of 3)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
-    const hp = container.querySelector('[data-stat="hero-points"]');
-    expect(hp, 'hero points tile').toBeTruthy();
-    expect(hp?.textContent).toContain('1/3');
-  });
-
-  it('renders languages (Hallit, Common)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
-    const langs = container.querySelector('[data-section="languages"]');
-    expect(langs, 'languages section').toBeTruthy();
-    expect(langs?.textContent).toContain('Hallit');
-    expect(langs?.textContent).toContain('Common');
-  });
-
-  it('renders traits (Human, Humanoid)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
-    const traits = container.querySelector('[data-section="traits"]');
-    expect(traits?.textContent).toContain('Human');
-    expect(traits?.textContent).toContain('Humanoid');
-  });
-
-  it("renders Amiri's land speed (25 ft)", () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
+  it("renders Amiri's land speed", () => {
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} characterLevel={1} />);
     expect(container.textContent).toContain('25 ft');
   });
 
-  it('renders the initiative tile (+5 for Amiri)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
-    const tile = container.querySelector('[data-stat="initiative"]');
-    expect(tile, 'initiative tile').toBeTruthy();
-    expect(tile?.textContent).toContain('+5');
-  });
-
   it('renders the conditions row (Dying/Wounded/Doomed)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} characterLevel={1} />);
     const row = container.querySelector('[data-section="conditions"]');
     expect(row, 'conditions row').toBeTruthy();
     for (const stat of ['dying', 'wounded', 'doomed']) {
       const cond = container.querySelector(`[data-stat="${stat}"]`);
       expect(cond, `${stat} tile`).toBeTruthy();
-      // Amiri is 0 for each.
       expect(cond?.textContent).toContain('0/');
     }
   });
 
   it('does not render an investiture counter (moved to Inventory tab)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} characterLevel={1} />);
     expect(container.querySelector('[data-stat="investiture"]')).toBeNull();
   });
 
   it('omits Focus and Mythic resources when max is zero', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} characterLevel={1} />);
     expect(container.querySelector('[data-stat="focus"]')).toBeNull();
     expect(container.querySelector('[data-stat="mythic-points"]')).toBeNull();
   });
 
-  it('renders all populated speeds (Land + Travel for Amiri)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
-    expect(container.querySelector('[data-speed="land"]')).toBeTruthy();
-    expect(container.querySelector('[data-speed="travel"]')).toBeTruthy();
-    // Unpopulated speeds should not render.
-    expect(container.querySelector('[data-speed="fly"]')).toBeNull();
-    expect(container.querySelector('[data-speed="climb"]')).toBeNull();
-  });
-
   it('hides the Defenses block when IWR are all empty (Amiri)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} characterLevel={1} />);
     expect(container.querySelector('[data-section="iwr"]')).toBeNull();
   });
 
@@ -159,53 +109,15 @@ describe('Character tab', () => {
         resistances: [{ type: 'physical', value: 2, exceptions: ['adamantine'] }],
       },
     } as CharacterSystem;
-    const { container } = render(<Character system={custom} actorId="test-actor" onActorChanged={() => undefined} />);
+    const { container } = render(<Character system={custom} actorId="test-actor" onActorChanged={() => undefined} items={[]} characterLevel={1} />);
     expect(container.querySelector('[data-section="iwr"]')).toBeTruthy();
     expect(container.querySelector('[data-iwr="immunities"]')?.textContent).toContain('Fire');
     expect(container.querySelector('[data-iwr="weaknesses"]')?.textContent).toContain('Cold 5');
     expect(container.querySelector('[data-iwr="resistances"]')?.textContent).toContain('Physical 2');
   });
 
-  it('shows handsFree value (2 for Amiri)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
-    const hf = container.querySelector('[data-stat="hands-free"]');
-    expect(hf, 'hands-free tile').toBeTruthy();
-    expect(hf?.textContent).toBe('2');
-  });
-
-  it('hides Reach when base is 5 and manipulate matches (Amiri default)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
-    expect(container.querySelector('[data-stat="reach"]')).toBeNull();
-  });
-
-  it('shows Reach when non-default', () => {
-    const reachy: CharacterSystem = {
-      ...system,
-      attributes: { ...system.attributes, reach: { base: 10, manipulate: 10 } },
-    };
-    const { container } = render(<Character system={reachy} actorId="test-actor" onActorChanged={() => undefined} />);
-    const reach = container.querySelector('[data-stat="reach"]');
-    expect(reach, 'reach tile').toBeTruthy();
-    expect(reach?.textContent).toContain('10 ft');
-  });
-
-  it('hides Deity when deity.value is empty (Amiri)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
-    expect(container.querySelector('[data-stat="deity"]')).toBeNull();
-  });
-
-  it('shows Deity when populated', () => {
-    const faithful: CharacterSystem = {
-      ...system,
-      details: { ...system.details, deity: { image: 'x.svg', value: 'Iomedae' } },
-    };
-    const { container } = render(<Character system={faithful} actorId="test-actor" onActorChanged={() => undefined} />);
-    const deity = container.querySelector('[data-stat="deity"]');
-    expect(deity?.textContent).toBe('Iomedae');
-  });
-
   it('hides Shield tile when no shield is equipped (Amiri)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} characterLevel={1} />);
     expect(container.querySelector('[data-stat="shield"]')).toBeNull();
   });
 
@@ -228,7 +140,7 @@ describe('Character tab', () => {
         },
       },
     };
-    const { container } = render(<Character system={shielded} actorId="test-actor" onActorChanged={() => undefined} />);
+    const { container } = render(<Character system={shielded} actorId="test-actor" onActorChanged={() => undefined} items={[]} characterLevel={1} />);
     const tile = container.querySelector('[data-stat="shield"]');
     expect(tile, 'shield tile').toBeTruthy();
     expect(tile?.textContent).toContain('Steel Shield');
@@ -239,9 +151,6 @@ describe('Character tab', () => {
 });
 
 // ─── Dispatcher end-to-end: all three save buttons ──────────────────────────
-//
-// Verifies that all three save tiles call api.dispatch with the expected
-// DispatchRequest shapes (saves.fortitude/reflex/will.roll).
 
 describe('Character tab — saves wired through dispatcher', () => {
   beforeEach(() => {
@@ -259,7 +168,7 @@ describe('Character tab — saves wired through dispatcher', () => {
     ['save-will', 'saves.will.roll'],
   ])('clicking the %s tile dispatches method=%s', async (dataStat, expectedMethod) => {
     const { container } = render(
-      <Character system={system} actorId="test-actor" onActorChanged={() => undefined} />,
+      <Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} characterLevel={1} />,
     );
 
     const tile = container.querySelector(`[data-stat="${dataStat}"]`) as HTMLButtonElement;
@@ -279,7 +188,7 @@ describe('Character tab — saves wired through dispatcher', () => {
 
   it('none of the save tiles call rollActorStatistic', async () => {
     const { container } = render(
-      <Character system={system} actorId="test-actor" onActorChanged={() => undefined} />,
+      <Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} characterLevel={1} />,
     );
 
     for (const stat of ['save-fortitude', 'save-reflex', 'save-will']) {

--- a/apps/player-portal/src/components/tabs/Character.tsx
+++ b/apps/player-portal/src/components/tabs/Character.tsx
@@ -1,17 +1,32 @@
+import { useState } from 'react';
 import { createPf2eClient } from '@foundry-toolkit/pf2e-rules';
 import { api } from '../../api/client';
-import type { AbilityKey, CharacterSystem, IWREntry, Save, Shield, Speed } from '../../api/types';
-import { ABILITY_KEYS } from '../../api/types';
+import type {
+  AbilityKey,
+  CharacterSystem,
+  IWREntry,
+  PreparedActorItem,
+  Save,
+  Shield,
+  SkillStatistic,
+  SpellcastingEntryItem,
+  Strike,
+} from '../../api/types';
+import { ABILITY_KEYS, isCantripSpell, isActionItem, isSpellItem, isSpellcastingEntryItem } from '../../api/types';
 import { t } from '../../i18n/t';
 import { formatSignedInt } from '../../lib/format';
 import { useActorAction, type ActorActionState } from '../../lib/useActorAction';
+import { ModifierTooltip } from '../common/ModifierTooltip';
 import { RankChip } from '../common/RankChip';
 import { SectionHeader } from '../common/SectionHeader';
-import { ConfirmDialog } from '../dialog/ConfirmDialog';
+import { QuickActionPicker, type QuickActionOption, type QAStrike, type QAItem, type QASpell } from '../sheet/QuickActionPicker';
+import { useQuickActions } from '../../lib/useQuickActions';
 
 interface Props {
   system: CharacterSystem;
   actorId: string;
+  items: PreparedActorItem[];
+  characterLevel: number;
   /** Fired after any server-acknowledged mutation from this tab — long
    *  rest, HP adjust, hero-point adjust — so the parent can refetch
    *  `/prepared` and redraw. */
@@ -22,14 +37,9 @@ interface Props {
 // stats, hero points, speeds, languages, traits. Ported in structure
 // from pf2e's static/templates/actors/character/tabs/character.hbs, but
 // read-only (no input widgets) and Tailwind-styled.
-export function Character({ system, actorId, onActorChanged }: Props): React.ReactElement {
+export function Character({ system, actorId, items, characterLevel, onActorChanged }: Props): React.ReactElement {
   const keyAbility = system.details.keyability.value;
   const classDC = system.attributes.classDC;
-  const speeds = populatedSpeeds(system.movement.speeds);
-  const xp = system.details.xp;
-  const reach = system.attributes.reach;
-  const showReach = reach.base !== 5 || reach.manipulate !== reach.base;
-  const deityName = system.details.deity?.value?.trim() ?? '';
 
   return (
     <section className="space-y-6">
@@ -37,69 +47,39 @@ export function Character({ system, actorId, onActorChanged }: Props): React.Rea
 
       <StatsBlock system={system} actorId={actorId} onActorChanged={onActorChanged} />
 
-      <ConditionsRow
-        dying={system.attributes.dying}
-        wounded={system.attributes.wounded}
-        doomed={system.attributes.doomed}
-        actorId={actorId}
-        onActorChanged={onActorChanged}
-      />
-
-      {system.attributes.shield.itemId !== null && <ShieldTile shield={system.attributes.shield} />}
-
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <ResourcesRow resources={system.resources} actorId={actorId} onActorChanged={onActorChanged} />
-        <LongRestButton actorId={actorId} onRested={onActorChanged} />
-      </div>
-
-      <MetaRow>
-        <MetaItem label="XP">
-          <XPBar value={xp.value} max={xp.max} pct={xp.pct} />
-        </MetaItem>
-        {speeds.length > 0 && (
-          <MetaItem label="Speed">
-            <SpeedList speeds={speeds} />
-          </MetaItem>
-        )}
-        <MetaItem label="Size">{humaniseSize(system.traits.size.value)}</MetaItem>
-        {showReach && (
-          <MetaItem label="Reach">
-            <span data-stat="reach" className="tabular-nums">
-              {reach.base} ft
-              {reach.manipulate !== reach.base && (
-                <span className="text-pf-text-muted"> · {reach.manipulate} ft (manipulate)</span>
-              )}
-            </span>
-          </MetaItem>
-        )}
-        <MetaItem label="Free Hands">
-          <span data-stat="hands-free" className="tabular-nums">
-            {system.attributes.handsFree}
-          </span>
-        </MetaItem>
-        {deityName !== '' && (
-          <MetaItem label="Deity">
-            <span data-stat="deity">{deityName}</span>
-          </MetaItem>
-        )}
-        {classDC && (
-          <MetaItem label="Class DC">
-            <span>
-              <strong className="tabular-nums">{classDC.dc}</strong>{' '}
-              <span className="text-pf-text-muted">({classDC.label})</span>
-            </span>
-          </MetaItem>
-        )}
-      </MetaRow>
-
       <IWRBlock
         immunities={system.attributes.immunities}
         weaknesses={system.attributes.weaknesses}
         resistances={system.attributes.resistances}
       />
 
-      <ChipList label="Languages" items={system.details.languages.value.map(humaniseSlug)} />
-      <ChipList label="Traits" items={system.traits.value.map(humaniseSlug)} />
+      <div className="flex items-start gap-4">
+        <div className="min-w-0 flex-1">
+          <SkillsBlock skills={system.skills} actorId={actorId} condensed />
+        </div>
+        <QuickActionsBlock
+          strikes={system.actions}
+          items={items}
+          characterLevel={characterLevel}
+          focusPoints={system.resources.focus}
+          actorId={actorId}
+          onActorChanged={onActorChanged}
+        />
+      </div>
+
+      <div data-section="conditions">
+        <SectionHeader>Conditions</SectionHeader>
+        <div className="space-y-3">
+          <ConditionsRow
+            dying={system.attributes.dying}
+            wounded={system.attributes.wounded}
+            doomed={system.attributes.doomed}
+            actorId={actorId}
+            onActorChanged={onActorChanged}
+          />
+          {system.attributes.shield.itemId !== null && <ShieldTile shield={system.attributes.shield} />}
+        </div>
+      </div>
     </section>
   );
 }
@@ -125,7 +105,7 @@ function AbilityBlock({
               key={ak}
               data-attribute={ak}
               className={[
-                'relative flex flex-col items-center rounded border px-2 py-3',
+                'relative flex flex-col items-center rounded border px-2 py-3 shadow-sm',
                 isKey ? 'border-pf-tertiary-dark bg-pf-tertiary/40' : 'border-pf-border bg-pf-bg',
               ].join(' ')}
             >
@@ -162,7 +142,7 @@ function StatsBlock({
   onActorChanged: () => void;
 }): React.ReactElement {
   const { ac, hp } = system.attributes;
-  const { perception, initiative } = system;
+  const { perception } = system;
   const saves = system.saves;
 
   const rollPerception = useActorAction({
@@ -199,10 +179,9 @@ function StatsBlock({
           pending={rollPerception.state === 'pending'}
         />
         <StatTile
-          label="Initiative"
-          value={formatSignedInt(initiative.value)}
-          title={initiative.breakdown}
-          data-stat="initiative"
+          label="Speed"
+          value={primarySpeed(system.movement.speeds)}
+          data-stat="speed"
         />
         {classDCTile(system)}
       </div>
@@ -261,7 +240,7 @@ function HpTile({
 
   return (
     <div
-      className="flex flex-col items-center rounded border border-pf-border bg-pf-bg px-2 py-2"
+      className="flex flex-col items-center rounded border border-pf-border bg-pf-bg px-2 py-2 shadow-sm"
       title={hp.breakdown}
       data-stat="hp"
     >
@@ -367,7 +346,7 @@ function StatTile({
   if (onRoll === undefined) {
     return (
       <div
-        className="flex flex-col items-center rounded border border-pf-border bg-pf-bg px-3 py-2"
+        className="flex flex-col items-center rounded border border-pf-border bg-pf-bg px-3 py-2 shadow-sm"
         title={title}
         {...rest}
       >
@@ -382,7 +361,7 @@ function StatTile({
       onClick={onRoll}
       disabled={pending === true}
       title={title}
-      className="flex flex-col items-center rounded border border-pf-border bg-pf-bg px-3 py-2 hover:border-pf-tertiary-dark hover:bg-pf-tertiary/40 disabled:opacity-60 disabled:hover:bg-pf-bg"
+      className="flex flex-col items-center rounded border border-pf-border bg-pf-bg px-3 py-2 shadow-sm hover:border-pf-tertiary-dark hover:bg-pf-tertiary/40 disabled:opacity-60 disabled:hover:bg-pf-bg"
       {...rest}
     >
       {contents}
@@ -390,120 +369,6 @@ function StatTile({
   );
 }
 
-function ResourcesRow({
-  resources,
-  actorId,
-  onActorChanged,
-}: {
-  resources: CharacterSystem['resources'];
-  actorId: string;
-  onActorChanged: () => void;
-}): React.ReactElement {
-  const { heroPoints, focus, mythicPoints } = resources;
-  const adjustHero = useActorAction({
-    run: (delta: number) => api.adjustActorResource(actorId, 'hero-points', delta),
-    onSuccess: onActorChanged,
-  });
-  const adjustFocus = useActorAction({
-    run: (delta: number) => api.adjustActorResource(actorId, 'focus-points', delta),
-    onSuccess: onActorChanged,
-  });
-  const error =
-    typeof adjustHero.state === 'object'
-      ? adjustHero.state.error
-      : typeof adjustFocus.state === 'object'
-        ? adjustFocus.state.error
-        : null;
-  return (
-    <div className="flex flex-col gap-1">
-      <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
-        <PipResource
-          label="Hero Points"
-          value={heroPoints.value}
-          max={heroPoints.max}
-          colorOn="border-rose-400 bg-rose-500"
-          data-stat="hero-points"
-          onAdjust={(delta) => { adjustHero.trigger(delta); }}
-          pending={adjustHero.state === 'pending'}
-        />
-        {focus.max > 0 && (
-          <PipResource
-            label="Focus"
-            value={focus.value}
-            max={focus.max}
-            colorOn="border-indigo-400 bg-indigo-500"
-            title={`Cap ${focus.cap.toString()}`}
-            data-stat="focus"
-            onAdjust={(delta) => { adjustFocus.trigger(delta); }}
-            pending={adjustFocus.state === 'pending'}
-          />
-        )}
-        {mythicPoints.max > 0 && (
-          <PipResource
-            label="Mythic"
-            value={mythicPoints.value}
-            max={mythicPoints.max}
-            colorOn="border-amber-400 bg-amber-500"
-            data-stat="mythic-points"
-          />
-        )}
-      </div>
-      {error !== null && (
-        <p className="text-[11px] text-red-700" data-role="resources-error">
-          {error}
-        </p>
-      )}
-    </div>
-  );
-}
-
-function PipResource({
-  label,
-  value,
-  max,
-  colorOn,
-  title,
-  onAdjust,
-  pending,
-  ...rest
-}: {
-  label: string;
-  value: number;
-  max: number;
-  colorOn: string;
-  title?: string;
-  /** When set, renders −/+ buttons that call `onAdjust(delta)` with
-   *  ±1. Omit to keep the resource read-only. */
-  onAdjust?: (delta: number) => void;
-  pending?: boolean;
-  'data-stat'?: string;
-}): React.ReactElement {
-  return (
-    <div className="flex items-center gap-2" title={title} {...rest}>
-      <span className="text-[11px] font-semibold uppercase tracking-widest text-pf-text-muted">{label}</span>
-      {onAdjust !== undefined && (
-        <StepButton label="−" disabled={pending ?? false} onClick={() => { onAdjust(-1); }} />
-      )}
-      <div className="flex gap-1" aria-label={`${value.toString()} of ${max.toString()}`}>
-        {Array.from({ length: max }, (_, i) => (
-          <span
-            key={i}
-            className={[
-              'inline-block h-3 w-3 rounded-full border',
-              i < value ? colorOn : 'border-pf-border bg-pf-bg',
-            ].join(' ')}
-          />
-        ))}
-      </div>
-      {onAdjust !== undefined && (
-        <StepButton label="+" disabled={pending ?? false} onClick={() => { onAdjust(1); }} />
-      )}
-      <span className="font-mono text-xs tabular-nums text-pf-text-muted">
-        {value}/{max}
-      </span>
-    </div>
-  );
-}
 
 function ShieldTile({ shield }: { shield: Shield }): React.ReactElement {
   const name = t(shield.name);
@@ -672,38 +537,6 @@ function Condition({
   );
 }
 
-const SPEED_LABELS: Record<string, string> = {
-  land: 'Land',
-  burrow: 'Burrow',
-  climb: 'Climb',
-  fly: 'Fly',
-  swim: 'Swim',
-  travel: 'Travel',
-};
-
-function populatedSpeeds(speeds: CharacterSystem['movement']['speeds']): Array<{ key: string; speed: Speed }> {
-  const order: (keyof CharacterSystem['movement']['speeds'])[] = ['land', 'burrow', 'climb', 'fly', 'swim', 'travel'];
-  const out: Array<{ key: string; speed: Speed }> = [];
-  for (const key of order) {
-    const s = speeds[key];
-    if (s) out.push({ key, speed: s });
-  }
-  return out;
-}
-
-function SpeedList({ speeds }: { speeds: Array<{ key: string; speed: Speed }> }): React.ReactElement {
-  return (
-    <span className="flex flex-wrap items-center gap-x-3 gap-y-0.5" data-section="speeds">
-      {speeds.map(({ key, speed }, idx) => (
-        <span key={key} className="inline-flex items-center gap-1" data-speed={key} title={speed.breakdown}>
-          <span className="tabular-nums">{speed.value} ft</span>
-          <span className="text-xs text-pf-text-muted">{SPEED_LABELS[key] ?? humaniseSlug(key)}</span>
-          {idx < speeds.length - 1 && <span className="text-pf-border">·</span>}
-        </span>
-      ))}
-    </span>
-  );
-}
 
 function IWRBlock({
   immunities,
@@ -744,89 +577,374 @@ function IWRRow({ label, entries }: { label: string; entries: IWREntry[] }): Rea
   );
 }
 
-function MetaRow({ children }: { children: React.ReactNode }): React.ReactElement {
-  return <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm">{children}</div>;
+
+function primarySpeed(speeds: CharacterSystem['movement']['speeds']): string {
+  const land = speeds.land;
+  if (land) return `${land.value.toString()} ft`;
+  const entries = Object.values(speeds);
+  const first = entries[0];
+  return first ? `${first.value.toString()} ft` : '—';
 }
 
-function XPBar({ value, max, pct }: { value: number; max: number; pct: number }): React.ReactElement {
-  const clamped = Math.max(0, Math.min(100, pct));
-  return (
-    <span className="flex items-center gap-2" data-stat="xp">
-      <span className="font-mono tabular-nums text-pf-text">
-        {value} / {max}
-      </span>
-      <span
-        className="inline-block h-1.5 w-16 overflow-hidden rounded bg-pf-bg-dark"
-        role="progressbar"
-        aria-valuenow={value}
-        aria-valuemin={0}
-        aria-valuemax={max}
-        title={`${clamped.toString()}% to next level`}
-      >
-        <span className="block h-full bg-pf-secondary" style={{ width: `${clamped.toString()}%` }} />
-      </span>
-    </span>
-  );
-}
 
-function MetaItem({ label, children }: { label: string; children: React.ReactNode }): React.ReactElement {
-  return (
-    <div className="flex items-center gap-2">
-      <span className="text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark">{label}</span>
-      <span className="text-pf-text">{children}</span>
-    </div>
-  );
-}
+function SkillsBlock({
+  skills,
+  actorId,
+  condensed = false,
+}: {
+  skills: CharacterSystem['skills'];
+  actorId: string;
+  condensed?: boolean;
+}): React.ReactElement {
+  const allSkills = Object.values(skills) as SkillStatistic[];
+  const coreSkills = allSkills.filter((s) => !s.lore);
+  const loreSkills = allSkills.filter((s) => s.lore);
 
-function ChipList({ label, items }: { label: string; items: string[] }): React.ReactElement | null {
-  if (items.length === 0) return null;
   return (
-    <div data-section={label.toLowerCase()}>
-      <SectionHeader>{label}</SectionHeader>
-      <ul className="flex flex-wrap gap-1.5">
-        {items.map((it) => (
-          <li
-            key={it}
-            className="rounded-full border border-pf-tertiary-dark bg-pf-tertiary/40 px-2.5 py-0.5 text-xs text-pf-alt-dark"
-          >
-            {it}
-          </li>
+    <div>
+      <SectionHeader>Skills</SectionHeader>
+      <ul className={condensed ? 'grid grid-cols-2 gap-1' : 'grid grid-cols-1 gap-2 sm:grid-cols-2'}>
+        {coreSkills.map((skill) => (
+          <SkillItem key={skill.slug} skill={skill} actorId={actorId} condensed={condensed} />
         ))}
       </ul>
+      {loreSkills.length > 0 && (
+        <ul className={condensed ? 'mt-1 grid grid-cols-2 gap-1' : 'mt-2 grid grid-cols-1 gap-2'}>
+          {loreSkills.map((skill) => (
+            <SkillItem key={skill.slug} skill={skill} actorId={actorId} condensed={condensed} />
+          ))}
+        </ul>
+      )}
     </div>
   );
 }
 
-function LongRestButton({ actorId, onRested }: { actorId: string; onRested: () => void }): React.ReactElement {
-  const { state, trigger, confirming } = useActorAction({
-    run: () => api.longRest(actorId),
-    confirm: 'Rest for the night? This restores HP, refreshes resources, and advances in-world time.',
-    onSuccess: onRested,
+function SkillItem({
+  skill,
+  actorId,
+  condensed = false,
+}: {
+  skill: SkillStatistic;
+  actorId: string;
+  condensed?: boolean;
+}): React.ReactElement {
+  const roll = useActorAction({
+    run: () => createPf2eClient(api.dispatch).character(actorId).rollSkill(skill.slug),
   });
-  const isError = typeof state === 'object';
 
   return (
-    <>
-      {confirming !== null && (
-        <ConfirmDialog
-          message={confirming.message}
-          confirmLabel="Rest"
-          onConfirm={confirming.accept}
-          onCancel={confirming.cancel}
-        />
-      )}
-      <div className="flex flex-col items-end gap-1" data-action="long-rest">
+    <li className="group relative rounded border border-pf-border bg-pf-bg shadow-sm" data-statistic={skill.slug}>
+      <button
+        type="button"
+        className={[
+          'flex w-full items-center gap-2 hover:bg-pf-bg-dark disabled:opacity-50',
+          condensed ? 'px-2 py-1' : 'px-3 py-2',
+        ].join(' ')}
+        onClick={() => {
+          roll.trigger();
+        }}
+        disabled={roll.state === 'pending'}
+      >
+        <span className="inline-flex w-8 justify-end font-mono text-sm tabular-nums text-pf-secondary">
+          {formatSignedInt(skill.value)}
+        </span>
+        <span className="flex-1 truncate text-sm text-pf-text">
+          {skill.lore === true ? skill.label : t(skill.label)}
+        </span>
+        <RankChip rank={skill.rank} condensed={condensed} />
+      </button>
+      <ModifierTooltip title={skill.label} breakdown={skill.breakdown} modifiers={skill.modifiers} />
+    </li>
+  );
+}
+
+function buildQuickOptions(
+  strikes: Strike[],
+  items: PreparedActorItem[],
+  characterLevel: number,
+): QuickActionOption[] {
+  const strikeOpts: QAStrike[] = strikes
+    .filter((s) => s.type === 'strike' && s.visible)
+    .map((s) => ({
+      kind: 'strike',
+      id: `strike:${s.slug}`,
+      slug: s.slug,
+      label: s.label,
+      img: s.item.img,
+      variants: s.variants,
+    }));
+
+  const itemOpts: QAItem[] = items.filter(isActionItem).map((item) => ({
+    kind: 'item',
+    id: `item:${item.id}`,
+    itemId: item.id,
+    label: item.name,
+    img: item.img,
+  }));
+
+  const spellOpts: QASpell[] = items.filter(isSpellItem).map((spell) => {
+    const isCantrip = isCantripSpell(spell);
+    const rank = isCantrip ? Math.ceil(characterLevel / 2) : (spell.system.level?.value ?? 1);
+    return {
+      kind: 'spell',
+      id: `spell:${spell.id}`,
+      spellId: spell.id,
+      label: spell.name,
+      img: spell.img,
+      entryId: spell.system.location?.value ?? '',
+      rank,
+      isCantrip,
+    };
+  });
+
+  return [...strikeOpts, ...itemOpts, ...spellOpts];
+}
+
+function QuickActionsBlock({
+  strikes,
+  items,
+  characterLevel,
+  focusPoints,
+  actorId,
+  onActorChanged,
+}: {
+  strikes: Strike[];
+  items: PreparedActorItem[];
+  characterLevel: number;
+  focusPoints: { value: number; max: number };
+  actorId: string;
+  onActorChanged: () => void;
+}): React.ReactElement {
+  const [selectedIds, setSelectedIds] = useQuickActions(actorId);
+  const [showPicker, setShowPicker] = useState(false);
+
+  const allOptions = buildQuickOptions(strikes, items, characterLevel);
+  const selected = selectedIds
+    .map((id) => allOptions.find((o) => o.id === id))
+    .filter((o): o is QuickActionOption => o !== undefined);
+
+  return (
+    <div className="w-48 shrink-0">
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="border-l-2 border-pf-primary pl-3 font-serif text-sm font-bold uppercase tracking-wider text-pf-alt-dark">
+          Quick Actions
+        </h2>
         <button
           type="button"
-          onClick={() => { trigger(); }}
-          disabled={state === 'pending'}
-          className="rounded border border-pf-tertiary-dark bg-pf-tertiary px-3 py-1.5 text-sm font-semibold text-pf-alt-dark hover:bg-pf-tertiary-dark hover:text-white disabled:opacity-50"
+          onClick={() => { setShowPicker(true); }}
+          title="Configure quick actions"
+          className="flex h-5 w-5 items-center justify-center rounded border border-pf-border text-pf-text-muted hover:bg-pf-bg-dark"
+          aria-label="Configure quick actions"
         >
-          {state === 'pending' ? 'Resting…' : 'Long Rest'}
+          <PencilIcon />
         </button>
-        {isError && <span className="text-xs text-red-700">{state.error}</span>}
       </div>
-    </>
+
+      {selected.length === 0 ? (
+        <p className="text-xs italic text-pf-text-muted">Tap the pencil to add quick actions.</p>
+      ) : (
+        <ul className="space-y-1.5">
+          {selected.map((opt) => {
+            if (opt.kind === 'strike') {
+              return <StrikeQuickRow key={opt.id} option={opt} actorId={actorId} />;
+            }
+            if (opt.kind === 'item') {
+              return <ItemQuickRow key={opt.id} option={opt} actorId={actorId} onUsed={onActorChanged} />;
+            }
+            return (
+              <SpellQuickRow
+                key={opt.id}
+                option={opt}
+                actorId={actorId}
+                items={items}
+                focusPoints={focusPoints}
+                onCast={onActorChanged}
+              />
+            );
+          })}
+        </ul>
+      )}
+
+      {showPicker && (
+        <QuickActionPicker
+          options={allOptions}
+          selectedIds={selectedIds}
+          onSelectionChange={setSelectedIds}
+          onClose={() => { setShowPicker(false); }}
+        />
+      )}
+    </div>
+  );
+}
+
+function StrikeQuickRow({ option, actorId }: { option: QAStrike; actorId: string }): React.ReactElement {
+  const damage = useActorAction({
+    run: () => createPf2eClient(api.dispatch).weapon(actorId, option.slug).rollDamage(false),
+  });
+  const crit = useActorAction({
+    run: () => createPf2eClient(api.dispatch).weapon(actorId, option.slug).rollDamage(true),
+  });
+  const imgSrc = option.img ? (option.img.startsWith('/') ? option.img : `/${option.img}`) : '';
+  return (
+    <li className="rounded border border-pf-border bg-pf-bg px-2 py-1.5 shadow-sm">
+      <div className="mb-1 flex items-center gap-1.5">
+        {imgSrc && (
+          <img src={imgSrc} alt="" className="h-5 w-5 shrink-0 rounded border border-pf-border/50 bg-pf-bg-dark object-cover" />
+        )}
+        <span className="flex-1 truncate text-[11px] font-medium text-pf-text">{option.label}</span>
+      </div>
+      <div className="flex flex-wrap gap-1">
+        {option.variants.map((v, i) => (
+          <VariantAttackButton key={i} label={v.label} actorId={actorId} slug={option.slug} variantIndex={i} />
+        ))}
+        <button
+          type="button"
+          onClick={() => { damage.trigger(); }}
+          disabled={damage.state === 'pending'}
+          className="rounded border border-pf-border bg-pf-bg px-2 py-0.5 text-[10px] font-semibold text-pf-text hover:bg-pf-bg-dark disabled:opacity-50"
+        >
+          Dmg
+        </button>
+        <button
+          type="button"
+          onClick={() => { crit.trigger(); }}
+          disabled={crit.state === 'pending'}
+          className="rounded border border-rose-300 bg-rose-50 px-2 py-0.5 text-[10px] font-semibold text-rose-900 hover:bg-rose-100 disabled:opacity-50"
+        >
+          Crit
+        </button>
+      </div>
+    </li>
+  );
+}
+
+function ItemQuickRow({
+  option,
+  actorId,
+  onUsed,
+}: {
+  option: QAItem;
+  actorId: string;
+  onUsed: () => void;
+}): React.ReactElement {
+  const use = useActorAction({
+    run: () => api.useItem(actorId, option.itemId),
+    onSuccess: onUsed,
+  });
+  const imgSrc = option.img ? (option.img.startsWith('/') ? option.img : `/${option.img}`) : '';
+  return (
+    <li className="rounded border border-pf-border bg-pf-bg px-2 py-1.5 shadow-sm">
+      <div className="flex items-center justify-between gap-1.5">
+        <div className="flex min-w-0 items-center gap-1.5">
+          {imgSrc && <img src={imgSrc} alt="" className="h-5 w-5 shrink-0 rounded border border-pf-border/50 bg-pf-bg-dark object-cover" />}
+          <span className="truncate text-[11px] font-medium text-pf-text">{option.label}</span>
+        </div>
+        <button
+          type="button"
+          onClick={() => { use.trigger(); }}
+          disabled={use.state === 'pending'}
+          className="shrink-0 rounded border border-pf-primary/40 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-pf-primary hover:bg-pf-primary/10 disabled:opacity-50"
+        >
+          Use
+        </button>
+      </div>
+    </li>
+  );
+}
+
+function SpellQuickRow({
+  option,
+  actorId,
+  items,
+  focusPoints,
+  onCast,
+}: {
+  option: QASpell;
+  actorId: string;
+  items: PreparedActorItem[];
+  focusPoints: { value: number; max: number };
+  onCast: () => void;
+}): React.ReactElement {
+  const entry = items.find(
+    (i): i is SpellcastingEntryItem => isSpellcastingEntryItem(i) && i.id === option.entryId,
+  );
+  const mode = entry?.system.prepared.value ?? 'prepared';
+  type SlotData = { value?: number; prepared?: { id: string; expended: boolean }[] };
+  const slots = entry?.system.slots as Record<string, SlotData> | undefined;
+  const slotData = slots?.[`slot${option.rank.toString()}`];
+
+  const isExpended =
+    !option.isCantrip && mode === 'prepared'
+      ? (slotData?.prepared?.find((p) => p.id === option.spellId)?.expended ?? false)
+      : false;
+  const noSlotsLeft = !option.isCantrip && mode === 'spontaneous' && (slotData?.value ?? 0) <= 0;
+  const noFocus = !option.isCantrip && mode === 'focus' && focusPoints.value <= 0;
+  const unavailable = isExpended || noSlotsLeft || noFocus;
+
+  const cast = useActorAction({
+    run: () =>
+      createPf2eClient(api.dispatch, api.invokeActorAction)
+        .spellEntry(actorId, option.entryId)
+        .cast(option.spellId, option.rank),
+    onSuccess: onCast,
+  });
+  const imgSrc = option.img ? (option.img.startsWith('/') ? option.img : `/${option.img}`) : '';
+  return (
+    <li className={['rounded border bg-pf-bg px-2 py-1.5 shadow-sm', unavailable ? 'border-pf-border/50 opacity-60' : 'border-pf-border'].join(' ')}>
+      <div className="flex items-center justify-between gap-1.5">
+        <div className="flex min-w-0 items-center gap-1.5">
+          {imgSrc && <img src={imgSrc} alt="" className="h-5 w-5 shrink-0 rounded border border-pf-border/50 bg-pf-bg-dark object-cover" />}
+          <span className={['truncate text-[11px] font-medium', unavailable ? 'text-pf-text-muted line-through' : 'text-pf-text'].join(' ')}>
+            {option.label}
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={() => { cast.trigger(); }}
+          disabled={cast.state === 'pending' || unavailable}
+          className="shrink-0 rounded border border-pf-primary/40 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-pf-primary hover:bg-pf-primary/10 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Cast
+        </button>
+      </div>
+    </li>
+  );
+}
+
+function VariantAttackButton({
+  label,
+  actorId,
+  slug,
+  variantIndex,
+}: {
+  label: string;
+  actorId: string;
+  slug: string;
+  variantIndex: number;
+}): React.ReactElement {
+  const roll = useActorAction({
+    run: () => createPf2eClient(api.dispatch).weapon(actorId, slug).rollAttack(variantIndex),
+  });
+  const bonus = label.split(' ')[0];
+  return (
+    <button
+      type="button"
+      onClick={() => { roll.trigger(); }}
+      disabled={roll.state === 'pending'}
+      title={label}
+      className="rounded border border-pf-border bg-pf-bg-dark px-1.5 py-0.5 font-mono text-[11px] tabular-nums text-pf-secondary hover:border-pf-tertiary-dark hover:bg-pf-tertiary/40 disabled:opacity-50"
+    >
+      {bonus}
+    </button>
+  );
+}
+
+function PencilIcon(): React.ReactElement {
+  return (
+    <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+      <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+    </svg>
   );
 }
 
@@ -835,16 +953,4 @@ function humaniseSlug(slug: string): string {
     .split('-')
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
     .join(' ');
-}
-
-function humaniseSize(size: string): string {
-  const map: Record<string, string> = {
-    tiny: 'Tiny',
-    sm: 'Small',
-    med: 'Medium',
-    lg: 'Large',
-    huge: 'Huge',
-    grg: 'Gargantuan',
-  };
-  return map[size] ?? humaniseSlug(size);
 }

--- a/apps/player-portal/src/components/tabs/Character.tsx
+++ b/apps/player-portal/src/components/tabs/Character.tsx
@@ -16,7 +16,6 @@ import { ABILITY_KEYS, isCantripSpell, isActionItem, isSpellItem, isSpellcasting
 import { t } from '../../i18n/t';
 import { formatSignedInt } from '../../lib/format';
 import { useActorAction, type ActorActionState } from '../../lib/useActorAction';
-import { ModifierTooltip } from '../common/ModifierTooltip';
 import { RankChip } from '../common/RankChip';
 import { SectionHeader } from '../common/SectionHeader';
 import { QuickActionPicker, type QuickActionOption, type QAStrike, type QAItem, type QASpell } from '../sheet/QuickActionPicker';
@@ -649,11 +648,11 @@ function SkillItem({
   });
 
   return (
-    <li className="group relative rounded border border-pf-border bg-pf-bg shadow-sm" data-statistic={skill.slug}>
+    <li className="rounded border border-pf-border shadow-sm" data-statistic={skill.slug}>
       <button
         type="button"
         className={[
-          'flex w-full items-center hover:bg-pf-bg-dark disabled:opacity-50',
+          'flex w-full items-center rounded bg-pf-bg hover:border-pf-tertiary-dark hover:bg-pf-tertiary/40 disabled:opacity-50',
           condensed ? 'gap-1.5 px-1.5 py-1' : 'gap-2 px-3 py-2',
         ].join(' ')}
         onClick={() => {
@@ -661,7 +660,7 @@ function SkillItem({
         }}
         disabled={roll.state === 'pending'}
       >
-        <span className="inline-flex w-8 justify-end font-mono text-sm tabular-nums text-pf-secondary">
+        <span className="inline-flex w-8 justify-end font-mono text-sm font-semibold tabular-nums text-pf-text">
           {formatSignedInt(skill.value)}
         </span>
         <span className="flex-1 truncate text-sm text-pf-text">
@@ -669,7 +668,6 @@ function SkillItem({
         </span>
         <RankChip rank={skill.rank} condensed={condensed} />
       </button>
-      <ModifierTooltip title={skill.label} breakdown={skill.breakdown} modifiers={skill.modifiers} />
     </li>
   );
 }

--- a/apps/player-portal/src/components/tabs/Character.tsx
+++ b/apps/player-portal/src/components/tabs/Character.tsx
@@ -84,7 +84,7 @@ export function Character({ system, actorId, items, characterLevel, onActorChang
       </div>
 
       <div data-section="conditions">
-        <SectionHeader>Conditions</SectionHeader>
+        <SectionHeader band>Conditions</SectionHeader>
         <div className="space-y-3">
           <ConditionsRow
             dying={system.attributes.dying}
@@ -111,7 +111,7 @@ function AbilityBlock({
 }): React.ReactElement {
   return (
     <div>
-      <SectionHeader>Ability Modifiers</SectionHeader>
+      <SectionHeader band>Ability Modifiers</SectionHeader>
       <ul className="grid grid-cols-3 gap-2 sm:grid-cols-6">
         {ABILITY_KEYS.map((ak) => {
           const a = abilities[ak];
@@ -181,7 +181,7 @@ function StatsBlock({
 
   return (
     <div>
-      <SectionHeader>Key Stats</SectionHeader>
+      <SectionHeader band>Key Stats</SectionHeader>
       <div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
         <StatTile label="AC" value={ac.value.toString()} title={ac.breakdown} />
         <HpTile hp={hp} actorId={actorId} onActorChanged={onActorChanged} />
@@ -566,7 +566,7 @@ function IWRBlock({
   if (immunities.length === 0 && weaknesses.length === 0 && resistances.length === 0) return null;
   return (
     <div data-section="iwr" className="space-y-2">
-      <SectionHeader>Defenses</SectionHeader>
+      <SectionHeader band>Defenses</SectionHeader>
       <IWRRow label="Immunities" entries={immunities} />
       <IWRRow label="Weaknesses" entries={weaknesses} />
       <IWRRow label="Resistances" entries={resistances} />
@@ -618,7 +618,7 @@ function SkillsBlock({
 
   return (
     <div>
-      <SectionHeader>Skills</SectionHeader>
+      <SectionHeader band>Skills</SectionHeader>
       <ul className={condensed ? 'grid grid-cols-2 gap-1' : 'grid grid-cols-1 gap-2 sm:grid-cols-2'}>
         {coreSkills.map((skill) => (
           <SkillItem key={skill.slug} skill={skill} actorId={actorId} condensed={condensed} />
@@ -746,15 +746,15 @@ function QuickActionsBlock({
       className="flex w-60 shrink-0 flex-col overflow-hidden rounded-lg border border-pf-border bg-pf-bg-dark p-4"
       style={maxHeight !== undefined ? { maxHeight } : undefined}
     >
-      <div className="mb-3 flex shrink-0 items-center justify-between">
-        <h2 className="border-l-2 border-pf-primary pl-3 font-serif text-sm font-bold uppercase tracking-wider text-pf-alt-dark">
+      <div className="-mx-4 -mt-4 mb-3 flex shrink-0 items-center justify-between rounded-t-lg border-b border-pf-border bg-pf-bg px-4 pb-2.5 pt-3">
+        <h2 className="font-serif text-sm font-bold uppercase tracking-wider text-pf-alt-dark">
           Quick Actions
         </h2>
         <button
           type="button"
           onClick={() => { setShowPicker(true); }}
           title="Configure quick actions"
-          className="flex h-5 w-5 items-center justify-center rounded border border-pf-border text-pf-text-muted hover:bg-pf-bg-dark"
+          className="flex h-5 w-5 items-center justify-center rounded border border-pf-primary/30 text-pf-text-muted hover:bg-pf-primary/10"
           aria-label="Configure quick actions"
         >
           <PencilIcon />

--- a/apps/player-portal/src/components/tabs/Character.tsx
+++ b/apps/player-portal/src/components/tabs/Character.tsx
@@ -764,7 +764,7 @@ function QuickActionsBlock({
       {selected.length === 0 ? (
         <p className="text-xs italic text-pf-text-muted">Tap the pencil to add quick actions.</p>
       ) : (
-        <ul className="min-h-0 flex-1 space-y-1.5 overflow-y-auto pr-0.5">
+        <ul className="scrollbar-pf min-h-0 flex-1 space-y-1.5 overflow-y-auto">
           {selected.map((opt) => {
             if (opt.kind === 'strike') {
               return <StrikeQuickRow key={opt.id} option={opt} actorId={actorId} />;

--- a/apps/player-portal/src/components/tabs/Character.tsx
+++ b/apps/player-portal/src/components/tabs/Character.tsx
@@ -861,7 +861,7 @@ function ItemQuickRow({
           type="button"
           onClick={() => { use.trigger(); }}
           disabled={use.state === 'pending'}
-          className="w-12 shrink-0 rounded border border-pf-primary/40 py-0.5 text-center text-[10px] font-semibold uppercase tracking-wide text-pf-primary hover:bg-pf-primary/10 disabled:opacity-50"
+          className="w-12 shrink-0 rounded border border-pf-border bg-pf-bg py-0.5 text-center text-[10px] font-semibold uppercase tracking-wide text-pf-text hover:bg-pf-bg-dark disabled:opacity-50"
         >
           Use
         </button>
@@ -920,7 +920,7 @@ function SpellQuickRow({
           type="button"
           onClick={() => { cast.trigger(); }}
           disabled={cast.state === 'pending' || unavailable}
-          className="w-12 shrink-0 rounded border border-pf-primary/40 py-0.5 text-center text-[10px] font-semibold uppercase tracking-wide text-pf-primary hover:bg-pf-primary/10 disabled:cursor-not-allowed disabled:opacity-40"
+          className="w-12 shrink-0 rounded border border-pf-border bg-pf-bg py-0.5 text-center text-[10px] font-semibold uppercase tracking-wide text-pf-text hover:bg-pf-bg-dark disabled:cursor-not-allowed disabled:opacity-40"
         >
           Cast
         </button>

--- a/apps/player-portal/src/components/tabs/Character.tsx
+++ b/apps/player-portal/src/components/tabs/Character.tsx
@@ -182,7 +182,7 @@ function StatsBlock({
       <SectionHeader band>Key Stats</SectionHeader>
       <div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
         <StatTile label="AC" value={ac.value.toString()} title={ac.breakdown} />
-        <HpTile hp={hp} actorId={actorId} onActorChanged={onActorChanged} />
+        <HpTile hp={hp} />
         <StatTile
           label="Perception"
           value={formatSignedInt(perception.value)}
@@ -232,25 +232,8 @@ function firstError(...states: ActorActionState[]): string | null {
   return null;
 }
 
-// Replaces the plain HP `StatTile` with a stepper. Keeps the stat-card
-// shape (label + value on top) and tucks −5 / −1 / +1 / +5 buttons
-// below so the tile still sits flush with the other stats in the grid.
-function HpTile({
-  hp,
-  actorId,
-  onActorChanged,
-}: {
-  hp: CharacterSystem['attributes']['hp'];
-  actorId: string;
-  onActorChanged: () => void;
-}): React.ReactElement {
+function HpTile({ hp }: { hp: CharacterSystem['attributes']['hp'] }): React.ReactElement {
   const value = hp.temp > 0 ? `${hp.value.toString()} (+${hp.temp.toString()})` : `${hp.value.toString()} / ${hp.max.toString()}`;
-  const { state, trigger } = useActorAction({
-    run: (delta: number) => api.adjustActorResource(actorId, 'hp', delta),
-    onSuccess: onActorChanged,
-  });
-  const isError = typeof state === 'object';
-
   return (
     <div
       className="flex flex-col items-center rounded border border-pf-border bg-pf-bg px-2 py-2 shadow-sm"
@@ -259,13 +242,6 @@ function HpTile({
     >
       <span className="text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark">HP</span>
       <span className="mt-0.5 font-mono text-xl font-semibold tabular-nums text-pf-text">{value}</span>
-      <div className="mt-1 flex gap-0.5" data-role="hp-stepper">
-        <StepButton label="−5" disabled={state === 'pending'} onClick={() => { trigger(-5); }} />
-        <StepButton label="−1" disabled={state === 'pending'} onClick={() => { trigger(-1); }} />
-        <StepButton label="+1" disabled={state === 'pending'} onClick={() => { trigger(1); }} />
-        <StepButton label="+5" disabled={state === 'pending'} onClick={() => { trigger(5); }} />
-      </div>
-      {isError && <span className="mt-1 text-[10px] text-red-700">{state.error}</span>}
     </div>
   );
 }

--- a/apps/player-portal/src/components/tabs/Character.tsx
+++ b/apps/player-portal/src/components/tabs/Character.tsx
@@ -38,7 +38,6 @@ interface Props {
 // read-only (no input widgets) and Tailwind-styled.
 export function Character({ system, actorId, items, characterLevel, onActorChanged }: Props): React.ReactElement {
   const keyAbility = system.details.keyability.value;
-  const classDC = system.attributes.classDC;
   const skillsCardRef = useRef<HTMLDivElement>(null);
   const [qaMaxHeight, setQaMaxHeight] = useState<number | undefined>(undefined);
 
@@ -78,7 +77,7 @@ export function Character({ system, actorId, items, characterLevel, onActorChang
           focusPoints={system.resources.focus}
           actorId={actorId}
           onActorChanged={onActorChanged}
-          maxHeight={qaMaxHeight}
+          {...(qaMaxHeight !== undefined ? { maxHeight: qaMaxHeight } : {})}
         />
       </div>
 

--- a/apps/player-portal/src/components/tabs/Character.tsx
+++ b/apps/player-portal/src/components/tabs/Character.tsx
@@ -861,7 +861,7 @@ function ItemQuickRow({
           type="button"
           onClick={() => { use.trigger(); }}
           disabled={use.state === 'pending'}
-          className="shrink-0 rounded border border-pf-primary/40 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-pf-primary hover:bg-pf-primary/10 disabled:opacity-50"
+          className="w-12 shrink-0 rounded border border-pf-primary/40 py-0.5 text-center text-[10px] font-semibold uppercase tracking-wide text-pf-primary hover:bg-pf-primary/10 disabled:opacity-50"
         >
           Use
         </button>
@@ -920,7 +920,7 @@ function SpellQuickRow({
           type="button"
           onClick={() => { cast.trigger(); }}
           disabled={cast.state === 'pending' || unavailable}
-          className="shrink-0 rounded border border-pf-primary/40 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-pf-primary hover:bg-pf-primary/10 disabled:cursor-not-allowed disabled:opacity-40"
+          className="w-12 shrink-0 rounded border border-pf-primary/40 py-0.5 text-center text-[10px] font-semibold uppercase tracking-wide text-pf-primary hover:bg-pf-primary/10 disabled:cursor-not-allowed disabled:opacity-40"
         >
           Cast
         </button>
@@ -944,13 +944,17 @@ function VariantAttackButton({
     run: () => createPf2eClient(api.dispatch).weapon(actorId, slug).rollAttack(variantIndex),
   });
   const bonus = label.split(' ')[0];
+  const color =
+    variantIndex === 0 ? 'border-emerald-300 bg-emerald-50 text-emerald-900 hover:bg-emerald-100'
+    : variantIndex === 1 ? 'border-amber-300 bg-amber-50 text-amber-900 hover:bg-amber-100'
+    : 'border-rose-300 bg-rose-50 text-rose-900 hover:bg-rose-100';
   return (
     <button
       type="button"
       onClick={() => { roll.trigger(); }}
       disabled={roll.state === 'pending'}
       title={label}
-      className="rounded border border-pf-border bg-pf-bg-dark px-1.5 py-0.5 font-mono text-[11px] tabular-nums text-pf-secondary hover:border-pf-tertiary-dark hover:bg-pf-tertiary/40 disabled:opacity-50"
+      className={`rounded border px-1.5 py-0.5 font-mono text-[11px] font-semibold tabular-nums disabled:opacity-50 ${color}`}
     >
       {bonus}
     </button>

--- a/apps/player-portal/src/components/tabs/Character.tsx
+++ b/apps/player-portal/src/components/tabs/Character.tsx
@@ -60,12 +60,6 @@ export function Character({ system, actorId, items, characterLevel, onActorChang
 
       <StatsBlock system={system} actorId={actorId} onActorChanged={onActorChanged} />
 
-      <IWRBlock
-        immunities={system.attributes.immunities}
-        weaknesses={system.attributes.weaknesses}
-        resistances={system.attributes.resistances}
-      />
-
       <div className="flex items-start gap-4 !rounded-none !border-0 !bg-transparent !p-0">
         <div ref={skillsCardRef} className="min-w-0 flex-1 rounded-lg border border-pf-border bg-pf-bg-dark p-4">
           <SkillsBlock skills={system.skills} actorId={actorId} condensed />
@@ -80,6 +74,12 @@ export function Character({ system, actorId, items, characterLevel, onActorChang
           {...(qaMaxHeight !== undefined ? { maxHeight: qaMaxHeight } : {})}
         />
       </div>
+
+      <IWRBlock
+        immunities={system.attributes.immunities}
+        weaknesses={system.attributes.weaknesses}
+        resistances={system.attributes.resistances}
+      />
 
       <div data-section="conditions">
         <SectionHeader band>Conditions</SectionHeader>

--- a/apps/player-portal/src/components/tabs/Character.tsx
+++ b/apps/player-portal/src/components/tabs/Character.tsx
@@ -58,7 +58,7 @@ export function Character({ system, actorId, items, characterLevel, onActorChang
     <section className="space-y-4 *:rounded-lg *:border *:border-pf-border *:bg-pf-bg-dark *:p-4">
       <AbilityBlock abilities={system.abilities} keyAbility={keyAbility} />
 
-      <StatsBlock system={system} actorId={actorId} onActorChanged={onActorChanged} />
+      <StatsBlock system={system} actorId={actorId} />
 
       <div className="flex items-start gap-4 !rounded-none !border-0 !bg-transparent !p-0">
         <div ref={skillsCardRef} className="min-w-0 flex-1 rounded-lg border border-pf-border bg-pf-bg-dark p-4">
@@ -149,11 +149,9 @@ function AbilityBlock({
 function StatsBlock({
   system,
   actorId,
-  onActorChanged,
 }: {
   system: CharacterSystem;
   actorId: string;
-  onActorChanged: () => void;
 }): React.ReactElement {
   const { ac, hp } = system.attributes;
   const { perception } = system;
@@ -580,7 +578,7 @@ function SkillsBlock({
   actorId: string;
   condensed?: boolean;
 }): React.ReactElement {
-  const allSkills = Object.values(skills) as SkillStatistic[];
+  const allSkills = Object.values(skills);
   const coreSkills = allSkills.filter((s) => !s.lore);
   const loreSkills = allSkills.filter((s) => s.lore);
 

--- a/apps/player-portal/src/components/tabs/Character.tsx
+++ b/apps/player-portal/src/components/tabs/Character.tsx
@@ -187,7 +187,6 @@ function StatsBlock({
           label="Perception"
           value={formatSignedInt(perception.value)}
           title={perception.breakdown}
-          rank={perception.rank}
           data-stat="perception"
           onRoll={() => { rollPerception.trigger(); }}
           pending={rollPerception.state === 'pending'}
@@ -300,7 +299,6 @@ function classDCTile(system: CharacterSystem): React.ReactElement {
       label="Class DC"
       value={classDC.dc.toString()}
       title={classDC.breakdown}
-      rank={classDC.rank}
       data-stat="class-dc"
     />
   );
@@ -320,7 +318,6 @@ function SaveTile({
       label={t(save.label)}
       value={formatSignedInt(save.value)}
       title={save.breakdown}
-      rank={save.rank}
       data-stat={`save-${save.slug}`}
       onRoll={onRoll}
       pending={pending}
@@ -332,7 +329,6 @@ function StatTile({
   label,
   value,
   title,
-  rank,
   onRoll,
   pending,
   ...rest
@@ -340,7 +336,6 @@ function StatTile({
   label: string;
   value: string;
   title?: string;
-  rank?: import('../../api/types').ProficiencyRank;
   /** When set, the tile becomes a clickable button that fires a
    *  roll. Omit to keep it as a display-only stat card. */
   onRoll?: () => void;
@@ -353,7 +348,6 @@ function StatTile({
       <span className="mt-0.5 font-mono text-xl font-semibold tabular-nums text-pf-text">
         {pending === true ? '…' : value}
       </span>
-      {rank !== undefined && <RankChip rank={rank} className="mt-1" />}
     </>
   );
 

--- a/apps/player-portal/src/components/tabs/Character.tsx
+++ b/apps/player-portal/src/components/tabs/Character.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { createPf2eClient } from '@foundry-toolkit/pf2e-rules';
 import { api } from '../../api/client';
 import type {
@@ -40,9 +40,24 @@ interface Props {
 export function Character({ system, actorId, items, characterLevel, onActorChanged }: Props): React.ReactElement {
   const keyAbility = system.details.keyability.value;
   const classDC = system.attributes.classDC;
+  const skillsCardRef = useRef<HTMLDivElement>(null);
+  const [qaMaxHeight, setQaMaxHeight] = useState<number | undefined>(undefined);
+
+  useEffect(() => {
+    const el = skillsCardRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      const h = entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height + 34;
+      setQaMaxHeight(h);
+    });
+    ro.observe(el);
+    return () => { ro.disconnect(); };
+  }, []);
 
   return (
-    <section className="space-y-6">
+    <section className="space-y-4 *:rounded-lg *:border *:border-pf-border *:bg-pf-bg-dark *:p-4">
       <AbilityBlock abilities={system.abilities} keyAbility={keyAbility} />
 
       <StatsBlock system={system} actorId={actorId} onActorChanged={onActorChanged} />
@@ -53,8 +68,8 @@ export function Character({ system, actorId, items, characterLevel, onActorChang
         resistances={system.attributes.resistances}
       />
 
-      <div className="flex items-start gap-4">
-        <div className="min-w-0 flex-1">
+      <div className="flex items-start gap-4 !rounded-none !border-0 !bg-transparent !p-0">
+        <div ref={skillsCardRef} className="min-w-0 flex-1 rounded-lg border border-pf-border bg-pf-bg-dark p-4">
           <SkillsBlock skills={system.skills} actorId={actorId} condensed />
         </div>
         <QuickActionsBlock
@@ -64,6 +79,7 @@ export function Character({ system, actorId, items, characterLevel, onActorChang
           focusPoints={system.resources.focus}
           actorId={actorId}
           onActorChanged={onActorChanged}
+          maxHeight={qaMaxHeight}
         />
       </div>
 
@@ -637,8 +653,8 @@ function SkillItem({
       <button
         type="button"
         className={[
-          'flex w-full items-center gap-2 hover:bg-pf-bg-dark disabled:opacity-50',
-          condensed ? 'px-2 py-1' : 'px-3 py-2',
+          'flex w-full items-center hover:bg-pf-bg-dark disabled:opacity-50',
+          condensed ? 'gap-1.5 px-1.5 py-1' : 'gap-2 px-3 py-2',
         ].join(' ')}
         onClick={() => {
           roll.trigger();
@@ -707,6 +723,7 @@ function QuickActionsBlock({
   focusPoints,
   actorId,
   onActorChanged,
+  maxHeight,
 }: {
   strikes: Strike[];
   items: PreparedActorItem[];
@@ -714,6 +731,7 @@ function QuickActionsBlock({
   focusPoints: { value: number; max: number };
   actorId: string;
   onActorChanged: () => void;
+  maxHeight?: number;
 }): React.ReactElement {
   const [selectedIds, setSelectedIds] = useQuickActions(actorId);
   const [showPicker, setShowPicker] = useState(false);
@@ -724,8 +742,11 @@ function QuickActionsBlock({
     .filter((o): o is QuickActionOption => o !== undefined);
 
   return (
-    <div className="w-48 shrink-0">
-      <div className="mb-3 flex items-center justify-between">
+    <div
+      className="flex w-60 shrink-0 flex-col overflow-hidden rounded-lg border border-pf-border bg-pf-bg-dark p-4"
+      style={maxHeight !== undefined ? { maxHeight } : undefined}
+    >
+      <div className="mb-3 flex shrink-0 items-center justify-between">
         <h2 className="border-l-2 border-pf-primary pl-3 font-serif text-sm font-bold uppercase tracking-wider text-pf-alt-dark">
           Quick Actions
         </h2>
@@ -743,7 +764,7 @@ function QuickActionsBlock({
       {selected.length === 0 ? (
         <p className="text-xs italic text-pf-text-muted">Tap the pencil to add quick actions.</p>
       ) : (
-        <ul className="space-y-1.5">
+        <ul className="min-h-0 flex-1 space-y-1.5 overflow-y-auto pr-0.5">
           {selected.map((opt) => {
             if (opt.kind === 'strike') {
               return <StrikeQuickRow key={opt.id} option={opt} actorId={actorId} />;

--- a/apps/player-portal/src/components/tabs/Feats.test.tsx
+++ b/apps/player-portal/src/components/tabs/Feats.test.tsx
@@ -51,11 +51,11 @@ describe('Feats tab', () => {
 
   it('shows a level label on each feat card', () => {
     const { container } = render(<Feats items={items} />);
-    // Every feat should show "Lv <n>" (Amiri's feats are all level 1).
+    // Every feat should show "Level <n>" in the expanded panel (Amiri's feats are all level 1).
     const levelLabels = container.querySelectorAll('[data-feat-slug]');
     expect(levelLabels.length).toBeGreaterThan(0);
     for (const el of Array.from(levelLabels)) {
-      expect(el.textContent).toMatch(/Lv \d/);
+      expect(el.textContent).toMatch(/Level \d/);
     }
   });
 

--- a/apps/player-portal/src/components/tabs/Feats.tsx
+++ b/apps/player-portal/src/components/tabs/Feats.tsx
@@ -71,18 +71,20 @@ function FeatCard({ feat }: { feat: FeatItem }): React.ReactElement {
   return (
     <li className="relative" data-item-id={feat.id} data-feat-slug={feat.system.slug ?? ''}>
       <details className="group rounded border border-pf-border bg-pf-bg open:rounded-b-none open:border-pf-primary/60 open:shadow-lg">
-        <summary className="flex cursor-pointer list-none items-start gap-3 px-3 py-2 hover:bg-pf-bg-dark/40">
+        <summary className="flex cursor-pointer list-none items-start gap-2 px-3 py-2 [&::-webkit-details-marker]:hidden hover:bg-pf-bg-dark/40">
           <img
             src={feat.img}
             alt=""
-            className="mt-0.5 h-8 w-8 flex-shrink-0 rounded border border-pf-border bg-pf-bg-dark"
+            className="mt-0.5 h-6 w-6 flex-shrink-0 rounded border border-pf-border bg-pf-bg-dark"
           />
-          <span className="line-clamp-2 min-h-[2.5em] min-w-0 flex-1 text-sm font-medium leading-snug text-pf-text">{feat.name}</span>
-          <span className="flex-shrink-0 font-mono text-[10px] uppercase tracking-widest text-pf-alt-dark">
-            Lv {level}
-          </span>
-          <span className="ml-1 text-[10px] text-pf-alt-dark group-open:hidden">▸</span>
-          <span className="ml-1 hidden text-[10px] text-pf-alt-dark group-open:inline">▾</span>
+          <div className="min-w-0 flex-1">
+            <span className="line-clamp-2 block text-sm font-medium leading-snug text-pf-text">{feat.name}</span>
+            <div className="mt-0.5 flex items-center gap-1">
+              <span className="font-mono text-[10px] uppercase tracking-widest text-pf-alt-dark">Lv {level}</span>
+              <span aria-hidden className="ml-auto text-[10px] text-pf-alt-dark group-open:hidden">▸</span>
+              <span aria-hidden className="ml-auto hidden text-[10px] text-pf-alt-dark group-open:inline">▾</span>
+            </div>
+          </div>
         </summary>
         {/* Absolute-positioned body overlays the grid below instead of
             pushing siblings down. Containing block is the `<li>`

--- a/apps/player-portal/src/components/tabs/Feats.tsx
+++ b/apps/player-portal/src/components/tabs/Feats.tsx
@@ -77,7 +77,7 @@ function FeatCard({ feat }: { feat: FeatItem }): React.ReactElement {
             alt=""
             className="mt-0.5 h-8 w-8 flex-shrink-0 rounded border border-pf-border bg-pf-bg-dark"
           />
-          <span className="min-h-[2.5em] min-w-0 flex-1 text-sm font-medium leading-snug text-pf-text">{feat.name}</span>
+          <span className="line-clamp-2 min-h-[2.5em] min-w-0 flex-1 text-sm font-medium leading-snug text-pf-text">{feat.name}</span>
           <span className="flex-shrink-0 font-mono text-[10px] uppercase tracking-widest text-pf-alt-dark">
             Lv {level}
           </span>

--- a/apps/player-portal/src/components/tabs/Feats.tsx
+++ b/apps/player-portal/src/components/tabs/Feats.tsx
@@ -93,7 +93,7 @@ function FeatCard({ feat }: { feat: FeatItem }): React.ReactElement {
               </p>
             )}
           </div>
-          <div className="mt-px min-w-0 flex-1 border-t border-pf-primary/60 px-4 py-3 text-sm text-pf-text">
+          <div className="min-w-0 flex-1 border-t border-pf-primary/60 px-4 py-3 text-sm text-pf-text">
             {enriched.length > 0 ? (
               <div
                 className="max-h-[28rem] overflow-y-auto pr-1 leading-relaxed [&_.pf-damage]:font-semibold [&_.pf-damage]:text-pf-primary [&_.pf-damage-heightened]:text-pf-prof-master [&_.pf-template]:italic [&_.pf-template]:text-pf-secondary [&_a]:cursor-pointer [&_a]:text-pf-primary [&_a]:underline [&_p]:my-2"

--- a/apps/player-portal/src/components/tabs/Feats.tsx
+++ b/apps/player-portal/src/components/tabs/Feats.tsx
@@ -77,14 +77,9 @@ function FeatCard({ feat }: { feat: FeatItem }): React.ReactElement {
             alt=""
             className="mt-0.5 h-6 w-6 flex-shrink-0 rounded border border-pf-border bg-pf-bg-dark"
           />
-          <div className="min-w-0 flex-1">
-            <span className="line-clamp-2 block text-sm font-medium leading-snug text-pf-text">{feat.name}</span>
-            <div className="mt-0.5 flex items-center gap-1">
-              <span className="font-mono text-[10px] uppercase tracking-widest text-pf-alt-dark">Lv {level}</span>
-              <span aria-hidden className="ml-auto text-[10px] text-pf-alt-dark group-open:hidden">▸</span>
-              <span aria-hidden className="ml-auto hidden text-[10px] text-pf-alt-dark group-open:inline">▾</span>
-            </div>
-          </div>
+          <span className="line-clamp-2 min-h-[2.5em] min-w-0 flex-1 text-sm font-medium leading-snug text-pf-text">{feat.name}</span>
+          <span aria-hidden className="flex-shrink-0 text-[10px] text-pf-alt-dark group-open:hidden">▸</span>
+          <span aria-hidden className="flex-shrink-0 hidden text-[10px] text-pf-alt-dark group-open:inline">▾</span>
         </summary>
         {/* Absolute-positioned body overlays the grid below instead of
             pushing siblings down. Containing block is the `<li>`
@@ -94,6 +89,7 @@ function FeatCard({ feat }: { feat: FeatItem }): React.ReactElement {
             sub-pixel width. Summary drops bottom-corner rounding
             while open to seal the seam. */}
         <div className="absolute left-0 right-0 top-full z-20 rounded-b border border-t-0 border-pf-primary/60 bg-pf-bg px-3 py-2 text-sm text-pf-text shadow-lg">
+          <p className="mb-2 font-mono text-[10px] uppercase tracking-widest text-pf-alt-dark">Level {level}</p>
           {traits.length > 0 && <TraitChips traits={traits} />}
           {prereqs.length > 0 && (
             <p className="mt-2 text-xs text-pf-alt-dark">

--- a/apps/player-portal/src/components/tabs/Feats.tsx
+++ b/apps/player-portal/src/components/tabs/Feats.tsx
@@ -81,8 +81,8 @@ function FeatCard({ feat }: { feat: FeatItem }): React.ReactElement {
           <span aria-hidden className="flex-shrink-0 text-[10px] text-pf-alt-dark group-open:hidden">▸</span>
           <span aria-hidden className="flex-shrink-0 hidden text-[10px] text-pf-alt-dark group-open:inline">▾</span>
         </summary>
-        {/* Right panel: level + traits beside the chip at the same height. */}
-        <div className="absolute left-full top-0 z-20 min-h-full w-44 rounded-r border border-l-0 border-pf-primary/60 bg-pf-bg px-4 py-2 text-sm text-pf-text shadow-lg">
+        {/* Right panel: all expand content beside the chip, grows freely downward. */}
+        <div className="absolute left-full top-0 z-20 min-h-full w-60 rounded-r border border-l-0 border-pf-primary/60 bg-pf-bg px-4 py-3 text-sm text-pf-text shadow-lg">
           <p className="mb-2 font-mono text-[10px] uppercase tracking-widest text-pf-alt-dark">Level {level}</p>
           {traits.length > 0 && <TraitChips traits={traits} />}
           {prereqs.length > 0 && (
@@ -90,16 +90,13 @@ function FeatCard({ feat }: { feat: FeatItem }): React.ReactElement {
               <span className="font-semibold uppercase tracking-widest">Prerequisites</span> {prereqs.join('; ')}
             </p>
           )}
-        </div>
-        {/* Description panel: below chip + right panel combined. */}
-        <div className="absolute left-0 top-full z-20 w-[calc(100%+11rem)] rounded-b border border-t-0 border-pf-primary/60 bg-pf-bg px-5 py-3 text-sm text-pf-text shadow-lg">
           {enriched.length > 0 ? (
             <div
-              className="max-h-[28rem] overflow-y-auto pr-1 leading-relaxed [&_.pf-damage]:font-semibold [&_.pf-damage]:text-pf-primary [&_.pf-damage-heightened]:text-pf-prof-master [&_.pf-template]:italic [&_.pf-template]:text-pf-secondary [&_a]:cursor-pointer [&_a]:text-pf-primary [&_a]:underline [&_p]:my-2"
+              className="mt-2 max-h-[28rem] overflow-y-auto pr-1 leading-relaxed [&_.pf-damage]:font-semibold [&_.pf-damage]:text-pf-primary [&_.pf-damage-heightened]:text-pf-prof-master [&_.pf-template]:italic [&_.pf-template]:text-pf-secondary [&_a]:cursor-pointer [&_a]:text-pf-primary [&_a]:underline [&_p]:my-2"
               dangerouslySetInnerHTML={{ __html: enriched }}
             />
           ) : (
-            <p className="italic text-neutral-400">No description.</p>
+            <p className="mt-2 italic text-neutral-400">No description.</p>
           )}
         </div>
       </details>

--- a/apps/player-portal/src/components/tabs/Feats.tsx
+++ b/apps/player-portal/src/components/tabs/Feats.tsx
@@ -88,7 +88,7 @@ function FeatCard({ feat }: { feat: FeatItem }): React.ReactElement {
             matching border edges regardless of the grid cell's
             sub-pixel width. Summary drops bottom-corner rounding
             while open to seal the seam. */}
-        <div className="absolute left-0 right-0 top-full z-20 rounded-b border border-t-0 border-pf-primary/60 bg-pf-bg px-3 py-2 text-sm text-pf-text shadow-lg">
+        <div className="absolute left-0 right-0 top-full z-20 rounded-b border border-t-0 border-pf-primary/60 bg-pf-bg px-5 py-3 text-sm text-pf-text shadow-lg">
           <p className="mb-2 font-mono text-[10px] uppercase tracking-widest text-pf-alt-dark">Level {level}</p>
           {traits.length > 0 && <TraitChips traits={traits} />}
           {prereqs.length > 0 && (

--- a/apps/player-portal/src/components/tabs/Feats.tsx
+++ b/apps/player-portal/src/components/tabs/Feats.tsx
@@ -83,7 +83,7 @@ function FeatCard({ feat }: { feat: FeatItem }): React.ReactElement {
         </summary>
         {/* Single bottom panel: two-column interior avoids z-index overlap entirely. */}
         <div className="absolute left-0 top-full z-20 flex w-[calc(200%+0.5rem)] rounded-b border border-t-0 border-pf-primary/60 bg-pf-bg shadow-lg">
-          <div className="w-36 flex-shrink-0 border-r border-pf-border px-3 py-3 text-sm text-pf-text">
+          <div className="w-36 flex-shrink-0 border-r border-t border-pf-primary/60 px-3 py-3 text-sm text-pf-text">
             <p className="mb-2 font-mono text-[10px] uppercase tracking-widest text-pf-alt-dark">Level {level}</p>
             {traits.length > 0 && <TraitChips traits={traits} />}
             {prereqs.length > 0 && (

--- a/apps/player-portal/src/components/tabs/Feats.tsx
+++ b/apps/player-portal/src/components/tabs/Feats.tsx
@@ -71,11 +71,11 @@ function FeatCard({ feat }: { feat: FeatItem }): React.ReactElement {
   return (
     <li className="relative" data-item-id={feat.id} data-feat-slug={feat.system.slug ?? ''}>
       <details className="group rounded border border-pf-border bg-pf-bg open:rounded-b-none open:border-pf-primary/60 open:shadow-lg">
-        <summary className="flex cursor-pointer list-none items-start gap-2 px-3 py-2 [&::-webkit-details-marker]:hidden hover:bg-pf-bg-dark/40">
+        <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 [&::-webkit-details-marker]:hidden hover:bg-pf-bg-dark/40">
           <img
             src={feat.img}
             alt=""
-            className="mt-0.5 h-6 w-6 flex-shrink-0 rounded border border-pf-border bg-pf-bg-dark"
+            className="h-8 w-8 flex-shrink-0 rounded border border-pf-border bg-pf-bg-dark"
           />
           <span className="line-clamp-2 min-h-[2.5em] min-w-0 flex-1 text-sm font-medium leading-tight text-pf-text">{feat.name}</span>
           <span aria-hidden className="flex-shrink-0 text-[10px] text-pf-alt-dark group-open:hidden">▸</span>

--- a/apps/player-portal/src/components/tabs/Feats.tsx
+++ b/apps/player-portal/src/components/tabs/Feats.tsx
@@ -93,7 +93,7 @@ function FeatCard({ feat }: { feat: FeatItem }): React.ReactElement {
               </p>
             )}
           </div>
-          <div className="min-w-0 flex-1 px-4 py-3 text-sm text-pf-text">
+          <div className="min-w-0 flex-1 border-t border-pf-border px-4 py-3 text-sm text-pf-text">
             {enriched.length > 0 ? (
               <div
                 className="max-h-[28rem] overflow-y-auto pr-1 leading-relaxed [&_.pf-damage]:font-semibold [&_.pf-damage]:text-pf-primary [&_.pf-damage-heightened]:text-pf-prof-master [&_.pf-template]:italic [&_.pf-template]:text-pf-secondary [&_a]:cursor-pointer [&_a]:text-pf-primary [&_a]:underline [&_p]:my-2"

--- a/apps/player-portal/src/components/tabs/Feats.tsx
+++ b/apps/player-portal/src/components/tabs/Feats.tsx
@@ -70,7 +70,7 @@ function FeatCard({ feat }: { feat: FeatItem }): React.ReactElement {
 
   return (
     <li className="relative" data-item-id={feat.id} data-feat-slug={feat.system.slug ?? ''}>
-      <details className="group rounded border border-pf-border bg-pf-bg open:rounded-b-none open:border-pf-primary/60 open:shadow-lg">
+      <details className="group rounded border border-pf-border bg-pf-bg open:rounded-none open:border-pf-primary/60 open:shadow-lg">
         <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 [&::-webkit-details-marker]:hidden hover:bg-pf-bg-dark/40">
           <img
             src={feat.img}
@@ -81,14 +81,8 @@ function FeatCard({ feat }: { feat: FeatItem }): React.ReactElement {
           <span aria-hidden className="flex-shrink-0 text-[10px] text-pf-alt-dark group-open:hidden">▸</span>
           <span aria-hidden className="flex-shrink-0 hidden text-[10px] text-pf-alt-dark group-open:inline">▾</span>
         </summary>
-        {/* Absolute-positioned body overlays the grid below instead of
-            pushing siblings down. Containing block is the `<li>`
-            (relative, no border/padding), so `left: 0 / right: 0`
-            gives body the same border-box as the details above —
-            matching border edges regardless of the grid cell's
-            sub-pixel width. Summary drops bottom-corner rounding
-            while open to seal the seam. */}
-        <div className="absolute -left-4 -right-4 top-full z-20 rounded-b border border-t-0 border-pf-primary/60 bg-pf-bg px-5 py-3 text-sm text-pf-text shadow-lg">
+        {/* Right panel: level + traits beside the chip at the same height. */}
+        <div className="absolute left-full top-0 z-20 min-h-full w-44 rounded-r border border-l-0 border-pf-primary/60 bg-pf-bg px-4 py-2 text-sm text-pf-text shadow-lg">
           <p className="mb-2 font-mono text-[10px] uppercase tracking-widest text-pf-alt-dark">Level {level}</p>
           {traits.length > 0 && <TraitChips traits={traits} />}
           {prereqs.length > 0 && (
@@ -96,13 +90,16 @@ function FeatCard({ feat }: { feat: FeatItem }): React.ReactElement {
               <span className="font-semibold uppercase tracking-widest">Prerequisites</span> {prereqs.join('; ')}
             </p>
           )}
+        </div>
+        {/* Description panel: below chip + right panel combined. */}
+        <div className="absolute left-0 top-full z-20 w-[calc(100%+11rem)] rounded-b border border-t-0 border-pf-primary/60 bg-pf-bg px-5 py-3 text-sm text-pf-text shadow-lg">
           {enriched.length > 0 ? (
             <div
-              className="mt-2 max-h-[28rem] overflow-y-auto pr-1 leading-relaxed [&_.pf-damage]:font-semibold [&_.pf-damage]:text-pf-primary [&_.pf-damage-heightened]:text-pf-prof-master [&_.pf-template]:italic [&_.pf-template]:text-pf-secondary [&_a]:cursor-pointer [&_a]:text-pf-primary [&_a]:underline [&_p]:my-2"
+              className="max-h-[28rem] overflow-y-auto pr-1 leading-relaxed [&_.pf-damage]:font-semibold [&_.pf-damage]:text-pf-primary [&_.pf-damage-heightened]:text-pf-prof-master [&_.pf-template]:italic [&_.pf-template]:text-pf-secondary [&_a]:cursor-pointer [&_a]:text-pf-primary [&_a]:underline [&_p]:my-2"
               dangerouslySetInnerHTML={{ __html: enriched }}
             />
           ) : (
-            <p className="mt-2 italic text-neutral-400">No description.</p>
+            <p className="italic text-neutral-400">No description.</p>
           )}
         </div>
       </details>

--- a/apps/player-portal/src/components/tabs/Feats.tsx
+++ b/apps/player-portal/src/components/tabs/Feats.tsx
@@ -93,7 +93,7 @@ function FeatCard({ feat }: { feat: FeatItem }): React.ReactElement {
               </p>
             )}
           </div>
-          <div className="min-w-0 flex-1 border-t border-pf-border px-4 py-3 text-sm text-pf-text">
+          <div className="-mt-px min-w-0 flex-1 border-t border-pf-border px-4 py-3 text-sm text-pf-text">
             {enriched.length > 0 ? (
               <div
                 className="max-h-[28rem] overflow-y-auto pr-1 leading-relaxed [&_.pf-damage]:font-semibold [&_.pf-damage]:text-pf-primary [&_.pf-damage-heightened]:text-pf-prof-master [&_.pf-template]:italic [&_.pf-template]:text-pf-secondary [&_a]:cursor-pointer [&_a]:text-pf-primary [&_a]:underline [&_p]:my-2"

--- a/apps/player-portal/src/components/tabs/Feats.tsx
+++ b/apps/player-portal/src/components/tabs/Feats.tsx
@@ -77,7 +77,7 @@ function FeatCard({ feat }: { feat: FeatItem }): React.ReactElement {
             alt=""
             className="mt-0.5 h-6 w-6 flex-shrink-0 rounded border border-pf-border bg-pf-bg-dark"
           />
-          <span className="line-clamp-2 min-h-[2.5em] min-w-0 flex-1 text-sm font-medium leading-snug text-pf-text">{feat.name}</span>
+          <span className="line-clamp-2 min-h-[2.5em] min-w-0 flex-1 text-sm font-medium leading-tight text-pf-text">{feat.name}</span>
           <span aria-hidden className="flex-shrink-0 text-[10px] text-pf-alt-dark group-open:hidden">▸</span>
           <span aria-hidden className="flex-shrink-0 hidden text-[10px] text-pf-alt-dark group-open:inline">▾</span>
         </summary>

--- a/apps/player-portal/src/components/tabs/Feats.tsx
+++ b/apps/player-portal/src/components/tabs/Feats.tsx
@@ -93,7 +93,7 @@ function FeatCard({ feat }: { feat: FeatItem }): React.ReactElement {
               </p>
             )}
           </div>
-          <div className="-mt-px min-w-0 flex-1 border-t border-pf-border px-4 py-3 text-sm text-pf-text">
+          <div className="-mt-px min-w-0 flex-1 border-t border-pf-primary/60 px-4 py-3 text-sm text-pf-text">
             {enriched.length > 0 ? (
               <div
                 className="max-h-[28rem] overflow-y-auto pr-1 leading-relaxed [&_.pf-damage]:font-semibold [&_.pf-damage]:text-pf-primary [&_.pf-damage-heightened]:text-pf-prof-master [&_.pf-template]:italic [&_.pf-template]:text-pf-secondary [&_a]:cursor-pointer [&_a]:text-pf-primary [&_a]:underline [&_p]:my-2"

--- a/apps/player-portal/src/components/tabs/Feats.tsx
+++ b/apps/player-portal/src/components/tabs/Feats.tsx
@@ -70,7 +70,7 @@ function FeatCard({ feat }: { feat: FeatItem }): React.ReactElement {
 
   return (
     <li className="relative" data-item-id={feat.id} data-feat-slug={feat.system.slug ?? ''}>
-      <details className="group rounded border border-pf-border bg-pf-bg open:rounded-none open:border-pf-primary/60 open:shadow-lg">
+      <details className="group rounded border border-pf-border bg-pf-bg open:rounded-b-none open:border-pf-primary/60 open:shadow-lg">
         <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 [&::-webkit-details-marker]:hidden hover:bg-pf-bg-dark/40">
           <img
             src={feat.img}
@@ -81,27 +81,28 @@ function FeatCard({ feat }: { feat: FeatItem }): React.ReactElement {
           <span aria-hidden className="flex-shrink-0 text-[10px] text-pf-alt-dark group-open:hidden">▸</span>
           <span aria-hidden className="flex-shrink-0 hidden text-[10px] text-pf-alt-dark group-open:inline">▾</span>
         </summary>
-        {/* Right panel: level + traits at chip height. z-30 keeps it above the description panel. */}
-        <div className="absolute left-full top-0 z-30 min-h-full w-36 rounded-r border border-l-0 border-pf-primary/60 bg-pf-bg px-3 py-3 text-sm text-pf-text shadow-lg">
-          <p className="mb-2 font-mono text-[10px] uppercase tracking-widest text-pf-alt-dark">Level {level}</p>
-          {traits.length > 0 && <TraitChips traits={traits} />}
-          {prereqs.length > 0 && (
-            <p className="mt-2 text-xs text-pf-alt-dark">
-              <span className="font-semibold uppercase tracking-widest">Prerequisites</span>{' '}
-              {prereqs.join('; ')}
-            </p>
-          )}
-        </div>
-        {/* Description panel: below chip + right panel, spans their combined width. */}
-        <div className="absolute left-0 top-full z-20 w-[calc(100%+9rem)] rounded-b border border-t-0 border-pf-primary/60 bg-pf-bg px-5 py-3 text-sm text-pf-text shadow-lg">
-          {enriched.length > 0 ? (
-            <div
-              className="max-h-[28rem] overflow-y-auto pr-1 leading-relaxed [&_.pf-damage]:font-semibold [&_.pf-damage]:text-pf-primary [&_.pf-damage-heightened]:text-pf-prof-master [&_.pf-template]:italic [&_.pf-template]:text-pf-secondary [&_a]:cursor-pointer [&_a]:text-pf-primary [&_a]:underline [&_p]:my-2"
-              dangerouslySetInnerHTML={{ __html: enriched }}
-            />
-          ) : (
-            <p className="italic text-neutral-400">No description.</p>
-          )}
+        {/* Single bottom panel: two-column interior avoids z-index overlap entirely. */}
+        <div className="absolute left-0 top-full z-20 flex w-[calc(200%+0.5rem)] rounded-b border border-t-0 border-pf-primary/60 bg-pf-bg shadow-lg">
+          <div className="w-36 flex-shrink-0 border-r border-pf-border px-3 py-3 text-sm text-pf-text">
+            <p className="mb-2 font-mono text-[10px] uppercase tracking-widest text-pf-alt-dark">Level {level}</p>
+            {traits.length > 0 && <TraitChips traits={traits} />}
+            {prereqs.length > 0 && (
+              <p className="mt-2 text-xs text-pf-alt-dark">
+                <span className="font-semibold uppercase tracking-widest">Prerequisites</span>{' '}
+                {prereqs.join('; ')}
+              </p>
+            )}
+          </div>
+          <div className="min-w-0 flex-1 px-4 py-3 text-sm text-pf-text">
+            {enriched.length > 0 ? (
+              <div
+                className="max-h-[28rem] overflow-y-auto pr-1 leading-relaxed [&_.pf-damage]:font-semibold [&_.pf-damage]:text-pf-primary [&_.pf-damage-heightened]:text-pf-prof-master [&_.pf-template]:italic [&_.pf-template]:text-pf-secondary [&_a]:cursor-pointer [&_a]:text-pf-primary [&_a]:underline [&_p]:my-2"
+                dangerouslySetInnerHTML={{ __html: enriched }}
+              />
+            ) : (
+              <p className="italic text-neutral-400">No description.</p>
+            )}
+          </div>
         </div>
       </details>
     </li>

--- a/apps/player-portal/src/components/tabs/Feats.tsx
+++ b/apps/player-portal/src/components/tabs/Feats.tsx
@@ -93,7 +93,7 @@ function FeatCard({ feat }: { feat: FeatItem }): React.ReactElement {
               </p>
             )}
           </div>
-          <div className="-mt-px min-w-0 flex-1 border-t border-pf-primary/60 px-4 py-3 text-sm text-pf-text">
+          <div className="mt-px min-w-0 flex-1 border-t border-pf-primary/60 px-4 py-3 text-sm text-pf-text">
             {enriched.length > 0 ? (
               <div
                 className="max-h-[28rem] overflow-y-auto pr-1 leading-relaxed [&_.pf-damage]:font-semibold [&_.pf-damage]:text-pf-primary [&_.pf-damage-heightened]:text-pf-prof-master [&_.pf-template]:italic [&_.pf-template]:text-pf-secondary [&_a]:cursor-pointer [&_a]:text-pf-primary [&_a]:underline [&_p]:my-2"

--- a/apps/player-portal/src/components/tabs/Feats.tsx
+++ b/apps/player-portal/src/components/tabs/Feats.tsx
@@ -44,7 +44,7 @@ export function Feats({ items }: Props): React.ReactElement {
             {inCategory.length === 0 ? (
               <p className="text-xs italic text-pf-text-muted">None yet</p>
             ) : (
-              <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+              <ul className="grid grid-cols-2 gap-2 sm:grid-cols-3">
                 {inCategory.map((feat) => (
                   <FeatCard key={feat.id} feat={feat} />
                 ))}
@@ -77,7 +77,7 @@ function FeatCard({ feat }: { feat: FeatItem }): React.ReactElement {
             alt=""
             className="mt-0.5 h-8 w-8 flex-shrink-0 rounded border border-pf-border bg-pf-bg-dark"
           />
-          <span className="min-w-0 flex-1 truncate text-sm font-medium text-pf-text">{feat.name}</span>
+          <span className="min-h-[2.5em] min-w-0 flex-1 text-sm font-medium leading-snug text-pf-text">{feat.name}</span>
           <span className="flex-shrink-0 font-mono text-[10px] uppercase tracking-widest text-pf-alt-dark">
             Lv {level}
           </span>
@@ -153,7 +153,7 @@ function renderUnknownCategories(grouped: Map<string, FeatItem[]>): React.ReactE
       {extras.map(([category, feats]) => (
         <div key={category} data-feat-category={category}>
           <SectionHeader band>{FEAT_CATEGORY_LABEL[category] ?? capitaliseSlug(category)}</SectionHeader>
-          <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+          <ul className="grid grid-cols-2 gap-2 sm:grid-cols-3">
             {feats.map((feat) => (
               <FeatCard key={feat.id} feat={feat} />
             ))}

--- a/apps/player-portal/src/components/tabs/Feats.tsx
+++ b/apps/player-portal/src/components/tabs/Feats.tsx
@@ -30,7 +30,7 @@ export function Feats({ items }: Props): React.ReactElement {
 
   return (
     <section
-      className="space-y-6"
+      className="space-y-4 *:rounded-lg *:border *:border-pf-border *:bg-pf-bg-dark *:p-4"
       onMouseOver={uuidHover.delegationHandlers.onMouseOver}
       onMouseOut={uuidHover.delegationHandlers.onMouseOut}
     >
@@ -40,9 +40,9 @@ export function Feats({ items }: Props): React.ReactElement {
         if (inCategory.length === 0 && !isCanonical) return null;
         return (
           <div key={category} data-feat-category={category}>
-            <SectionHeader>{FEAT_CATEGORY_LABEL[category] ?? category}</SectionHeader>
+            <SectionHeader band>{FEAT_CATEGORY_LABEL[category] ?? category}</SectionHeader>
             {inCategory.length === 0 ? (
-              <p className="text-xs italic text-neutral-400">None yet</p>
+              <p className="text-xs italic text-pf-text-muted">None yet</p>
             ) : (
               <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                 {inCategory.map((feat) => (
@@ -152,7 +152,7 @@ function renderUnknownCategories(grouped: Map<string, FeatItem[]>): React.ReactE
     <>
       {extras.map(([category, feats]) => (
         <div key={category} data-feat-category={category}>
-          <SectionHeader>{FEAT_CATEGORY_LABEL[category] ?? capitaliseSlug(category)}</SectionHeader>
+          <SectionHeader band>{FEAT_CATEGORY_LABEL[category] ?? capitaliseSlug(category)}</SectionHeader>
           <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
             {feats.map((feat) => (
               <FeatCard key={feat.id} feat={feat} />

--- a/apps/player-portal/src/components/tabs/Feats.tsx
+++ b/apps/player-portal/src/components/tabs/Feats.tsx
@@ -88,7 +88,7 @@ function FeatCard({ feat }: { feat: FeatItem }): React.ReactElement {
             matching border edges regardless of the grid cell's
             sub-pixel width. Summary drops bottom-corner rounding
             while open to seal the seam. */}
-        <div className="absolute left-0 right-0 top-full z-20 rounded-b border border-t-0 border-pf-primary/60 bg-pf-bg px-5 py-3 text-sm text-pf-text shadow-lg">
+        <div className="absolute -left-4 -right-4 top-full z-20 rounded-b border border-t-0 border-pf-primary/60 bg-pf-bg px-5 py-3 text-sm text-pf-text shadow-lg">
           <p className="mb-2 font-mono text-[10px] uppercase tracking-widest text-pf-alt-dark">Level {level}</p>
           {traits.length > 0 && <TraitChips traits={traits} />}
           {prereqs.length > 0 && (

--- a/apps/player-portal/src/components/tabs/Feats.tsx
+++ b/apps/player-portal/src/components/tabs/Feats.tsx
@@ -81,22 +81,26 @@ function FeatCard({ feat }: { feat: FeatItem }): React.ReactElement {
           <span aria-hidden className="flex-shrink-0 text-[10px] text-pf-alt-dark group-open:hidden">▸</span>
           <span aria-hidden className="flex-shrink-0 hidden text-[10px] text-pf-alt-dark group-open:inline">▾</span>
         </summary>
-        {/* Right panel: all expand content beside the chip, grows freely downward. */}
-        <div className="absolute left-full top-0 z-20 min-h-full w-60 rounded-r border border-l-0 border-pf-primary/60 bg-pf-bg px-4 py-3 text-sm text-pf-text shadow-lg">
+        {/* Right panel: level + traits at chip height. z-30 keeps it above the description panel. */}
+        <div className="absolute left-full top-0 z-30 min-h-full w-36 rounded-r border border-l-0 border-pf-primary/60 bg-pf-bg px-3 py-3 text-sm text-pf-text shadow-lg">
           <p className="mb-2 font-mono text-[10px] uppercase tracking-widest text-pf-alt-dark">Level {level}</p>
           {traits.length > 0 && <TraitChips traits={traits} />}
           {prereqs.length > 0 && (
             <p className="mt-2 text-xs text-pf-alt-dark">
-              <span className="font-semibold uppercase tracking-widest">Prerequisites</span> {prereqs.join('; ')}
+              <span className="font-semibold uppercase tracking-widest">Prerequisites</span>{' '}
+              {prereqs.join('; ')}
             </p>
           )}
+        </div>
+        {/* Description panel: below chip + right panel, spans their combined width. */}
+        <div className="absolute left-0 top-full z-20 w-[calc(100%+9rem)] rounded-b border border-t-0 border-pf-primary/60 bg-pf-bg px-5 py-3 text-sm text-pf-text shadow-lg">
           {enriched.length > 0 ? (
             <div
-              className="mt-2 max-h-[28rem] overflow-y-auto pr-1 leading-relaxed [&_.pf-damage]:font-semibold [&_.pf-damage]:text-pf-primary [&_.pf-damage-heightened]:text-pf-prof-master [&_.pf-template]:italic [&_.pf-template]:text-pf-secondary [&_a]:cursor-pointer [&_a]:text-pf-primary [&_a]:underline [&_p]:my-2"
+              className="max-h-[28rem] overflow-y-auto pr-1 leading-relaxed [&_.pf-damage]:font-semibold [&_.pf-damage]:text-pf-primary [&_.pf-damage-heightened]:text-pf-prof-master [&_.pf-template]:italic [&_.pf-template]:text-pf-secondary [&_a]:cursor-pointer [&_a]:text-pf-primary [&_a]:underline [&_p]:my-2"
               dangerouslySetInnerHTML={{ __html: enriched }}
             />
           ) : (
-            <p className="mt-2 italic text-neutral-400">No description.</p>
+            <p className="italic text-neutral-400">No description.</p>
           )}
         </div>
       </details>

--- a/apps/player-portal/src/components/tabs/Inventory.test.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.test.tsx
@@ -44,17 +44,19 @@ describe('Inventory tab', () => {
     expect(joined).toContain('Backpack');
   });
 
-  it('marks the Hide Armor as equipped and the Backpack as worn', () => {
+  it('marks the Hide Armor as equipped and the Backpack as worn via emerald tint', () => {
+    // Grid view uses colour instead of a chip — equipped/worn items get an
+    // emerald border/bg on their <details> element rather than "Equipped" text.
     const { container } = render(<Inventory items={items} />);
     const armor = Array.from(container.querySelectorAll('[data-item-type="armor"]')).find((el) =>
       el.textContent?.includes('Hide Armor'),
     );
-    expect(armor?.textContent).toContain('Equipped');
+    expect(armor?.querySelector('details')?.className, 'Hide Armor equipped tint').toMatch(/item-equipped/);
 
     const backpack = Array.from(container.querySelectorAll('[data-item-type="backpack"]')).find((el) =>
       el.textContent?.includes('Backpack'),
     );
-    expect(backpack?.textContent).toContain('Worn');
+    expect(backpack?.querySelector('details')?.className, 'Backpack worn tint').toMatch(/item-equipped/);
   });
 
   it('shows the Javelin quantity (×4) and Healing Potion (×2)', () => {

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -814,6 +814,13 @@ function isEquippedItem(item: PhysicalItem): boolean {
   return false;
 }
 
+function isInvestedItem(item: PhysicalItem): boolean {
+  return item.system.equipped.invested === true && item.system.traits.value.includes('invested');
+}
+
+const EQUIPPED_BG = 'var(--item-equipped)';
+const INVESTED_BG = 'var(--item-invested)';
+
 function GridTile({
   item,
   sellContext,
@@ -825,15 +832,30 @@ function GridTile({
 }): React.ReactElement {
   const hasInvestButton = investContext !== undefined && supportsInvestment(item);
   const equipped = isEquippedItem(item);
+  const invested = isInvestedItem(item);
+  const both = equipped && invested;
+
+  const detailsClass = [
+    'group relative rounded border open:z-10 open:rounded-r-none open:border-pf-primary/60 open:shadow-lg',
+    both ? 'border-item-equipped' :
+    equipped ? 'border-item-equipped bg-item-equipped' :
+    invested ? 'border-item-invested bg-item-invested' :
+    'border-pf-border bg-pf-bg',
+  ].join(' ');
+
+  const detailsStyle: React.CSSProperties | undefined = both
+    ? { background: `linear-gradient(135deg, ${EQUIPPED_BG} 50%, ${INVESTED_BG} 50%)` }
+    : undefined;
+
+  const summaryHover =
+    equipped || invested ? 'hover:brightness-95' : 'hover:bg-pf-bg-dark/40';
+
   return (
     <li className="relative" data-item-id={item.id} data-item-type={item.type}>
-      <details className={[
-        'group relative rounded border open:z-10 open:rounded-r-none open:border-pf-primary/60 open:shadow-lg',
-        equipped ? 'border-emerald-500/40 bg-emerald-500/10' : 'border-pf-border bg-pf-bg',
-      ].join(' ')}>
+      <details className={detailsClass} style={detailsStyle}>
         <summary className={[
           'flex cursor-pointer list-none flex-col items-center gap-1.5 p-2 text-center',
-          equipped ? 'hover:bg-emerald-500/20' : 'hover:bg-pf-bg-dark/40',
+          summaryHover,
         ].join(' ')}>
           <div className="relative w-full">
             <div className="aspect-square w-full overflow-hidden rounded border border-pf-border bg-pf-bg-dark">
@@ -848,10 +870,14 @@ function GridTile({
           <span className="line-clamp-2 min-h-[2.5em] text-[11px] font-medium leading-tight text-pf-text" title={item.name}>
             {item.name}
           </span>
-          {hasInvestButton && <InvestButton item={item} context={investContext} />}
           {sellContext && <SellButton item={item} context={sellContext} />}
         </summary>
-        <div className="absolute left-full top-0 z-20 min-h-full w-[300%] overflow-y-auto rounded-r border border-l-0 border-pf-primary/60 bg-pf-bg p-4 text-sm text-pf-text shadow-lg">
+        <div className="absolute left-full top-0 z-20 min-h-full w-max min-w-[150%] max-w-[300%] overflow-y-auto rounded-r border border-l-0 border-pf-primary/60 bg-pf-bg p-4 text-sm text-pf-text shadow-lg">
+          {hasInvestButton && (
+            <div className="mb-3">
+              <InvestButton item={item} context={investContext} />
+            </div>
+          )}
           <ItemDescription item={item} />
         </div>
       </details>

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -429,8 +429,7 @@ function CategorizedInventory({
               </ul>
             ) : (
               <ul
-                className="grid gap-2"
-                style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(8rem, 1fr))' }}
+                className="grid grid-cols-5 gap-2"
                 data-view="grid"
               >
                 {bucket.map((item) => (
@@ -808,6 +807,13 @@ function ContainerChildRow({ item }: { item: PhysicalItem }): React.ReactElement
   );
 }
 
+function isEquippedItem(item: PhysicalItem): boolean {
+  const eq = item.system.equipped;
+  if (eq.handsHeld !== undefined && eq.handsHeld > 0) return true;
+  if ((item.type === 'armor' || item.type === 'backpack') && eq.inSlot === true) return true;
+  return false;
+}
+
 function GridTile({
   item,
   sellContext,
@@ -818,16 +824,21 @@ function GridTile({
   investContext: InvestContext | undefined;
 }): React.ReactElement {
   const hasInvestButton = investContext !== undefined && supportsInvestment(item);
+  const equipped = isEquippedItem(item);
   return (
     <li className="relative" data-item-id={item.id} data-item-type={item.type}>
-      {/* open:min-w-[18rem] expands the tile rightward to match the panel
-          so both share the same right border edge. Panel uses left-0
-          right-0 (spans exactly the <details> width) rather than a
-          fixed pixel value so it always tracks the tile. */}
-      <details className="group relative rounded border border-pf-border bg-pf-bg open:z-10 open:min-w-[18rem] open:rounded-b-none open:border-pf-primary/60 open:shadow-lg">
-        <summary className="flex cursor-pointer list-none flex-col items-start gap-1 p-2 hover:bg-pf-bg-dark/40">
-          <div className="relative">
-            <img src={item.img} alt="" className="h-14 w-14 rounded border border-pf-border bg-pf-bg-dark" />
+      <details className={[
+        'group relative rounded border open:z-10 open:min-w-[18rem] open:rounded-b-none open:border-pf-primary/60 open:shadow-lg',
+        equipped ? 'border-emerald-500/40 bg-emerald-500/10' : 'border-pf-border bg-pf-bg',
+      ].join(' ')}>
+        <summary className={[
+          'flex cursor-pointer list-none flex-col items-center gap-1.5 p-2 text-center',
+          equipped ? 'hover:bg-emerald-500/20' : 'hover:bg-pf-bg-dark/40',
+        ].join(' ')}>
+          <div className="relative w-full">
+            <div className="aspect-square w-full overflow-hidden rounded border border-pf-border bg-pf-bg-dark">
+              <img src={item.img} alt="" className="h-full w-full object-contain p-1" />
+            </div>
             {item.system.quantity > 1 && (
               <span className="absolute -right-1 -top-1 rounded bg-pf-primary px-1 text-[10px] font-semibold text-white shadow">
                 ×{item.system.quantity}
@@ -837,9 +848,6 @@ function GridTile({
           <span className="line-clamp-2 min-h-[2.5em] text-[11px] font-medium leading-tight text-pf-text" title={item.name}>
             {item.name}
           </span>
-          <div className="flex min-h-[16px] flex-wrap gap-1">
-            <EquippedBadge item={item} suppressInvested={hasInvestButton} />
-          </div>
           {hasInvestButton && <InvestButton item={item} context={investContext} />}
           {sellContext && <SellButton item={item} context={sellContext} />}
         </summary>

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
 import { api } from '../../api/client';
 import type { PhysicalItem, PhysicalItemType, PointPool, PreparedActorItem } from '../../api/types';
 import { isCoin, isContainer, isPhysicalItem } from '../../api/types';
@@ -855,9 +855,22 @@ function GridTile({
     equipped || invested ? 'hover:brightness-95' : 'hover:bg-pf-bg-dark/40';
 
   const [zIndex, setZIndex] = useState<number | undefined>(undefined);
+  const [flipLeft, setFlipLeft] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    if (zIndex === undefined) { setFlipLeft(false); return; }
+    const panel = panelRef.current;
+    if (!panel) return;
+    setFlipLeft(panel.getBoundingClientRect().right > window.innerWidth - 8);
+  }, [zIndex]);
+
+  const openCorner = flipLeft ? 'open:rounded-l-none' : 'open:rounded-r-none';
+  const detailsClassFull = `${detailsClass.replace('open:rounded-r-none', '')} ${openCorner}`;
+
   return (
     <li className="relative" style={zIndex !== undefined ? { zIndex } : undefined} data-item-id={item.id} data-item-type={item.type}>
-      <details className={detailsClass} style={detailsStyle} onToggle={(e) => {
+      <details className={detailsClassFull} style={detailsStyle} onToggle={(e) => {
         setZIndex(e.currentTarget.open ? ++tileOpenCounter : undefined);
       }}>
         <summary className={[
@@ -881,7 +894,7 @@ function GridTile({
           </div>
           {sellContext && <SellButton item={item} context={sellContext} />}
         </summary>
-        <div className="absolute -top-px left-full z-20 min-h-[calc(100%+2px)] w-max min-w-[150%] max-w-[300%] overflow-y-auto rounded-r border border-pf-primary/60 bg-pf-bg p-4 text-sm text-pf-text shadow-lg">
+        <div ref={panelRef} className={`absolute -top-px ${flipLeft ? 'right-full' : 'left-full'} z-20 min-h-[calc(100%+2px)] w-max min-w-[150%] max-w-[300%] overflow-y-auto ${flipLeft ? 'rounded-l' : 'rounded-r'} border border-pf-primary/60 bg-pf-bg p-4 text-sm text-pf-text shadow-lg`}>
           {hasInvestButton && (
             <div className="mb-3">
               <InvestButton item={item} context={investContext} />

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -902,7 +902,7 @@ function GridTile({
           <div className="relative w-full">
             <div className="relative aspect-square w-full overflow-hidden rounded border border-pf-border bg-pf-bg-dark">
               <img src={item.img} alt="" className="h-full w-full object-contain" />
-              <div className="absolute inset-x-0 bottom-0 bg-black/30 px-1.5 py-1">
+              <div className="absolute inset-x-0 bottom-0 bg-black/40 px-1.5 py-1">
                 <span className="line-clamp-2 block text-[10px] font-medium leading-tight text-white" title={item.name}>
                   {item.name}
                 </span>

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -110,7 +110,7 @@ export function Inventory({ items, actorId, onActorChanged, investiture }: Props
   const [pendingInvestments, setPendingInvestments] = useState<Set<string>>(new Set());
   const [txError, setTxError] = useState<string | null>(null);
   const shopMode = useShopMode();
-  const [tileColumns, setTileColumns] = useState(5);
+  const [tileColumns, setTileColumns] = useState(6);
 
   const canTransact = actorId !== undefined && onActorChanged !== undefined;
 

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -409,12 +409,12 @@ function CategorizedInventory({
     return <p className="text-sm text-pf-text-muted">No items yet.</p>;
   }
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 *:rounded-lg *:border *:border-pf-border *:bg-pf-bg-dark *:p-4">
       {presentCategories.map((category) => {
         const bucket = buckets.get(category) ?? [];
         return (
           <div key={category} data-category={category}>
-            <SectionHeader>{CATEGORY_LABEL[category]}</SectionHeader>
+            <SectionHeader band>{CATEGORY_LABEL[category]}</SectionHeader>
             {view === 'list' ? (
               <ul className="space-y-1.5">
                 {bucket.map((item) => (

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -902,7 +902,7 @@ function GridTile({
           <div className="relative w-full">
             <div className="relative aspect-square w-full overflow-hidden rounded border border-pf-border bg-pf-bg-dark">
               <img src={item.img} alt="" className="h-full w-full object-contain" />
-              <div className="absolute inset-x-0 bottom-0 bg-black/50 px-1.5 py-1">
+              <div className="absolute inset-x-0 bottom-0 bg-black/30 px-1.5 py-1">
                 <span className="line-clamp-2 block text-[10px] font-medium leading-tight text-white" title={item.name}>
                   {item.name}
                 </span>

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -874,7 +874,7 @@ function GridTile({
           </div>
           {sellContext && <SellButton item={item} context={sellContext} />}
         </summary>
-        <div className="absolute left-full top-0 z-20 min-h-full w-max min-w-[150%] max-w-[300%] overflow-y-auto rounded-r border border-l-0 border-pf-primary/60 bg-pf-bg p-4 text-sm text-pf-text shadow-lg">
+        <div className="absolute left-full top-0 z-20 min-h-full w-max min-w-[150%] max-w-[300%] overflow-y-auto rounded-r border border-pf-primary/60 bg-pf-bg p-4 text-sm text-pf-text shadow-lg">
           {hasInvestButton && (
             <div className="mb-3">
               <InvestButton item={item} context={investContext} />

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -212,6 +212,7 @@ export function Inventory({ items, actorId, onActorChanged, investiture }: Props
   // inventory pane so the toggle doesn't strand the user on an empty
   // shop tab.
   const effectiveShopView: ShopView = shopMode.enabled && canTransact ? shopView : 'inventory';
+  const effectiveTileColumns = shopMode.enabled ? 5 : tileColumns;
 
   return (
     <section
@@ -254,7 +255,7 @@ export function Inventory({ items, actorId, onActorChanged, investiture }: Props
           ) : (
             <CategorizedInventory
               view={view}
-              tileColumns={tileColumns}
+              tileColumns={effectiveTileColumns}
               topLevelByCategory={topLevelByCategory}
               allByCategory={allByCategory}
               byContainer={byContainer}

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -902,7 +902,7 @@ function GridTile({
           <div className="relative w-full">
             <div className="relative aspect-square w-full overflow-hidden rounded border border-pf-border bg-pf-bg-dark">
               <img src={item.img} alt="" className="h-full w-full object-contain" />
-              <div className="absolute inset-x-0 bottom-0 bg-black/60 px-1.5 py-1">
+              <div className="absolute inset-x-0 bottom-0 bg-black/50 px-1.5 py-1">
                 <span className="line-clamp-2 block text-[10px] font-medium leading-tight text-white" title={item.name}>
                   {item.name}
                 </span>

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -850,9 +850,10 @@ function GridTile({
   const summaryHover =
     equipped || invested ? 'hover:brightness-95' : 'hover:bg-pf-bg-dark/40';
 
+  const [isOpen, setIsOpen] = useState(false);
   return (
-    <li className="relative [&:has(details[open])]:z-30" data-item-id={item.id} data-item-type={item.type}>
-      <details className={detailsClass} style={detailsStyle}>
+    <li className={`relative ${isOpen ? 'z-30' : ''}`} data-item-id={item.id} data-item-type={item.type}>
+      <details className={detailsClass} style={detailsStyle} onToggle={(e) => { setIsOpen(e.currentTarget.open); }}>
         <summary className={[
           'flex cursor-pointer list-none flex-col items-center p-2',
           summaryHover,

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -859,7 +859,7 @@ function GridTile({
         ].join(' ')}>
           <div className="relative w-full">
             <div className="relative aspect-square w-full overflow-hidden rounded border border-pf-border bg-pf-bg-dark">
-              <img src={item.img} alt="" className="h-full w-full object-contain p-1" />
+              <img src={item.img} alt="" className="h-full w-full object-contain" />
               <div className="absolute inset-x-0 bottom-0 bg-black/60 px-1.5 py-1">
                 <span className="line-clamp-2 block text-[10px] font-medium leading-tight text-white" title={item.name}>
                   {item.name}

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -110,6 +110,7 @@ export function Inventory({ items, actorId, onActorChanged, investiture }: Props
   const [pendingInvestments, setPendingInvestments] = useState<Set<string>>(new Set());
   const [txError, setTxError] = useState<string | null>(null);
   const shopMode = useShopMode();
+  const [tileColumns, setTileColumns] = useState(5);
 
   const canTransact = actorId !== undefined && onActorChanged !== undefined;
 
@@ -233,7 +234,7 @@ export function Inventory({ items, actorId, onActorChanged, investiture }: Props
               {shopMode.enabled && canTransact && (
                 <ShopViewToggle view={effectiveShopView} onChange={setShopView} />
               )}
-              <ShopGearMenu shopMode={shopMode} />
+              <ShopGearMenu shopMode={shopMode} tileColumns={tileColumns} onTileColumnsChange={setTileColumns} />
             </div>
             <div className="flex items-center gap-4">
             {investiture !== undefined && investiture.max > 0 && (
@@ -253,6 +254,7 @@ export function Inventory({ items, actorId, onActorChanged, investiture }: Props
           ) : (
             <CategorizedInventory
               view={view}
+              tileColumns={tileColumns}
               topLevelByCategory={topLevelByCategory}
               allByCategory={allByCategory}
               byContainer={byContainer}
@@ -390,6 +392,7 @@ async function applyCoinChanges(
 // since tile layout doesn't carry the parent/child relationship.
 function CategorizedInventory({
   view,
+  tileColumns,
   topLevelByCategory,
   allByCategory,
   byContainer,
@@ -397,6 +400,7 @@ function CategorizedInventory({
   investContext,
 }: {
   view: ViewMode;
+  tileColumns: number;
   topLevelByCategory: Map<InventoryCategory, PhysicalItem[]>;
   allByCategory: Map<InventoryCategory, PhysicalItem[]>;
   byContainer: Map<string, PhysicalItem[]>;
@@ -429,7 +433,8 @@ function CategorizedInventory({
               </ul>
             ) : (
               <ul
-                className="grid grid-cols-5 gap-2"
+                className="grid gap-2"
+                style={{ gridTemplateColumns: `repeat(${tileColumns}, minmax(0, 1fr))` }}
                 data-view="grid"
               >
                 {bucket.map((item) => (
@@ -451,8 +456,12 @@ function CategorizedInventory({
 // the browser handles focus-trap and keyboard behaviour for free.
 function ShopGearMenu({
   shopMode,
+  tileColumns,
+  onTileColumnsChange,
 }: {
   shopMode: ReturnType<typeof useShopMode>;
+  tileColumns: number;
+  onTileColumnsChange: (n: number) => void;
 }): React.ReactElement {
   return (
     <details className="relative" data-section="shop-debug">
@@ -497,6 +506,19 @@ function ShopGearMenu({
             className="flex-1 accent-pf-primary"
           />
           <span className="w-10 text-right font-mono tabular-nums">{Math.round(shopMode.sellRatio * 100)}%</span>
+        </label>
+        <label className="mt-2 flex items-center gap-2">
+          <span className="w-16 shrink-0">Chip size</span>
+          <input
+            type="range"
+            min={2}
+            max={8}
+            step={1}
+            value={tileColumns}
+            onChange={(e): void => { onTileColumnsChange(Number(e.target.value)); }}
+            className="flex-1 accent-pf-primary"
+          />
+          <span className="w-10 text-right font-mono tabular-nums">{tileColumns} col</span>
         </label>
       </div>
     </details>

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -212,7 +212,6 @@ export function Inventory({ items, actorId, onActorChanged, investiture }: Props
   // inventory pane so the toggle doesn't strand the user on an empty
   // shop tab.
   const effectiveShopView: ShopView = shopMode.enabled && canTransact ? shopView : 'inventory';
-  const effectiveTileColumns = shopMode.enabled ? 5 : tileColumns;
 
   return (
     <section
@@ -255,7 +254,7 @@ export function Inventory({ items, actorId, onActorChanged, investiture }: Props
           ) : (
             <CategorizedInventory
               view={view}
-              tileColumns={effectiveTileColumns}
+              tileColumns={tileColumns}
               topLevelByCategory={topLevelByCategory}
               allByCategory={allByCategory}
               byContainer={byContainer}

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -854,12 +854,17 @@ function GridTile({
     <li className="relative" data-item-id={item.id} data-item-type={item.type}>
       <details className={detailsClass} style={detailsStyle}>
         <summary className={[
-          'flex cursor-pointer list-none flex-col items-center gap-1.5 p-2 text-center',
+          'flex cursor-pointer list-none flex-col items-center p-2',
           summaryHover,
         ].join(' ')}>
           <div className="relative w-full">
             <div className="aspect-square w-full overflow-hidden rounded border border-pf-border bg-pf-bg-dark">
               <img src={item.img} alt="" className="h-full w-full object-contain p-1" />
+              <div className="absolute inset-x-0 bottom-0 bg-black/60 px-1.5 py-1">
+                <span className="line-clamp-2 block text-[10px] font-medium leading-tight text-white" title={item.name}>
+                  {item.name}
+                </span>
+              </div>
             </div>
             {item.system.quantity > 1 && (
               <span className="absolute -right-1 -top-1 rounded bg-pf-primary px-1 text-[10px] font-semibold text-white shadow">
@@ -867,9 +872,6 @@ function GridTile({
               </span>
             )}
           </div>
-          <span className="line-clamp-2 min-h-[2.5em] text-[11px] font-medium leading-tight text-pf-text" title={item.name}>
-            {item.name}
-          </span>
           {sellContext && <SellButton item={item} context={sellContext} />}
         </summary>
         <div className="absolute left-full top-0 z-20 min-h-full w-max min-w-[150%] max-w-[300%] overflow-y-auto rounded-r border border-l-0 border-pf-primary/60 bg-pf-bg p-4 text-sm text-pf-text shadow-lg">

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -828,7 +828,7 @@ function GridTile({
   return (
     <li className="relative" data-item-id={item.id} data-item-type={item.type}>
       <details className={[
-        'group relative rounded border open:z-10 open:min-w-[18rem] open:rounded-b-none open:border-pf-primary/60 open:shadow-lg',
+        'group relative rounded border open:z-10 open:rounded-r-none open:border-pf-primary/60 open:shadow-lg',
         equipped ? 'border-emerald-500/40 bg-emerald-500/10' : 'border-pf-border bg-pf-bg',
       ].join(' ')}>
         <summary className={[
@@ -851,7 +851,7 @@ function GridTile({
           {hasInvestButton && <InvestButton item={item} context={investContext} />}
           {sellContext && <SellButton item={item} context={sellContext} />}
         </summary>
-        <div className="absolute left-0 right-0 top-full z-20 rounded-b border border-t-0 border-pf-primary/60 bg-pf-bg p-3 text-left text-sm text-pf-text shadow-lg">
+        <div className="absolute left-full top-0 z-20 min-h-full w-[300%] overflow-y-auto rounded-r border border-l-0 border-pf-primary/60 bg-pf-bg p-4 text-sm text-pf-text shadow-lg">
           <ItemDescription item={item} />
         </div>
       </details>

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -821,6 +821,10 @@ function isInvestedItem(item: PhysicalItem): boolean {
 const EQUIPPED_BG = 'var(--item-equipped)';
 const INVESTED_BG = 'var(--item-invested)';
 
+// Each tile that opens claims the next value, ensuring the most recently
+// opened tile always renders above all other open tiles.
+let tileOpenCounter = 30;
+
 function GridTile({
   item,
   sellContext,
@@ -850,10 +854,12 @@ function GridTile({
   const summaryHover =
     equipped || invested ? 'hover:brightness-95' : 'hover:bg-pf-bg-dark/40';
 
-  const [isOpen, setIsOpen] = useState(false);
+  const [zIndex, setZIndex] = useState<number | undefined>(undefined);
   return (
-    <li className={`relative ${isOpen ? 'z-30' : ''}`} data-item-id={item.id} data-item-type={item.type}>
-      <details className={detailsClass} style={detailsStyle} onToggle={(e) => { setIsOpen(e.currentTarget.open); }}>
+    <li className="relative" style={zIndex !== undefined ? { zIndex } : undefined} data-item-id={item.id} data-item-type={item.type}>
+      <details className={detailsClass} style={detailsStyle} onToggle={(e) => {
+        setZIndex(e.currentTarget.open ? ++tileOpenCounter : undefined);
+      }}>
         <summary className={[
           'flex cursor-pointer list-none flex-col items-center p-2',
           summaryHover,

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -250,7 +250,7 @@ export function Inventory({ items, actorId, onActorChanged, investiture }: Props
           </div>
           </div>
           {effectiveShopView === 'shop' && canTransact ? (
-            <ItemShopPicker items={items} onBuy={handleBuy} pending={pendingBuys} />
+            <ItemShopPicker items={items} onBuy={handleBuy} pending={pendingBuys} disabledRarities={shopMode.disabledRarities} />
           ) : (
             <CategorizedInventory
               view={view}
@@ -520,6 +520,24 @@ function ShopGearMenu({
           />
           <span className="w-10 text-right font-mono tabular-nums">{tileColumns} col</span>
         </label>
+        <p className="mb-1 mt-3 text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark">
+          Visible rarities
+        </p>
+        {(['common', 'uncommon', 'rare', 'unique'] as const).map((r) => (
+          <label key={r} className="flex items-center gap-2 capitalize">
+            <input
+              type="checkbox"
+              checked={!shopMode.disabledRarities.includes(r)}
+              onChange={(e): void => {
+                const next = e.target.checked
+                  ? shopMode.disabledRarities.filter((x) => x !== r)
+                  : [...shopMode.disabledRarities, r];
+                shopMode.setDisabledRarities(next);
+              }}
+            />
+            <span>{r}</span>
+          </label>
+        ))}
       </div>
     </details>
   );

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -874,7 +874,7 @@ function GridTile({
           </div>
           {sellContext && <SellButton item={item} context={sellContext} />}
         </summary>
-        <div className="absolute left-full top-0 z-20 min-h-full w-max min-w-[150%] max-w-[300%] overflow-y-auto rounded-r border border-pf-primary/60 bg-pf-bg p-4 text-sm text-pf-text shadow-lg">
+        <div className="absolute -top-px left-full z-20 min-h-[calc(100%+2px)] w-max min-w-[150%] max-w-[300%] overflow-y-auto rounded-r border border-pf-primary/60 bg-pf-bg p-4 text-sm text-pf-text shadow-lg">
           {hasInvestButton && (
             <div className="mb-3">
               <InvestButton item={item} context={investContext} />

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -851,7 +851,7 @@ function GridTile({
     equipped || invested ? 'hover:brightness-95' : 'hover:bg-pf-bg-dark/40';
 
   return (
-    <li className="relative" data-item-id={item.id} data-item-type={item.type}>
+    <li className="relative [&:has(details[open])]:z-30" data-item-id={item.id} data-item-type={item.type}>
       <details className={detailsClass} style={detailsStyle}>
         <summary className={[
           'flex cursor-pointer list-none flex-col items-center p-2',

--- a/apps/player-portal/src/components/tabs/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.tsx
@@ -858,7 +858,7 @@ function GridTile({
           summaryHover,
         ].join(' ')}>
           <div className="relative w-full">
-            <div className="aspect-square w-full overflow-hidden rounded border border-pf-border bg-pf-bg-dark">
+            <div className="relative aspect-square w-full overflow-hidden rounded border border-pf-border bg-pf-bg-dark">
               <img src={item.img} alt="" className="h-full w-full object-contain p-1" />
               <div className="absolute inset-x-0 bottom-0 bg-black/60 px-1.5 py-1">
                 <span className="line-clamp-2 block text-[10px] font-medium leading-tight text-white" title={item.name}>

--- a/apps/player-portal/src/components/tabs/Proficiencies.test.tsx
+++ b/apps/player-portal/src/components/tabs/Proficiencies.test.tsx
@@ -1,25 +1,11 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { render, cleanup, within } from '@testing-library/react';
+import { render, cleanup } from '@testing-library/react';
 import amiri from '../../fixtures/amiri-prepared.json';
 import type { CharacterSystem } from '../../api/types';
 import { Proficiencies } from './Proficiencies';
 
-// Amiri is a level-1 human barbarian. Expected values from the live
-// /prepared payload (see src/fixtures/amiri-prepared.json). Keep these
-// baseline — not exhaustive — so the test remains stable as fields are
-// added. Each skill row + class DC row contains the label both as the
-// visible name and inside the ModifierTooltip heading, so we always scope
-// queries by data-statistic / data-slug rather than globally.
-
-const EXPECTED_SKILLS: Record<string, { value: number; rank: number }> = {
-  acrobatics: { value: 5, rank: 1 },
-  athletics: { value: 7, rank: 1 },
-  arcana: { value: 0, rank: 0 },
-  intimidation: { value: 4, rank: 1 },
-  survival: { value: 3, rank: 1 },
-  stealth: { value: 2, rank: 0 },
-  'tanning-lore': { value: 3, rank: 1 },
-};
+// Amiri is a level-1 human barbarian. Skills now live on the Character tab;
+// Proficiencies only renders Attacks, Defenses, Spellcasting, Class DCs.
 
 const system = (amiri as unknown as { system: CharacterSystem }).system;
 
@@ -28,27 +14,8 @@ describe('Proficiencies', () => {
     cleanup();
   });
 
-  it('renders every core skill and its value + rank', () => {
-    const { container } = render(<Proficiencies system={system} actorId="test-actor" />);
-    for (const [slug, { value, rank }] of Object.entries(EXPECTED_SKILLS)) {
-      const row = container.querySelector(`[data-statistic="${slug}"]`);
-      expect(row, `row for ${slug}`).toBeTruthy();
-      const expected = value >= 0 ? `+${value.toString()}` : value.toString();
-      expect(within(row as HTMLElement).getAllByText(expected).length).toBeGreaterThan(0);
-      const chip = row?.querySelector('[data-rank]');
-      expect(chip?.getAttribute('data-rank')).toBe(String(rank));
-    }
-  });
-
-  it('renders the lore skill (Tanning Lore, from Hunter background) as a named row', () => {
-    const { container } = render(<Proficiencies system={system} actorId="test-actor" />);
-    const row = container.querySelector('[data-statistic="tanning-lore"]');
-    expect(row, 'tanning-lore row').toBeTruthy();
-    expect(within(row as HTMLElement).getAllByText('Tanning Lore').length).toBeGreaterThan(0);
-  });
-
   it('renders martial attack proficiencies', () => {
-    const { container } = render(<Proficiencies system={system} actorId="test-actor" />);
+    const { container } = render(<Proficiencies system={system} />);
     for (const slug of ['simple', 'martial', 'advanced', 'unarmed']) {
       const row = container.querySelector(`[data-slug="${slug}"]`);
       expect(row, `attack row for ${slug}`).toBeTruthy();
@@ -56,7 +23,7 @@ describe('Proficiencies', () => {
   });
 
   it('renders martial defense proficiencies', () => {
-    const { container } = render(<Proficiencies system={system} actorId="test-actor" />);
+    const { container } = render(<Proficiencies system={system} />);
     for (const slug of ['unarmored', 'light', 'medium', 'heavy']) {
       const row = container.querySelector(`[data-slug="${slug}"]`);
       expect(row, `defense row for ${slug}`).toBeTruthy();
@@ -64,8 +31,7 @@ describe('Proficiencies', () => {
   });
 
   it('renders the class DC — Barbarian at DC 17', () => {
-    const { container } = render(<Proficiencies system={system} actorId="test-actor" />);
-    // The ClassDC row has no data-slug attribute yet; query by unique content.
+    const { container } = render(<Proficiencies system={system} />);
     const dcRows = Array.from(container.querySelectorAll('li')).filter((li) => li.textContent?.includes('17'));
     expect(dcRows.length).toBeGreaterThan(0);
     const barbRow = dcRows.find((li) => li.textContent?.includes('Barbarian'));
@@ -73,7 +39,7 @@ describe('Proficiencies', () => {
   });
 
   it('omits spellcasting when rank is 0', () => {
-    const { container } = render(<Proficiencies system={system} actorId="test-actor" />);
+    const { container } = render(<Proficiencies system={system} />);
     // Amiri has spellcasting rank 0; the Spells header key shouldn't render.
     const headers = Array.from(container.querySelectorAll('h2')).map((h) => h.textContent);
     expect(headers.some((h) => h?.includes('Spells'))).toBe(false);

--- a/apps/player-portal/src/components/tabs/Proficiencies.tsx
+++ b/apps/player-portal/src/components/tabs/Proficiencies.tsx
@@ -1,40 +1,24 @@
-import { createPf2eClient } from '@foundry-toolkit/pf2e-rules';
 import type {
   CharacterSystem,
   ClassDC,
   MartialProficiency,
   Modifier,
   ProficiencyRank,
-  SkillStatistic,
 } from '../../api/types';
-import { api } from '../../api/client';
 import { t } from '../../i18n/t';
 import { formatSignedInt } from '../../lib/format';
 import { ATTACK_LABEL_KEY, DEFENSE_LABEL_KEY } from '../../lib/pf2e-maps';
-import { useActorAction } from '../../lib/useActorAction';
 import { ModifierTooltip } from '../common/ModifierTooltip';
 import { RankChip } from '../common/RankChip';
 import { SectionHeader } from '../common/SectionHeader';
 
 interface Props {
   system: CharacterSystem;
-  actorId: string;
 }
 
-// Proficiencies tab — a direct port of the data shape consumed by
-// pf2e's static/templates/actors/character/tabs/proficiencies.hbs.
-// Renders the sections the Foundry sheet renders, in order:
-//   1. Core skills (acrobatics, arcana, ...; excluding lore)
-//   2. Lore skills (ones with `.lore = true`, came from embedded items)
-//   3. Attack proficiencies (simple/martial/advanced/unarmed + custom)
-//   4. Defense proficiencies (unarmored/light/medium/heavy/barding)
-//   5. Spellcasting (omitted when rank is 0)
-//   6. Class DCs (one per class; most characters have exactly one)
-export function Proficiencies({ system, actorId }: Props): React.ReactElement {
-  const skills = Object.values(system.skills);
-  const coreSkills = skills.filter((s) => !s.lore);
-  const loreSkills = skills.filter((s) => s.lore);
-
+// Proficiencies tab — attack proficiencies, defense proficiencies,
+// spellcasting, and class DCs. Skills have moved to the Character tab.
+export function Proficiencies({ system }: Props): React.ReactElement {
   const attacks = filterVisible(system.proficiencies.attacks);
   const defenses = filterVisible(system.proficiencies.defenses);
   const classDCs = Object.values(system.proficiencies.classDCs);
@@ -42,24 +26,6 @@ export function Proficiencies({ system, actorId }: Props): React.ReactElement {
 
   return (
     <section className="space-y-6">
-      <SectionHeader>{t('PF2E.CoreSkillsHeader')}</SectionHeader>
-      <ProficiencyGrid>
-        {coreSkills.map((skill) => (
-          <SkillRow key={skill.slug} skill={skill} actorId={actorId} />
-        ))}
-      </ProficiencyGrid>
-
-      {loreSkills.length > 0 && (
-        <>
-          <SectionHeader>{t('PF2E.LoreSkillsHeader')}</SectionHeader>
-          <ProficiencyGrid>
-            {loreSkills.map((skill) => (
-              <SkillRow key={skill.slug} skill={skill} actorId={actorId} spanFull />
-            ))}
-          </ProficiencyGrid>
-        </>
-      )}
-
       <SectionHeader>{t('PF2E.Actor.Character.Proficiency.Attack.Title')}</SectionHeader>
       <ProficiencyGrid>
         {attacks.map(([slug, prof]) => (
@@ -124,46 +90,6 @@ function ProficiencyGrid({ children }: { children: React.ReactNode }): React.Rea
 
 // ─── Row renderers ─────────────────────────────────────────────────────
 
-function SkillRow({
-  skill,
-  actorId,
-  spanFull,
-}: {
-  skill: SkillStatistic;
-  actorId: string;
-  spanFull?: boolean;
-}): React.ReactElement {
-  const roll = useActorAction({
-    run: () => createPf2eClient(api.dispatch).character(actorId).rollSkill(skill.slug),
-  });
-
-  return (
-    <li
-      className={[
-        'group relative rounded border border-pf-border bg-pf-bg',
-        spanFull === true ? 'sm:col-span-2' : '',
-      ]
-        .filter(Boolean)
-        .join(' ')}
-      data-statistic={skill.slug}
-    >
-      <button
-        type="button"
-        className="flex w-full items-center gap-3 px-3 py-2 hover:bg-pf-bg-dark disabled:opacity-50"
-        onClick={() => {
-          roll.trigger();
-        }}
-        disabled={roll.state === 'pending'}
-      >
-        <Modifier value={skill.value} />
-        <span className="flex-1 truncate text-sm text-pf-text">{renderLabel(skill.label, skill.lore === true)}</span>
-        <RankChip rank={skill.rank} />
-      </button>
-      <ModifierTooltip title={skill.label} breakdown={skill.breakdown} modifiers={skill.modifiers} />
-    </li>
-  );
-}
-
 function MartialRow({
   slug,
   prof,
@@ -178,7 +104,7 @@ function MartialRow({
   return (
     <li
       className={[
-        'flex items-center gap-3 rounded border border-pf-border bg-pf-bg px-3 py-2',
+        'flex items-center gap-3 rounded border border-pf-border bg-pf-bg px-3 py-2 shadow-sm',
         spanFull === true ? 'sm:col-span-2' : '',
       ].join(' ')}
       data-slug={slug}
@@ -195,7 +121,7 @@ function ClassDCRow({ classDC, spanFull }: { classDC: ClassDC; spanFull: boolean
   return (
     <li
       className={[
-        'group relative flex items-center gap-3 rounded border border-pf-border bg-pf-bg px-3 py-2',
+        'group relative flex items-center gap-3 rounded border border-pf-border bg-pf-bg px-3 py-2 shadow-sm',
         spanFull ? 'sm:col-span-2' : '',
       ].join(' ')}
     >
@@ -209,7 +135,7 @@ function ClassDCRow({ classDC, spanFull }: { classDC: ClassDC; spanFull: boolean
 
 function Modifier({ value }: { value: number }): React.ReactElement {
   return (
-    <span className="inline-flex w-8 justify-end font-mono text-sm tabular-nums text-emerald-900">
+    <span className="inline-flex w-8 justify-end font-mono text-sm tabular-nums text-pf-secondary">
       {formatSignedInt(value)}
     </span>
   );
@@ -223,16 +149,7 @@ function filterVisible<T extends { visible?: boolean; rank: ProficiencyRank }>(
   return Object.entries(map).filter(([, p]) => p.visible !== false);
 }
 
-function renderLabel(label: string, isLore: boolean): string {
-  // Lore labels are free text set by the user ("Tanning Lore"), not i18n
-  // keys. Core skill labels are keys like "PF2E.AbilitySkillCore.acrobatics".
-  return isLore ? label : t(label);
-}
-
 function resolveMartialLabel(slug: string, fallback: string | undefined, keyMap: Record<string, string>): string {
-  // Attack/defense proficiency labels aren't on the payload. Resolve via
-  // the canonical PF2E.Actor.Character.Proficiency.* keys from en.json.
-  // Unmapped slugs (user-added custom proficiencies) humanise the slug.
   const key = keyMap[slug];
   if (key !== undefined) return t(key);
   if (fallback !== undefined) return t(fallback);

--- a/apps/player-portal/src/components/tabs/Proficiencies.tsx
+++ b/apps/player-portal/src/components/tabs/Proficiencies.tsx
@@ -25,34 +25,38 @@ export function Proficiencies({ system }: Props): React.ReactElement {
   const showSpellcasting = system.proficiencies.spellcasting.rank > 0;
 
   return (
-    <section className="space-y-6">
-      <SectionHeader>{t('PF2E.Actor.Character.Proficiency.Attack.Title')}</SectionHeader>
-      <ProficiencyGrid>
-        {attacks.map(([slug, prof]) => (
-          <MartialRow
-            key={`atk-${slug}`}
-            slug={slug}
-            prof={prof}
-            label={resolveMartialLabel(slug, prof.label, ATTACK_LABEL_KEY)}
-          />
-        ))}
-      </ProficiencyGrid>
+    <section className="space-y-4 *:rounded-lg *:border *:border-pf-border *:bg-pf-bg-dark *:p-4">
+      <div>
+        <SectionHeader band>{t('PF2E.Actor.Character.Proficiency.Attack.Title')}</SectionHeader>
+        <ProficiencyGrid>
+          {attacks.map(([slug, prof]) => (
+            <MartialRow
+              key={`atk-${slug}`}
+              slug={slug}
+              prof={prof}
+              label={resolveMartialLabel(slug, prof.label, ATTACK_LABEL_KEY)}
+            />
+          ))}
+        </ProficiencyGrid>
+      </div>
 
-      <SectionHeader>{t('PF2E.Actor.Character.Proficiency.Defense.Title')}</SectionHeader>
-      <ProficiencyGrid>
-        {defenses.map(([slug, prof]) => (
-          <MartialRow
-            key={`def-${slug}`}
-            slug={slug}
-            prof={prof}
-            label={resolveMartialLabel(slug, prof.label, DEFENSE_LABEL_KEY)}
-          />
-        ))}
-      </ProficiencyGrid>
+      <div>
+        <SectionHeader band>{t('PF2E.Actor.Character.Proficiency.Defense.Title')}</SectionHeader>
+        <ProficiencyGrid>
+          {defenses.map(([slug, prof]) => (
+            <MartialRow
+              key={`def-${slug}`}
+              slug={slug}
+              prof={prof}
+              label={resolveMartialLabel(slug, prof.label, DEFENSE_LABEL_KEY)}
+            />
+          ))}
+        </ProficiencyGrid>
+      </div>
 
       {showSpellcasting && (
-        <>
-          <SectionHeader>{t('PF2E.Item.Spell.Plural')}</SectionHeader>
+        <div>
+          <SectionHeader band>{t('PF2E.Item.Spell.Plural')}</SectionHeader>
           <ProficiencyGrid>
             <MartialRow
               slug="spellcasting"
@@ -65,18 +69,18 @@ export function Proficiencies({ system }: Props): React.ReactElement {
               spanFull
             />
           </ProficiencyGrid>
-        </>
+        </div>
       )}
 
       {classDCs.length > 0 && (
-        <>
-          <SectionHeader>{t('PF2E.Actor.Character.ClassDC.Plural')}</SectionHeader>
+        <div>
+          <SectionHeader band>{t('PF2E.Actor.Character.ClassDC.Plural')}</SectionHeader>
           <ProficiencyGrid>
             {classDCs.map((classDC) => (
               <ClassDCRow key={classDC.slug} classDC={classDC} spanFull={classDCs.length === 1} />
             ))}
           </ProficiencyGrid>
-        </>
+        </div>
       )}
     </section>
   );

--- a/apps/player-portal/src/components/tabs/Progression.tsx
+++ b/apps/player-portal/src/components/tabs/Progression.tsx
@@ -240,8 +240,7 @@ export function Progression({ characterLevel, items, characterContext }: Props):
     <section className="space-y-4 *:rounded-lg *:border *:border-pf-border *:bg-pf-bg-dark *:p-4" data-section="progression">
       <div>
         <SectionHeader band>{classItem.name} Progression</SectionHeader>
-      </div>
-      <ol className="space-y-1.5" {...pickedHover.delegationHandlers}>
+        <ol className="space-y-1.5" {...pickedHover.delegationHandlers}>
         {/* eslint-disable-next-line react-hooks/refs -- cache snapshot taken per render; docsVersion bump in useEffect re-renders whenever either cache mutates */}
         {LEVELS.map((level) => {
           const features = featuresByLevel.get(level) ?? [];
@@ -261,7 +260,8 @@ export function Progression({ characterLevel, items, characterContext }: Props):
             />
           );
         })}
-      </ol>
+        </ol>
+      </div>
       {pickedHover.popover}
       {pickerTarget && pickerFilters && (
         <FeatPicker

--- a/apps/player-portal/src/components/tabs/Progression.tsx
+++ b/apps/player-portal/src/components/tabs/Progression.tsx
@@ -240,10 +240,6 @@ export function Progression({ characterLevel, items, characterContext }: Props):
     <section className="space-y-4 *:rounded-lg *:border *:border-pf-border *:bg-pf-bg-dark *:p-4" data-section="progression">
       <div>
         <SectionHeader band>{classItem.name} Progression</SectionHeader>
-        <p className="mb-3 text-xs text-pf-alt">
-          Class features auto-granted at each level, plus the feat and skill slots the rules open. Click a feat chip to
-          pick one; selections are held in memory until the scratch-actor flow lands.
-        </p>
       </div>
       <ol className="space-y-1.5" {...pickedHover.delegationHandlers}>
         {/* eslint-disable-next-line react-hooks/refs -- cache snapshot taken per render; docsVersion bump in useEffect re-renders whenever either cache mutates */}

--- a/apps/player-portal/src/components/tabs/Progression.tsx
+++ b/apps/player-portal/src/components/tabs/Progression.tsx
@@ -237,9 +237,9 @@ export function Progression({ characterLevel, items, characterContext }: Props):
     : null;
 
   return (
-    <section className="space-y-4" data-section="progression">
+    <section className="space-y-4 *:rounded-lg *:border *:border-pf-border *:bg-pf-bg-dark *:p-4" data-section="progression">
       <div>
-        <SectionHeader>{classItem.name} Progression</SectionHeader>
+        <SectionHeader band>{classItem.name} Progression</SectionHeader>
         <p className="mb-3 text-xs text-pf-alt">
           Class features auto-granted at each level, plus the feat and skill slots the rules open. Click a feat chip to
           pick one; selections are held in memory until the scratch-actor flow lands.

--- a/apps/player-portal/src/components/tabs/Spells.tsx
+++ b/apps/player-portal/src/components/tabs/Spells.tsx
@@ -236,7 +236,7 @@ function RankGroup({
   return (
     <div data-spell-rank={label}>
       <h3 className="mb-1 font-serif text-xs font-semibold uppercase tracking-widest text-pf-alt-dark">{label}</h3>
-      <ul className="space-y-1">
+      <ul className="grid grid-cols-2 gap-2">
         {spells.map((spell) => (
           <SpellCard key={spell.id} spell={spell} characterLevel={characterLevel} />
         ))}
@@ -290,7 +290,7 @@ function RankGroupWithEntry({
         {label}
         {slotBadge}
       </h3>
-      <ul className="space-y-1">
+      <ul className="grid grid-cols-2 gap-2">
         {spells.map((spell) => (
           <SpellCardWithCast
             key={spell.id}
@@ -318,11 +318,11 @@ function SpellCard({ spell, characterLevel }: { spell: SpellItem; characterLevel
 
   return (
     <li
-      className="rounded border border-pf-border bg-pf-bg"
+      className="relative rounded border border-pf-border bg-pf-bg"
       data-item-id={spell.id}
       data-spell-slug={spell.system.slug ?? ''}
     >
-      <details className="group">
+      <details className="group open:rounded-b-none open:border-pf-primary/60 open:shadow-md">
         <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 hover:bg-pf-bg-dark/40">
           <img src={spell.img} alt="" className="h-6 w-6 flex-shrink-0 rounded border border-pf-border bg-pf-bg-dark" />
           <span className="truncate text-sm font-medium text-pf-text">{spell.name}</span>
@@ -334,9 +334,13 @@ function SpellCard({ spell, characterLevel }: { spell: SpellItem; characterLevel
               {castCost}
             </span>
           )}
+          <span className="ml-auto text-[10px] text-pf-alt-dark group-open:hidden">▸</span>
+          <span className="ml-auto hidden text-[10px] text-pf-alt-dark group-open:inline">▾</span>
+        </summary>
+        <div className="absolute left-0 right-0 top-full z-20 rounded-b border border-t-0 border-pf-primary/60 bg-pf-bg px-3 py-2 text-sm text-pf-text shadow-lg">
           {traits.length > 0 && (
-            <ul className="flex flex-wrap gap-1">
-              {traits.slice(0, 6).map((t) => (
+            <ul className="mb-2 flex flex-wrap gap-1">
+              {traits.map((t) => (
                 <li
                   key={t}
                   className="rounded-full border border-pf-tertiary-dark bg-pf-tertiary/40 px-1.5 py-0.5 text-[10px] text-pf-alt-dark"
@@ -346,10 +350,6 @@ function SpellCard({ spell, characterLevel }: { spell: SpellItem; characterLevel
               ))}
             </ul>
           )}
-          <span className="ml-auto text-[10px] text-pf-alt-dark group-open:hidden">▸</span>
-          <span className="ml-auto hidden text-[10px] text-pf-alt-dark group-open:inline">▾</span>
-        </summary>
-        <div className="border-t border-pf-border bg-pf-bg/60 px-3 py-2 text-sm text-pf-text">
           <SpellMeta spell={spell} />
           {enriched.length > 0 ? (
             <div
@@ -357,7 +357,7 @@ function SpellCard({ spell, characterLevel }: { spell: SpellItem; characterLevel
               dangerouslySetInnerHTML={{ __html: enriched }}
             />
           ) : (
-            <p className="mt-2 italic text-neutral-400">No description.</p>
+            <p className="mt-2 italic text-pf-text-muted">No description.</p>
           )}
         </div>
       </details>
@@ -415,20 +415,14 @@ function SpellCardWithCast({
 
   return (
     <li
-      className="rounded border border-pf-border bg-pf-bg"
+      className="relative rounded border border-pf-border bg-pf-bg"
       data-item-id={spell.id}
       data-spell-slug={spell.system.slug ?? ''}
     >
-      <details className="group">
+      <details className="group open:rounded-b-none open:border-pf-primary/60 open:shadow-md">
         <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 hover:bg-pf-bg-dark/40">
           <img src={spell.img} alt="" className="h-6 w-6 flex-shrink-0 rounded border border-pf-border bg-pf-bg-dark" />
-          <span
-            className={
-              isExpended
-                ? 'truncate text-sm font-medium text-pf-text-muted line-through'
-                : 'truncate text-sm font-medium text-pf-text'
-            }
-          >
+          <span className={['truncate text-sm font-medium', isExpended ? 'text-pf-text-muted line-through' : 'text-pf-text'].join(' ')}>
             {spell.name}
           </span>
           {castCost !== null && (
@@ -439,9 +433,28 @@ function SpellCardWithCast({
               {castCost}
             </span>
           )}
+          {/* Cast button — stopPropagation prevents toggling the <details>. */}
+          <button
+            type="button"
+            disabled={castDisabled}
+            onClick={(e) => { e.preventDefault(); trigger(); }}
+            className="ml-auto flex-shrink-0 rounded border border-pf-primary/60 bg-pf-primary/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest text-pf-primary transition-colors hover:bg-pf-primary/20 disabled:cursor-not-allowed disabled:opacity-40"
+            aria-label={pending ? 'Casting…' : `Cast ${spell.name}`}
+          >
+            {pending ? '…' : 'Cast'}
+          </button>
+          <span className="flex-shrink-0 text-[10px] text-pf-alt-dark group-open:hidden">▸</span>
+          <span className="flex-shrink-0 hidden text-[10px] text-pf-alt-dark group-open:inline">▾</span>
+        </summary>
+        <div className="absolute left-0 right-0 top-full z-20 rounded-b border border-t-0 border-pf-primary/60 bg-pf-bg px-3 py-2 text-sm text-pf-text shadow-lg">
+          {castError !== null && (
+            <p className="mb-2 rounded border border-red-400/40 bg-red-400/10 px-2 py-1 text-xs text-red-400">
+              {castError}
+            </p>
+          )}
           {traits.length > 0 && (
-            <ul className="flex flex-wrap gap-1">
-              {traits.slice(0, 6).map((t) => (
+            <ul className="mb-2 flex flex-wrap gap-1">
+              {traits.map((t) => (
                 <li
                   key={t}
                   className="rounded-full border border-pf-tertiary-dark bg-pf-tertiary/40 px-1.5 py-0.5 text-[10px] text-pf-alt-dark"
@@ -451,28 +464,6 @@ function SpellCardWithCast({
               ))}
             </ul>
           )}
-          {/* Cast button — stopPropagation prevents toggling the <details>. */}
-          <button
-            type="button"
-            disabled={castDisabled}
-            onClick={(e) => {
-              e.preventDefault();
-              trigger();
-            }}
-            className="ml-auto flex-shrink-0 rounded border border-pf-primary/60 bg-pf-primary/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest text-pf-primary transition-colors hover:bg-pf-primary/20 disabled:cursor-not-allowed disabled:opacity-40"
-            aria-label={pending ? 'Casting…' : `Cast ${spell.name}`}
-          >
-            {pending ? '…' : 'Cast'}
-          </button>
-          <span className="flex-shrink-0 text-[10px] text-pf-alt-dark group-open:hidden">▸</span>
-          <span className="flex-shrink-0 hidden text-[10px] text-pf-alt-dark group-open:inline">▾</span>
-        </summary>
-        <div className="border-t border-pf-border bg-pf-bg/60 px-3 py-2 text-sm text-pf-text">
-          {castError !== null && (
-            <p className="mb-2 rounded border border-red-400/40 bg-red-400/10 px-2 py-1 text-xs text-red-400">
-              {castError}
-            </p>
-          )}
           <SpellMeta spell={spell} />
           {enriched.length > 0 ? (
             <div
@@ -480,7 +471,7 @@ function SpellCardWithCast({
               dangerouslySetInnerHTML={{ __html: enriched }}
             />
           ) : (
-            <p className="mt-2 italic text-neutral-400">No description.</p>
+            <p className="mt-2 italic text-pf-text-muted">No description.</p>
           )}
         </div>
       </details>

--- a/apps/player-portal/src/components/tabs/Spells.tsx
+++ b/apps/player-portal/src/components/tabs/Spells.tsx
@@ -438,7 +438,7 @@ function SpellCardWithCast({
             type="button"
             disabled={castDisabled}
             onClick={(e) => { e.preventDefault(); trigger(); }}
-            className="ml-auto flex-shrink-0 rounded border border-pf-primary/60 bg-pf-primary/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest text-pf-primary transition-colors hover:bg-pf-primary/20 disabled:cursor-not-allowed disabled:opacity-40"
+            className="ml-auto flex-shrink-0 rounded border border-pf-border bg-pf-bg px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-pf-text hover:bg-pf-bg-dark disabled:cursor-not-allowed disabled:opacity-40"
             aria-label={pending ? 'Casting…' : `Cast ${spell.name}`}
           >
             {pending ? '…' : 'Cast'}

--- a/apps/player-portal/src/components/tabs/Spells.tsx
+++ b/apps/player-portal/src/components/tabs/Spells.tsx
@@ -41,7 +41,7 @@ export function Spells({ items, characterLevel, actorId, onCast, focusPoints }: 
 
   return (
     <section
-      className="space-y-8"
+      className="space-y-4 *:rounded-lg *:border *:border-pf-border *:bg-pf-bg-dark *:p-4"
       onMouseOver={uuidHover.delegationHandlers.onMouseOver}
       onMouseOut={uuidHover.delegationHandlers.onMouseOut}
     >
@@ -58,7 +58,7 @@ export function Spells({ items, characterLevel, actorId, onCast, focusPoints }: 
       ))}
       {orphans.length > 0 && (
         <div data-testid="spells-orphans">
-          <SectionHeader>Orphaned Spells</SectionHeader>
+          <SectionHeader band>Orphaned Spells</SectionHeader>
           {/* Orphaned spells have no entry context — render read-only. */}
           <RankedSpellList spells={orphans} characterLevel={characterLevel} />
         </div>
@@ -97,10 +97,10 @@ function EntryBlock({
 
   return (
     <div data-spellcasting-entry-id={entry.id}>
-      <div className="mb-2 flex flex-wrap items-baseline gap-x-2 border-b border-pf-border pb-1">
-        <h2 className="font-serif text-base font-semibold text-pf-text">{entry.name}</h2>
+      <div className="-mx-4 -mt-4 mb-3 flex flex-wrap items-center gap-x-2 rounded-t-lg border-b border-pf-border bg-pf-bg px-4 pb-2.5 pt-3">
+        <h2 className="font-serif text-sm font-bold uppercase tracking-wider text-pf-alt-dark">{entry.name}</h2>
         {meta.length > 0 && (
-          <span className="text-[10px] uppercase tracking-widest text-pf-alt-dark">{meta.join(' · ')}</span>
+          <span className="text-[10px] uppercase tracking-widest text-pf-text-muted">{meta.join(' · ')}</span>
         )}
         {isFocus && focusPoints.max > 0 && (
           <FocusControl focusPoints={focusPoints} actorId={actorId} onChanged={onCast} />

--- a/apps/player-portal/src/components/tabs/Spells.tsx
+++ b/apps/player-portal/src/components/tabs/Spells.tsx
@@ -103,7 +103,7 @@ function EntryBlock({
           <span className="text-[10px] uppercase tracking-widest text-pf-alt-dark">{meta.join(' · ')}</span>
         )}
         {isFocus && focusPoints.max > 0 && (
-          <FocusDots value={focusPoints.value} max={focusPoints.max} />
+          <FocusControl focusPoints={focusPoints} actorId={actorId} onChanged={onCast} />
         )}
       </div>
       {spells.length === 0 ? (
@@ -485,6 +485,42 @@ function SpellCardWithCast({
         </div>
       </details>
     </li>
+  );
+}
+
+function FocusControl({
+  focusPoints,
+  actorId,
+  onChanged,
+}: {
+  focusPoints: FocusPool;
+  actorId: string;
+  onChanged: () => void;
+}): React.ReactElement {
+  const adjust = useActorAction({
+    run: (delta: number) => api.adjustActorResource(actorId, 'focus-points', delta),
+    onSuccess: onChanged,
+  });
+  return (
+    <span className="flex items-center gap-1" data-stat="focus">
+      <button
+        type="button"
+        onClick={() => { adjust.trigger(-1); }}
+        disabled={adjust.state === 'pending'}
+        className="rounded border border-pf-border bg-pf-bg px-1 py-0.5 font-mono text-[10px] text-pf-text hover:bg-pf-bg-dark disabled:opacity-50"
+      >
+        −
+      </button>
+      <FocusDots value={focusPoints.value} max={focusPoints.max} />
+      <button
+        type="button"
+        onClick={() => { adjust.trigger(1); }}
+        disabled={adjust.state === 'pending'}
+        className="rounded border border-pf-border bg-pf-bg px-1 py-0.5 font-mono text-[10px] text-pf-text hover:bg-pf-bg-dark disabled:opacity-50"
+      >
+        +
+      </button>
+    </span>
   );
 }
 

--- a/apps/player-portal/src/lib/tabUtils.test.ts
+++ b/apps/player-portal/src/lib/tabUtils.test.ts
@@ -3,7 +3,7 @@ import { normalizeTabId } from './tabUtils';
 
 describe('normalizeTabId', () => {
   it('passes through all valid tab IDs unchanged', () => {
-    const valid = ['character', 'actions', 'spells', 'inventory', 'feats', 'proficiencies', 'progression', 'background'];
+    const valid = ['character', 'actions', 'spells', 'inventory', 'feats', 'details', 'progression'];
     for (const id of valid) {
       expect(normalizeTabId(id), `valid id: ${id}`).toBe(id);
     }
@@ -11,6 +11,11 @@ describe('normalizeTabId', () => {
 
   it('redirects the removed "crafting" tab to "inventory"', () => {
     expect(normalizeTabId('crafting')).toBe('inventory');
+  });
+
+  it('redirects the removed "proficiencies" and "background" tabs to "details"', () => {
+    expect(normalizeTabId('proficiencies')).toBe('details');
+    expect(normalizeTabId('background')).toBe('details');
   });
 
   it('falls back to "character" for unrecognised IDs', () => {

--- a/apps/player-portal/src/lib/tabUtils.ts
+++ b/apps/player-portal/src/lib/tabUtils.ts
@@ -2,9 +2,9 @@
  * Canonical character-sheet tab IDs.
  *
  * 'crafting' was removed as a standalone tab; its content is now rendered as
- * a section within the 'inventory' tab. Any serialised reference to the old
- * 'crafting' id (e.g. from localStorage or a future URL-param scheme) is
- * redirected to 'inventory' by {@link normalizeTabId}.
+ * a section within the 'inventory' tab.
+ * 'proficiencies' and 'background' were merged into 'details'.
+ * Any serialised reference to old IDs is redirected by {@link normalizeTabId}.
  */
 export type TabId =
   | 'character'
@@ -12,9 +12,8 @@ export type TabId =
   | 'spells'
   | 'inventory'
   | 'feats'
-  | 'proficiencies'
-  | 'progression'
-  | 'background';
+  | 'details'
+  | 'progression';
 
 // Compile-time guard: the literal array must cover every TabId exactly.
 const VALID_TABS = new Set<string>(
@@ -24,15 +23,16 @@ const VALID_TABS = new Set<string>(
     'spells',
     'inventory',
     'feats',
-    'proficiencies',
+    'details',
     'progression',
-    'background',
   ] satisfies TabId[],
 );
 
 /** Removed tab IDs and the canonical tab they redirect to. */
 const LEGACY_REDIRECTS: Readonly<Record<string, TabId>> = {
   crafting: 'inventory',
+  proficiencies: 'details',
+  background: 'details',
 };
 
 /**

--- a/apps/player-portal/src/lib/usePreferences.ts
+++ b/apps/player-portal/src/lib/usePreferences.ts
@@ -4,11 +4,14 @@ import { useCallback, useEffect, useState } from 'react';
 // survive reloads. Currently just the color scheme; add more fields
 // alongside as the settings dialog grows.
 
+// Swatch colors are intentionally absent — the SettingsDialog renders each
+// button with data-color-scheme set so var(--color-pf-primary) resolves live
+// from CSS. Adding a new theme: add a block to color-schemes.css + one entry here.
 export const COLOR_SCHEMES = [
-  { id: 'classic', label: 'Classic', swatch: '#5e0000' },
-  { id: 'arcane', label: 'Arcane', swatch: '#4a1a6b' },
-  { id: 'verdant', label: 'Verdant', swatch: '#1f4e2b' },
-  { id: 'frost', label: 'Frost', swatch: '#1d4a80' },
+  { id: 'classic', label: 'Classic' },
+  { id: 'arcane', label: 'Arcane' },
+  { id: 'verdant', label: 'Verdant' },
+  { id: 'frost', label: 'Frost' },
 ] as const;
 
 export type ColorScheme = (typeof COLOR_SCHEMES)[number]['id'];
@@ -39,13 +42,9 @@ export function usePreferences(): {
 
   // Reflect the scheme onto <html data-color-scheme="..."> so the CSS
   // overrides in styles/color-schemes.css cascade into every component.
+  // Classic now has its own CSS block, so we always setAttribute.
   useEffect(() => {
-    const root = document.documentElement;
-    if (colorScheme === DEFAULT_SCHEME) {
-      root.removeAttribute('data-color-scheme');
-    } else {
-      root.setAttribute('data-color-scheme', colorScheme);
-    }
+    document.documentElement.setAttribute('data-color-scheme', colorScheme);
   }, [colorScheme]);
 
   const setColorScheme = useCallback((scheme: ColorScheme): void => {

--- a/apps/player-portal/src/lib/usePreferences.ts
+++ b/apps/player-portal/src/lib/usePreferences.ts
@@ -12,6 +12,7 @@ export const COLOR_SCHEMES = [
   { id: 'arcane', label: 'Arcane' },
   { id: 'verdant', label: 'Verdant' },
   { id: 'frost', label: 'Frost' },
+  { id: 'dark', label: 'Dark' },
 ] as const;
 
 export type ColorScheme = (typeof COLOR_SCHEMES)[number]['id'];

--- a/apps/player-portal/src/lib/useQuickActions.ts
+++ b/apps/player-portal/src/lib/useQuickActions.ts
@@ -1,7 +1,5 @@
 import { useState, useCallback } from 'react';
 
-const MAX_QUICK_ACTIONS = 5;
-
 export function useQuickActions(actorId: string): [string[], (ids: string[]) => void] {
   const key = `qt:${actorId}`;
 
@@ -16,10 +14,9 @@ export function useQuickActions(actorId: string): [string[], (ids: string[]) => 
 
   const setAndPersist = useCallback(
     (next: string[]) => {
-      const clamped = next.slice(0, MAX_QUICK_ACTIONS);
-      setIds(clamped);
+      setIds(next);
       try {
-        localStorage.setItem(key, JSON.stringify(clamped));
+        localStorage.setItem(key, JSON.stringify(next));
       } catch {
         // localStorage unavailable — state still updates in memory
       }

--- a/apps/player-portal/src/lib/useQuickActions.ts
+++ b/apps/player-portal/src/lib/useQuickActions.ts
@@ -1,0 +1,31 @@
+import { useState, useCallback } from 'react';
+
+const MAX_QUICK_ACTIONS = 5;
+
+export function useQuickActions(actorId: string): [string[], (ids: string[]) => void] {
+  const key = `qt:${actorId}`;
+
+  const [ids, setIds] = useState<string[]>(() => {
+    try {
+      const raw = localStorage.getItem(key);
+      return raw ? (JSON.parse(raw) as string[]) : [];
+    } catch {
+      return [];
+    }
+  });
+
+  const setAndPersist = useCallback(
+    (next: string[]) => {
+      const clamped = next.slice(0, MAX_QUICK_ACTIONS);
+      setIds(clamped);
+      try {
+        localStorage.setItem(key, JSON.stringify(clamped));
+      } catch {
+        // localStorage unavailable — state still updates in memory
+      }
+    },
+    [key],
+  );
+
+  return [ids, setAndPersist];
+}

--- a/apps/player-portal/src/lib/useShopMode.test.tsx
+++ b/apps/player-portal/src/lib/useShopMode.test.tsx
@@ -11,10 +11,11 @@ afterEach(() => {
 });
 
 describe('useShopMode', () => {
-  it('defaults to disabled / sellRatio 0.5', () => {
+  it('defaults to disabled / sellRatio 0.5 / rare+unique hidden', () => {
     const { result } = renderHook(() => useShopMode());
     expect(result.current.enabled).toBe(false);
     expect(result.current.sellRatio).toBe(0.5);
+    expect(result.current.disabledRarities).toEqual(['rare', 'unique']);
   });
 
   it('setEnabled updates state and persists to localStorage', () => {
@@ -62,6 +63,6 @@ describe('window.__shopMode programmatic API', () => {
       .__shopMode;
     expect(api).toBeDefined();
     api?.set({ enabled: true, sellRatio: 0.25 });
-    expect(api?.get()).toEqual({ enabled: true, sellRatio: 0.25 });
+    expect(api?.get()).toEqual({ enabled: true, sellRatio: 0.25, disabledRarities: ['rare', 'unique'] });
   });
 });

--- a/apps/player-portal/src/lib/useShopMode.ts
+++ b/apps/player-portal/src/lib/useShopMode.ts
@@ -11,6 +11,8 @@ export interface ShopModeState {
   // Fraction of an item's price that the player receives when selling.
   // 0.5 is the pf2e baseline; rolled lower by haggle, up by lore.
   sellRatio: number;
+  // Rarities hidden from the shop grid entirely. DM-configured.
+  disabledRarities: string[];
 }
 
 const STORAGE_KEY = 'shopMode';
@@ -19,6 +21,7 @@ const CHANGE_EVENT = 'shopmode:change';
 const DEFAULT_STATE: ShopModeState = {
   enabled: false,
   sellRatio: 0.5,
+  disabledRarities: ['rare', 'unique'],
 };
 
 function readState(): ShopModeState {
@@ -33,6 +36,9 @@ function readState(): ShopModeState {
         typeof parsed.sellRatio === 'number' && Number.isFinite(parsed.sellRatio)
           ? clampRatio(parsed.sellRatio)
           : DEFAULT_STATE.sellRatio,
+      disabledRarities: Array.isArray(parsed.disabledRarities)
+        ? (parsed.disabledRarities as unknown[]).filter((v): v is string => typeof v === 'string')
+        : DEFAULT_STATE.disabledRarities,
     };
   } catch {
     return DEFAULT_STATE;
@@ -64,6 +70,7 @@ export function setShopMode(patch: Partial<ShopModeState>): ShopModeState {
   const next: ShopModeState = {
     enabled: patch.enabled ?? current.enabled,
     sellRatio: patch.sellRatio !== undefined ? clampRatio(patch.sellRatio) : current.sellRatio,
+    disabledRarities: patch.disabledRarities ?? current.disabledRarities,
   };
   writeState(next);
   return next;
@@ -84,6 +91,7 @@ if (typeof window !== 'undefined') {
 export function useShopMode(): ShopModeState & {
   setEnabled: (v: boolean) => void;
   setSellRatio: (r: number) => void;
+  setDisabledRarities: (v: string[]) => void;
 } {
   const [state, setState] = useState<ShopModeState>(() => readState());
 
@@ -110,6 +118,9 @@ export function useShopMode(): ShopModeState & {
     },
     setSellRatio: (r: number): void => {
       setShopMode({ sellRatio: r });
+    },
+    setDisabledRarities: (v: string[]): void => {
+      setShopMode({ disabledRarities: v });
     },
   };
 }

--- a/apps/player-portal/src/routes/CharacterSheet.tsx
+++ b/apps/player-portal/src/routes/CharacterSheet.tsx
@@ -155,6 +155,8 @@ function CharacterSheetInner({ actorId, onBack, preferences }: InnerProps): Reac
         >
           <SheetHeader
             character={state.actor}
+            actorId={actorId}
+            onActorChanged={reloadActor}
             onBack={onBack}
             onSettingsOpen={(): void => {
               setSettingsOpen(true);
@@ -162,7 +164,13 @@ function CharacterSheetInner({ actorId, onBack, preferences }: InnerProps): Reac
           />
           <TabStrip tabs={TABS} active={activeTab} onChange={setActiveTab} />
           {activeTab === 'character' && (
-            <Character system={state.actor.system} actorId={actorId} onActorChanged={reloadActor} />
+            <Character
+              system={state.actor.system}
+              actorId={actorId}
+              items={state.actor.items}
+              characterLevel={state.actor.system.details.level.value}
+              onActorChanged={reloadActor}
+            />
           )}
           {activeTab === 'actions' && (
             <Actions
@@ -197,7 +205,7 @@ function CharacterSheetInner({ actorId, onBack, preferences }: InnerProps): Reac
             </>
           )}
           {activeTab === 'feats' && <Feats items={state.actor.items} />}
-          {activeTab === 'proficiencies' && <Proficiencies system={state.actor.system} actorId={actorId} />}
+          {activeTab === 'proficiencies' && <Proficiencies system={state.actor.system} />}
           {activeTab === 'progression' && (
             <Progression
               characterLevel={state.actor.system.details.level.value}
@@ -205,7 +213,9 @@ function CharacterSheetInner({ actorId, onBack, preferences }: InnerProps): Reac
               characterContext={fromPreparedCharacter(state.actor)}
             />
           )}
-          {activeTab === 'background' && <Background details={state.actor.system.details} />}
+          {activeTab === 'background' && (
+            <Background details={state.actor.system.details} traits={state.actor.system.traits.value} />
+          )}
         </div>
       )}
       {settingsOpen && state.kind === 'ready' && (

--- a/apps/player-portal/src/routes/CharacterSheet.tsx
+++ b/apps/player-portal/src/routes/CharacterSheet.tsx
@@ -23,6 +23,7 @@ import { usePreferences } from '../lib/usePreferences';
 import { prefetchIcons } from '../lib/prefetchIcons';
 import { PromptQueue } from '../components/dialog/PromptQueue';
 import type { TabId } from '../lib/tabUtils';
+import { useShopMode } from '../lib/useShopMode';
 
 type State =
   | { kind: 'loading' }
@@ -60,6 +61,7 @@ interface InnerProps {
 }
 
 function CharacterSheetInner({ actorId, onBack, preferences }: InnerProps): React.ReactElement {
+  const shopMode = useShopMode();
   const [state, setState] = useState<State>({ kind: 'loading' });
   const [activeTab, setActiveTab] = useState<TabId>('character');
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -198,10 +200,12 @@ function CharacterSheetInner({ actorId, onBack, preferences }: InnerProps): Reac
                 onActorChanged={reloadActor}
                 investiture={state.actor.system.resources.investiture}
               />
-              <div className="mt-10 border-t border-pf-border pt-6">
-                <SectionHeader>Crafting</SectionHeader>
-                <Crafting actorId={actorId} crafting={state.actor.system.crafting} />
-              </div>
+              {!shopMode.enabled && (
+                <div className="mt-10 border-t border-pf-border pt-6">
+                  <SectionHeader>Crafting</SectionHeader>
+                  <Crafting actorId={actorId} crafting={state.actor.system.crafting} />
+                </div>
+              )}
             </>
           )}
           {activeTab === 'feats' && <Feats items={state.actor.items} />}

--- a/apps/player-portal/src/routes/CharacterSheet.tsx
+++ b/apps/player-portal/src/routes/CharacterSheet.tsx
@@ -15,6 +15,7 @@ import { Feats } from '../components/tabs/Feats';
 import { Inventory } from '../components/tabs/Inventory';
 import { Proficiencies } from '../components/tabs/Proficiencies';
 import { Progression } from '../components/tabs/Progression';
+
 import { Spells } from '../components/tabs/Spells';
 import { useEventChannel } from '../lib/useEventChannel';
 import { fromPreparedCharacter } from '../prereqs';
@@ -37,9 +38,8 @@ const TABS: readonly Tab<TabId>[] = [
   { id: 'spells', label: 'Spells' },
   { id: 'inventory', label: 'Inventory' },
   { id: 'feats', label: 'Feats' },
-  { id: 'proficiencies', label: 'Proficiencies' },
   { id: 'progression', label: 'Progression' },
-  { id: 'background', label: 'Background' },
+  { id: 'details', label: 'Details' },
 ];
 
 export function CharacterSheet(): React.ReactElement {
@@ -205,7 +205,6 @@ function CharacterSheetInner({ actorId, onBack, preferences }: InnerProps): Reac
             </>
           )}
           {activeTab === 'feats' && <Feats items={state.actor.items} />}
-          {activeTab === 'proficiencies' && <Proficiencies system={state.actor.system} />}
           {activeTab === 'progression' && (
             <Progression
               characterLevel={state.actor.system.details.level.value}
@@ -213,8 +212,11 @@ function CharacterSheetInner({ actorId, onBack, preferences }: InnerProps): Reac
               characterContext={fromPreparedCharacter(state.actor)}
             />
           )}
-          {activeTab === 'background' && (
-            <Background details={state.actor.system.details} traits={state.actor.system.traits.value} />
+          {activeTab === 'details' && (
+            <div className="space-y-6">
+              <Background details={state.actor.system.details} traits={state.actor.system.traits.value} />
+              <Proficiencies system={state.actor.system} />
+            </div>
           )}
         </div>
       )}

--- a/apps/player-portal/src/styles/index.css
+++ b/apps/player-portal/src/styles/index.css
@@ -102,14 +102,12 @@
   border-color: var(--item-invested-border);
 }
 
-/* Reserve scrollbar-gutter space so the page doesn't shift when content
-   overflows, but hide the scrollbar visually. */
-html {
-  scrollbar-gutter: stable;
-  scrollbar-width: none;
+/* Hide the main window scrollbar while keeping scroll functional. */
+:root {
+  scrollbar-width: none !important;
 }
-html::-webkit-scrollbar {
-  display: none;
+::-webkit-scrollbar {
+  display: none !important;
 }
 
 /* Palette-matched thin scrollbar for in-sheet scroll regions. */

--- a/apps/player-portal/src/styles/index.css
+++ b/apps/player-portal/src/styles/index.css
@@ -103,9 +103,25 @@
 }
 
 /* Reserve scrollbar-gutter space always so the page doesn't horizontally
-   shift when content grows past the viewport and a scrollbar appears. */
+   shift when content grows past the viewport and a scrollbar appears.
+   Also applies the palette-matched thin scrollbar to the main window. */
 html {
   scrollbar-gutter: stable;
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-pf-border) transparent;
+}
+html::-webkit-scrollbar {
+  width: 6px;
+}
+html::-webkit-scrollbar-track {
+  background: transparent;
+}
+html::-webkit-scrollbar-thumb {
+  background-color: var(--color-pf-border);
+  border-radius: 9999px;
+}
+html::-webkit-scrollbar-thumb:hover {
+  background-color: var(--color-pf-alt);
 }
 
 /* Palette-matched thin scrollbar for in-sheet scroll regions. */

--- a/apps/player-portal/src/styles/index.css
+++ b/apps/player-portal/src/styles/index.css
@@ -80,6 +80,28 @@
   background: linear-gradient(to bottom, var(--portal-bg), transparent);
 }
 
+/* Item state tokens — used for inventory grid tiles and any other surface
+ * that needs to communicate equipped / invested status via colour. */
+:root {
+  --item-equipped: rgba(34, 197, 94, 0.20);   /* emerald-500 @ 20% */
+  --item-invested: rgba(139, 92, 246, 0.20);   /* violet-500  @ 20% */
+  --item-equipped-border: rgba(34, 197, 94, 0.60);
+  --item-invested-border: rgba(139, 92, 246, 0.60);
+}
+
+@utility bg-item-equipped {
+  background-color: var(--item-equipped);
+}
+@utility bg-item-invested {
+  background-color: var(--item-invested);
+}
+@utility border-item-equipped {
+  border-color: var(--item-equipped-border);
+}
+@utility border-item-invested {
+  border-color: var(--item-invested-border);
+}
+
 /* Reserve scrollbar-gutter space always so the page doesn't horizontally
    shift when content grows past the viewport and a scrollbar appears. */
 html {

--- a/apps/player-portal/src/styles/index.css
+++ b/apps/player-portal/src/styles/index.css
@@ -121,6 +121,25 @@ html {
   scrollbar-gutter: stable;
 }
 
+/* Palette-matched thin scrollbar for in-sheet scroll regions. */
+.scrollbar-pf {
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-pf-border) transparent;
+}
+.scrollbar-pf::-webkit-scrollbar {
+  width: 4px;
+}
+.scrollbar-pf::-webkit-scrollbar-track {
+  background: transparent;
+}
+.scrollbar-pf::-webkit-scrollbar-thumb {
+  background-color: var(--color-pf-border);
+  border-radius: 9999px;
+}
+.scrollbar-pf::-webkit-scrollbar-thumb:hover {
+  background-color: var(--color-pf-alt);
+}
+
 /* Sheet-wide base: cream parchment surface, Gelasio for long-form text.
    Individual components override via `font-sans` / `font-serif` utilities
    as needed. */

--- a/apps/player-portal/src/styles/index.css
+++ b/apps/player-portal/src/styles/index.css
@@ -24,53 +24,18 @@
 }
 
 [data-portal-theme='dark'] {
-  /* Portal nav/page surface tokens */
+  /* Portal nav/page surface tokens only. The character sheet is themed
+   * independently via [data-color-scheme] on <html> — select the "Dark"
+   * scheme in the settings dialog to darken the sheet itself. */
   --portal-bg: #0d111e;
   --portal-surface: #141928;
   --portal-surface-hover: #1b2236;
   --portal-border: #252e45;
   --portal-text: #e8e4dc;
   --portal-text-muted: #8a8fa5;
-  --portal-accent: var(--color-pf-tertiary-dark); /* #cbb77a parchment gold */
+  --portal-accent: var(--color-pf-tertiary-dark);
   --portal-accent-subtle: rgba(203, 183, 122, 0.12);
   --portal-accent-border: rgba(203, 183, 122, 0.4);
-
-  /* PF2e token overrides — extend dark mode to CharactersLayout, the
-   * character sheet, and the character creator. CharactersLayout uses
-   * var(--color-pf-bg/text) inline; sheet/creator use bg-pf-* / text-pf-*
-   * Tailwind utilities. All cascade from this ancestor div. */
-
-  /* Surfaces */
-  --color-pf-bg: #0d111e;
-  --color-pf-bg-dark: #141928;
-  --color-pf-sub: #8a8fa5;
-  --color-pf-text: #e8e4dc;
-  --color-pf-text-muted: #8a8fa5;
-  --color-pf-border: #252e45;
-
-  /* Palette — brightened so these remain legible as text/accents on dark
-   * surfaces (text-pf-primary links, text-pf-secondary templated text,
-   * text-pf-alt-dark section headers). bg-pf-primary/secondary buttons
-   * keep their own white text so contrast is unaffected there. */
-  --color-pf-primary: #b50000;
-  --color-pf-primary-dark: #8a0000;
-  --color-pf-primary-light: #d01010;
-  --color-pf-secondary: #3b56d4;
-  --color-pf-secondary-dark: #2a3fb5;
-  --color-pf-secondary-light: #5a70e8;
-  --color-pf-alt: #a89070;
-  --color-pf-alt-dark: #c4b098; /* was #443730 — section headers need light text */
-  --color-pf-alt-light: #d4c0a8;
-  /* Tertiary — darkened from parchment gold (#e9d7a1) to warm amber so
-   * bg-pf-tertiary buttons/chips are readable without being blinding. */
-  --color-pf-tertiary: #b08828;
-  --color-pf-tertiary-dark: #7a5e10;
-  --color-pf-tertiary-light: #d4a840;
-  /* Tertiary (gold) and rarity/proficiency/success colors stay unchanged —
-   * they're light or semantic and already work on dark backgrounds. */
-
-  /* Dark overlay for background-image sheets (matches dark --color-pf-bg) */
-  --pf-bg-overlay: rgba(13, 17, 30, 0.88);
 }
 
 /* Custom Tailwind utilities for portal theming. Using @utility (not @theme)

--- a/apps/player-portal/src/styles/index.css
+++ b/apps/player-portal/src/styles/index.css
@@ -102,26 +102,14 @@
   border-color: var(--item-invested-border);
 }
 
-/* Reserve scrollbar-gutter space always so the page doesn't horizontally
-   shift when content grows past the viewport and a scrollbar appears.
-   Also applies the palette-matched thin scrollbar to the main window. */
+/* Reserve scrollbar-gutter space so the page doesn't shift when content
+   overflows, but hide the scrollbar visually. */
 html {
   scrollbar-gutter: stable;
-  scrollbar-width: thin;
-  scrollbar-color: var(--color-pf-border) transparent;
+  scrollbar-width: none;
 }
 html::-webkit-scrollbar {
-  width: 6px;
-}
-html::-webkit-scrollbar-track {
-  background: transparent;
-}
-html::-webkit-scrollbar-thumb {
-  background-color: var(--color-pf-border);
-  border-radius: 9999px;
-}
-html::-webkit-scrollbar-thumb:hover {
-  background-color: var(--color-pf-alt);
+  display: none;
 }
 
 /* Palette-matched thin scrollbar for in-sheet scroll regions. */

--- a/apps/player-portal/src/test-setup.ts
+++ b/apps/player-portal/src/test-setup.ts
@@ -1,0 +1,7 @@
+// jsdom doesn't implement ResizeObserver. Provide a no-op stub so
+// components that use it (e.g. Character's height-sync effect) don't throw.
+global.ResizeObserver = class ResizeObserver {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+};

--- a/apps/player-portal/vitest.config.ts
+++ b/apps/player-portal/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: false,
+    setupFiles: ['src/test-setup.ts'],
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
   },
 });

--- a/packages/shared/tokens/color-schemes.css
+++ b/packages/shared/tokens/color-schemes.css
@@ -15,6 +15,24 @@
  * Derived from foundryvtt/pf2e (Apache-2.0) — see NOTICE.
  */
 
+/* Classic — default PF2e palette (heraldic red + navy + parchment gold).
+ * Explicit block so every scheme is applied via the same setAttribute path;
+ * Classic is no longer a special "remove the attribute" case in JS. */
+[data-color-scheme='classic'] {
+  --color-pf-primary: #5e0000;
+  --color-pf-primary-dark: #4a0000;
+  --color-pf-primary-light: #7a0000;
+  --color-pf-secondary: #171f69;
+  --color-pf-secondary-dark: #0f1547;
+  --color-pf-secondary-light: #2a358f;
+  --color-pf-tertiary: #e9d7a1;
+  --color-pf-tertiary-dark: #cbb77a;
+  --color-pf-tertiary-light: #f3e6be;
+  --color-pf-alt: #786452;
+  --color-pf-alt-dark: #443730;
+  --color-pf-alt-light: #9a8471;
+}
+
 /* Arcane — violet + deep teal, muted lilac accents. */
 [data-color-scheme='arcane'] {
   --color-pf-primary: #4a1a6b;

--- a/packages/shared/tokens/color-schemes.css
+++ b/packages/shared/tokens/color-schemes.css
@@ -1,24 +1,40 @@
 /*
  * Alternate color schemes for PF2e-themed surfaces.
  *
- * The default palette lives in pf2e.css under @theme — that's the PF2e
- * Classic look (deep heraldic red + navy + parchment gold). Each
- * [data-color-scheme="..."] block below replaces the core palette CSS
- * variables; Tailwind 4 utilities (`bg-pf-primary`, `text-pf-secondary`,
- * etc.) all reference those variables via var(), so re-cascading them at
- * the document-root level retunes the whole surface.
+ * Each [data-color-scheme="..."] block overrides two groups of tokens:
  *
- * Rarity, proficiency, and degree-of-success colors are deliberately left
- * alone — they're semantic (rare is always blue, unique is always purple)
- * and shouldn't drift between palettes.
+ *   1. PALETTE  — primary/secondary/tertiary/alt accent colours.
+ *   2. SURFACES — bg, bg-dark, border, text, text-muted, sub, and the
+ *                 pf-bg-overlay rgba value used for background-image sheets.
+ *
+ * Tailwind 4 utilities (bg-pf-primary, bg-pf-bg, text-pf-text, etc.) all
+ * reference these variables via var(), so re-cascading them at the document
+ * root retunes the entire surface — cards, headers, chip backgrounds, borders.
+ *
+ * The portal surface tokens (--portal-bg, --portal-surface, …) in index.css
+ * are defined as var(--color-pf-bg/border/…), so they inherit scheme changes
+ * automatically without extra overrides here.
+ *
+ * Dark mode ([data-portal-theme='dark'] in index.css) applies to the Layout
+ * root div, which is a descendant of <html>. Because CSS custom properties
+ * cascade by element, dark-mode overrides on the Layout div win over scheme
+ * overrides on <html> for everything inside — so dark mode stays dark
+ * regardless of scheme. Per-scheme dark variants can be added later by
+ * combining both selectors.
+ *
+ * Rarity, proficiency, and degree-of-success colours are deliberately left
+ * alone — they're semantic and shouldn't drift between palettes.
+ *
+ * To add a new theme: add one block here + one entry in usePreferences.ts.
  *
  * Derived from foundryvtt/pf2e (Apache-2.0) — see NOTICE.
  */
 
-/* Classic — default PF2e palette (heraldic red + navy + parchment gold).
- * Explicit block so every scheme is applied via the same setAttribute path;
- * Classic is no longer a special "remove the attribute" case in JS. */
+/* Classic — warm cream parchment + heraldic red + navy + parchment gold.
+ * Explicit block so Classic is applied via the same setAttribute path as
+ * other schemes (no longer a "remove the attribute" special case in JS). */
 [data-color-scheme='classic'] {
+  /* Palette */
   --color-pf-primary: #5e0000;
   --color-pf-primary-dark: #4a0000;
   --color-pf-primary-light: #7a0000;
@@ -31,10 +47,19 @@
   --color-pf-alt: #786452;
   --color-pf-alt-dark: #443730;
   --color-pf-alt-light: #9a8471;
+  /* Surfaces */
+  --color-pf-bg: #f8f4f1;
+  --color-pf-bg-dark: #e6dfd7;
+  --color-pf-border: #baa991;
+  --color-pf-text: #1c1c1c;
+  --color-pf-text-muted: #605856;
+  --color-pf-sub: #605856;
+  --pf-bg-overlay: rgba(248, 244, 241, 0.88);
 }
 
-/* Arcane — violet + deep teal, muted lilac accents. */
+/* Arcane — cool violet-tinged vellum + violet + deep teal + lilac. */
 [data-color-scheme='arcane'] {
+  /* Palette */
   --color-pf-primary: #4a1a6b;
   --color-pf-primary-dark: #381252;
   --color-pf-primary-light: #5e2585;
@@ -47,10 +72,19 @@
   --color-pf-alt: #5a4a7a;
   --color-pf-alt-dark: #3a2f52;
   --color-pf-alt-light: #7d6ba0;
+  /* Surfaces — lavender-tinged vellum */
+  --color-pf-bg: #f4f1f8;
+  --color-pf-bg-dark: #e8e2f0;
+  --color-pf-border: #c4b4d8;
+  --color-pf-text: #1a1520;
+  --color-pf-text-muted: #6b5f7e;
+  --color-pf-sub: #6b5f7e;
+  --pf-bg-overlay: rgba(244, 241, 248, 0.88);
 }
 
-/* Verdant — forest green + teal, sage accents. */
+/* Verdant — sage-green parchment + forest green + teal + soft sage. */
 [data-color-scheme='verdant'] {
+  /* Palette */
   --color-pf-primary: #1f4e2b;
   --color-pf-primary-dark: #163a1f;
   --color-pf-primary-light: #2a6a3c;
@@ -63,10 +97,19 @@
   --color-pf-alt: #556445;
   --color-pf-alt-dark: #343e27;
   --color-pf-alt-light: #7a8a68;
+  /* Surfaces — sage-tinted parchment */
+  --color-pf-bg: #f1f5ef;
+  --color-pf-bg-dark: #e1eadb;
+  --color-pf-border: #b4c8aa;
+  --color-pf-text: #161a14;
+  --color-pf-text-muted: #5a6652;
+  --color-pf-sub: #5a6652;
+  --pf-bg-overlay: rgba(241, 245, 239, 0.88);
 }
 
-/* Frost — steel blue + slate indigo, pale sky accents. */
+/* Frost — pale blue-white + steel blue + slate indigo + sky. */
 [data-color-scheme='frost'] {
+  /* Palette */
   --color-pf-primary: #1d4a80;
   --color-pf-primary-dark: #133560;
   --color-pf-primary-light: #2a66a8;
@@ -79,4 +122,12 @@
   --color-pf-alt: #4e5e74;
   --color-pf-alt-dark: #2e3847;
   --color-pf-alt-light: #7687a0;
+  /* Surfaces — cool pale blue-white */
+  --color-pf-bg: #f0f4f8;
+  --color-pf-bg-dark: #dce6f0;
+  --color-pf-border: #afc3d6;
+  --color-pf-text: #141c24;
+  --color-pf-text-muted: #526070;
+  --color-pf-sub: #526070;
+  --pf-bg-overlay: rgba(240, 244, 248, 0.88);
 }

--- a/packages/shared/tokens/color-schemes.css
+++ b/packages/shared/tokens/color-schemes.css
@@ -107,6 +107,31 @@
   --pf-bg-overlay: rgba(241, 245, 239, 0.88);
 }
 
+/* Dark — navy midnight surfaces + brightened classic palette for legibility. */
+[data-color-scheme='dark'] {
+  /* Surfaces */
+  --color-pf-bg: #0d111e;
+  --color-pf-bg-dark: #141928;
+  --color-pf-border: #252e45;
+  --color-pf-text: #e8e4dc;
+  --color-pf-text-muted: #8a8fa5;
+  --color-pf-sub: #8a8fa5;
+  --pf-bg-overlay: rgba(13, 17, 30, 0.88);
+  /* Palette — brightened for legibility on dark surfaces */
+  --color-pf-primary: #b50000;
+  --color-pf-primary-dark: #8a0000;
+  --color-pf-primary-light: #d01010;
+  --color-pf-secondary: #3b56d4;
+  --color-pf-secondary-dark: #2a3fb5;
+  --color-pf-secondary-light: #5a70e8;
+  --color-pf-tertiary: #b08828;
+  --color-pf-tertiary-dark: #7a5e10;
+  --color-pf-tertiary-light: #d4a840;
+  --color-pf-alt: #a89070;
+  --color-pf-alt-dark: #c4b098;
+  --color-pf-alt-light: #d4c0a8;
+}
+
 /* Frost — pale blue-white + steel blue + slate indigo + sky. */
 [data-color-scheme='frost'] {
   /* Palette */


### PR DESCRIPTION
## Apps touched
- `apps/player-portal` — `npm run dev:player-portal:mock`

## Summary

Design pass on the player-facing character sheet and shop picker.

### Character sheet
- Feat chips: 3-column grid, expand panel shows traits + description side-by-side, level badge inline
- Inventory grid tiles: square art with semi-transparent name overlay, z-ordered expand panels, viewport-aware panel flip, chip-size slider in debug menu
- Character tab: IWR block between Skills/QA and Conditions; Long Rest button neutral colour; proficiency rank chips removed from Key Stats; HP adjustment buttons removed; unused `onActorChanged` param cleaned up
- Progression tab: removed placeholder text; merged progression header and level list into single card
- Scrollbar hidden globally

### Shop picker
- **Item grouping**: items following `"$name ($variant)"` are collapsed into one tile. Known quality tiers (Minor→True, Young→Wyrm, 1st-Rank→9th-Rank) sort in order within the group; unknown variants (e.g. Aeon Stone colours) sort alphabetically
- **Variants badge**: multi-variant tiles show "Variants: N" chip; detail panel shows variant selector buttons that swap description/price/traits
- **Rarity**: footer bar tinted amber/blue/purple by rarity; rarity chip in detail panel header; multi-select rarity filter chips in control strip
- **Debug menu**: "Visible rarities" checkboxes default to hiding Rare + Unique, persisted in localStorage via `useShopMode`
- **Crafting section** hidden while shop mode is active
- Detail panel no longer clipped when grid has only one row (anchors top, grows downward)
- Removed bottom pagination controls
- 5-column fixed grid, 25 items per page

## Test plan
- [ ] Open character sheet in mock mode (`npm run dev:player-portal:mock`)
- [ ] Verify feat expand panels are wide and show traits + description
- [ ] Verify inventory grid tiles open expand panels; right-edge tiles flip left
- [ ] Enable shop mode via debug gear menu; verify Crafting section hides
- [ ] Browse shop: confirm potion variants group ("Healing Potion (Minor/Lesser/…)"), Aeon Stones group, wand ranks group
- [ ] Toggle rarity filter chips; toggle visibility in debug menu
- [ ] Open item detail; switch variants; verify description/price updates