### PR TITLE
feat(foundry-mcp): add filtered chat SSE stream and backfill route

### DIFF
--- a/apps/foundry-mcp/src/chat/chat-filter.ts
+++ b/apps/foundry-mcp/src/chat/chat-filter.ts
@@ -1,0 +1,26 @@
+import type { ChatMessageSnapshot } from '@foundry-toolkit/shared/rpc';
+
+/**
+ * Server-side predicate for the `/api/live/chat/:actorId/stream` and
+ * `/api/live/chat/:actorId/recent` routes. Returns true if the message
+ * should be delivered to a subscriber viewing `actorId`, identified as
+ * `userId` (null when the caller didn't provide an identity).
+ *
+ * Rules (any match → include):
+ *  1. Public: whisper list is empty.
+ *  2. Speaker: the message was spoken/rolled by actorId.
+ *  3. Whisper recipient: userId appears in the whisper list.
+ *
+ * Rule 4 (broadcast party-member rolls) is deferred — see the chat-relay
+ * plan at ~/.claude/plans/read-only-investigation-plan-mode-delightful-perlis.md.
+ */
+export function messagePassesFilter(
+  message: ChatMessageSnapshot,
+  actorId: string,
+  userId: string | null,
+): boolean {
+  if (message.whisper.length === 0) return true;
+  if (message.speaker?.actor === actorId) return true;
+  if (userId !== null && message.whisper.includes(userId)) return true;
+  return false;
+}

