### PR TITLE
docs: refresh root README to reflect current state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,55 +1,130 @@
 # foundry-toolkit
 
-Monorepo consolidating four Foundry VTT companion tools into one npm-workspaces project.
+A personal companion stack for running Pathfinder 2e in Foundry VTT. Four apps and four shared
+packages, consolidated into one npm-workspaces monorepo.
+
+The two main surfaces are:
+
+- **dm-tool** — an Electron desktop app the GM runs alongside Foundry. Browses a tagged map
+  library, reads PF2e books, runs AI chat/loot/hook agents, and manages combat and party inventory.
+- **player-portal** — a web app players open in a browser. Renders a live PF2e character sheet
+  outside Foundry (dark/light themed, grid layouts), handles spell casting, skill rolls, feat
+  prereqs, item investment, and long-rest mechanics. Backed by a Fastify server that proxies
+  Foundry data and pushes live state.
+
+Both apps talk to **foundry-mcp** (a self-hosted MCP + REST server) via **foundry-api-bridge** (a
+Foundry VTT module that opens an outbound WebSocket to the MCP server).
 
 ## Layout
 
 ```
 foundry-toolkit/
 ├── apps/
-│   ├── dm-tool/              Electron desktop app (GM-side)
-│   ├── player-portal/        Player-facing web app + Fastify server
-│   │                           serves the SPA, /api/live/* (ex-sidecar),
-│   │                           /api/mcp/* (proxy to foundry-mcp), /map/*,
-│   │                           and the Foundry asset prefixes. Includes
-│   │                           the PF2e character creator/sheet surface.
-│   ├── foundry-mcp/          Self-hosted MCP server (Fly.io deploy)
-│   └── foundry-api-bridge/   Foundry VTT module — WebSocket bridge to MCP
+│   ├── dm-tool/              Electron desktop app (GM-side): map browser, book reader,
+│   │                           AI agents, combat tracker, monster browser, party inventory
+│   ├── player-portal/        Player-facing React SPA + Fastify server: PF2e character sheet,
+│   │                           inventory, Golarion globe, Aurus leaderboard, asset proxy
+│   ├── foundry-mcp/          Self-hosted MCP + REST server; WebSocket bridge to Foundry;
+│   │                           SSE event channels (rolls, chat, combat, actors)
+│   └── foundry-api-bridge/   Foundry VTT module — opens outbound WS to foundry-mcp,
+│                               routes commands, relays Foundry dialogs to player-portal
 ├── packages/
-│   ├── ai/                   PF2e GM assistant agents (chat, hooks, loot, classifier)
-│   ├── db/                   Data layer (pf2e.db, BookDb, MapDb)
-│   ├── pf2e-rules/           Pure PF2e rules math (XP budgets, treasure tables)
-│   └── shared/               Types + shared UI
-├── resources/                dm-tool Electron icons
-├── tagger/                   Python map-indexing subtool (built separately)
+│   ├── ai/                   PF2e GM assistant agents (chat, hooks, loot, classifier);
+│   │                           Vercel AI SDK v6, adversarial two-pass chat pattern
+│   ├── db/                   SQLite data layer for dm-tool (settings, combat, maps, books)
+│   ├── pf2e-rules/           Pure PF2e rules math — XP budgets, treasure tables, no I/O
+│   └── shared/               Wire-contract types (foundry-api, rpc), shared UI components
+│                               (MissionBriefing, Golarion globe), PF2e design tokens
 ├── tools/
-│   └── launcher/             Tiny Electron GUI to run `dev:*` scripts per worktree
-└── tsconfig.base.json        Shared strict TS config
+│   └── launcher/             Electron GUI to spawn dev:* scripts per worktree
+├── tagger/                   Python map-indexing subtool (not an npm workspace)
+├── auto-wall-bin/            Prebuilt wall-detection binary (extraResources for dm-tool)
+└── tsconfig.base.json        Shared strict TypeScript config
 ```
 
-## Scripts (root)
+Internal dependency graph:
 
-- `npm install` — installs everything + rebuilds better-sqlite3 for dm-tool's Electron ABI
-- `npm run typecheck` — type-check all workspaces
-- `npm run test` — run all workspace test suites
-- `npm run lint` — root ESLint + per-workspace lint scripts
-- `npm run knip` — dead-code/unused-deps scan across the workspaces listed in `knip.json`
-- `npm run build` — build all workspaces
-- `npm run dev:dm-tool` — launch dm-tool Electron dev
-- `npm run dev:mcp` — launch foundry-mcp server
-- `npm run dev:player-portal` — launch player-portal (Vite + Fastify concurrently)
-- `npm run dev:player-portal:mock` — same but with the in-process MCP/asset mock
-- `npm run dev:api-bridge` — vite watch build for the Foundry module
-- `npm run launcher` — open `tools/launcher`, a small Electron GUI that lists every worktree × `dev:*` app pair and spawns the selected one in a new Windows Terminal tab
+- `shared` + `pf2e-rules` → `ai` → `db` → `dm-tool`
+- `shared` → `player-portal` (MCP wire contract + design tokens)
+- `shared` → `foundry-mcp` (wire contract types + Zod schemas)
+- `foundry-api-bridge` is standalone
 
-See each workspace's README / CLAUDE.md for app-specific details.
+## Getting started
 
-## CI and deployment
+```bash
+npm install   # installs all workspaces; rebuilds better-sqlite3 for dm-tool's Electron ABI
+```
 
