### PR TITLE
feat(scripts): add upscale-icons script for PF2e equipment icons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
 
       - name: Tests
         run: |
+          npm run test:scripts
           npm run test --workspace apps/dm-tool
           npm run test --workspace apps/player-portal
           npm run test --workspace apps/foundry-api-bridge

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ apps/dm-tool/config.json
 # Claude Code (worktrees, session data, plans, etc.)
 .claude/
 
+# Upscaled icon output (scripts/upscale-icons.ts)
+output/
+
 # Python artifacts (tagger/)
 __pycache__/
 *.pyc

--- a/knip.json
+++ b/knip.json
@@ -2,6 +2,8 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "workspaces": {
     ".": {
+      "entry": ["scripts/*.ts"],
+      "project": ["scripts/**/*.ts"],
       "ignoreDependencies": [
         "@secretlint/secretlint-rule-anthropic",
         "@secretlint/secretlint-rule-aws",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@secretlint/secretlint-rule-github": "^12.3.0",
         "@secretlint/secretlint-rule-openai": "^12.3.0",
         "@secretlint/secretlint-rule-pattern": "^12.3.0",
+        "@types/node": "^25.6.0",
         "eslint": "^10.2.1",
         "eslint-config-prettier": "^10.1.8",
         "husky": "^9.1.7",
@@ -28,8 +29,10 @@
         "lint-staged": "^16.4.0",
         "prettier": "^3.8.3",
         "secretlint": "^12.3.0",
+        "tsx": "^4.19.0",
         "typescript": "^6.0.3",
-        "typescript-eslint": "^8.58.2"
+        "typescript-eslint": "^8.58.2",
+        "vitest": "^4.1.4"
       }
     },
     "apps/character-creator": {

--- a/package.json
+++ b/package.json
@@ -13,12 +13,14 @@
   ],
   "scripts": {
     "prepare": "husky",
-    "typecheck": "npm run typecheck --workspaces --if-present",
+    "typecheck": "tsc --noEmit && npm run typecheck --workspaces --if-present",
     "test": "npm run test --workspaces --if-present",
+    "test:scripts": "vitest run scripts/",
     "lint": "eslint . && npm run lint --workspaces --if-present",
     "lint:fix": "eslint . --fix",
     "knip": "knip --include files,dependencies,unresolved",
     "build": "npm run build --workspaces --if-present",
+    "upscale-icons": "tsx scripts/upscale-icons.ts",
     "dev:dm-tool": "npm --workspace apps/dm-tool run dev",
     "dev:mcp": "npm --workspace apps/foundry-mcp run dev",
     "dev:player-portal": "npm --workspace apps/player-portal run dev",
@@ -37,6 +39,7 @@
     "@secretlint/secretlint-rule-github": "^12.3.0",
     "@secretlint/secretlint-rule-openai": "^12.3.0",
     "@secretlint/secretlint-rule-pattern": "^12.3.0",
+    "@types/node": "^25.6.0",
     "eslint": "^10.2.1",
     "eslint-config-prettier": "^10.1.8",
     "husky": "^9.1.7",
@@ -44,8 +47,10 @@
     "lint-staged": "^16.4.0",
     "prettier": "^3.8.3",
     "secretlint": "^12.3.0",
+    "tsx": "^4.19.0",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.58.2"
+    "typescript-eslint": "^8.58.2",
+    "vitest": "^4.1.4"
   },
   "lint-staged": {
     "*.{ts,tsx,js,json,md,html,css,scss,py}": "secretlint"

--- a/scripts/upscale-icons.test.ts
+++ b/scripts/upscale-icons.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi } from 'vitest';
+import { join } from 'node:path';
+import { outputPathFor, parseArgs, runWithConcurrency, shouldSkip, type StatFn } from './upscale-icons.js';
+
+// ── outputPathFor ──────────────────────────────────────────────────────────────
+
+describe('outputPathFor', () => {
+  it('preserves subdirectory structure and keeps .webp extension', () => {
+    expect(outputPathFor('/icons/weapons/sword.webp', '/icons', '/out')).toBe(join('/out', 'weapons', 'sword.webp'));
+  });
+
+  it('converts .png input to .webp output', () => {
+    expect(outputPathFor('/icons/armor/plate.png', '/icons', '/out')).toBe(join('/out', 'armor', 'plate.webp'));
+  });
+
+  it('handles deeply nested directories', () => {
+    expect(outputPathFor('/icons/a/b/c/item.webp', '/icons', '/out')).toBe(join('/out', 'a', 'b', 'c', 'item.webp'));
+  });
+
+  it('handles a file at the root of inputDir', () => {
+    expect(outputPathFor('/icons/ring.webp', '/icons', '/out')).toBe(join('/out', 'ring.webp'));
+  });
+});
+
+// ── shouldSkip ────────────────────────────────────────────────────────────────
+
+describe('shouldSkip', () => {
+  const makeStatFn = (responses: Array<{ mtimeMs: number } | Error>): StatFn => {
+    let call = 0;
+    return async (_path: string) => {
+      const r = responses[call++];
+      if (r instanceof Error) throw r;
+      return r;
+    };
+  };
+
+  it('returns false immediately when force=true, without calling stat', async () => {
+    const statFn = vi.fn() as unknown as StatFn;
+    expect(await shouldSkip('/in/f.webp', '/out/f.webp', true, statFn)).toBe(false);
+    expect(statFn).not.toHaveBeenCalled();
+  });
+
+  it('returns true when output exists and is newer than input', async () => {
+    const statFn = makeStatFn([{ mtimeMs: 1000 }, { mtimeMs: 2000 }]);
+    expect(await shouldSkip('/in/f.webp', '/out/f.webp', false, statFn)).toBe(true);
+  });
+
+  it('returns true when output mtime equals input mtime', async () => {
+    const statFn = makeStatFn([{ mtimeMs: 1000 }, { mtimeMs: 1000 }]);
+    expect(await shouldSkip('/in/f.webp', '/out/f.webp', false, statFn)).toBe(true);
+  });
+
+  it('returns false when output is older than input', async () => {
+    const statFn = makeStatFn([{ mtimeMs: 2000 }, { mtimeMs: 1000 }]);
+    expect(await shouldSkip('/in/f.webp', '/out/f.webp', false, statFn)).toBe(false);
+  });
+
+  it('returns false when output does not exist (stat throws)', async () => {
+    const statFn = makeStatFn([{ mtimeMs: 1000 }, new Error('ENOENT')]);
+    expect(await shouldSkip('/in/f.webp', '/out/f.webp', false, statFn)).toBe(false);
+  });
+
+  it('returns false when input stat fails', async () => {
+    const statFn = makeStatFn([new Error('ENOENT'), { mtimeMs: 2000 }]);
+    expect(await shouldSkip('/in/f.webp', '/out/f.webp', false, statFn)).toBe(false);
+  });
+});
+
+// ── parseArgs ─────────────────────────────────────────────────────────────────
+
+describe('parseArgs', () => {
+  it('returns defaults when no flags are provided', () => {
+    const cfg = parseArgs(['node', 'script.ts']);
+    expect(cfg.input).toBeUndefined();
+    expect(cfg.output).toBe('./output/equipment');
+    expect(cfg.concurrency).toBe(2);
+    expect(cfg.force).toBe(false);
+    expect(cfg.realesrganBin).toBe('realesrgan-ncnn-vulkan');
+    expect(cfg.help).toBe(false);
+  });
+
+  it('parses --input', () => {
+    expect(parseArgs(['node', 'script.ts', '--input', '/my/icons']).input).toBe('/my/icons');
+  });
+
+  it('parses --output', () => {
+    expect(parseArgs(['node', 'script.ts', '--output', '/my/out']).output).toBe('/my/out');
+  });
+
+  it('parses --concurrency', () => {
+    expect(parseArgs(['node', 'script.ts', '--concurrency', '4']).concurrency).toBe(4);
+  });
+
+  it('parses --force', () => {
+    expect(parseArgs(['node', 'script.ts', '--force']).force).toBe(true);
+  });
+
+  it('parses --realesrgan-bin', () => {
+    expect(parseArgs(['node', 'script.ts', '--realesrgan-bin', '/usr/local/bin/realesrgan']).realesrganBin).toBe(
+      '/usr/local/bin/realesrgan',
+    );
+  });
+
+  it('parses --help / -h', () => {
+    expect(parseArgs(['node', 'script.ts', '--help']).help).toBe(true);
+    expect(parseArgs(['node', 'script.ts', '-h']).help).toBe(true);
+  });
+
+  it('parses all flags together', () => {
+    const cfg = parseArgs([
+      'node',
+      'script.ts',
+      '--input',
+      '/in',
+      '--output',
+      '/out',
+      '--concurrency',
+      '8',
+      '--force',
+      '--realesrgan-bin',
+      '/bin/realesrgan',
+    ]);
+    expect(cfg).toMatchObject({
+      input: '/in',
+      output: '/out',
+      concurrency: 8,
+      force: true,
+      realesrganBin: '/bin/realesrgan',
+    });
+  });
+});
+
+// ── runWithConcurrency ────────────────────────────────────────────────────────
+
+describe('runWithConcurrency', () => {
+  it('runs all tasks exactly once', async () => {
+    const executed: number[] = [];
+    const tasks = [1, 2, 3, 4, 5].map((n) => async () => {
+      executed.push(n);
+    });
+    await runWithConcurrency(tasks, 2);
+    expect(executed.sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('resolves immediately for an empty task list', async () => {
+    await expect(runWithConcurrency([], 2)).resolves.toBeUndefined();
+  });
+
+  it('handles concurrency larger than task count', async () => {
+    const executed: number[] = [];
+    const tasks = [1, 2].map((n) => async () => {
+      executed.push(n);
+    });
+    await runWithConcurrency(tasks, 10);
+    expect(executed).toHaveLength(2);
+  });
+
+  it('respects concurrency limit (no more than n in-flight at once)', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const tasks = Array.from({ length: 8 }, () => async () => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await Promise.resolve(); // yield
+      inFlight--;
+    });
+    await runWithConcurrency(tasks, 3);
+    expect(maxInFlight).toBeLessThanOrEqual(3);
+  });
+});

--- a/scripts/upscale-icons.ts
+++ b/scripts/upscale-icons.ts
@@ -1,0 +1,287 @@
+/**
+ * Upscale PF2e equipment icons 4× using realesrgan-ncnn-vulkan.
+ *
+ * Run:  npm run upscale-icons -- [flags]
+ *       tsx scripts/upscale-icons.ts --help
+ */
+import { spawn } from 'node:child_process';
+import { access, mkdir, readdir, stat } from 'node:fs/promises';
+import { dirname, extname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const LOG_PREFIX = '[icon-upscale]';
+
+// Default source directory — the standard Foundry VTT PF2e data layout.
+// If this path doesn't exist at runtime, the script exits and asks for --input.
+const WELL_KNOWN_INPUT = 'E:/TTRPG/Tools/data/Data/systems/pf2e/icons/equipment';
+const DEFAULT_OUTPUT = './output/equipment';
+const DEFAULT_CONCURRENCY = 2;
+const DEFAULT_BIN = 'realesrgan-ncnn-vulkan';
+
+export interface Config {
+  input: string | undefined;
+  output: string;
+  concurrency: number;
+  force: boolean;
+  realesrganBin: string;
+  help: boolean;
+}
+
+export function parseArgs(argv: string[]): Config {
+  const args = argv.slice(2);
+  const config: Config = {
+    input: undefined,
+    output: DEFAULT_OUTPUT,
+    concurrency: DEFAULT_CONCURRENCY,
+    force: false,
+    realesrganBin: DEFAULT_BIN,
+    help: false,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    switch (arg) {
+      case '--help':
+      case '-h':
+        config.help = true;
+        break;
+      case '--input':
+        config.input = args[++i];
+        break;
+      case '--output':
+        config.output = args[++i];
+        break;
+      case '--concurrency': {
+        const n = parseInt(args[++i], 10);
+        if (isNaN(n) || n < 1) {
+          console.error(`${LOG_PREFIX} ERROR --concurrency must be a positive integer`);
+          process.exit(1);
+        }
+        config.concurrency = n;
+        break;
+      }
+      case '--force':
+        config.force = true;
+        break;
+      case '--realesrgan-bin':
+        config.realesrganBin = args[++i];
+        break;
+      default:
+        console.error(`${LOG_PREFIX} ERROR Unknown flag: ${arg}`);
+        process.exit(1);
+    }
+  }
+
+  return config;
+}
+
+function printHelp(): void {
+  console.log(
+    `
+${LOG_PREFIX} Upscale PF2e equipment icons 4× using realesrgan-ncnn-vulkan (model: realesrgan-x4plus-anime).
+
+Usage:
+  npm run upscale-icons -- [options]
+  tsx scripts/upscale-icons.ts [options]
+
+Options:
+  --input <dir>             Source directory of .webp/.png icons
+                            (default: ${WELL_KNOWN_INPUT})
+  --output <dir>            Output directory, mirroring the input tree structure
+                            (default: ${DEFAULT_OUTPUT})
+  --concurrency <n>         Max parallel realesrgan processes (default: ${DEFAULT_CONCURRENCY})
+  --force                   Re-upscale even if output exists and is newer than input
+  --realesrgan-bin <path>   Path to realesrgan-ncnn-vulkan executable
+                            (default: realesrgan-ncnn-vulkan resolved from PATH)
+  --help, -h                Show this help
+
+Prerequisites:
+  Download realesrgan-ncnn-vulkan from:
+    https://github.com/xinntao/Real-ESRGAN-ncnn-vulkan/releases
+  Add the extracted directory to your PATH, or pass --realesrgan-bin <path>.
+    `.trim(),
+  );
+}
+
+/** Maps an input file path to its corresponding output .webp path. */
+export function outputPathFor(inputFile: string, inputDir: string, outputDir: string): string {
+  const rel = relative(inputDir, inputFile);
+  const noExt = rel.slice(0, rel.length - extname(rel).length);
+  return join(outputDir, noExt + '.webp');
+}
+
+/** Minimal stat interface used by shouldSkip — injectable for tests. */
+export type StatFn = (path: string) => Promise<{ mtimeMs: number }>;
+
+/**
+ * Returns true when the output file exists and is at least as new as the input,
+ * meaning a previous run already produced this file.  force=true always returns false.
+ */
+export async function shouldSkip(
+  inputFile: string,
+  outputFile: string,
+  force: boolean,
+  statFn: StatFn = stat,
+): Promise<boolean> {
+  if (force) return false;
+  try {
+    const [inStat, outStat] = await Promise.all([statFn(inputFile), statFn(outputFile)]);
+    return outStat.mtimeMs >= inStat.mtimeMs;
+  } catch {
+    // Output missing, or input vanished — don't skip.
+    return false;
+  }
+}
+
+async function walkDir(dir: string): Promise<string[]> {
+  const results: string[] = [];
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...(await walkDir(full)));
+    } else if (entry.isFile()) {
+      const ext = extname(entry.name).toLowerCase();
+      if (ext === '.webp' || ext === '.png') {
+        results.push(full);
+      }
+    }
+  }
+  return results;
+}
+
+function runRealesrgan(bin: string, inputFile: string, outputFile: string): Promise<void> {
+  return new Promise((res, rej) => {
+    const child = spawn(bin, [
+      '-i',
+      inputFile,
+      '-o',
+      outputFile,
+      '-n',
+      'realesrgan-x4plus-anime',
+      '-s',
+      '4',
+      '-f',
+      'webp',
+    ]);
+    const stderrChunks: string[] = [];
+    child.stderr.on('data', (chunk: Buffer) => stderrChunks.push(chunk.toString()));
+    child.on('close', (code) => {
+      if (code === 0) {
+        res();
+      } else {
+        const tail = stderrChunks.join('').split('\n').slice(-5).join('\n').trim();
+        rej(new Error(`exited with code ${code}${tail ? `. stderr: ${tail}` : ''}`));
+      }
+    });
+    child.on('error', rej);
+  });
+}
+
+/** Runs tasks with at most `concurrency` in flight at a time. */
+export async function runWithConcurrency(tasks: (() => Promise<void>)[], concurrency: number): Promise<void> {
+  let index = 0;
+  const worker = async () => {
+    while (index < tasks.length) {
+      const i = index++;
+      await tasks[i]();
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(concurrency, tasks.length) }, () => worker()));
+}
+
+async function main(): Promise<void> {
+  const config = parseArgs(process.argv);
+
+  if (config.help) {
+    printHelp();
+    return;
+  }
+
+  // Resolve and verify the input directory.
+  let inputDir: string;
+  if (config.input !== undefined) {
+    try {
+      await access(config.input);
+    } catch {
+      console.error(`${LOG_PREFIX} ERROR Input directory not found: ${config.input}`);
+      process.exit(1);
+    }
+    inputDir = config.input;
+  } else {
+    try {
+      await access(WELL_KNOWN_INPUT);
+    } catch {
+      console.error(`${LOG_PREFIX} ERROR Default input directory not found: ${WELL_KNOWN_INPUT}`);
+      console.error(`${LOG_PREFIX} ERROR Specify the source directory with --input <dir>`);
+      process.exit(1);
+    }
+    inputDir = WELL_KNOWN_INPUT;
+  }
+
+  console.info(`${LOG_PREFIX} Input:       ${inputDir}`);
+  console.info(`${LOG_PREFIX} Output:      ${config.output}`);
+  console.info(`${LOG_PREFIX} Concurrency: ${config.concurrency}`);
+  console.info(`${LOG_PREFIX} Force:       ${config.force}`);
+  console.info(`${LOG_PREFIX} Binary:      ${config.realesrganBin}`);
+
+  const inputFiles = await walkDir(inputDir);
+  console.info(`${LOG_PREFIX} Found ${inputFiles.length} icon file(s) in ${inputDir}`);
+
+  if (inputFiles.length === 0) {
+    console.info(`${LOG_PREFIX} Nothing to do.`);
+    return;
+  }
+
+  const startTime = Date.now();
+  let processed = 0;
+  let skipped = 0;
+  const failures: string[] = [];
+  const total = inputFiles.length;
+
+  const tasks = inputFiles.map((inputFile, idx) => async () => {
+    const outputFile = outputPathFor(inputFile, inputDir, config.output);
+    const relInput = relative(inputDir, inputFile);
+
+    if (await shouldSkip(inputFile, outputFile, config.force)) {
+      skipped++;
+      return;
+    }
+
+    await mkdir(dirname(outputFile), { recursive: true });
+
+    console.info(`${LOG_PREFIX} [${idx + 1}/${total}] ${relInput} -> ${outputFile}`);
+
+    try {
+      await runRealesrgan(config.realesrganBin, inputFile, outputFile);
+      processed++;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.warn(`${LOG_PREFIX} WARN failed ${relInput}: ${msg}`);
+      failures.push(relInput);
+    }
+  });
+
+  await runWithConcurrency(tasks, config.concurrency);
+
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+  console.info(
+    `${LOG_PREFIX} Done in ${elapsed}s — processed: ${processed}, skipped: ${skipped}, errors: ${failures.length}`,
+  );
+
+  if (failures.length > 0) {
+    console.warn(`${LOG_PREFIX} WARN ${failures.length} icon(s) failed:`);
+    for (const f of failures) {
+      console.warn(`${LOG_PREFIX} WARN   ${f}`);
+    }
+    process.exitCode = 1;
+  }
+}
+
+// Run only when invoked directly (not when imported by tests).
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+  main().catch((e: unknown) => {
+    console.error(`${LOG_PREFIX} fatal:`, e);
+    process.exit(1);
+  });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["scripts/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Adds `scripts/upscale-icons.ts` — a CLI that walks a directory of PF2e equipment icons and produces 4× upscaled WebP copies via [`realesrgan-ncnn-vulkan`](https://github.com/xinntao/Real-ESRGAN-ncnn-vulkan) using the `realesrgan-x4plus-anime` model (illustration-tuned, appropriate for game icons). Output mirrors the source tree under `./output/equipment/` (gitignored). Skips files already upscaled unless `--force` is passed, so re-runs are cache-friendly. This is producer-only — no asset proxy or source replacement changes. Whether to wire the upscaled set into the app is a separate decision.

**Apps touched:** none. This PR adds a root-level script with no runtime dependencies on any app. No `npm run dev:*` needed to validate.

## Changes

- `scripts/upscale-icons.ts` — main script with `--input`, `--output`, `--concurrency`, `--force`, `--realesrgan-bin` flags; concurrency-limited queue; per-file skip-if-exists; failure collection with non-zero exit
- `scripts/upscale-icons.test.ts` — 22 Vitest tests covering `outputPathFor`, `shouldSkip` (mtime logic + force flag), `parseArgs` (all flags, defaults), and `runWithConcurrency` (task completion, concurrency cap)
- `tsconfig.json` (root) — new; covers `scripts/**/*.ts` so the root `tsc` pass typechecks them
- `package.json` — adds `upscale-icons` and `test:scripts` scripts; adds `tsx`, `vitest`, `@types/node` to root devDependencies; updates `typecheck` to run root `tsc` before the workspace fan-out
- `.gitignore` — adds `output/`
- `knip.json` — registers `scripts/` entry points so knip doesn't flag them as dead code
- `.github/workflows/ci.yml` — adds `npm run test:scripts` to the Tests step

## Prerequisites (manual — not gated in CI)

Install `realesrgan-ncnn-vulkan` from its [releases page](https://github.com/xinntao/Real-ESRGAN-ncnn-vulkan/releases) and add the extracted directory to PATH (or use `--realesrgan-bin`). The model weights ship with the binary — no separate download.

## Usage

```
npm run upscale-icons -- --help

# Default input (E:/TTRPG/Tools/data/Data/systems/pf2e/icons/equipment):
npm run upscale-icons

# Custom input, higher concurrency:
npm run upscale-icons -- --input /path/to/icons --concurrency 4
```

## Test plan

- [x] `npm run test:scripts` — 22 tests pass
- [x] `npm run typecheck` (root tsc pass) — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [ ] Manual: `npm run upscale-icons -- --help` — verify help output (requires no binary)
- [ ] Manual: run against a small subset once `realesrgan-ncnn-vulkan` is installed