### PR TITLE
feat(shared): add chat-relay wire types and speakerOwnerIds enrichment

### DIFF
--- a/apps/foundry-api-bridge/src/events/EventChannelController.ts
+++ b/apps/foundry-api-bridge/src/events/EventChannelController.ts
@@ -313,6 +313,19 @@ export class EventChannelController {
 
 // ---- Serializers --------------------------------------------------------
 
+function computeSpeakerOwnerIds(speaker: FoundrySpeaker | null | undefined): string[] {
+  const actorId = speaker?.actor;
+  if (!actorId) return [];
+  const g = (globalThis as Record<string, unknown>)['game'] as
+    | { actors?: { get(id: string): { ownership?: Record<string, number> } | null | undefined } }
+    | undefined;
+  const actor = g?.actors?.get(actorId);
+  if (!actor?.ownership) return [];
+  return Object.entries(actor.ownership)
+    .filter(([userId, level]) => userId !== 'default' && level === 3)
+    .map(([userId]) => userId);
+}
+
 function serializeChatMessage(m: FoundryChatMessage): Record<string, unknown> {
   return {
     id: m.id,
@@ -338,6 +351,7 @@ function serializeChatMessage(m: FoundryChatMessage): Record<string, unknown> {
           })) ?? [],
       })) ?? [],
     flags: m.flags ?? {},
+    speakerOwnerIds: computeSpeakerOwnerIds(m.speaker),
   };
 }
 

--- a/apps/foundry-api-bridge/src/events/__tests__/EventChannelController.test.ts
+++ b/apps/foundry-api-bridge/src/events/__tests__/EventChannelController.test.ts
@@ -217,4 +217,107 @@ describe('EventChannelController', () => {
       ]);
     });
   });
+
+  describe('speakerOwnerIds enrichment', () => {
+    function makeGameMock(actorId: string, ownership: Record<string, number>) {
+      (global as unknown as Record<string, unknown>)['game'] = {
+        actors: {
+          get(id: string) {
+            return id === actorId ? { ownership } : null;
+          },
+        },
+      };
+    }
+
+    afterEach(() => {
+      delete (global as unknown as Record<string, unknown>)['game'];
+    });
+
+    it('returns an empty array when the message has no speaker actor', () => {
+      const { publisher, pushEvent } = makePublisher();
+      const controller = new EventChannelController(publisher);
+      controller.enable('chat', {});
+
+      hooksMock.fire('createChatMessage', { id: 'msg1', isRoll: false, content: 'hi' });
+
+      const payload = pushEvent.mock.calls[0]?.[1] as { eventType: string; data: Record<string, unknown> };
+      expect(payload.data['speakerOwnerIds']).toEqual([]);
+    });
+
+    it('returns an empty array when the actor is not found in game.actors', () => {
+      (global as unknown as Record<string, unknown>)['game'] = { actors: { get: () => null } };
+      const { publisher, pushEvent } = makePublisher();
+      const controller = new EventChannelController(publisher);
+      controller.enable('chat', {});
+
+      hooksMock.fire('createChatMessage', { id: 'msg1', isRoll: false, speaker: { actor: 'missing-id' } });
+
+      const payload = pushEvent.mock.calls[0]?.[1] as { eventType: string; data: Record<string, unknown> };
+      expect(payload.data['speakerOwnerIds']).toEqual([]);
+    });
+
+    it('returns only user IDs with ownership level 3 (OWNER)', () => {
+      makeGameMock('actor-001', { userA: 3, userB: 1, userC: 2 });
+      const { publisher, pushEvent } = makePublisher();
+      const controller = new EventChannelController(publisher);
+      controller.enable('chat', {});
+
+      hooksMock.fire('createChatMessage', { id: 'msg1', isRoll: false, speaker: { actor: 'actor-001' } });
+
+      const payload = pushEvent.mock.calls[0]?.[1] as { eventType: string; data: Record<string, unknown> };
+      expect(payload.data['speakerOwnerIds']).toEqual(['userA']);
+    });
+
+    it('returns all owner user IDs when there are multiple owners', () => {
+      makeGameMock('actor-001', { userA: 3, userB: 3, userC: 1 });
+      const { publisher, pushEvent } = makePublisher();
+      const controller = new EventChannelController(publisher);
+      controller.enable('chat', {});
+
+      hooksMock.fire('createChatMessage', { id: 'msg1', isRoll: false, speaker: { actor: 'actor-001' } });
+
+      const payload = pushEvent.mock.calls[0]?.[1] as { eventType: string; data: Record<string, unknown> };
+      expect((payload.data['speakerOwnerIds'] as string[]).sort()).toEqual(['userA', 'userB']);
+    });
+
+    it('excludes the special "default" key even if its level is 3', () => {
+      makeGameMock('actor-001', { default: 3, userA: 3 });
+      const { publisher, pushEvent } = makePublisher();
+      const controller = new EventChannelController(publisher);
+      controller.enable('chat', {});
+
+      hooksMock.fire('createChatMessage', { id: 'msg1', isRoll: false, speaker: { actor: 'actor-001' } });
+
+      const payload = pushEvent.mock.calls[0]?.[1] as { eventType: string; data: Record<string, unknown> };
+      expect(payload.data['speakerOwnerIds']).toEqual(['userA']);
+    });
+
+    it('existing serialized fields are unchanged (regression)', () => {
+      makeGameMock('actor-001', { userA: 3 });
+      const { publisher, pushEvent } = makePublisher();
+      const controller = new EventChannelController(publisher);
+      controller.enable('chat', {});
+
+      hooksMock.fire('createChatMessage', {
+        id: 'msg-reg',
+        isRoll: false,
+        content: '<p>Hello</p>',
+        flavor: 'IC',
+        speaker: { actor: 'actor-001', alias: 'Valeros' },
+        whisper: [],
+        author: { id: 'u1', name: 'Player' },
+        flags: { pf2e: {} },
+      });
+
+      const payload = pushEvent.mock.calls[0]?.[1] as { eventType: string; data: Record<string, unknown> };
+      const data = payload.data;
+      expect(data['id']).toBe('msg-reg');
+      expect(data['content']).toBe('<p>Hello</p>');
+      expect(data['flavor']).toBe('IC');
+      expect(data['whisper']).toEqual([]);
+      expect(data['isRoll']).toBe(false);
+      expect(data['author']).toEqual({ id: 'u1', name: 'Player' });
+      expect(data['speakerOwnerIds']).toEqual(['userA']);
+    });
+  });
 });

