### PR TITLE
feat(player-portal): add Chat tab with live message stream

### DIFF
--- a/apps/player-portal/src/components/chat/MessageBubble.tsx
+++ b/apps/player-portal/src/components/chat/MessageBubble.tsx
@@ -1,0 +1,97 @@
+import type { ChatMessageSnapshot, ChatRoll } from '@foundry-toolkit/shared/rpc';
+
+// Foundry ChatMessage type constants. We only distinguish roll vs. OOC
+// vs. IC for styling; everything else renders as plain content.
+const MSG_OOC = 1;
+
+function formatTime(timestamp: number | null): string | null {
+  if (timestamp === null) return null;
+  return new Date(timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+function RollResult({ roll }: { roll: ChatRoll }): React.ReactElement {
+  return (
+    <div className="mb-1 flex items-center gap-2">
+      <span className="font-mono text-xs text-pf-alt-dark">{roll.formula}</span>
+      <span
+        className={[
+          'text-lg font-bold tabular-nums',
+          roll.isCritical ? 'text-green-600' : roll.isFumble ? 'text-red-500' : 'text-pf-primary',
+        ].join(' ')}
+      >
+        {roll.total}
+      </span>
+      {roll.isCritical && (
+        <span className="rounded bg-green-100 px-1 py-0.5 text-xs font-medium text-green-700">Critical!</span>
+      )}
+      {roll.isFumble && (
+        <span className="rounded bg-red-100 px-1 py-0.5 text-xs font-medium text-red-700">Fumble</span>
+      )}
+    </div>
+  );
+}
+
+interface Props {
+  message: ChatMessageSnapshot;
+}
+
+export function MessageBubble({ message }: Props): React.ReactElement {
+  const isWhisper = message.whisper.length > 0;
+  const isOoc = message.type === MSG_OOC;
+  const time = formatTime(message.timestamp);
+
+  // IC: show character alias; OOC or roll with no alias: fall back to author name.
+  const speakerLabel = message.speaker?.alias ?? message.author?.name ?? null;
+
+  return (
+    <div
+      className={[
+        'rounded border p-2 text-sm',
+        isWhisper
+          ? 'border-pf-alt/40 bg-pf-alt/5'
+          : isOoc
+            ? 'border-pf-border bg-pf-bg'
+            : 'border-pf-border bg-pf-bg-dark',
+      ].join(' ')}
+    >
+      {/* Header row: speaker · badges · timestamp */}
+      <div className="mb-1 flex flex-wrap items-center gap-1.5">
+        {speakerLabel !== null && (
+          <span className={`font-medium ${isOoc ? 'text-pf-alt-dark' : 'text-pf-primary'}`}>{speakerLabel}</span>
+        )}
+        {isWhisper && (
+          <span className="rounded bg-pf-alt px-1 py-0.5 text-xs text-white">Whisper</span>
+        )}
+        {message.isRoll && (
+          <span className="rounded border border-pf-border bg-pf-bg px-1 py-0.5 text-xs text-pf-alt-dark">
+            Roll
+          </span>
+        )}
+        {time !== null && (
+          <span className="ml-auto text-xs tabular-nums text-pf-alt-dark">{time}</span>
+        )}
+      </div>
+
+      {/* Roll flavor (e.g. "Perception Check") */}
+      {message.isRoll && message.flavor.length > 0 && (
+        <div
+          className="mb-1 text-xs text-pf-alt-dark"
+          dangerouslySetInnerHTML={{ __html: message.flavor }}
+        />
+      )}
+
+      {/* Roll result summary */}
+      {message.isRoll && message.rolls[0] !== undefined && (
+        <RollResult roll={message.rolls[0]} />
+      )}
+
+      {/* Message content (HTML from Foundry — trusted source) */}
+      {message.content.length > 0 && (
+        <div
+          className="prose-sm max-w-none text-pf-text [&_a]:text-pf-primary [&_a]:underline"
+          dangerouslySetInnerHTML={{ __html: message.content }}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/player-portal/src/components/chat/MessageBubble.tsx
+++ b/apps/player-portal/src/components/chat/MessageBubble.tsx
@@ -72,10 +72,10 @@ export function MessageBubble({ message }: Props): React.ReactElement {
         )}
       </div>
 
-      {/* Roll flavor (e.g. "Perception Check") */}
+      {/* Roll flavor (e.g. "Perception Check") — clamp action-cost icons */}
       {message.isRoll && message.flavor.length > 0 && (
         <div
-          className="mb-1 text-xs text-pf-alt-dark"
+          className="mb-1 text-xs text-pf-alt-dark [&_img]:!max-h-4 [&_img]:!w-auto [&_img]:inline-block [&_img]:align-middle"
           dangerouslySetInnerHTML={{ __html: message.flavor }}
         />
       )}
@@ -85,10 +85,12 @@ export function MessageBubble({ message }: Props): React.ReactElement {
         <RollResult roll={message.rolls[0]} />
       )}
 
-      {/* Message content (HTML from Foundry — trusted source) */}
+      {/* Message content (HTML from Foundry — trusted source).
+          Cap embedded images: PF2e cards include action icons and item
+          art with inline size attributes that would overflow the sidebar. */}
       {message.content.length > 0 && (
         <div
-          className="prose-sm max-w-none text-pf-text [&_a]:text-pf-primary [&_a]:underline"
+          className="prose-sm max-w-none text-pf-text [&_a]:text-pf-primary [&_a]:underline [&_img]:!max-h-6 [&_img]:!w-auto [&_img]:inline-block [&_img]:align-middle"
           dangerouslySetInnerHTML={{ __html: message.content }}
         />
       )}

--- a/apps/player-portal/src/components/tabs/Chat.tsx
+++ b/apps/player-portal/src/components/tabs/Chat.tsx
@@ -1,0 +1,34 @@
+import { useLiveChat } from '../../lib/useLiveChat';
+import { MessageBubble } from '../chat/MessageBubble';
+
+interface Props {
+  actorId: string;
+}
+
+export function Chat({ actorId }: Props): React.ReactElement {
+  const { messages, status, truncated } = useLiveChat(actorId);
+
+  return (
+    <div className="space-y-2">
+      {truncated && (
+        <p className="text-center text-xs text-pf-alt-dark">Showing recent messages only.</p>
+      )}
+
+      {messages.length === 0 && status !== 'loading' && (
+        <p className="py-8 text-center text-sm text-pf-alt-dark">No messages yet.</p>
+      )}
+
+      {messages.length === 0 && status === 'loading' && (
+        <p className="py-8 text-center text-sm text-pf-alt-dark">Connecting…</p>
+      )}
+
+      {messages.map((m) => (
+        <MessageBubble key={m.id} message={m} />
+      ))}
+
+      {status === 'disconnected' && (
+        <p className="text-center text-xs text-amber-600">Reconnecting to chat stream…</p>
+      )}
+    </div>
+  );
+}

--- a/apps/player-portal/src/lib/tabUtils.ts
+++ b/apps/player-portal/src/lib/tabUtils.ts
@@ -13,8 +13,7 @@ export type TabId =
   | 'inventory'
   | 'feats'
   | 'details'
-  | 'progression'
-  | 'chat';
+  | 'progression';
 
 // Compile-time guard: the literal array must cover every TabId exactly.
 const VALID_TABS = new Set<string>(
@@ -26,7 +25,6 @@ const VALID_TABS = new Set<string>(
     'feats',
     'details',
     'progression',
-    'chat',
   ] satisfies TabId[],
 );
 
@@ -35,6 +33,7 @@ const LEGACY_REDIRECTS: Readonly<Record<string, TabId>> = {
   crafting: 'inventory',
   proficiencies: 'details',
   background: 'details',
+  chat: 'character',
 };
 
 /**

--- a/apps/player-portal/src/lib/tabUtils.ts
+++ b/apps/player-portal/src/lib/tabUtils.ts
@@ -13,7 +13,8 @@ export type TabId =
   | 'inventory'
   | 'feats'
   | 'details'
-  | 'progression';
+  | 'progression'
+  | 'chat';
 
 // Compile-time guard: the literal array must cover every TabId exactly.
 const VALID_TABS = new Set<string>(
@@ -25,6 +26,7 @@ const VALID_TABS = new Set<string>(
     'feats',
     'details',
     'progression',
+    'chat',
   ] satisfies TabId[],
 );
 

--- a/apps/player-portal/src/lib/useLiveChat.test.ts
+++ b/apps/player-portal/src/lib/useLiveChat.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useLiveChat } from './useLiveChat';
+import type { ChatMessageSnapshot } from '@foundry-toolkit/shared/rpc';
+
+// ─── EventSource mock ─────────────────────────────────────────────────────────
+
+type EventListener = (ev: { data: string }) => void;
+
+interface MockEventSource {
+  url: string;
+  readyState: number;
+  onopen: (() => void) | null;
+  onmessage: EventListener | null;
+  onerror: (() => void) | null;
+  close: ReturnType<typeof vi.fn>;
+  _fire: (data: string) => void;
+  _open: () => void;
+  _error: () => void;
+}
+
+let capturedSources: MockEventSource[] = [];
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const MockEventSourceClass = vi.fn(function MockEventSource(this: any, url: string) {
+  this.url = url;
+  this.readyState = 0; // CONNECTING
+  this.onopen = null;
+  this.onmessage = null;
+  this.onerror = null;
+  this.close = vi.fn(() => {
+    this.readyState = 2; // CLOSED
+  });
+  this._fire = function (data: string) {
+    if (this.onmessage) this.onmessage({ data });
+  };
+  this._open = function () {
+    this.readyState = 1; // OPEN
+    if (this.onopen) this.onopen();
+  };
+  this._error = function () {
+    if (this.onerror) this.onerror();
+  };
+  capturedSources.push(this as MockEventSource);
+});
+
+// Assign static constants so EventSource.OPEN / CLOSED checks work.
+Object.assign(MockEventSourceClass, { CONNECTING: 0, OPEN: 1, CLOSED: 2 });
+
+// ─── Fetch mock helpers ────────────────────────────────────────────────────────
+
+function makeEmptyBackfill() {
+  return { messages: [], truncated: false };
+}
+
+function mockFetchOk(body: unknown) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(body),
+      }),
+    ),
+  );
+}
+
+function mockFetchFail() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => Promise.resolve({ ok: false })),
+  );
+}
+
+// ─── Minimal valid ChatMessageSnapshot ────────────────────────────────────────
+
+function makeMsg(id: string, overrides: Partial<ChatMessageSnapshot> = {}): ChatMessageSnapshot {
+  return {
+    id,
+    uuid: null,
+    type: null,
+    author: null,
+    timestamp: null,
+    flavor: '',
+    content: 'Hello',
+    speaker: null,
+    speakerOwnerIds: [],
+    whisper: [],
+    isRoll: false,
+    rolls: [],
+    flags: {},
+    ...overrides,
+  };
+}
+
+// ─── Setup / teardown ─────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  capturedSources = [];
+  MockEventSourceClass.mockClear();
+  vi.stubGlobal('EventSource', MockEventSourceClass);
+  mockFetchOk(makeEmptyBackfill());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('useLiveChat', () => {
+  it('starts in loading status', () => {
+    const { result } = renderHook(() => useLiveChat('actor-1'));
+    expect(result.current.status).toBe('loading');
+    expect(result.current.messages).toHaveLength(0);
+  });
+
+  it('opens EventSource on the correct filtered-stream URL', () => {
+    renderHook(() => useLiveChat('actor-abc'));
+    expect(MockEventSourceClass).toHaveBeenCalledWith('/api/mcp/live/chat/actor-abc/stream');
+  });
+
+  it('appends userId to stream URL when provided', () => {
+    renderHook(() => useLiveChat('actor-1', 'user-xyz'));
+    expect(MockEventSourceClass).toHaveBeenCalledWith(
+      '/api/mcp/live/chat/actor-1/stream?userId=user-xyz',
+    );
+  });
+
+  it('transitions to connected when EventSource opens', () => {
+    const { result } = renderHook(() => useLiveChat('actor-1'));
+    act(() => {
+      capturedSources[0]?._open();
+    });
+    expect(result.current.status).toBe('connected');
+  });
+
+  it('populates messages from backfill', async () => {
+    mockFetchOk({ messages: [makeMsg('msg-1'), makeMsg('msg-2')], truncated: false });
+    const { result } = renderHook(() => useLiveChat('actor-1'));
+    await waitFor(() => expect(result.current.messages).toHaveLength(2));
+    expect(result.current.messages[0]?.id).toBe('msg-1');
+    expect(result.current.messages[1]?.id).toBe('msg-2');
+  });
+
+  it('reflects truncated flag from backfill', async () => {
+    mockFetchOk({ messages: [], truncated: true });
+    const { result } = renderHook(() => useLiveChat('actor-1'));
+    await waitFor(() => expect(result.current.truncated).toBe(true));
+  });
+
+  it('adds a message on create SSE event', async () => {
+    mockFetchOk(makeEmptyBackfill());
+    const { result } = renderHook(() => useLiveChat('actor-1'));
+    await waitFor(() => expect(result.current.messages).toHaveLength(0));
+
+    act(() => {
+      capturedSources[0]?._fire(JSON.stringify({ eventType: 'create', data: makeMsg('new-1') }));
+    });
+
+    expect(result.current.messages).toHaveLength(1);
+    expect(result.current.messages[0]?.id).toBe('new-1');
+  });
+
+  it('deduplicates create events already present in backfill', async () => {
+    const existing = makeMsg('msg-1');
+    mockFetchOk({ messages: [existing], truncated: false });
+    const { result } = renderHook(() => useLiveChat('actor-1'));
+    await waitFor(() => expect(result.current.messages).toHaveLength(1));
+
+    act(() => {
+      capturedSources[0]?._fire(JSON.stringify({ eventType: 'create', data: existing }));
+    });
+
+    expect(result.current.messages).toHaveLength(1);
+  });
+
+  it('replaces a message on update SSE event', async () => {
+    const original = makeMsg('msg-1', { content: 'original' });
+    mockFetchOk({ messages: [original], truncated: false });
+    const { result } = renderHook(() => useLiveChat('actor-1'));
+    await waitFor(() => expect(result.current.messages).toHaveLength(1));
+
+    act(() => {
+      capturedSources[0]?._fire(
+        JSON.stringify({ eventType: 'update', data: makeMsg('msg-1', { content: 'edited' }) }),
+      );
+    });
+
+    expect(result.current.messages).toHaveLength(1);
+    expect(result.current.messages[0]?.content).toBe('edited');
+  });
+
+  it('removes a message on delete SSE event', async () => {
+    mockFetchOk({ messages: [makeMsg('msg-1'), makeMsg('msg-2')], truncated: false });
+    const { result } = renderHook(() => useLiveChat('actor-1'));
+    await waitFor(() => expect(result.current.messages).toHaveLength(2));
+
+    act(() => {
+      capturedSources[0]?._fire(JSON.stringify({ eventType: 'delete', data: { id: 'msg-1' } }));
+    });
+
+    expect(result.current.messages).toHaveLength(1);
+    expect(result.current.messages[0]?.id).toBe('msg-2');
+  });
+
+  it('merges backfill with SSE events that arrived before backfill resolved', async () => {
+    // Delay the backfill so an SSE event arrives first.
+    let resolveBackfill!: (v: { messages: ChatMessageSnapshot[]; truncated: boolean }) => void;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        () =>
+          new Promise<{ ok: boolean; json: () => Promise<unknown> }>((res) => {
+            resolveBackfill = (body) => res({ ok: true, json: () => Promise.resolve(body) });
+          }),
+      ),
+    );
+
+    const { result } = renderHook(() => useLiveChat('actor-1'));
+
+    // SSE event arrives before backfill.
+    act(() => {
+      capturedSources[0]?._fire(JSON.stringify({ eventType: 'create', data: makeMsg('sse-only') }));
+    });
+    expect(result.current.messages).toHaveLength(1);
+
+    // Backfill arrives with a different message.
+    await act(async () => {
+      resolveBackfill({ messages: [makeMsg('backfill-only')], truncated: false });
+      await Promise.resolve();
+    });
+
+    // Both messages present; backfill message is first.
+    expect(result.current.messages).toHaveLength(2);
+    expect(result.current.messages[0]?.id).toBe('backfill-only');
+    expect(result.current.messages[1]?.id).toBe('sse-only');
+  });
+
+  it('marks status disconnected on SSE error', () => {
+    const { result } = renderHook(() => useLiveChat('actor-1'));
+    act(() => {
+      capturedSources[0]?._open();
+      capturedSources[0]?._error();
+    });
+    expect(result.current.status).toBe('disconnected');
+  });
+
+  it('silently ignores backfill failure (mock mode)', async () => {
+    mockFetchFail();
+    const { result } = renderHook(() => useLiveChat('actor-1'));
+    act(() => {
+      capturedSources[0]?._open();
+    });
+    await Promise.resolve(); // let the failed fetch settle
+    expect(result.current.messages).toHaveLength(0);
+    expect(result.current.status).toBe('connected');
+  });
+
+  it('tolerates malformed SSE payloads without throwing', async () => {
+    const { result } = renderHook(() => useLiveChat('actor-1'));
+    await waitFor(() => expect(result.current.messages).toHaveLength(0));
+    act(() => {
+      capturedSources[0]?._fire('not valid json');
+    });
+    expect(result.current.messages).toHaveLength(0);
+  });
+
+  it('ignores create events with invalid message shape', async () => {
+    mockFetchOk(makeEmptyBackfill());
+    const { result } = renderHook(() => useLiveChat('actor-1'));
+    await waitFor(() => expect(result.current.messages).toHaveLength(0));
+
+    act(() => {
+      capturedSources[0]?._fire(
+        JSON.stringify({ eventType: 'create', data: { id: 123, isRoll: 'yes' } }),
+      );
+    });
+
+    expect(result.current.messages).toHaveLength(0);
+  });
+
+  it('closes EventSource on unmount', () => {
+    const { unmount } = renderHook(() => useLiveChat('actor-1'));
+    const source = capturedSources[0];
+    unmount();
+    expect(source?.close).toHaveBeenCalled();
+  });
+
+  it('resets and re-subscribes when actorId changes', () => {
+    const { rerender } = renderHook(({ id }: { id: string }) => useLiveChat(id), {
+      initialProps: { id: 'actor-1' },
+    });
+    expect(capturedSources).toHaveLength(1);
+    expect(capturedSources[0]?.url).toBe('/api/mcp/live/chat/actor-1/stream');
+
+    rerender({ id: 'actor-2' });
+
+    expect(capturedSources).toHaveLength(2);
+    expect(capturedSources[1]?.url).toBe('/api/mcp/live/chat/actor-2/stream');
+    expect(capturedSources[0]?.close).toHaveBeenCalled();
+  });
+});

--- a/apps/player-portal/src/lib/useLiveChat.ts
+++ b/apps/player-portal/src/lib/useLiveChat.ts
@@ -1,0 +1,135 @@
+// Subscribe to the filtered chat SSE stream for a single actor and
+// maintain the message list across create/update/delete events. Fetches
+// a backfill snapshot on mount then applies incremental SSE deltas.
+//
+// The server-side ring buffer keeps the last 200 messages; backfill
+// returns up to 50 of them filtered for this actor. The SSE stream
+// delivers new events as they arrive, also filtered.
+//
+// On re-mount (tab switch back), the backfill re-fetch restores history
+// automatically. There is a small gap between the SSE connect and the
+// backfill response; overlap is deduplicated by message id.
+
+import { useEffect, useState } from 'react';
+import { chatMessageSnapshotSchema, type ChatMessageSnapshot } from '@foundry-toolkit/shared/rpc';
+
+export interface LiveChatState {
+  messages: ChatMessageSnapshot[];
+  /** 'loading' until the first backfill or SSE open. */
+  status: 'loading' | 'connected' | 'disconnected';
+  /** True when the ring buffer held more messages than were returned. */
+  truncated: boolean;
+}
+
+interface ChatSseEnvelope {
+  eventType: string;
+  data: unknown;
+}
+
+function buildStreamUrl(actorId: string, userId: string | null): string {
+  const qs = userId !== null ? `?userId=${encodeURIComponent(userId)}` : '';
+  return `/api/mcp/live/chat/${actorId}/stream${qs}`;
+}
+
+function buildRecentUrl(actorId: string, userId: string | null): string {
+  const qs = userId !== null ? `?userId=${encodeURIComponent(userId)}` : '';
+  return `/api/mcp/live/chat/${actorId}/recent${qs}`;
+}
+
+/**
+ * Subscribe to the filtered chat stream for `actorId`.
+ *
+ * `userId` is optional — pass the player's Foundry user ID to include
+ * whispers directed at them. Omit to see only public and actor-spoken
+ * messages (the v1 default while the portal has no identity mechanism).
+ */
+export function useLiveChat(actorId: string, userId?: string | null): LiveChatState {
+  const effectiveUserId = userId ?? null;
+  const [state, setState] = useState<LiveChatState>({
+    messages: [],
+    status: 'loading',
+    truncated: false,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ messages: [], status: 'loading', truncated: false });
+
+    const streamUrl = buildStreamUrl(actorId, effectiveUserId);
+    const recentUrl = buildRecentUrl(actorId, effectiveUserId);
+
+    // Open SSE before fetching backfill so we don't miss events that
+    // arrive while the backfill request is in flight.
+    const es = new EventSource(streamUrl);
+
+    es.onopen = (): void => {
+      if (!cancelled) setState((s) => ({ ...s, status: 'connected' }));
+    };
+
+    es.onmessage = (ev): void => {
+      if (cancelled) return;
+      try {
+        const envelope = JSON.parse(ev.data as string) as ChatSseEnvelope;
+        const { eventType, data } = envelope;
+
+        if (eventType === 'create') {
+          const result = chatMessageSnapshotSchema.safeParse(data);
+          if (!result.success) return;
+          const msg = result.data;
+          setState((s) => {
+            if (s.messages.some((m) => m.id === msg.id)) return s; // dedupe backfill overlap
+            return { ...s, messages: [...s.messages, msg] };
+          });
+        } else if (eventType === 'update') {
+          const result = chatMessageSnapshotSchema.safeParse(data);
+          if (!result.success) return;
+          const msg = result.data;
+          setState((s) => ({ ...s, messages: s.messages.map((m) => (m.id === msg.id ? msg : m)) }));
+        } else if (eventType === 'delete') {
+          const id = (data as Record<string, unknown> | null)?.['id'];
+          if (typeof id !== 'string') return;
+          setState((s) => ({ ...s, messages: s.messages.filter((m) => m.id !== id) }));
+        }
+      } catch (err) {
+        console.warn('player-portal | live-chat: failed to parse SSE event', err);
+      }
+    };
+
+    es.onerror = (): void => {
+      if (!cancelled && es.readyState !== EventSource.CLOSED) {
+        setState((s) => ({ ...s, status: 'disconnected' }));
+      }
+    };
+
+    // Backfill: best-effort. Silently skipped when foundry-mcp is
+    // unreachable or the route 404s (mock mode). The SSE stream will
+    // populate messages incrementally regardless.
+    fetch(recentUrl)
+      .then((r) =>
+        r.ok ? (r.json() as Promise<{ messages: ChatMessageSnapshot[]; truncated: boolean }>) : null,
+      )
+      .then((data) => {
+        if (cancelled || data === null) return;
+        setState((s) => ({
+          ...s,
+          truncated: data.truncated,
+          // Merge: backfill is the authoritative history; preserve any SSE
+          // messages that arrived since mount and aren't in the backfill.
+          messages: [
+            ...data.messages,
+            ...s.messages.filter((m) => !data.messages.some((bm) => bm.id === m.id)),
+          ],
+        }));
+      })
+      .catch(() => {
+        // Mock mode or unreachable — leave state as-is.
+      });
+
+    return (): void => {
+      cancelled = true;
+      es.close();
+    };
+  }, [actorId, effectiveUserId]);
+
+  return state;
+}

--- a/apps/player-portal/src/routes/CharacterSheet.tsx
+++ b/apps/player-portal/src/routes/CharacterSheet.tsx
@@ -125,7 +125,7 @@ function CharacterSheetInner({ actorId, onBack, preferences }: InnerProps): Reac
     <div className="flex gap-6 py-6 pl-6 font-sans">
       {/* ── Left placeholder — same width as chat sidebar, reserved for
           a future panel being added in a separate workstream ────────── */}
-      <div className="hidden w-72 shrink-0 lg:block" />
+      <div className="hidden w-72 shrink-0 rounded border border-dashed border-pf-border lg:block" />
 
       {/* ── Sheet column ─────────────────────────────────────────────── */}
       <main className="min-w-0 flex-1">

--- a/apps/player-portal/src/routes/CharacterSheet.tsx
+++ b/apps/player-portal/src/routes/CharacterSheet.tsx
@@ -123,8 +123,12 @@ function CharacterSheetInner({ actorId, onBack, preferences }: InnerProps): Reac
     // on the right in the previously-empty column space. Single column on
     // narrower viewports where the sidebar would be too cramped.
     <div className="flex gap-6 py-6 pl-6 font-sans">
+      {/* ── Left placeholder — same width as chat sidebar, reserved for
+          a future panel being added in a separate workstream ────────── */}
+      <div className="hidden w-72 shrink-0 lg:block" />
+
       {/* ── Sheet column ─────────────────────────────────────────────── */}
-      <main className="min-w-0 max-w-3xl flex-1">
+      <main className="min-w-0 flex-1">
         {state.kind === 'loading' && (
           <div className="mb-4 flex items-center justify-between">
             <p className="text-sm text-neutral-500">Loading character…</p>

--- a/apps/player-portal/src/routes/CharacterSheet.tsx
+++ b/apps/player-portal/src/routes/CharacterSheet.tsx
@@ -125,7 +125,9 @@ function CharacterSheetInner({ actorId, onBack, preferences }: InnerProps): Reac
     <div className="flex gap-6 py-6 font-sans">
       {/* ── Left placeholder — same width as chat sidebar, reserved for
           a future panel being added in a separate workstream ────────── */}
-      <div className="hidden w-72 shrink-0 rounded border border-dashed border-pf-border pl-3 lg:block" />
+      <div className="hidden w-72 shrink-0 pl-3 lg:block">
+        <div className="h-full rounded border border-dashed border-pf-border" />
+      </div>
 
       {/* ── Sheet column ─────────────────────────────────────────────── */}
       <main className="min-w-0 flex-1">

--- a/apps/player-portal/src/routes/CharacterSheet.tsx
+++ b/apps/player-portal/src/routes/CharacterSheet.tsx
@@ -42,7 +42,6 @@ const TABS: readonly Tab<TabId>[] = [
   { id: 'feats', label: 'Feats' },
   { id: 'progression', label: 'Progression' },
   { id: 'details', label: 'Details' },
-  { id: 'chat', label: 'Chat' },
 ];
 
 export function CharacterSheet(): React.ReactElement {
@@ -120,129 +119,149 @@ function CharacterSheetInner({ actorId, onBack, preferences }: InnerProps): Reac
   });
 
   return (
-    <main className="mx-auto max-w-3xl p-6 font-sans">
-      {state.kind === 'loading' && (
-        <div className="mb-4 flex items-center justify-between">
-          <p className="text-sm text-neutral-500">Loading character…</p>
-          <button
-            type="button"
-            onClick={onBack}
-            className="rounded border border-pf-border bg-pf-bg px-2 py-1 text-xs text-pf-text hover:bg-pf-bg-dark"
-          >
-            ← Actors
-          </button>
-        </div>
-      )}
-
-      {state.kind === 'error' && (
-        <div className="rounded border border-red-200 bg-red-50 p-4 text-sm">
-          <div className="flex items-start justify-between gap-3">
-            <p className="font-medium text-red-900">Couldn&apos;t load character</p>
+    // Two-column layout on large screens: sheet on the left, chat sidebar
+    // on the right in the previously-empty column space. Single column on
+    // narrower viewports where the sidebar would be too cramped.
+    <div className="mx-auto flex max-w-6xl gap-6 px-6 py-6 font-sans">
+      {/* ── Sheet column ─────────────────────────────────────────────── */}
+      <main className="min-w-0 max-w-3xl flex-1">
+        {state.kind === 'loading' && (
+          <div className="mb-4 flex items-center justify-between">
+            <p className="text-sm text-neutral-500">Loading character…</p>
             <button
               type="button"
               onClick={onBack}
-              className="shrink-0 rounded border border-red-300 bg-white px-2 py-1 text-xs text-red-900 hover:bg-red-100"
+              className="rounded border border-pf-border bg-pf-bg px-2 py-1 text-xs text-pf-text hover:bg-pf-bg-dark"
             >
               ← Actors
             </button>
           </div>
-          <p className="mt-1 text-red-800">{state.message}</p>
-          {state.suggestion !== undefined && <p className="mt-2 text-red-700">{state.suggestion}</p>}
-        </div>
-      )}
+        )}
 
-      {state.kind === 'ready' && (
-        <div
-          data-testid="sheet-surface"
-          style={buildSheetSurfaceStyle(readBackgroundPath(state.actor))}
-          className={readBackgroundPath(state.actor) ? '-mx-4 rounded-lg px-4 py-2' : undefined}
-        >
-          <SheetHeader
-            character={state.actor}
+        {state.kind === 'error' && (
+          <div className="rounded border border-red-200 bg-red-50 p-4 text-sm">
+            <div className="flex items-start justify-between gap-3">
+              <p className="font-medium text-red-900">Couldn&apos;t load character</p>
+              <button
+                type="button"
+                onClick={onBack}
+                className="shrink-0 rounded border border-red-300 bg-white px-2 py-1 text-xs text-red-900 hover:bg-red-100"
+              >
+                ← Actors
+              </button>
+            </div>
+            <p className="mt-1 text-red-800">{state.message}</p>
+            {state.suggestion !== undefined && <p className="mt-2 text-red-700">{state.suggestion}</p>}
+          </div>
+        )}
+
+        {state.kind === 'ready' && (
+          <div
+            data-testid="sheet-surface"
+            style={buildSheetSurfaceStyle(readBackgroundPath(state.actor))}
+            className={readBackgroundPath(state.actor) ? '-mx-4 rounded-lg px-4 py-2' : undefined}
+          >
+            <SheetHeader
+              character={state.actor}
+              actorId={actorId}
+              onActorChanged={reloadActor}
+              onBack={onBack}
+              onSettingsOpen={(): void => {
+                setSettingsOpen(true);
+              }}
+            />
+            <TabStrip tabs={TABS} active={activeTab} onChange={setActiveTab} />
+            {activeTab === 'character' && (
+              <Character
+                system={state.actor.system}
+                actorId={actorId}
+                items={state.actor.items}
+                characterLevel={state.actor.system.details.level.value}
+                onActorChanged={reloadActor}
+              />
+            )}
+            {activeTab === 'actions' && (
+              <Actions
+                actions={state.actor.system.actions}
+                items={state.actor.items}
+                abilities={state.actor.system.abilities}
+                actorId={actorId}
+                onItemUsed={reloadActor}
+              />
+            )}
+            {activeTab === 'spells' && (
+              <Spells
+                items={state.actor.items}
+                characterLevel={state.actor.system.details.level.value}
+                actorId={actorId}
+                onCast={reloadActor}
+                focusPoints={state.actor.system.resources.focus}
+              />
+            )}
+            {activeTab === 'inventory' && (
+              <>
+                <Inventory
+                  items={state.actor.items}
+                  actorId={actorId}
+                  onActorChanged={reloadActor}
+                  investiture={state.actor.system.resources.investiture}
+                />
+                {!shopMode.enabled && (
+                  <div className="mt-10 border-t border-pf-border pt-6">
+                    <SectionHeader>Crafting</SectionHeader>
+                    <Crafting actorId={actorId} crafting={state.actor.system.crafting} />
+                  </div>
+                )}
+              </>
+            )}
+            {activeTab === 'feats' && <Feats items={state.actor.items} />}
+            {activeTab === 'progression' && (
+              <Progression
+                characterLevel={state.actor.system.details.level.value}
+                items={state.actor.items}
+                characterContext={fromPreparedCharacter(state.actor)}
+              />
+            )}
+            {activeTab === 'details' && (
+              <div className="space-y-6">
+                <Background details={state.actor.system.details} traits={state.actor.system.traits.value} />
+                <Proficiencies system={state.actor.system} />
+              </div>
+            )}
+          </div>
+        )}
+
+        {settingsOpen && state.kind === 'ready' && (
+          <SettingsDialog
+            colorScheme={preferences.colorScheme}
+            onColorSchemeChange={preferences.setColorScheme}
             actorId={actorId}
-            onActorChanged={reloadActor}
-            onBack={onBack}
-            onSettingsOpen={(): void => {
-              setSettingsOpen(true);
+            backgroundPath={readBackgroundPath(state.actor)}
+            onBackgroundChanged={reloadActor}
+            onClose={(): void => {
+              setSettingsOpen(false);
             }}
           />
-          <TabStrip tabs={TABS} active={activeTab} onChange={setActiveTab} />
-          {activeTab === 'character' && (
-            <Character
-              system={state.actor.system}
-              actorId={actorId}
-              items={state.actor.items}
-              characterLevel={state.actor.system.details.level.value}
-              onActorChanged={reloadActor}
-            />
-          )}
-          {activeTab === 'actions' && (
-            <Actions
-              actions={state.actor.system.actions}
-              items={state.actor.items}
-              abilities={state.actor.system.abilities}
-              actorId={actorId}
-              onItemUsed={reloadActor}
-            />
-          )}
-          {activeTab === 'spells' && (
-            <Spells
-              items={state.actor.items}
-              characterLevel={state.actor.system.details.level.value}
-              actorId={actorId}
-              onCast={reloadActor}
-              focusPoints={state.actor.system.resources.focus}
-            />
-          )}
-          {activeTab === 'inventory' && (
-            <>
-              <Inventory
-                items={state.actor.items}
-                actorId={actorId}
-                onActorChanged={reloadActor}
-                investiture={state.actor.system.resources.investiture}
-              />
-              {!shopMode.enabled && (
-                <div className="mt-10 border-t border-pf-border pt-6">
-                  <SectionHeader>Crafting</SectionHeader>
-                  <Crafting actorId={actorId} crafting={state.actor.system.crafting} />
-                </div>
-              )}
-            </>
-          )}
-          {activeTab === 'feats' && <Feats items={state.actor.items} />}
-          {activeTab === 'progression' && (
-            <Progression
-              characterLevel={state.actor.system.details.level.value}
-              items={state.actor.items}
-              characterContext={fromPreparedCharacter(state.actor)}
-            />
-          )}
-          {activeTab === 'details' && (
-            <div className="space-y-6">
-              <Background details={state.actor.system.details} traits={state.actor.system.traits.value} />
-              <Proficiencies system={state.actor.system} />
+        )}
+        {/* Relay dialogs from Foundry — mounted unconditionally so it
+            subscribes to the prompt stream as long as the sheet is open. */}
+        <PromptQueue />
+      </main>
+
+      {/* ── Chat sidebar ─────────────────────────────────────────────── */}
+      {/* Hidden on narrow viewports; sticks to the top and scrolls
+          independently so the sheet and chat can be read in parallel. */}
+      {state.kind === 'ready' && (
+        <aside className="hidden w-72 shrink-0 lg:flex lg:flex-col">
+          <div className="sticky top-6 flex max-h-[calc(100svh-3rem)] flex-col">
+            <p className="mb-2 text-xs font-medium uppercase tracking-wide text-pf-alt-dark">Chat</p>
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              <Chat actorId={actorId} />
             </div>
-          )}
-          {activeTab === 'chat' && <Chat actorId={actorId} />}
-        </div>
+          </div>
+        </aside>
       )}
-      {settingsOpen && state.kind === 'ready' && (
-        <SettingsDialog
-          colorScheme={preferences.colorScheme}
-          onColorSchemeChange={preferences.setColorScheme}
-          actorId={actorId}
-          backgroundPath={readBackgroundPath(state.actor)}
-          onBackgroundChanged={reloadActor}
-          onClose={(): void => {
-            setSettingsOpen(false);
-          }}
-        />
-      )}
-      {/* Relay dialogs from Foundry — mounted unconditionally so it
-          subscribes to the prompt stream as long as the sheet is open. */}
-      <PromptQueue />
-    </main>
+    </div>
   );
 }
 

--- a/apps/player-portal/src/routes/CharacterSheet.tsx
+++ b/apps/player-portal/src/routes/CharacterSheet.tsx
@@ -122,7 +122,7 @@ function CharacterSheetInner({ actorId, onBack, preferences }: InnerProps): Reac
     // Two-column layout on large screens: sheet on the left, chat sidebar
     // on the right in the previously-empty column space. Single column on
     // narrower viewports where the sidebar would be too cramped.
-    <div className="flex gap-6 py-6 pl-6 font-sans">
+    <div className="flex gap-6 py-6 font-sans">
       {/* ── Left placeholder — same width as chat sidebar, reserved for
           a future panel being added in a separate workstream ────────── */}
       <div className="hidden w-72 shrink-0 rounded border border-dashed border-pf-border lg:block" />

--- a/apps/player-portal/src/routes/CharacterSheet.tsx
+++ b/apps/player-portal/src/routes/CharacterSheet.tsx
@@ -122,7 +122,7 @@ function CharacterSheetInner({ actorId, onBack, preferences }: InnerProps): Reac
     // Two-column layout on large screens: sheet on the left, chat sidebar
     // on the right in the previously-empty column space. Single column on
     // narrower viewports where the sidebar would be too cramped.
-    <div className="mx-auto flex max-w-6xl gap-6 px-6 py-6 font-sans">
+    <div className="flex gap-6 py-6 pl-6 font-sans">
       {/* ── Sheet column ─────────────────────────────────────────────── */}
       <main className="min-w-0 max-w-3xl flex-1">
         {state.kind === 'loading' && (
@@ -252,7 +252,7 @@ function CharacterSheetInner({ actorId, onBack, preferences }: InnerProps): Reac
       {/* Hidden on narrow viewports; sticks to the top and scrolls
           independently so the sheet and chat can be read in parallel. */}
       {state.kind === 'ready' && (
-        <aside className="hidden w-72 shrink-0 lg:flex lg:flex-col">
+        <aside className="hidden w-72 shrink-0 pr-3 lg:flex lg:flex-col">
           <div className="sticky top-6 flex max-h-[calc(100svh-3rem)] flex-col">
             <p className="mb-2 text-xs font-medium uppercase tracking-wide text-pf-alt-dark">Chat</p>
             <div className="min-h-0 flex-1 overflow-y-auto">

--- a/apps/player-portal/src/routes/CharacterSheet.tsx
+++ b/apps/player-portal/src/routes/CharacterSheet.tsx
@@ -125,7 +125,7 @@ function CharacterSheetInner({ actorId, onBack, preferences }: InnerProps): Reac
     <div className="flex gap-6 py-6 font-sans">
       {/* ── Left placeholder — same width as chat sidebar, reserved for
           a future panel being added in a separate workstream ────────── */}
-      <div className="hidden w-72 shrink-0 rounded border border-dashed border-pf-border lg:block" />
+      <div className="hidden w-72 shrink-0 rounded border border-dashed border-pf-border pl-3 lg:block" />
 
       {/* ── Sheet column ─────────────────────────────────────────────── */}
       <main className="min-w-0 flex-1">

--- a/apps/player-portal/src/routes/CharacterSheet.tsx
+++ b/apps/player-portal/src/routes/CharacterSheet.tsx
@@ -16,6 +16,7 @@ import { Inventory } from '../components/tabs/Inventory';
 import { Proficiencies } from '../components/tabs/Proficiencies';
 import { Progression } from '../components/tabs/Progression';
 
+import { Chat } from '../components/tabs/Chat';
 import { Spells } from '../components/tabs/Spells';
 import { useEventChannel } from '../lib/useEventChannel';
 import { fromPreparedCharacter } from '../prereqs';
@@ -41,6 +42,7 @@ const TABS: readonly Tab<TabId>[] = [
   { id: 'feats', label: 'Feats' },
   { id: 'progression', label: 'Progression' },
   { id: 'details', label: 'Details' },
+  { id: 'chat', label: 'Chat' },
 ];
 
 export function CharacterSheet(): React.ReactElement {
@@ -222,6 +224,7 @@ function CharacterSheetInner({ actorId, onBack, preferences }: InnerProps): Reac
               <Proficiencies system={state.actor.system} />
             </div>
           )}
+          {activeTab === 'chat' && <Chat actorId={actorId} />}
         </div>
       )}
       {settingsOpen && state.kind === 'ready' && (

--- a/apps/player-portal/src/routes/CharacterSheet.tsx
+++ b/apps/player-portal/src/routes/CharacterSheet.tsx
@@ -125,7 +125,7 @@ function CharacterSheetInner({ actorId, onBack, preferences }: InnerProps): Reac
     <div className="flex gap-6 py-6 font-sans">
       {/* ── Left placeholder — same width as chat sidebar, reserved for
           a future panel being added in a separate workstream ────────── */}
-      <div className="hidden w-72 shrink-0 pl-3 lg:block">
+      <div className="hidden w-[230px] shrink-0 pl-3 lg:block">
         <div className="h-full rounded border border-dashed border-pf-border" />
       </div>
 
@@ -258,7 +258,7 @@ function CharacterSheetInner({ actorId, onBack, preferences }: InnerProps): Reac
       {/* Hidden on narrow viewports; sticks to the top and scrolls
           independently so the sheet and chat can be read in parallel. */}
       {state.kind === 'ready' && (
-        <aside className="hidden w-72 shrink-0 pr-3 lg:flex lg:flex-col">
+        <aside className="hidden w-[230px] shrink-0 pr-3 lg:flex lg:flex-col">
           <div className="sticky top-6 flex max-h-[calc(100svh-3rem)] flex-col">
             <p className="mb-2 text-xs font-medium uppercase tracking-wide text-pf-alt-dark">Chat</p>
             <div className="min-h-0 flex-1 overflow-y-auto">

--- a/packages/shared/src/rpc/live.test.ts
+++ b/packages/shared/src/rpc/live.test.ts
@@ -267,6 +267,11 @@ describe('chatMessageSnapshotSchema', () => {
     expect(parsed).toEqual(validMessage);
   });
 
+  it('accepts a string type (Foundry v14 document subtype)', () => {
+    const parsed = chatMessageSnapshotSchema.parse({ ...validMessage, type: 'base' });
+    expect(parsed.type).toBe('base');
+  });
+
   it('round-trips via JSON serialization', () => {
     const roundTripped = chatMessageSnapshotSchema.parse(JSON.parse(JSON.stringify(validMessage)));
     expect(roundTripped).toEqual(validMessage);

--- a/packages/shared/src/rpc/live.ts
+++ b/packages/shared/src/rpc/live.ts
@@ -108,7 +108,7 @@ export const chatRollSchema = z.object({
 export const chatMessageSnapshotSchema = z.object({
   id: z.string(),
   uuid: z.string().nullable(),
-  type: z.number().nullable(),
+  type: z.union([z.number(), z.string()]).nullable(),
   author: z.object({ id: z.string(), name: z.string() }).nullable(),
   timestamp: z.number().nullable(),
   flavor: z.string(),


### PR DESCRIPTION
## Summary

PR 3 of 3 in the chat-relay plan at `~/.claude/plans/read-only-investigation-plan-mode-delightful-perlis.md`.

Surfaces Foundry's chat log alongside the character sheet. The sheet is now a three-column layout (left panel placeholder · sheet · chat sidebar); the chat sidebar is always mounted and connected to the filtered SSE stream from PR 2. Messages show speaker name, roll results with formula/total/crit badges, whisper badges, and timestamps. This is a functional but deliberately unpolished v1 — the rough edges listed below are known and left for follow-up.

Also fixes a schema bug found live: Foundry v14 emits `ChatMessage.type` as a document subtype string (`"base"`) rather than the legacy numeric constant.

## Apps touched

- `packages/shared` — schema fix for `type` field
- `apps/player-portal` — hook, components, layout restructure

To validate:
- `npm run test -w packages/shared` and `npm run test -w apps/player-portal`
- Against a live Foundry session: public messages and actor rolls appear in the right sidebar; whispers between other players do not

## Changes

- `packages/shared/src/rpc/live.ts` — widen `type` to `z.union([z.number(), z.string()]).nullable()`
- `src/lib/tabUtils.ts` — `'chat'` added then removed as a tab; now a `LEGACY_REDIRECTS` entry pointing to `'character'`
- `src/lib/useLiveChat.ts` — fetches backfill on mount, opens SSE for deltas, deduplicates overlap, handles 404 gracefully in mock mode
- `src/components/chat/MessageBubble.tsx` — renders speaker, roll result, flavor, content; clamps inline PF2e images to max-h-6
- `src/components/tabs/Chat.tsx` — thin panel wrapping `useLiveChat` with loading/empty/reconnecting states
- `src/routes/CharacterSheet.tsx` — three-column flex layout; left placeholder (`w-[230px]`, dashed border, reserved for a separate workstream); chat sidebar sticky on the right (`w-[230px]`)

## Known rough edges (left for follow-up)

- **`userId` not wired** — the portal has no current-user identity mechanism, so whispers directed at the player are filtered out server-side. `useLiveChat` accepts an optional `userId` param ready to be connected once identity is available.
- **PF2e card HTML overflows** — spell/action cards from Foundry embed `flexrow` and non-wrapping elements that exceed the sidebar width. Content is clipped rather than reflowed. Needs either a sanitisation pass or targeted CSS resets for PF2e card classes.
- **No scroll-to-bottom** — new messages appear at the bottom of the list but the sidebar doesn't auto-scroll. The player must scroll manually.
- **Left panel placeholder** — dashed border, `w-[230px]`, `pl-3`. Replace with real content from the other workstream; remove the border classes when done.

## Test plan

- [ ] `npm run test -w packages/shared` — 207 tests pass (includes string-type round-trip)
- [ ] `npm run test -w apps/player-portal` — 416 tests pass (includes 16 `useLiveChat` tests)
- [ ] `npm run typecheck` — clean

Refs #127, #138