### PR TITLE
chore: remove stale better-sqlite3 references after node:sqlite migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Internal dependency graph:
 ## Getting started
 
 ```bash
-npm install   # installs all workspaces; rebuilds better-sqlite3 for dm-tool's Electron ABI
+npm install   # installs all workspaces
 ```
 
 Then launch whichever app you need:

--- a/apps/dm-tool/CLAUDE.md
+++ b/apps/dm-tool/CLAUDE.md
@@ -42,7 +42,6 @@ Workspace deps (raw TS, transpiled by electron-vite): `@foundry-toolkit/ai`, `@f
 - **Session hook** on `defaultSession.webRequest.onHeadersReceived`: strips `X-Frame-Options` and `frame-ancestors` (so external sites embed in iframes), and injects `Access-Control-Allow-Origin: *` for `https://map.pathfinderwiki.com/` so MapLibre can fetch PMTiles, sprites, and font glyphs from the renderer.
 - `sandbox: false` on the BrowserWindow — preload needs `fs` access via `ipcRenderer`.
 - **Packaging pulls external binaries** that aren't npm modules: `../../tagger/dist/map-tagger.exe` and `../../auto-wall-bin/Auto-Wall.exe`. Both must exist at `package` time.
-- **`better-sqlite3` rebuild** is covered by root `postinstall` + electron-builder's `npmRebuild: true`. If the renderer shows ABI-mismatch errors, run `npm run rebuild-sqlite` from the monorepo root.
 - `MapDb` is a read-only consumer of the map-tagger index (the `tagger/` Python subtool is the writer). `BookDb` shares the `pf2e.db` connection opened at startup.
 - **Tailwind 4 JIT + HMR quirk**: newly-introduced utility classes occasionally fail to materialize during hot reload. For layout-critical sizing, prefer inline styles until a full reload.
 

--- a/apps/dm-tool/electron.vite.config.ts
+++ b/apps/dm-tool/electron.vite.config.ts
@@ -13,11 +13,6 @@ import react from '@vitejs/plugin-react';
 // Vite transform them during build.
 const workspaceBundled = ['@foundry-toolkit/ai', '@foundry-toolkit/db', '@foundry-toolkit/shared'];
 
-// Native modules pulled in transitively by bundled workspace packages must be
-// re-externalized so their `.node` binaries resolve at runtime instead of
-// being inlined by Rollup (which breaks the `bindings` loader).
-const nativeDeps = ['better-sqlite3'];
-
 // Monorepo root holds the single .env. All three build targets point at it
 // so Vite's `import.meta.env.VITE_*` resolution reads the same file. The
 // main process also calls loadRootEnv() at startup (via
@@ -27,7 +22,7 @@ const rootEnvDir = resolve(__dirname, '../..');
 export default defineConfig({
   main: {
     envDir: rootEnvDir,
-    plugins: [externalizeDepsPlugin({ exclude: workspaceBundled, include: nativeDeps })],
+    plugins: [externalizeDepsPlugin({ exclude: workspaceBundled })],
     build: {
       rollupOptions: {
         input: {

--- a/packages/db/CLAUDE.md
+++ b/packages/db/CLAUDE.md
@@ -11,7 +11,7 @@ Part of the foundry-toolkit monorepo at `packages/db` — see the root [CLAUDE.m
 ## Tech stack
 
 - TypeScript (raw — consumers transpile)
-- `better-sqlite3` (native module; rebuild handled by the root `postinstall`)
+- `node:sqlite` (Node built-in, no native compilation)
 
 ## Build & run
 
@@ -29,7 +29,6 @@ Subpath exports map to `src/<name>/index.ts`:
 ## Key decisions / gotchas
 
 - Consumed **only** by dm-tool's Electron main process — never the renderer. If you find yourself importing from the renderer (`src/`), stop and route through IPC instead.
-- `better-sqlite3` native rebuild: root `postinstall` covers it; `npm run rebuild-sqlite` is the manual escape hatch.
 - `MapDb` is read-only — the `tagger/` Python subtool is the writer of its index.
 - `BookDb` shares the `pf2e.db` connection; its constructor runs a `CREATE TABLE` migration for the books table.
 


### PR DESCRIPTION
## Summary

- `apps/dm-tool/electron.vite.config.ts`: remove `nativeDeps = ['better-sqlite3']` and the `include: nativeDeps` from `externalizeDepsPlugin` — no native `.node` file to re-externalize now that the codebase uses the built-in `node:sqlite`
- `apps/dm-tool/CLAUDE.md`, `packages/db/CLAUDE.md`, `README.md`: remove references to `better-sqlite3` rebuilding and `rebuild-sqlite` escape hatch

**Apps touched**

- `apps/dm-tool` — `npm run dev:dm-tool` (build config change; no runtime behaviour change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)