--- a/packages/shared/src/rpc/live.test.ts
+++ b/packages/shared/src/rpc/live.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import {
   aurusSnapshotSchema,
+  chatLogBackfillSchema,
+  chatMessageSnapshotSchema,
   globeSnapshotSchema,
   inventorySnapshotSchema,
   type AurusSnapshot,
+  type ChatLogBackfill,
+  type ChatMessageSnapshot,
   type GlobeSnapshot,
   type InventorySnapshot,
 } from './live';
@@ -228,5 +232,169 @@ describe('globeSnapshotSchema', () => {
 
   it('rejects a snapshot missing updatedAt', () => {
     expect(() => globeSnapshotSchema.parse({ pins: [] })).toThrow();
+  });
+});
+
+// ─── ChatMessageSnapshot ──────────────────────────────────────────────────────
+
+describe('chatMessageSnapshotSchema', () => {
+  const validMessage: ChatMessageSnapshot = {
+    id: 'msg-001',
+    uuid: 'ChatMessage.msg-001',
+    type: 1,
+    author: { id: 'user-gm', name: 'GM' },
+    timestamp: 1711497600000,
+    flavor: 'Athletics check',
+    content: '<p>Rolls Athletics!</p>',
+    speaker: { alias: 'Valeros', actor: 'actor-001', scene: 'scene-001', token: 'token-001' },
+    speakerOwnerIds: ['user-player1'],
+    whisper: [],
+    isRoll: true,
+    rolls: [
+      {
+        formula: '1d20+7',
+        total: 22,
+        isCritical: true,
+        isFumble: false,
+        dice: [{ faces: 20, results: [{ result: 15, active: true }] }],
+      },
+    ],
+    flags: { pf2e: { context: { type: 'skill-check' } } },
+  };
+
+  it('round-trips a valid message', () => {
+    const parsed: ChatMessageSnapshot = chatMessageSnapshotSchema.parse(validMessage);
+    expect(parsed).toEqual(validMessage);
+  });
+
+  it('round-trips via JSON serialization', () => {
+    const roundTripped = chatMessageSnapshotSchema.parse(JSON.parse(JSON.stringify(validMessage)));
+    expect(roundTripped).toEqual(validMessage);
+  });
+
+  it('accepts null for nullable fields', () => {
+    const parsed = chatMessageSnapshotSchema.parse({
+      ...validMessage,
+      uuid: null,
+      type: null,
+      author: null,
+      timestamp: null,
+      speaker: null,
+    });
+    expect(parsed.uuid).toBeNull();
+    expect(parsed.type).toBeNull();
+    expect(parsed.author).toBeNull();
+    expect(parsed.timestamp).toBeNull();
+    expect(parsed.speaker).toBeNull();
+  });
+
+  it('accepts an empty speakerOwnerIds and whisper array', () => {
+    const parsed = chatMessageSnapshotSchema.parse({ ...validMessage, speakerOwnerIds: [], whisper: [] });
+    expect(parsed.speakerOwnerIds).toHaveLength(0);
+    expect(parsed.whisper).toHaveLength(0);
+  });
+
+  it('accepts a message with no rolls (non-roll message)', () => {
+    const parsed = chatMessageSnapshotSchema.parse({ ...validMessage, isRoll: false, rolls: [] });
+    expect(parsed.isRoll).toBe(false);
+    expect(parsed.rolls).toHaveLength(0);
+  });
+
+  it('strips unknown fields on roll objects (passthrough-lenient, not strict)', () => {
+    const parsed = chatMessageSnapshotSchema.parse({
+      ...validMessage,
+      rolls: [{ formula: '1d6', total: 4, isCritical: false, isFumble: false, dice: [], unknownField: 'surprise' }],
+    });
+    expect(parsed.rolls[0]).not.toHaveProperty('unknownField');
+  });
+
+  it('rejects a message missing the required id field', () => {
+    const { id: _id, ...withoutId } = validMessage;
+    expect(() => chatMessageSnapshotSchema.parse(withoutId)).toThrow();
+  });
+
+  it('rejects a message missing the required content field', () => {
+    const { content: _c, ...withoutContent } = validMessage;
+    expect(() => chatMessageSnapshotSchema.parse(withoutContent)).toThrow();
+  });
+
+  it('rejects isRoll with wrong type', () => {
+    expect(() => chatMessageSnapshotSchema.parse({ ...validMessage, isRoll: 'true' })).toThrow();
+  });
+
+  it('rejects whisper as a non-array string', () => {
+    expect(() => chatMessageSnapshotSchema.parse({ ...validMessage, whisper: 'public' })).toThrow();
+  });
+
+  it('rejects a roll with a non-numeric total', () => {
+    expect(() =>
+      chatMessageSnapshotSchema.parse({
+        ...validMessage,
+        rolls: [{ formula: '1d20', total: 'high', isCritical: false, isFumble: false, dice: [] }],
+      }),
+    ).toThrow();
+  });
+});
+
+// ─── ChatLogBackfill ──────────────────────────────────────────────────────────
+
+describe('chatLogBackfillSchema', () => {
+  const minimalMessage: ChatMessageSnapshot = {
+    id: 'msg-001',
+    uuid: null,
+    type: null,
+    author: null,
+    timestamp: null,
+    flavor: '',
+    content: 'Hello',
+    speaker: null,
+    speakerOwnerIds: [],
+    whisper: [],
+    isRoll: false,
+    rolls: [],
+    flags: {},
+  };
+
+  const validBackfill: ChatLogBackfill = {
+    messages: [minimalMessage],
+    truncated: false,
+  };
+
+  it('round-trips a valid backfill', () => {
+    const parsed: ChatLogBackfill = chatLogBackfillSchema.parse(validBackfill);
+    expect(parsed).toEqual(validBackfill);
+  });
+
+  it('round-trips via JSON serialization', () => {
+    const roundTripped = chatLogBackfillSchema.parse(JSON.parse(JSON.stringify(validBackfill)));
+    expect(roundTripped).toEqual(validBackfill);
+  });
+
+  it('accepts an empty messages array with truncated=false', () => {
+    const parsed = chatLogBackfillSchema.parse({ messages: [], truncated: false });
+    expect(parsed.messages).toHaveLength(0);
+    expect(parsed.truncated).toBe(false);
+  });
+
+  it('accepts truncated=true when the buffer was capped', () => {
+    const parsed = chatLogBackfillSchema.parse({ messages: [], truncated: true });
+    expect(parsed.truncated).toBe(true);
+  });
+
+  it('rejects a backfill missing the truncated field', () => {
+    expect(() => chatLogBackfillSchema.parse({ messages: [] })).toThrow();
+  });
+
+  it('rejects a backfill where truncated is not a boolean', () => {
+    expect(() => chatLogBackfillSchema.parse({ messages: [], truncated: 1 })).toThrow();
+  });
+
+  it('rejects a backfill where a message is invalid', () => {
+    expect(() =>
+      chatLogBackfillSchema.parse({
+        messages: [{ ...minimalMessage, isRoll: 'yes' }],
+        truncated: false,
+      }),
+    ).toThrow();
   });
 });