--- a/apps/foundry-mcp/src/chat/chat-ring-buffer.ts
+++ b/apps/foundry-mcp/src/chat/chat-ring-buffer.ts
@@ -1,0 +1,96 @@
+import { chatMessageSnapshotSchema, type ChatMessageSnapshot } from '@foundry-toolkit/shared/rpc';
+import type { ChannelManager } from '../events/channel-manager.js';
+import { channelManager } from '../events/channel-manager.js';
+import { log } from '../logger.js';
+
+function parseSseData(chunk: string): { eventType: string; data: unknown } | null {
+  const line = chunk.split('\n')[0] ?? '';
+  if (!line.startsWith('data: ')) return null;
+  try {
+    const parsed = JSON.parse(line.slice(6)) as unknown;
+    if (typeof parsed !== 'object' || parsed === null) return null;
+    const { eventType, data } = parsed as Record<string, unknown>;
+    if (typeof eventType !== 'string') return null;
+    return { eventType, data };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * In-memory ring buffer of recent chat messages, populated by subscribing
+ * to the 'chat' channel on the ChannelManager. Keeps the last `maxSize`
+ * messages. Create/update/delete events are processed in order so the
+ * buffer stays consistent with Foundry's chat log.
+ *
+ * Pass a ChannelManager in the constructor for testability; production
+ * code uses the module-level singleton export `chatRingBuffer`.
+ */
+export class ChatRingBuffer {
+  private messages: ChatMessageSnapshot[] = [];
+
+  constructor(
+    private readonly maxSize: number = 200,
+    mgr: ChannelManager = channelManager,
+  ) {
+    mgr.subscribe('chat', (chunk) => this.handleChunk(chunk));
+  }
+
+  private handleChunk(chunk: string): void {
+    const envelope = parseSseData(chunk);
+    if (!envelope) return;
+    const { eventType, data } = envelope;
+
+    switch (eventType) {
+      case 'create': {
+        const result = chatMessageSnapshotSchema.safeParse(data);
+        if (!result.success) {
+          log.warn(`ChatRingBuffer: invalid create payload — ${result.error.message}`);
+          return;
+        }
+        this.insert(result.data);
+        break;
+      }
+      case 'update': {
+        const result = chatMessageSnapshotSchema.safeParse(data);
+        if (result.success) this.replace(result.data);
+        break;
+      }
+      case 'delete': {
+        const id = (data as Record<string, unknown> | null | undefined)?.['id'];
+        if (typeof id === 'string') this.erase(id);
+        break;
+      }
+    }
+  }
+
+  private insert(message: ChatMessageSnapshot): void {
+    this.messages.push(message);
+    if (this.messages.length > this.maxSize) {
+      this.messages.shift();
+    }
+  }
+
+  private replace(message: ChatMessageSnapshot): void {
+    const idx = this.messages.findIndex((m) => m.id === message.id);
+    if (idx !== -1) this.messages[idx] = message;
+  }
+
+  private erase(id: string): void {
+    this.messages = this.messages.filter((m) => m.id !== id);
+  }
+
+  /**
+   * Returns up to `limit` of the most recent messages (chronological order)
+   * and whether the buffer held more than `limit` messages before slicing.
+   */
+  recent(limit: number = 50): { messages: ChatMessageSnapshot[]; truncated: boolean } {
+    const total = this.messages.length;
+    return {
+      messages: this.messages.slice(-limit),
+      truncated: total > limit,
+    };
+  }
+}
+
+export const chatRingBuffer = new ChatRingBuffer();

--- a/apps/foundry-mcp/src/http/app.ts
+++ b/apps/foundry-mcp/src/http/app.ts
@@ -9,9 +9,11 @@ import { registerCompendiumRoutes } from './routes/compendium.js';
 import { registerDispatchRoute } from './routes/dispatch.js';
 import { registerEvalRoutes } from './routes/eval.js';
 import { registerEventRoutes } from './routes/events.js';
+import { registerLiveChatRoutes } from './routes/live-chat.js';
 import { registerLiveRoutes } from './routes/live.js';
 import { registerPromptRoutes } from './routes/prompts.js';
 import { registerUploadRoutes } from './routes/uploads.js';
+import { chatRingBuffer } from '../chat/chat-ring-buffer.js';
 
 export async function buildHttpApp(): Promise<FastifyInstance> {
   // The parent http.Server routes `/api/*` and most other GETs into this
@@ -78,6 +80,7 @@ export async function buildHttpApp(): Promise<FastifyInstance> {
   registerCompendiumRoutes(app);
   registerEvalRoutes(app);
   registerEventRoutes(app);
+  registerLiveChatRoutes(app, chatRingBuffer);
   registerLiveRoutes(app, new LiveDb(LIVE_DB_PATH), SHARED_SECRET);
   registerPromptRoutes(app);
   registerUploadRoutes(app);

--- a/apps/foundry-mcp/src/http/routes/live-chat.ts
+++ b/apps/foundry-mcp/src/http/routes/live-chat.ts
@@ -1,0 +1,88 @@
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod/v4';
+import { chatMessageSnapshotSchema } from '@foundry-toolkit/shared/rpc';
+import { channelManager } from '../../events/channel-manager.js';
+import type { ChatRingBuffer } from '../../chat/chat-ring-buffer.js';
+import { messagePassesFilter } from '../../chat/chat-filter.js';
+
+const actorIdParam = z.object({ actorId: z.string().min(1) });
+
+const liveChatQuery = z.object({
+  userId: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(200).default(50),
+});
+
+function parseSseData(chunk: string): { eventType: string; data: unknown } | null {
+  const line = chunk.split('\n')[0] ?? '';
+  if (!line.startsWith('data: ')) return null;
+  try {
+    const parsed = JSON.parse(line.slice(6)) as unknown;
+    if (typeof parsed !== 'object' || parsed === null) return null;
+    const { eventType, data } = parsed as Record<string, unknown>;
+    if (typeof eventType !== 'string') return null;
+    return { eventType, data };
+  } catch {
+    return null;
+  }
+}
+
+export function registerLiveChatRoutes(app: FastifyInstance, buffer: ChatRingBuffer): void {
+  // Returns the last `limit` messages from the ring buffer filtered for
+  // actorId + userId. Suitable for initial load when the Chat tab opens.
+  app.get('/api/live/chat/:actorId/recent', async (req, reply) => {
+    const { actorId } = actorIdParam.parse(req.params);
+    const parsed = liveChatQuery.parse(req.query);
+    const userId = parsed.userId ?? null;
+    const limit = parsed.limit;
+
+    const { messages, truncated } = buffer.recent(limit);
+    const filtered = messages.filter((m) => messagePassesFilter(m, actorId, userId));
+
+    return reply.send({ messages: filtered, truncated });
+  });
+
+  // Filtered SSE stream: delivers chat events in real-time, scoped to
+  // what `actorId` (and optionally `userId`) should see. Subscribes to
+  // the raw 'chat' channel and applies messagePassesFilter before forwarding.
+  app.get('/api/live/chat/:actorId/stream', (req, reply) => {
+    const { actorId } = actorIdParam.parse(req.params);
+    const parsed = liveChatQuery.parse(req.query);
+    const userId = parsed.userId ?? null;
+
+    reply.raw.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    });
+    reply.raw.write(`: connected\n\n`);
+
+    const unsubscribe = channelManager.subscribe('chat', (chunk) => {
+      const envelope = parseSseData(chunk);
+      if (!envelope) return;
+      const { eventType, data } = envelope;
+
+      if (eventType === 'delete') {
+        // Always forward deletes — the client no-ops on IDs it never received.
+        reply.raw.write(chunk);
+        return;
+      }
+
+      const result = chatMessageSnapshotSchema.safeParse(data);
+      if (!result.success) return;
+
+      if (messagePassesFilter(result.data, actorId, userId)) {
+        reply.raw.write(chunk);
+      }
+    });
+
+    const heartbeat = setInterval(() => {
+      reply.raw.write(`: ping\n\n`);
+    }, 20_000);
+
+    req.raw.on('close', () => {
+      clearInterval(heartbeat);
+      unsubscribe();
+    });
+  });
+}

--- a/apps/foundry-mcp/test/chat-filter.test.ts
+++ b/apps/foundry-mcp/test/chat-filter.test.ts
@@ -1,0 +1,122 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { messagePassesFilter } from '../src/chat/chat-filter.js';
+import type { ChatMessageSnapshot } from '@foundry-toolkit/shared/rpc';
+
+const ACTOR_A = 'actor-aaa';
+const ACTOR_B = 'actor-bbb';
+const USER_1 = 'user-111';
+const USER_2 = 'user-222';
+
+function makeMessage(overrides: Partial<ChatMessageSnapshot> = {}): ChatMessageSnapshot {
+  return {
+    id: 'msg-x',
+    uuid: null,
+    type: null,
+    author: null,
+    timestamp: null,
+    flavor: '',
+    content: 'test',
+    speaker: null,
+    speakerOwnerIds: [],
+    whisper: [],
+    isRoll: false,
+    rolls: [],
+    flags: {},
+    ...overrides,
+  };
+}
+
+describe('messagePassesFilter', () => {
+  // Rule 1 — public messages (empty whisper list)
+
+  it('passes a public message for any actorId regardless of userId', () => {
+    const msg = makeMessage({ whisper: [] });
+    assert.equal(messagePassesFilter(msg, ACTOR_A, null), true);
+    assert.equal(messagePassesFilter(msg, ACTOR_B, USER_1), true);
+  });
+
+  it('passes a public roll for any actor', () => {
+    const msg = makeMessage({ whisper: [], isRoll: true });
+    assert.equal(messagePassesFilter(msg, ACTOR_A, USER_1), true);
+    assert.equal(messagePassesFilter(msg, ACTOR_B, null), true);
+  });
+
+  // Rule 2 — speaker is the watched actor
+
+  it('passes when the message speaker is actorId (even if whispered)', () => {
+    const msg = makeMessage({
+      speaker: { actor: ACTOR_A },
+      whisper: [USER_2], // whispered to someone else
+    });
+    assert.equal(messagePassesFilter(msg, ACTOR_A, USER_1), true);
+  });
+
+  it('does not pass on Rule 2 when speaker is a different actor', () => {
+    const msg = makeMessage({
+      speaker: { actor: ACTOR_B },
+      whisper: [USER_2],
+    });
+    // ACTOR_A is watching, ACTOR_B spoke — no match on Rule 2
+    assert.equal(messagePassesFilter(msg, ACTOR_A, USER_1), false);
+  });
+
+  it('passes on Rule 2 when speaker has no userId but is watching actor', () => {
+    const msg = makeMessage({
+      speaker: { actor: ACTOR_A },
+      whisper: [USER_2],
+    });
+    assert.equal(messagePassesFilter(msg, ACTOR_A, null), true);
+  });
+
+  // Rule 3 — userId is a whisper recipient
+
+  it('passes when userId is in the whisper list', () => {
+    const msg = makeMessage({ whisper: [USER_1, USER_2] });
+    assert.equal(messagePassesFilter(msg, ACTOR_A, USER_1), true);
+  });
+
+  it('does not pass when userId is not in the whisper list', () => {
+    const msg = makeMessage({ whisper: [USER_2] });
+    assert.equal(messagePassesFilter(msg, ACTOR_A, USER_1), false);
+  });
+
+  it('does not apply Rule 3 when userId is null', () => {
+    const msg = makeMessage({ whisper: [USER_1] });
+    // No speaker match, empty actor in speaker, userId null → Rule 3 skipped
+    assert.equal(messagePassesFilter(msg, ACTOR_A, null), false);
+  });
+
+  // Exclusion cases
+
+  it('excludes a whisper between two other parties', () => {
+    const msg = makeMessage({
+      speaker: { actor: ACTOR_B },
+      whisper: [USER_2],
+    });
+    // ACTOR_A watches as USER_1 — none of the rules match
+    assert.equal(messagePassesFilter(msg, ACTOR_A, USER_1), false);
+  });
+
+  it('excludes a whisper from an actor without speaker info', () => {
+    const msg = makeMessage({ speaker: null, whisper: [USER_2] });
+    assert.equal(messagePassesFilter(msg, ACTOR_A, USER_1), false);
+  });
+
+  it('excludes a whisper when speaker.actor is undefined', () => {
+    const msg = makeMessage({ speaker: { alias: 'GM' }, whisper: [USER_2] });
+    assert.equal(messagePassesFilter(msg, ACTOR_A, USER_1), false);
+  });
+
+  // Rule precedence — first matching rule wins; order doesn't matter here
+  // since all rules are OR-combined, but verify multi-rule messages pass once.
+
+  it('passes when both Rule 2 and Rule 3 match (no double-count issue)', () => {
+    const msg = makeMessage({
+      speaker: { actor: ACTOR_A },
+      whisper: [USER_1],
+    });
+    // Actor-A speaks and whispers to User-1 who is watching Actor-A
+    assert.equal(messagePassesFilter(msg, ACTOR_A, USER_1), true);
+  });
+});

--- a/apps/foundry-mcp/test/chat-ring-buffer.test.ts
+++ b/apps/foundry-mcp/test/chat-ring-buffer.test.ts
@@ -1,0 +1,174 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { ChannelManager } from '../src/events/channel-manager.js';
+import { ChatRingBuffer } from '../src/chat/chat-ring-buffer.js';
+import type { ChatMessageSnapshot } from '@foundry-toolkit/shared/rpc';
+
+// Minimal valid ChatMessageSnapshot to use throughout tests.
+function makeMessage(id: string, overrides: Partial<ChatMessageSnapshot> = {}): ChatMessageSnapshot {
+  return {
+    id,
+    uuid: null,
+    type: null,
+    author: null,
+    timestamp: null,
+    flavor: '',
+    content: 'Hello',
+    speaker: null,
+    speakerOwnerIds: [],
+    whisper: [],
+    isRoll: false,
+    rolls: [],
+    flags: {},
+    ...overrides,
+  };
+}
+
+// Publish a chat event through a ChannelManager and check the ring buffer.
+function publishCreate(mgr: ChannelManager, message: ChatMessageSnapshot): void {
+  mgr.publish('chat', { eventType: 'create', data: message });
+}
+
+function publishUpdate(mgr: ChannelManager, message: ChatMessageSnapshot): void {
+  mgr.publish('chat', { eventType: 'update', data: message });
+}
+
+function publishDelete(mgr: ChannelManager, id: string): void {
+  mgr.publish('chat', { eventType: 'delete', data: { id } });
+}
+
+describe('ChatRingBuffer', () => {
+  it('starts empty', () => {
+    const mgr = new ChannelManager();
+    const buffer = new ChatRingBuffer(10, mgr);
+    const { messages, truncated } = buffer.recent(10);
+    assert.equal(messages.length, 0);
+    assert.equal(truncated, false);
+  });
+
+  it('stores a created message', () => {
+    const mgr = new ChannelManager();
+    const buffer = new ChatRingBuffer(10, mgr);
+    publishCreate(mgr, makeMessage('msg-1'));
+    const { messages } = buffer.recent(10);
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0]?.id, 'msg-1');
+  });
+
+  it('accumulates messages in chronological order', () => {
+    const mgr = new ChannelManager();
+    const buffer = new ChatRingBuffer(10, mgr);
+    publishCreate(mgr, makeMessage('a'));
+    publishCreate(mgr, makeMessage('b'));
+    publishCreate(mgr, makeMessage('c'));
+    const { messages } = buffer.recent(10);
+    assert.deepEqual(
+      messages.map((m) => m.id),
+      ['a', 'b', 'c'],
+    );
+  });
+
+  it('evicts oldest messages when maxSize is exceeded', () => {
+    const mgr = new ChannelManager();
+    const buffer = new ChatRingBuffer(3, mgr);
+    publishCreate(mgr, makeMessage('old-1'));
+    publishCreate(mgr, makeMessage('old-2'));
+    publishCreate(mgr, makeMessage('keep-1'));
+    publishCreate(mgr, makeMessage('keep-2')); // evicts old-1
+    const { messages } = buffer.recent(10);
+    assert.equal(messages.length, 3);
+    assert.deepEqual(
+      messages.map((m) => m.id),
+      ['old-2', 'keep-1', 'keep-2'],
+    );
+  });
+
+  it('replaces an existing message on update', () => {
+    const mgr = new ChannelManager();
+    const buffer = new ChatRingBuffer(10, mgr);
+    publishCreate(mgr, makeMessage('msg-1', { content: 'original' }));
+    publishUpdate(mgr, makeMessage('msg-1', { content: 'edited' }));
+    const { messages } = buffer.recent(10);
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0]?.content, 'edited');
+  });
+
+  it('ignores update for a message not in the buffer', () => {
+    const mgr = new ChannelManager();
+    const buffer = new ChatRingBuffer(10, mgr);
+    publishCreate(mgr, makeMessage('a'));
+    publishUpdate(mgr, makeMessage('z', { content: 'ghost' }));
+    const { messages } = buffer.recent(10);
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0]?.id, 'a');
+  });
+
+  it('removes a message on delete', () => {
+    const mgr = new ChannelManager();
+    const buffer = new ChatRingBuffer(10, mgr);
+    publishCreate(mgr, makeMessage('msg-1'));
+    publishCreate(mgr, makeMessage('msg-2'));
+    publishDelete(mgr, 'msg-1');
+    const { messages } = buffer.recent(10);
+    assert.deepEqual(
+      messages.map((m) => m.id),
+      ['msg-2'],
+    );
+  });
+
+  it('ignores delete for unknown id', () => {
+    const mgr = new ChannelManager();
+    const buffer = new ChatRingBuffer(10, mgr);
+    publishCreate(mgr, makeMessage('msg-1'));
+    publishDelete(mgr, 'ghost');
+    assert.equal(buffer.recent(10).messages.length, 1);
+  });
+
+  it('recent() returns at most `limit` messages (the newest)', () => {
+    const mgr = new ChannelManager();
+    const buffer = new ChatRingBuffer(100, mgr);
+    for (let i = 0; i < 10; i++) publishCreate(mgr, makeMessage(`msg-${i}`));
+    const { messages } = buffer.recent(3);
+    assert.equal(messages.length, 3);
+    assert.deepEqual(
+      messages.map((m) => m.id),
+      ['msg-7', 'msg-8', 'msg-9'],
+    );
+  });
+
+  it('truncated is false when buffer has <= limit messages', () => {
+    const mgr = new ChannelManager();
+    const buffer = new ChatRingBuffer(100, mgr);
+    publishCreate(mgr, makeMessage('a'));
+    publishCreate(mgr, makeMessage('b'));
+    assert.equal(buffer.recent(5).truncated, false);
+  });
+
+  it('truncated is true when buffer exceeds the requested limit', () => {
+    const mgr = new ChannelManager();
+    const buffer = new ChatRingBuffer(100, mgr);
+    for (let i = 0; i < 5; i++) publishCreate(mgr, makeMessage(`msg-${i}`));
+    assert.equal(buffer.recent(3).truncated, true);
+  });
+
+  it('ignores an unknown eventType silently', () => {
+    const mgr = new ChannelManager();
+    const buffer = new ChatRingBuffer(10, mgr);
+    mgr.publish('chat', { eventType: 'magic', data: makeMessage('x') });
+    assert.equal(buffer.recent(10).messages.length, 0);
+  });
+
+  it('ignores a create event with an invalid payload', () => {
+    const mgr = new ChannelManager();
+    const buffer = new ChatRingBuffer(10, mgr);
+    mgr.publish('chat', { eventType: 'create', data: { id: 123, isRoll: 'yes' } });
+    assert.equal(buffer.recent(10).messages.length, 0);
+  });
+
+  it('events on other channels do not affect the buffer', () => {
+    const mgr = new ChannelManager();
+    const buffer = new ChatRingBuffer(10, mgr);
+    mgr.publish('rolls', { eventType: 'create', data: makeMessage('r') });
+    assert.equal(buffer.recent(10).messages.length, 0);
+  });
+});


