### PR TITLE
feat(dm-tool): dual-write live-state snapshots to foundry-mcp alongside sidecar

### DIFF
--- a/apps/dm-tool/electron/ipc/aurus.ts
+++ b/apps/dm-tool/electron/ipc/aurus.ts
@@ -5,15 +5,14 @@ import { ipcMain } from 'electron';
 import type { DmToolConfig } from '../config.js';
 import type { AurusTeam } from '@foundry-toolkit/shared/types';
 import { deleteAurusTeam, listAurusTeams, upsertAurusTeam } from '@foundry-toolkit/db/pf2e';
-import { pushToSidecar } from '../sidecar-client.js';
+import { pushToFoundryMcp, pushToSidecar } from '../sidecar-client.js';
 
 async function pushSnapshot(cfg: DmToolConfig): Promise<void> {
-  await pushToSidecar(
-    cfg,
-    '/api/live/aurus',
-    { teams: listAurusTeams(), updatedAt: new Date().toISOString() },
-    'aurus',
-  );
+  const payload = { teams: listAurusTeams(), updatedAt: new Date().toISOString() };
+  await Promise.all([
+    pushToSidecar(cfg, '/api/live/aurus', payload, 'aurus'),
+    pushToFoundryMcp(cfg, '/api/live/aurus', payload, 'aurus'),
+  ]);
 }
 
 export function registerAurusHandlers(cfg: DmToolConfig): void {

--- a/apps/dm-tool/electron/ipc/globe.ts
+++ b/apps/dm-tool/electron/ipc/globe.ts
@@ -7,7 +7,7 @@ import { listGlobePins, upsertGlobePin, deleteGlobePin, setMissionMarkdown } fro
 import type { GlobePin, GlobeDeployProgress, GlobeDeployResult, MissionData } from '@foundry-toolkit/shared/types';
 import { missionNoteTemplate, parseMissionNote } from '../mission-parser.js';
 import { findNoteByPinId, safeFileName, stampPinId } from '../mission-notes.js';
-import { pushToSidecar } from '../sidecar-client.js';
+import { pushToFoundryMcp, pushToSidecar } from '../sidecar-client.js';
 
 /** Default public URL shown in the "Pushed" toast if not configured. */
 const DEFAULT_PUBLIC_URL = 'http://server.ad:30002';
@@ -19,7 +19,11 @@ export function registerGlobeHandlers(cfg: DmToolConfig, getMainWindow: () => El
    *  has already succeeded and the next successful push will reconcile. */
   async function pushSnapshot(): Promise<void> {
     const payload = await buildExportPayload();
-    await pushToSidecar(cfg, '/api/live/globe', { pins: payload.pins, updatedAt: new Date().toISOString() }, 'globe');
+    const body = { pins: payload.pins, updatedAt: new Date().toISOString() };
+    await Promise.all([
+      pushToSidecar(cfg, '/api/live/globe', body, 'globe'),
+      pushToFoundryMcp(cfg, '/api/live/globe', body, 'globe'),
+    ]);
   }
 
   /** Collect every pin and, for mission pins with an Obsidian vault
@@ -264,17 +268,21 @@ export function registerGlobeHandlers(cfg: DmToolConfig, getMainWindow: () => El
       const payload = await buildExportPayload();
 
       sendProgress({ stage: 'docker', message: 'Pushing to player portal...' });
+      const deployBody = { pins: payload.pins, updatedAt: new Date().toISOString() };
       const res = await fetch(`${cfg.sidecarUrl.replace(/\/+$/, '')}/api/live/globe`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${cfg.sidecarSecret}`,
         },
-        body: JSON.stringify({ pins: payload.pins, updatedAt: new Date().toISOString() }),
+        body: JSON.stringify(deployBody),
       });
       if (!res.ok) {
         return { ok: false, error: `push failed: ${res.status} ${res.statusText}` };
       }
+
+      // Best-effort mirror to foundry-mcp (dual-write; failures don't block the user).
+      void pushToFoundryMcp(cfg, '/api/live/globe', deployBody, 'globe deploy');
 
       sendProgress({ stage: 'done', message: `Live at ${publicUrl}` });
       return { ok: true, url: publicUrl };

--- a/apps/dm-tool/electron/ipc/inventory.ts
+++ b/apps/dm-tool/electron/ipc/inventory.ts
@@ -8,15 +8,14 @@ import { ipcMain } from 'electron';
 import type { DmToolConfig } from '../config.js';
 import type { PartyInventoryItem } from '@foundry-toolkit/shared/types';
 import { deleteInventory, listInventory, upsertInventory } from '@foundry-toolkit/db/pf2e';
-import { pushToSidecar } from '../sidecar-client.js';
+import { pushToFoundryMcp, pushToSidecar } from '../sidecar-client.js';
 
 async function pushSnapshot(cfg: DmToolConfig): Promise<void> {
-  await pushToSidecar(
-    cfg,
-    '/api/live/inventory',
-    { items: listInventory(), updatedAt: new Date().toISOString() },
-    'inventory',
-  );
+  const payload = { items: listInventory(), updatedAt: new Date().toISOString() };
+  await Promise.all([
+    pushToSidecar(cfg, '/api/live/inventory', payload, 'inventory'),
+    pushToFoundryMcp(cfg, '/api/live/inventory', payload, 'inventory'),
+  ]);
 }
 
 export function registerInventoryHandlers(cfg: DmToolConfig): void {

--- a/apps/dm-tool/electron/sidecar-client.test.ts
+++ b/apps/dm-tool/electron/sidecar-client.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { pushToFoundryMcp, pushToSidecar } from './sidecar-client.js';
+import type { DmToolConfig } from './config.js';
+
+const BASE_CONFIG: Pick<DmToolConfig, 'libraryPath' | 'indexDbPath' | 'inboxPath' | 'quarantinePath'> = {
+  libraryPath: '/lib',
+  indexDbPath: '/lib/index.db',
+  inboxPath: '/inbox',
+  quarantinePath: '/quarantine',
+};
+
+function cfg(overrides: Partial<DmToolConfig> = {}): DmToolConfig {
+  return { ...BASE_CONFIG, ...overrides } as DmToolConfig;
+}
+
+describe('pushToSidecar', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('is a no-op when sidecarUrl is not configured', async () => {
+    await pushToSidecar(cfg(), '/api/live/inventory', {}, 'test');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when sidecarSecret is not configured', async () => {
+    await pushToSidecar(cfg({ sidecarUrl: 'http://sidecar:3000' }), '/api/live/inventory', {}, 'test');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('POSTs to sidecarUrl with Bearer auth', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 200 }));
+    const body = { items: [], updatedAt: '2024-01-01T00:00:00.000Z' };
+    await pushToSidecar(
+      cfg({ sidecarUrl: 'http://sidecar:3000', sidecarSecret: 'abc' }),
+      '/api/live/inventory',
+      body,
+      'inventory',
+    );
+    expect(fetch).toHaveBeenCalledWith('http://sidecar:3000/api/live/inventory', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer abc' },
+      body: JSON.stringify(body),
+    });
+  });
+
+  it('strips trailing slash from sidecarUrl', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 200 }));
+    await pushToSidecar(
+      cfg({ sidecarUrl: 'http://sidecar:3000/', sidecarSecret: 'x' }),
+      '/api/live/aurus',
+      {},
+      'aurus',
+    );
+    expect(vi.mocked(fetch).mock.calls[0]?.[0]).toBe('http://sidecar:3000/api/live/aurus');
+  });
+
+  it('swallows non-2xx responses', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 503 }));
+    await expect(
+      pushToSidecar(cfg({ sidecarUrl: 'http://sidecar:3000', sidecarSecret: 'x' }), '/api/live/inventory', {}, 'test'),
+    ).resolves.toBeUndefined();
+  });
+
+  it('swallows network errors', async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error('ECONNREFUSED'));
+    await expect(
+      pushToSidecar(cfg({ sidecarUrl: 'http://sidecar:3000', sidecarSecret: 'x' }), '/api/live/inventory', {}, 'test'),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('pushToFoundryMcp', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('is a no-op when foundryMcpUrl is not configured', async () => {
+    await pushToFoundryMcp(cfg(), '/api/live/inventory', {}, 'test');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('POSTs to foundryMcpUrl without auth when sidecarSecret is unset', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 200 }));
+    const body = { items: [], updatedAt: '2024-01-01T00:00:00.000Z' };
+    await pushToFoundryMcp(cfg({ foundryMcpUrl: 'http://mcp:8765' }), '/api/live/inventory', body, 'inventory');
+    expect(fetch).toHaveBeenCalledWith('http://mcp:8765/api/live/inventory', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  });
+
+  it('includes Bearer auth when sidecarSecret is set', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 200 }));
+    await pushToFoundryMcp(
+      cfg({ foundryMcpUrl: 'http://mcp:8765', sidecarSecret: 'secret' }),
+      '/api/live/aurus',
+      {},
+      'aurus',
+    );
+    const [, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer secret');
+  });
+
+  it('strips trailing slash from foundryMcpUrl', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 200 }));
+    await pushToFoundryMcp(cfg({ foundryMcpUrl: 'http://mcp:8765/' }), '/api/live/globe', {}, 'globe');
+    expect(vi.mocked(fetch).mock.calls[0]?.[0]).toBe('http://mcp:8765/api/live/globe');
+  });
+
+  it('swallows non-2xx responses', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 503 }));
+    await expect(
+      pushToFoundryMcp(cfg({ foundryMcpUrl: 'http://mcp:8765' }), '/api/live/inventory', {}, 'test'),
+    ).resolves.toBeUndefined();
+  });
+
+  it('swallows network errors', async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error('ECONNREFUSED'));
+    await expect(
+      pushToFoundryMcp(cfg({ foundryMcpUrl: 'http://mcp:8765' }), '/api/live/inventory', {}, 'test'),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/dm-tool/electron/sidecar-client.ts
+++ b/apps/dm-tool/electron/sidecar-client.ts
@@ -1,7 +1,7 @@
-// Shared helper for best-effort POST of JSON payloads to the live-sync
-// sidecar. Callers (inventory, aurus, globe) assume the local SQLite
-// write has already succeeded — a sidecar failure is logged as a warning
-// and swallowed so it never surfaces to the user.
+// Shared helpers for best-effort POST of live-state snapshots to the
+// player-portal sidecar and/or foundry-mcp. Callers assume the local
+// SQLite write has already succeeded — remote failures are logged as
+// warnings and swallowed so they never surface to the user.
 
 import type { DmToolConfig } from './config.js';
 
@@ -27,5 +27,26 @@ export async function pushToSidecar(cfg: DmToolConfig, path: string, body: unkno
     }
   } catch (err) {
     console.warn(`${label} sidecar push error:`, (err as Error).message);
+  }
+}
+
+/**
+ * Best-effort POST of a JSON payload to a foundry-mcp /api/live/* endpoint.
+ * Silent no-op if foundryMcpUrl is not configured.
+ * Auth header is included when sidecarSecret is set (foundry-mcp uses the
+ * same SHARED_SECRET; when unset POSTs are open).
+ */
+export async function pushToFoundryMcp(cfg: DmToolConfig, path: string, body: unknown, label: string): Promise<void> {
+  if (!cfg.foundryMcpUrl) return;
+  const url = `${cfg.foundryMcpUrl.replace(/\/+$/, '')}${path}`;
+  try {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (cfg.sidecarSecret) headers['Authorization'] = `Bearer ${cfg.sidecarSecret}`;
+    const res = await fetch(url, { method: 'POST', headers, body: JSON.stringify(body) });
+    if (!res.ok) {
+      console.warn(`${label} foundry-mcp push failed: ${res.status} ${res.statusText}`);
+    }
+  } catch (err) {
+    console.warn(`${label} foundry-mcp push error:`, (err as Error).message);
   }
 }


### PR DESCRIPTION
## Apps touched

- `apps/dm-tool` — `npm run dev:dm-tool`

No app needs to be spun up to verify — the new code path is only exercised when `foundryMcpUrl` is configured in settings and foundry-mcp is running alongside the sidecar.

## What changed

Adds `pushToFoundryMcp` to `electron/sidecar-client.ts` — a mirror of `pushToSidecar` that targets `foundryMcpUrl + /api/live/*` instead of `sidecarUrl`. Updates the inventory, aurus, and globe IPC handlers to fire both destinations concurrently via `Promise.all`. The globe deploy (`globeDeployPlayer`) also mirrors to foundry-mcp as a best-effort fire-and-forget after the primary sidecar push succeeds.

Neither destination is required: each is silently skipped when its URL is unconfigured. Existing setups that have only `sidecarUrl` or only `foundryMcpUrl` continue to work unchanged.

## This is PR 3 of 6 in the live-state migration

1. ✅ Extract snapshot types to `packages/shared` (PR #123)
2. ✅ Add live-state storage + GET/POST/SSE routes to `foundry-mcp` (PR #124)
3. **This PR** — dm-tool dual-writes to both sidecar and foundry-mcp
4. player-portal SPA switches from WebSocket to SSE (`EventSource` against foundry-mcp)
5. Retire the sidecar (drop player-portal's in-memory store + WS routes)
6. Drop moved tables from pf2e.db

🤖 Generated with [Claude Code](https://claude.com/claude-code)