--- a/packages/shared/src/rpc/live.ts
+++ b/packages/shared/src/rpc/live.ts
@@ -73,3 +73,60 @@ export type GlobePin = z.infer<typeof globePinSchema>;
 export type InventorySnapshot = z.infer<typeof inventorySnapshotSchema>;
 export type AurusSnapshot = z.infer<typeof aurusSnapshotSchema>;
 export type GlobeSnapshot = z.infer<typeof globeSnapshotSchema>;
+
+// ── Chat relay wire types ──────────────────────────────────────────────────
+// Mirrors the output of serializeChatMessage() in foundry-api-bridge, plus
+// the speakerOwnerIds field added in PR 1. PR 2 uses these to type the
+// filtered SSE stream and backfill route; PR 3 uses them in the portal.
+
+export const chatSpeakerSchema = z.object({
+  alias: z.string().optional(),
+  actor: z.string().optional(),
+  scene: z.string().optional(),
+  token: z.string().optional(),
+});
+
+export const chatRollDieResultSchema = z.object({
+  result: z.number(),
+  active: z.boolean(),
+});
+
+export const chatRollDiceTermSchema = z.object({
+  faces: z.number(),
+  results: z.array(chatRollDieResultSchema),
+});
+
+export const chatRollSchema = z.object({
+  formula: z.string(),
+  total: z.number(),
+  isCritical: z.boolean(),
+  isFumble: z.boolean(),
+  dice: z.array(chatRollDiceTermSchema),
+});
+
+// All nullable fields match the ?? null / ?? [] fallbacks in serializeChatMessage.
+export const chatMessageSnapshotSchema = z.object({
+  id: z.string(),
+  uuid: z.string().nullable(),
+  type: z.number().nullable(),
+  author: z.object({ id: z.string(), name: z.string() }).nullable(),
+  timestamp: z.number().nullable(),
+  flavor: z.string(),
+  content: z.string(),
+  speaker: chatSpeakerSchema.nullable(),
+  speakerOwnerIds: z.array(z.string()),
+  whisper: z.array(z.string()),
+  isRoll: z.boolean(),
+  rolls: z.array(chatRollSchema),
+  flags: z.record(z.string(), z.unknown()),
+});
+
+export const chatLogBackfillSchema = z.object({
+  messages: z.array(chatMessageSnapshotSchema),
+  truncated: z.boolean(),
+});
+
+export type ChatSpeaker = z.infer<typeof chatSpeakerSchema>;
+export type ChatRoll = z.infer<typeof chatRollSchema>;
+export type ChatMessageSnapshot = z.infer<typeof chatMessageSnapshotSchema>;
+export type ChatLogBackfill = z.infer<typeof chatLogBackfillSchema>;