### PR DESCRIPTION
## Summary

PR 2 of 3 in the chat-relay plan at `~/.claude/plans/read-only-investigation-plan-mode-delightful-perlis.md`.

Adds a 200-message in-memory ring buffer in `foundry-mcp` that taps the existing `'chat'` ChannelManager channel and keeps up to date with create/update/delete events. Builds a server-side filter predicate (public messages, speaker-is-actorId, whisper-to-userId) and exposes two new routes so the portal's Chat tab (PR 3) can subscribe without needing to filter on the client or receive messages for other actors.

## Apps touched

- `apps/foundry-mcp` — new `src/chat/` module + two routes

To validate, run tests — no `dev:*` needed:
- `npm run test -w apps/foundry-mcp`

## Changes

- `src/chat/chat-ring-buffer.ts` — `ChatRingBuffer` class subscribed to the `'chat'` channel; handles create/update/delete; `recent(limit)` returns the last N messages + `truncated` flag. Exported as a singleton.
- `src/chat/chat-filter.ts` — `messagePassesFilter(message, actorId, userId)`: rule 1 public, rule 2 speaker, rule 3 whisper-recipient. Rule 4 (party-member roll broadcast) deferred to #139.
- `src/http/routes/live-chat.ts` — `GET /api/live/chat/:actorId/recent?userId&limit` (JSON backfill) and `GET /api/live/chat/:actorId/stream?userId` (filtered SSE, 20s heartbeat, same pattern as `/api/events/:channel/stream`)
- `src/http/app.ts` — register live-chat routes

## Test plan

- [ ] `npm run test -w apps/foundry-mcp` — 7 new suites (14 ring-buffer tests, 12 filter tests), all 136 tests pass
- [ ] `npm run typecheck` — clean
- [ ] Manual: `curl -N 'http://localhost:8765/api/live/chat/<actorId>/stream'` while a GM types in Foundry — public messages should arrive; whispers between others should not

## Follow-ups

- #139 — Rule 4: broadcast party-member rolls to portal subscribers

Refs #127