-- **CI**: a minimal lint/typecheck/test/knip pipeline runs in [.github/workflows/ci.yml](.github/workflows/ci.yml). Per-app workflows (Docker publish, Fly deploy) from the pre-consolidation repos were not ported.
-- **Deployments**: Fly.io (foundry-mcp), electron-builder (dm-tool), GHCR images (api-bridge, player-portal) all still reference the old per-repo identifiers. Re-point when productionizing.
-- **Branches**: feature branches stay in the source repos until explicitly carried over.
+Then launch whichever app you need:
+
+```bash
+npm run dev:dm-tool              # GM Electron app
+npm run dev:mcp                  # foundry-mcp REST + MCP server
+npm run dev:player-portal        # player-portal (Vite :5173 + Fastify :3000)
+npm run dev:player-portal:mock   # same, but with fixture mock (no Foundry required)
+npm run dev:api-bridge           # Vite watch build for the Foundry module
+npm run launcher                 # Electron GUI — pick a worktree + dev:* combo
+```
+
+Other root commands:
+
+```bash
+npm run typecheck    # fan out across all workspaces
+npm run test         # fan out across all workspaces
+npm run lint         # root ESLint pass + per-workspace lint scripts
+npm run lint:fix     # autofix where possible
+npm run build        # fan out across all workspaces
+npm run knip         # dead-code / unused-deps scan
+```
+
+Each workspace has its own `CLAUDE.md` with app-specific build notes and gotchas. The root
+`CLAUDE.md` covers the monorepo toolchain, lint workflow, and contribution rules.
+
+## What's notable
+
+**Dialog relay** — When a player triggers an action (attack roll, skill check, saving throw),
+foundry-api-bridge suppresses Foundry's native dialog and relays it to the player-portal character
+sheet as a typed overlay. Players interact with a styled PF2e dialog rather than a browser popup.
+
+**Dispatcher pattern** — A generic Foundry command dispatcher routes typed PF2e client calls
+(saves, strikes, damage, spell casting) through `pf2e-rules` for the math and `foundry-mcp` for
+execution. Decouples PF2e rules logic from Foundry API specifics and makes the action surface
+incrementally extendable.
+
+**Player-portal character sheet** — A full PF2e character sheet rendered in the browser, outside
+Foundry: dark/light themes using PF2e design tokens, grid and list views, feat prerequisite
+evaluation, skill rolls, spell slots with casting support, item investment, inventory with crafting,
+and live sync from dm-tool via WebSocket.
+
+**Golarion globe** — A shared React component displaying an interactive Golarion world map:
+auto-rotate, procedural starfield, east-drifting ambient cloud layer, atmospheric depth halo, and
+clickable map pins with fill-color customization.
+
+**Live event channels** — foundry-mcp exposes SSE endpoints (`/api/events/:channel/stream`) for
+`rolls`, `chat`, `combat`, and `actors`. The Foundry module registers `Hooks.on` lazily — only
+while a subscriber is connected — and tears them down when the last consumer disconnects. External
+consumers (dm-tool, player-portal, Discord bots, stream overlays) subscribe without polling.
+
+## Toolchain
+
+- TypeScript 6, ESM throughout (`"type": "module"` at root)
+- Vite 7 / electron-vite for bundling; React 19; Tailwind CSS 4; Fastify 5
+- ESLint 10 flat config + typescript-eslint + Prettier 3 (120-col)
+- Vitest 4 for most workspaces; Jest in `foundry-api-bridge` (forked upstream test suite)
+- CI: lint + typecheck + test + knip in `.github/workflows/ci.yml`
+
+## Status and scope
+
+Personal-use project, not aimed at distribution. Some deployment artifacts are vestigial: Fly.io
+configs and GHCR references still point at pre-consolidation per-repo identifiers. Deployment
+workflows weren't ported when the four source repos were consolidated here. Re-point before
+productionizing.
+
+`tagger/` and `auto-wall-bin/` are not npm workspaces and must be built separately before
+`dm-tool` can be packaged.
 
 ## License
 
-[MIT](LICENSE) © Alex Dickerson. `apps/foundry-api-bridge` additionally preserves upstream fork attribution; `apps/player-portal` includes Apache-2.0 derived files (ported from `foundryvtt/pf2e` for the character creator/sheet surface) — see its [NOTICE](apps/player-portal/NOTICE).
+[MIT](LICENSE) © Alex Dickerson. `apps/foundry-api-bridge` preserves upstream fork attribution.
+`apps/player-portal` includes Apache-2.0 derived files ported from `foundryvtt/pf2e` for the
+character creator/sheet surface — see [NOTICE](apps/player-portal/NOTICE).


### PR DESCRIPTION
## Summary

The root README hadn't been meaningfully updated since PR #54 (April 24). In the two days since, ~65 PRs merged — adding the dialog relay, the Foundry dispatcher pattern, the full PF2e character sheet with design tokens and dark/light themes, Golarion globe atmospherics, live event channels, spell casting, and more. The README was still describing the repo as it existed before all of that.

This rewrites the README as project documentation for a human (or LLM) landing on the GitHub page: what the project is, what's in each workspace, how to run it, and what's architecturally interesting. Agent instructions, lint workflow, branch discipline, and the /api/eval section stay in `CLAUDE.md` only.

## Changes

- Rewrote the opening description to name both main surfaces (dm-tool, player-portal) concisely
- Updated the layout tree with accurate one-line descriptions per workspace
- Replaced the flat script list with a Getting started section (install + dev commands + other root commands)
- Added a "What's notable" section covering: dialog relay, dispatcher pattern, character sheet, Golarion globe, live event channels
- Added a short Toolchain section
- Added a Status and scope note (personal-use, vestigial deployment refs)
- Removed the "Branches" bullet that referenced pre-consolidation source repos (no longer meaningful)

## Test plan

- [ ] `npm run format:check` passes (verified locally before commit)
- [ ] No apps touched — no `npm run dev:*` needed; CI runs format:check

**Apps touched:** none — root `README.md` only.