### PR DESCRIPTION
## Summary

PR 1 of 3 in the chat-relay plan at `~/.claude/plans/read-only-investigation-plan-mode-delightful-perlis.md`.

Adds two Zod schemas to `packages/shared/src/rpc/live.ts` — `ChatMessageSnapshot` and `ChatLogBackfill` — that type the wire contract for the upcoming filtered chat SSE channel (PR 2) and the portal Chat tab (PR 3). Extends `serializeChatMessage()` in `foundry-api-bridge` with a `speakerOwnerIds` field: the list of user IDs whose ownership level is OWNER (3) for the message's speaker actor. The future filter predicate (PR 2) uses this to decide whether a subscriber's actor owns the speaker without re-querying world data.

## Apps touched

- `packages/shared` — new Zod schemas + inferred TS types in `src/rpc/live.ts`
- `apps/foundry-api-bridge` — `speakerOwnerIds` field added to `serializeChatMessage()` in `src/events/EventChannelController.ts`

No `npm run dev:*` needed to validate — run tests only:
- `npm run test -w packages/shared`
- `npm run test -w apps/foundry-api-bridge`

## Changes

- `packages/shared/src/rpc/live.ts`: `chatMessageSnapshotSchema`, `chatLogBackfillSchema`, and supporting sub-schemas (`chatSpeakerSchema`, `chatRollSchema`, etc.) with `z.infer<>` types
- `apps/foundry-api-bridge/src/events/EventChannelController.ts`: `computeSpeakerOwnerIds()` helper reads `game.actors.get(actorId).ownership`, filters to level-3 entries, excludes the `'default'` pseudo-key; result appended to every `serializeChatMessage()` payload
- Tests for both workspaces: round-trips, rejection cases, single/multiple owners, `'default'` exclusion, regression on existing fields

## Test plan

- [ ] `npm run test -w packages/shared` — 12 test files pass (new `ChatMessageSnapshot` + `ChatLogBackfill` suites included)
- [ ] `npm run test -w apps/foundry-api-bridge` — 53 suites pass (new `speakerOwnerIds enrichment` describe block included)
- [ ] `npm run typecheck` — clean across all workspaces