### PR TITLE
refactor(player-portal): extract CompendiumPicker generic base from FeatPicker and ItemShopPicker

### DIFF
--- a/apps/player-portal/src/components/creator/AbilityBoostPicker.tsx
+++ b/apps/player-portal/src/components/creator/AbilityBoostPicker.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 import type { AbilityKey } from '../../api/types';
 import { ABILITY_KEYS } from '../../api/types';
 import { formatSignedInt } from '../../lib/format';
@@ -88,7 +89,10 @@ export function AbilityBoostPicker({
 
   const canApply = selected.length === BOOSTS_PER_SET;
 
-  return (
+  // Portal to document.body so the modal escapes any ancestor's
+  // child-selector utilities (e.g. Progression.tsx's `*:bg-pf-bg-dark`
+  // section, which would otherwise paint the backdrop solid).
+  return createPortal(
     <div
       role="dialog"
       aria-modal="true"
@@ -177,6 +181,7 @@ export function AbilityBoostPicker({
           </button>
         </footer>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/apps/player-portal/src/components/creator/FeatDetailPanel.tsx
+++ b/apps/player-portal/src/components/creator/FeatDetailPanel.tsx
@@ -1,0 +1,206 @@
+import { useEffect, useState } from 'react';
+import { api } from '../../api/client';
+import type { CompendiumMatch } from '../../api/types';
+import { enrichDescription } from '@foundry-toolkit/shared/foundry-enrichers';
+import { useUuidHover } from '../../lib/useUuidHover';
+import { extractDetailBio } from './feat-bio';
+import { type DetailState } from './useFeatDetail';
+
+export function FeatDetailPanel({
+  target,
+  detail,
+  prereqCache,
+  onPick,
+  onClose,
+}: {
+  target: CompendiumMatch | null;
+  detail: DetailState;
+  prereqCache: React.RefObject<Map<string, string | null>>;
+  onPick: () => void;
+  onClose: () => void;
+}): React.ReactElement | null {
+  const uuidHover = useUuidHover();
+  const [prereqResolutions, setPrereqResolutions] = useState<Map<string, string | null>>(new Map());
+
+  const doc = detail.kind === 'ready' ? detail.doc : null;
+  const bio = extractDetailBio(doc);
+  const prereqsKey = (bio.prerequisites ?? []).join('|');
+
+  useEffect(() => {
+    const prereqs = bio.prerequisites;
+    if (!prereqs || prereqs.length === 0) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setPrereqResolutions(new Map());
+      return;
+    }
+    let cancelled = false;
+    const initial = new Map<string, string | null>();
+    for (const p of prereqs) {
+      const cached = prereqCache.current.get(p.toLowerCase());
+      if (cached !== undefined) initial.set(p, cached);
+    }
+    setPrereqResolutions(initial);
+
+    // The prefetch usually has these cached already, but fall back to
+    // on-demand lookup for anything still missing.
+    void (async (): Promise<void> => {
+      await Promise.all(
+        prereqs.map(async (text) => {
+          const key = text.toLowerCase();
+          if (prereqCache.current.has(key)) return;
+          try {
+            const response = await api.searchCompendium({ q: text, documentType: 'Item', limit: 5 });
+            const exact = response.matches.find((m) => m.name.toLowerCase() === key);
+            const uuid = exact?.uuid ?? null;
+            prereqCache.current.set(key, uuid);
+            if (!cancelled) {
+              setPrereqResolutions((prev) => {
+                const next = new Map(prev);
+                next.set(text, uuid);
+                return next;
+              });
+            }
+          } catch {
+            prereqCache.current.set(key, null);
+            if (!cancelled) {
+              setPrereqResolutions((prev) => {
+                const next = new Map(prev);
+                next.set(text, null);
+                return next;
+              });
+            }
+          }
+        }),
+      );
+    })();
+
+    return (): void => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [prereqsKey]);
+
+  if (!target) return null;
+  return (
+    <aside className="flex min-w-0 flex-1 flex-col" data-testid="feat-picker-detail" data-detail-uuid={target.uuid}>
+      <header className="flex items-start gap-3 border-b border-pf-border px-4 py-3">
+        {target.img && (
+          <img src={target.img} alt="" className="h-12 w-12 shrink-0 rounded border border-pf-border bg-pf-bg-dark" />
+        )}
+        <div className="min-w-0 flex-1">
+          <h3 className="font-serif text-base font-semibold text-pf-text">{target.name}</h3>
+          <p className="mt-0.5 text-[10px] uppercase tracking-widest text-pf-alt">
+            {target.packLabel}
+            {target.level !== undefined && ` · L${target.level.toString()}`}
+          </p>
+          {target.traits && target.traits.length > 0 && (
+            <ul className="mt-1 flex flex-wrap gap-1">
+              {target.traits.map((t) => (
+                <li
+                  key={t}
+                  className="rounded-full border border-pf-tertiary-dark bg-pf-tertiary/40 px-1.5 py-0.5 text-[10px] text-pf-alt-dark"
+                >
+                  {t}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close detail"
+          className="rounded px-2 py-0.5 text-lg text-pf-alt-dark hover:bg-pf-bg-dark hover:text-pf-primary"
+        >
+          ×
+        </button>
+      </header>
+
+      <div className="flex-1 overflow-y-auto px-4 py-3">
+        {detail.kind === 'loading' && <p className="text-sm italic text-pf-alt">Loading…</p>}
+        {detail.kind === 'error' && <p className="text-sm text-pf-primary">Failed to load: {detail.message}</p>}
+        {detail.kind === 'ready' && (
+          <div className="space-y-3">
+            {bio.prerequisites && bio.prerequisites.length > 0 && (
+              <PrereqRow prereqs={bio.prerequisites} resolutions={prereqResolutions} />
+            )}
+            {bio.actions && <DetailRow label="Actions" value={bio.actions} />}
+            {bio.trigger && <DetailRow label="Trigger" value={bio.trigger} />}
+            {bio.frequency && <DetailRow label="Frequency" value={bio.frequency} />}
+            {bio.requirements && <DetailRow label="Requirements" value={bio.requirements} />}
+            {bio.description && (
+              <div
+                {...uuidHover.delegationHandlers}
+                className="text-sm leading-relaxed text-pf-text [&_.pf-damage]:font-semibold [&_.pf-damage]:text-pf-primary [&_.pf-template]:italic [&_.pf-template]:text-pf-secondary [&_a]:cursor-pointer [&_a]:text-pf-primary [&_a]:underline [&_p]:my-2 [&_p]:leading-relaxed"
+                // Trusted source: our own Foundry. enrichDescription converts
+                // Foundry enricher tokens into styled inline elements.
+                dangerouslySetInnerHTML={{ __html: enrichDescription(bio.description) }}
+              />
+            )}
+            {uuidHover.popover}
+          </div>
+        )}
+      </div>
+
+      <footer className="flex items-center justify-end gap-2 border-t border-pf-border px-4 py-2">
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded border border-pf-border bg-pf-bg px-3 py-1 text-xs font-semibold uppercase tracking-widest text-pf-alt-dark hover:text-pf-primary"
+        >
+          Back
+        </button>
+        <button
+          type="button"
+          onClick={onPick}
+          data-testid="feat-picker-pick"
+          className="rounded border border-pf-primary bg-pf-primary px-3 py-1 text-xs font-semibold uppercase tracking-widest text-white hover:brightness-110"
+        >
+          Pick {target.name}
+        </button>
+      </footer>
+    </aside>
+  );
+}
+
+function DetailRow({ label, value }: { label: string; value: string }): React.ReactElement {
+  return (
+    <div className="flex flex-col gap-0.5 sm:flex-row sm:gap-3">
+      <dt className="w-32 shrink-0 text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark">{label}</dt>
+      <dd className="text-sm text-pf-text">{value}</dd>
+    </div>
+  );
+}
+
+function PrereqRow({
+  prereqs,
+  resolutions,
+}: {
+  prereqs: string[];
+  resolutions: Map<string, string | null>;
+}): React.ReactElement {
+  return (
+    <div className="flex flex-col gap-0.5 sm:flex-row sm:gap-3">
+      <dt className="w-32 shrink-0 text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark">
+        Prerequisites
+      </dt>
+      <dd className="text-sm text-pf-text">
+        {prereqs.map((p, i) => {
+          const uuid = resolutions.get(p);
+          return (
+            <span key={`${p}-${i.toString()}`}>
+              {i > 0 && '; '}
+              {uuid ? (
+                <a data-uuid={uuid} className="cursor-pointer text-pf-primary underline" title={uuid}>
+                  {p}
+                </a>
+              ) : (
+                p
+              )}
+            </span>
+          );
+        })}
+      </dd>
+    </div>
+  );
+}

--- a/apps/player-portal/src/components/creator/FeatFilters.tsx
+++ b/apps/player-portal/src/components/creator/FeatFilters.tsx
@@ -1,0 +1,266 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { RemoteDataState } from '../../lib/useRemoteData';
+import type { CompendiumSource } from '../../api/types';
+import type { CompendiumSearchOptions } from '../../api/types';
+
+export type SortMode = 'alpha' | 'level';
+export type SortDir = 'asc' | 'desc';
+export interface SortState {
+  mode: SortMode;
+  dir: SortDir;
+}
+
+// ─── Source multi-select ────────────────────────────────────────────────
+
+export function SourcePicker({
+  sources,
+  selected,
+  onChange,
+}: {
+  sources: RemoteDataState<CompendiumSource[]>;
+  selected: string[];
+  onChange: (next: string[]) => void;
+}): React.ReactElement {
+  const [open, setOpen] = useState(false);
+  const [filter, setFilter] = useState('');
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onDocClick(e: MouseEvent): void {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', onDocClick);
+    return (): void => {
+      document.removeEventListener('mousedown', onDocClick);
+    };
+  }, [open]);
+
+  const count = selected.length;
+  const label =
+    sources.kind === 'loading' ? 'Sources (…)' : count === 0 ? 'All sources' : `Sources (${count.toString()})`;
+
+  const selectedSet = useMemo(() => new Set(selected.map((s) => s.toLowerCase())), [selected]);
+  const filtered = useMemo(() => {
+    if (sources.kind !== 'ready') return [];
+    const needle = filter.trim().toLowerCase();
+    if (!needle) return sources.data;
+    return sources.data.filter((s) => s.title.toLowerCase().includes(needle));
+  }, [sources, filter]);
+
+  const toggle = (title: string): void => {
+    const lower = title.toLowerCase();
+    onChange(selectedSet.has(lower) ? selected.filter((s) => s.toLowerCase() !== lower) : [...selected, title]);
+  };
+  const selectAllVisible = (): void => {
+    const nextLowers = new Set(selected.map((s) => s.toLowerCase()));
+    const next = [...selected];
+    for (const s of filtered) {
+      if (!nextLowers.has(s.title.toLowerCase())) {
+        next.push(s.title);
+        nextLowers.add(s.title.toLowerCase());
+      }
+    }
+    onChange(next);
+  };
+  const clearAll = (): void => {
+    onChange([]);
+  };
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        data-testid="source-picker-trigger"
+        onClick={(): void => {
+          setOpen((v) => !v);
+        }}
+        className={[
+          'rounded border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest transition-colors',
+          count > 0
+            ? 'border-pf-primary bg-pf-primary/10 text-pf-primary'
+            : 'border-pf-border bg-pf-bg text-pf-alt-dark hover:text-pf-primary',
+        ].join(' ')}
+      >
+        {label} {open ? '▴' : '▾'}
+      </button>
+      {open && (
+        <div
+          role="listbox"
+          data-testid="source-picker-panel"
+          className="absolute left-0 top-full z-10 mt-1 flex max-h-72 w-80 flex-col rounded border border-pf-border bg-pf-bg shadow-lg"
+        >
+          <div className="flex items-center gap-1 border-b border-pf-border p-2">
+            <input
+              type="search"
+              value={filter}
+              onChange={(e): void => {
+                setFilter(e.target.value);
+              }}
+              placeholder="Filter sources…"
+              className="flex-1 rounded border border-pf-border bg-pf-bg px-2 py-0.5 text-xs text-pf-text placeholder:text-pf-alt focus:border-pf-primary focus:outline-none"
+              data-testid="source-picker-filter"
+            />
+          </div>
+          <div className="flex items-center gap-2 border-b border-pf-border px-2 py-1 text-[10px] uppercase tracking-widest">
+            <button
+              type="button"
+              onClick={selectAllVisible}
+              className="text-pf-alt-dark hover:text-pf-primary"
+              data-testid="source-picker-select-all"
+            >
+              Select visible
+            </button>
+            <span className="text-pf-border">·</span>
+            <button
+              type="button"
+              onClick={clearAll}
+              className="text-pf-alt-dark hover:text-pf-primary"
+              data-testid="source-picker-clear"
+            >
+              Clear
+            </button>
+            <span className="ml-auto text-pf-alt">
+              {sources.kind === 'ready' ? `${filtered.length.toString()} shown` : ''}
+            </span>
+          </div>
+          <ul className="flex-1 overflow-y-auto">
+            {sources.kind === 'loading' && <li className="p-2 text-xs italic text-pf-alt">Loading sources…</li>}
+            {sources.kind === 'error' && (
+              <li className="p-2 text-xs text-pf-primary">Failed to load sources: {sources.message}</li>
+            )}
+            {sources.kind === 'ready' && filtered.length === 0 && (
+              <li className="p-2 text-xs italic text-pf-alt">No sources match that filter.</li>
+            )}
+            {sources.kind === 'ready' &&
+              filtered.map((src) => {
+                const active = selectedSet.has(src.title.toLowerCase());
+                return (
+                  <li key={src.title}>
+                    <label
+                      data-source-title={src.title}
+                      className={[
+                        'flex cursor-pointer items-center gap-2 px-2 py-1 text-xs',
+                        active ? 'bg-pf-tertiary/40' : 'hover:bg-pf-tertiary/20',
+                      ].join(' ')}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={active}
+                        onChange={(): void => {
+                          toggle(src.title);
+                        }}
+                        className="accent-pf-primary"
+                      />
+                      <span className="flex-1 truncate text-pf-text">{src.title}</span>
+                      <span className="shrink-0 font-mono text-[10px] tabular-nums text-pf-alt">{src.count}</span>
+                    </label>
+                  </li>
+                );
+              })}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Sort toggle ────────────────────────────────────────────────────────
+
+export function SortToggle({
+  sort,
+  onChange,
+}: {
+  sort: SortState;
+  onChange: (mode: SortMode) => void;
+}): React.ReactElement {
+  const options: Array<{ value: SortMode; label: string }> = [
+    { value: 'alpha', label: 'A–Z' },
+    { value: 'level', label: 'Level' },
+  ];
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Sort results"
+      data-testid="feat-picker-sort"
+      className="inline-flex shrink-0 overflow-hidden rounded border border-pf-border text-[10px] font-semibold uppercase tracking-widest"
+    >
+      {options.map((opt) => {
+        const active = sort.mode === opt.value;
+        const arrow = active ? (sort.dir === 'asc' ? ' ↑' : ' ↓') : '';
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            data-sort-option={opt.value}
+            data-sort-dir={active ? sort.dir : undefined}
+            title={
+              active
+                ? `Sorting ${opt.label} ${sort.dir === 'asc' ? '↑' : '↓'} — click to reverse`
+                : `Sort by ${opt.label}`
+            }
+            onClick={(): void => {
+              onChange(opt.value);
+            }}
+            className={[
+              'px-2 py-0.5 transition-colors',
+              active
+                ? 'bg-pf-primary text-white'
+                : 'bg-pf-bg text-pf-alt-dark hover:bg-pf-tertiary/40 hover:text-pf-primary',
+            ].join(' ')}
+          >
+            {opt.label}
+            {arrow}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── Unmet-prereq toggle ────────────────────────────────────────────────
+
+export function UnmetToggle({
+  hide,
+  onChange,
+}: {
+  hide: boolean;
+  onChange: (next: boolean) => void;
+}): React.ReactElement {
+  return (
+    <label
+      data-testid="feat-picker-hide-unmet"
+      className="inline-flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark"
+    >
+      <input
+        type="checkbox"
+        checked={hide}
+        onChange={(e): void => {
+          onChange(e.target.checked);
+        }}
+        className="accent-pf-primary"
+      />
+      Hide unmet
+    </label>
+  );
+}
+
+// ─── Filter summary ─────────────────────────────────────────────────────
+
+export function FilterSummary({
+  filters,
+}: {
+  filters: Pick<CompendiumSearchOptions, 'traits' | 'maxLevel'>;
+}): React.ReactElement | null {
+  const parts: string[] = [];
+  if (filters.traits && filters.traits.length > 0) parts.push(`traits: ${filters.traits.join(', ')}`);
+  if (filters.maxLevel !== undefined) parts.push(`level ≤ ${filters.maxLevel.toString()}`);
+  if (parts.length === 0) return null;
+  return <p className="text-[10px] uppercase tracking-widest text-pf-alt">{parts.join(' · ')}</p>;
+}

--- a/apps/player-portal/src/components/creator/FeatMatchRow.tsx
+++ b/apps/player-portal/src/components/creator/FeatMatchRow.tsx
@@ -1,0 +1,144 @@
+import type { CompendiumMatch } from '../../api/types';
+import type { Evaluation } from '../../prereqs';
+
+// ─── Match list ─────────────────────────────────────────────────────────
+
+/**
+ * Splits results into ancestry-specific + versatile buckets when any match
+ * carries `isVersatile`. Keeps a flat list otherwise so non-heritage
+ * searches render unchanged.
+ */
+export function FeatMatchList({
+  matches,
+  evaluations,
+  activeUuid,
+  onSelect,
+}: {
+  matches: CompendiumMatch[];
+  evaluations: Map<string, Evaluation>;
+  activeUuid: string | undefined;
+  onSelect: (m: CompendiumMatch) => void;
+}): React.ReactElement {
+  const ancestrySpecific = matches.filter((m) => m.isVersatile !== true);
+  const versatile = matches.filter((m) => m.isVersatile === true);
+
+  if (versatile.length === 0) {
+    return (
+      <ul className="divide-y divide-pf-border">
+        {matches.map((match) => (
+          <li key={match.uuid}>
+            <FeatMatchRow
+              match={match}
+              active={activeUuid === match.uuid}
+              evaluation={evaluations.get(match.uuid)}
+              onSelect={onSelect}
+            />
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  return (
+    <>
+      {ancestrySpecific.length > 0 && (
+        <ul className="divide-y divide-pf-border" data-match-group="ancestry-specific">
+          {ancestrySpecific.map((match) => (
+            <li key={match.uuid}>
+              <FeatMatchRow
+                match={match}
+                active={activeUuid === match.uuid}
+                evaluation={evaluations.get(match.uuid)}
+                onSelect={onSelect}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+      <h3 className="border-t border-pf-border bg-pf-bg-dark/40 px-3 py-1.5 font-serif text-xs font-semibold uppercase tracking-widest text-pf-alt-dark">
+        Versatile Heritages
+      </h3>
+      <ul className="divide-y divide-pf-border" data-match-group="versatile">
+        {versatile.map((match) => (
+          <li key={match.uuid}>
+            <FeatMatchRow
+              match={match}
+              active={activeUuid === match.uuid}
+              evaluation={evaluations.get(match.uuid)}
+              onSelect={onSelect}
+            />
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+}
+
+// ─── Individual row ─────────────────────────────────────────────────────
+
+export function FeatMatchRow({
+  match,
+  active,
+  evaluation,
+  onSelect,
+}: {
+  match: CompendiumMatch;
+  active: boolean;
+  evaluation: Evaluation | undefined;
+  onSelect: (match: CompendiumMatch) => void;
+}): React.ReactElement {
+  const traitsSummary = match.traits && match.traits.length > 0 ? match.traits.slice(0, 5).join(', ') : '';
+  const fails = evaluation === 'fails';
+  const unknown = evaluation === 'unknown';
+  const rowTitle = fails
+    ? "Character doesn't meet this feat's prerequisites"
+    : unknown
+      ? "Prereqs couldn't be auto-checked — verify manually before picking"
+      : undefined;
+  return (
+    <button
+      type="button"
+      onClick={(): void => {
+        onSelect(match);
+      }}
+      data-match-uuid={match.uuid}
+      data-prereq-state={evaluation ?? 'pending'}
+      aria-pressed={active}
+      title={rowTitle}
+      className={[
+        'flex w-full items-center gap-3 px-4 py-2 text-left transition-colors',
+        active ? 'bg-pf-tertiary/50' : 'hover:bg-pf-tertiary/20',
+        fails ? 'opacity-60' : '',
+      ].join(' ')}
+    >
+      {match.img && (
+        <img src={match.img} alt="" className="h-8 w-8 shrink-0 rounded border border-pf-border bg-pf-bg-dark" />
+      )}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline justify-between gap-2">
+          <span className="flex min-w-0 items-baseline gap-1.5">
+            <span className="truncate text-sm font-medium text-pf-text">{match.name}</span>
+            {unknown && (
+              <span
+                data-testid="prereq-unknown-badge"
+                aria-label="Prereqs unchecked"
+                className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-amber-500 bg-amber-100 text-[10px] font-semibold text-amber-800"
+              >
+                !
+              </span>
+            )}
+          </span>
+          {match.level !== undefined && (
+            <span className="shrink-0 font-mono text-[10px] uppercase tracking-widest text-pf-alt-dark">
+              L{match.level}
+            </span>
+          )}
+        </div>
+        <div className="flex items-baseline justify-between gap-2 text-[10px] text-pf-alt">
+          <span className="truncate">{match.packLabel}</span>
+          {traitsSummary && <span className="truncate">{traitsSummary}</span>}
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/apps/player-portal/src/components/creator/FeatPicker.test.tsx
+++ b/apps/player-portal/src/components/creator/FeatPicker.test.tsx
@@ -41,7 +41,7 @@ describe('FeatPicker', () => {
   });
 
   it('renders the title, filter summary, and match list', async () => {
-    const { container, getByText } = render(
+    const { getByText } = render(
       <FeatPicker
         title="Pick a Class Feat (Level 1)"
         filters={{ packIds: ['pf2e.feats-srd'], documentType: 'Item', traits: ['barbarian'], maxLevel: 1 }}
@@ -51,12 +51,12 @@ describe('FeatPicker', () => {
     );
     expect(getByText('Pick a Class Feat (Level 1)')).toBeTruthy();
     await waitFor(() => {
-      expect(container.querySelector('[data-match-uuid]')).toBeTruthy();
+      expect(document.querySelector('[data-match-uuid]')).toBeTruthy();
     });
     expect(getByText('Sudden Charge')).toBeTruthy();
     expect(getByText('Raging Intimidation')).toBeTruthy();
-    expect(container.textContent).toContain('traits: barbarian');
-    expect(container.textContent).toContain('level ≤ 1');
+    expect(document.body.textContent).toContain('traits: barbarian');
+    expect(document.body.textContent).toContain('level ≤ 1');
   });
 
   it('calls searchCompendium with the configured filters', async () => {
@@ -82,18 +82,18 @@ describe('FeatPicker', () => {
 
   it('calls onPick with the selected match via the detail panel Pick button', async () => {
     const onPick = vi.fn();
-    const { container, getByTestId } = render(
+    const { getByTestId } = render(
       <FeatPicker title="t" filters={{ traits: ['barbarian'] }} onPick={onPick} onClose={vi.fn()} />,
     );
     await waitFor(() => {
-      expect(container.querySelector('[data-match-uuid]')).toBeTruthy();
+      expect(document.querySelector('[data-match-uuid]')).toBeTruthy();
     });
     // Two-pane flow: clicking a row opens the detail panel; picking
     // happens via the Pick button in the panel footer.
-    const row = container.querySelector('[data-match-uuid="Compendium.pf2e.feats-srd.Item.a"]') as HTMLElement;
+    const row = document.querySelector('[data-match-uuid="Compendium.pf2e.feats-srd.Item.a"]') as HTMLElement;
     fireEvent.click(row);
     await waitFor(() => {
-      expect(container.querySelector('[data-testid="feat-picker-detail"]')).toBeTruthy();
+      expect(document.querySelector('[data-testid="feat-picker-detail"]')).toBeTruthy();
     });
     fireEvent.click(getByTestId('feat-picker-pick'));
     expect(onPick).toHaveBeenCalledTimes(1);
@@ -109,11 +109,11 @@ describe('FeatPicker', () => {
 
   it('closes when the backdrop is clicked but not when the card is clicked', async () => {
     const onClose = vi.fn();
-    const { getByTestId, container } = render(
+    const { getByTestId } = render(
       <FeatPicker title="t" filters={{ traits: ['barbarian'] }} onPick={vi.fn()} onClose={onClose} />,
     );
     await waitFor(() => {
-      expect(container.querySelector('[data-match-uuid]')).toBeTruthy();
+      expect(document.querySelector('[data-match-uuid]')).toBeTruthy();
     });
     // Click the card — should NOT close.
     fireEvent.click(getByTestId('feat-picker-results'));
@@ -125,32 +125,32 @@ describe('FeatPicker', () => {
 
   it('shows an empty-state message when no matches come back', async () => {
     searchSpy.mockResolvedValueOnce({ matches: [], total: 0 });
-    const { container } = render(
+    render(
       <FeatPicker title="t" filters={{ traits: ['barbarian'] }} onPick={vi.fn()} onClose={vi.fn()} />,
     );
     await waitFor(() => {
-      expect(container.textContent).toMatch(/no matches/i);
+      expect(document.body.textContent).toMatch(/no matches/i);
     });
   });
 
   it('shows an error banner when the search throws', async () => {
     searchSpy.mockRejectedValueOnce(new Error('boom'));
-    const { container } = render(
+    render(
       <FeatPicker title="t" filters={{ traits: ['barbarian'] }} onPick={vi.fn()} onClose={vi.fn()} />,
     );
     await waitFor(() => {
-      expect(container.textContent).toMatch(/search failed/i);
+      expect(document.body.textContent).toMatch(/search failed/i);
     });
   });
 
   // --- Sort toggle --------------------------------------------------------
 
   it('renders an A-Z / Level sort toggle with A-Z selected by default', async () => {
-    const { container, getByTestId } = render(
+    const { getByTestId } = render(
       <FeatPicker title="t" filters={{ traits: ['barbarian'] }} onPick={vi.fn()} onClose={vi.fn()} />,
     );
     await waitFor(() => {
-      expect(container.querySelector('[data-match-uuid]')).toBeTruthy();
+      expect(document.querySelector('[data-match-uuid]')).toBeTruthy();
     });
     const toggle = getByTestId('feat-picker-sort');
     const alpha = toggle.querySelector('[data-sort-option="alpha"]');
@@ -161,13 +161,13 @@ describe('FeatPicker', () => {
 
   it('sorts matches A-Z by default regardless of server order', async () => {
     // Server returns Sudden Charge first; A-Z should surface Raging Intimidation first.
-    const { container } = render(
+    render(
       <FeatPicker title="t" filters={{ traits: ['barbarian'] }} onPick={vi.fn()} onClose={vi.fn()} />,
     );
     await waitFor(() => {
-      expect(container.querySelector('[data-match-uuid]')).toBeTruthy();
+      expect(document.querySelector('[data-match-uuid]')).toBeTruthy();
     });
-    const names = Array.from(container.querySelectorAll('[data-match-uuid]')).map(
+    const names = Array.from(document.querySelectorAll('[data-match-uuid]')).map(
       (el) => el.querySelector('span')?.textContent,
     );
     expect(names).toEqual(['Raging Intimidation', 'Sudden Charge']);
@@ -212,16 +212,16 @@ describe('FeatPicker', () => {
       ],
       total: 3,
     });
-    const { container, getByTestId } = render(
+    const { getByTestId } = render(
       <FeatPicker title="t" filters={{ traits: ['x'] }} onPick={vi.fn()} onClose={vi.fn()} />,
     );
     await waitFor(() => {
-      expect(container.querySelector('[data-match-uuid]')).toBeTruthy();
+      expect(document.querySelector('[data-match-uuid]')).toBeTruthy();
     });
     const levelBtn = getByTestId('feat-picker-sort').querySelector('[data-sort-option="level"]') as HTMLElement;
     fireEvent.click(levelBtn);
 
-    const order = Array.from(container.querySelectorAll('[data-match-uuid]')).map((el) =>
+    const order = Array.from(document.querySelectorAll('[data-match-uuid]')).map((el) =>
       el.getAttribute('data-match-uuid'),
     );
     // Ascending by level: 1, 3, 5 → B, C, A
@@ -231,18 +231,18 @@ describe('FeatPicker', () => {
   });
 
   it('reverses direction when the active sort option is clicked again', async () => {
-    const { container, getByTestId } = render(
+    const { getByTestId } = render(
       <FeatPicker title="t" filters={{ traits: ['barbarian'] }} onPick={vi.fn()} onClose={vi.fn()} />,
     );
     await waitFor(() => {
-      expect(container.querySelector('[data-match-uuid]')).toBeTruthy();
+      expect(document.querySelector('[data-match-uuid]')).toBeTruthy();
     });
     const toggle = getByTestId('feat-picker-sort');
     const alpha = toggle.querySelector('[data-sort-option="alpha"]') as HTMLElement;
 
     // First load: asc, so names A-Z.
     expect(alpha.getAttribute('data-sort-dir')).toBe('asc');
-    const ascOrder = Array.from(container.querySelectorAll('[data-match-uuid]')).map(
+    const ascOrder = Array.from(document.querySelectorAll('[data-match-uuid]')).map(
       (el) => el.querySelector('span')?.textContent,
     );
     expect(ascOrder).toEqual(['Raging Intimidation', 'Sudden Charge']);
@@ -251,7 +251,7 @@ describe('FeatPicker', () => {
     fireEvent.click(alpha);
     expect(alpha.getAttribute('data-sort-dir')).toBe('desc');
     expect(alpha.textContent).toMatch(/↓/);
-    const descOrder = Array.from(container.querySelectorAll('[data-match-uuid]')).map(
+    const descOrder = Array.from(document.querySelectorAll('[data-match-uuid]')).map(
       (el) => el.querySelector('span')?.textContent,
     );
     expect(descOrder).toEqual(['Sudden Charge', 'Raging Intimidation']);
@@ -296,18 +296,18 @@ describe('FeatPicker', () => {
       ],
       total: 3,
     });
-    const { container, getByTestId } = render(
+    const { getByTestId } = render(
       <FeatPicker title="t" filters={{ traits: ['x'] }} onPick={vi.fn()} onClose={vi.fn()} />,
     );
     await waitFor(() => {
-      expect(container.querySelector('[data-match-uuid]')).toBeTruthy();
+      expect(document.querySelector('[data-match-uuid]')).toBeTruthy();
     });
     const level = getByTestId('feat-picker-sort').querySelector('[data-sort-option="level"]') as HTMLElement;
 
     // Click once → Level asc (1, 5, 10).
     fireEvent.click(level);
     expect(level.getAttribute('data-sort-dir')).toBe('asc');
-    const asc = Array.from(container.querySelectorAll('[data-match-uuid]')).map((el) =>
+    const asc = Array.from(document.querySelectorAll('[data-match-uuid]')).map((el) =>
       el.getAttribute('data-match-uuid'),
     );
     expect(asc).toEqual(['L1', 'L5', 'L10']);
@@ -315,7 +315,7 @@ describe('FeatPicker', () => {
     // Click again → Level desc (10, 5, 1).
     fireEvent.click(level);
     expect(level.getAttribute('data-sort-dir')).toBe('desc');
-    const desc = Array.from(container.querySelectorAll('[data-match-uuid]')).map((el) =>
+    const desc = Array.from(document.querySelectorAll('[data-match-uuid]')).map((el) =>
       el.getAttribute('data-match-uuid'),
     );
     expect(desc).toEqual(['L10', 'L5', 'L1']);
@@ -359,16 +359,16 @@ describe('FeatPicker', () => {
       ],
       total: 3,
     });
-    const { container, getByTestId } = render(
+    const { getByTestId } = render(
       <FeatPicker title="t" filters={{ traits: ['x'] }} onPick={vi.fn()} onClose={vi.fn()} />,
     );
     await waitFor(() => {
-      expect(container.querySelector('[data-match-uuid]')).toBeTruthy();
+      expect(document.querySelector('[data-match-uuid]')).toBeTruthy();
     });
     const level = getByTestId('feat-picker-sort').querySelector('[data-sort-option="level"]') as HTMLElement;
     fireEvent.click(level); // asc
     fireEvent.click(level); // desc
-    const order = Array.from(container.querySelectorAll('[data-match-uuid]')).map((el) =>
+    const order = Array.from(document.querySelectorAll('[data-match-uuid]')).map((el) =>
       el.getAttribute('data-match-uuid'),
     );
     // L10 first (Ancient), L1 next (Basic), Unknown (no level) at the bottom.
@@ -376,11 +376,11 @@ describe('FeatPicker', () => {
   });
 
   it('resets direction to asc when switching between modes', async () => {
-    const { container, getByTestId } = render(
+    const { getByTestId } = render(
       <FeatPicker title="t" filters={{ traits: ['barbarian'] }} onPick={vi.fn()} onClose={vi.fn()} />,
     );
     await waitFor(() => {
-      expect(container.querySelector('[data-match-uuid]')).toBeTruthy();
+      expect(document.querySelector('[data-match-uuid]')).toBeTruthy();
     });
     const toggle = getByTestId('feat-picker-sort');
     const alpha = toggle.querySelector('[data-sort-option="alpha"]') as HTMLElement;
@@ -434,14 +434,14 @@ describe('FeatPicker', () => {
       ],
       total: 3,
     });
-    const { container, getByTestId } = render(
+    const { getByTestId } = render(
       <FeatPicker title="t" filters={{ traits: ['x'] }} onPick={vi.fn()} onClose={vi.fn()} />,
     );
     await waitFor(() => {
-      expect(container.querySelector('[data-match-uuid]')).toBeTruthy();
+      expect(document.querySelector('[data-match-uuid]')).toBeTruthy();
     });
     fireEvent.click(getByTestId('feat-picker-sort').querySelector('[data-sort-option="level"]') as HTMLElement);
-    const order = Array.from(container.querySelectorAll('[data-match-uuid]')).map((el) =>
+    const order = Array.from(document.querySelectorAll('[data-match-uuid]')).map((el) =>
       el.getAttribute('data-match-uuid'),
     );
     // L1 alpha first (Alpha before Beta), then the unlevelled entry at the bottom.
@@ -453,24 +453,24 @@ describe('FeatPicker', () => {
   it('shows a "Load more" button when the server total exceeds the page', async () => {
     // Return 2 matches but declare total=10 → "Load more" should appear.
     searchSpy.mockResolvedValue({ matches: sampleMatches, total: 10 });
-    const { container } = render(
+    render(
       <FeatPicker title="t" filters={{ traits: ['barbarian'] }} onPick={vi.fn()} onClose={vi.fn()} />,
     );
     await waitFor(() => {
-      expect(container.querySelector('[data-match-uuid]')).toBeTruthy();
+      expect(document.querySelector('[data-match-uuid]')).toBeTruthy();
     });
-    expect(container.querySelector('[data-testid="feat-picker-load-more"]')).toBeTruthy();
+    expect(document.querySelector('[data-testid="feat-picker-load-more"]')).toBeTruthy();
   });
 
   it('does not show "Load more" when total equals the loaded count', async () => {
     // Default mock has total === matches.length (2) → no more button.
-    const { container } = render(
+    render(
       <FeatPicker title="t" filters={{ traits: ['barbarian'] }} onPick={vi.fn()} onClose={vi.fn()} />,
     );
     await waitFor(() => {
-      expect(container.querySelector('[data-match-uuid]')).toBeTruthy();
+      expect(document.querySelector('[data-match-uuid]')).toBeTruthy();
     });
-    expect(container.querySelector('[data-testid="feat-picker-load-more"]')).toBeFalsy();
+    expect(document.querySelector('[data-testid="feat-picker-load-more"]')).toBeFalsy();
   });
 
   it('fetches the next page and appends results when "Load more" is clicked', async () => {
@@ -492,24 +492,25 @@ describe('FeatPicker', () => {
     // Page 1: remaining 1 item
     searchSpy.mockResolvedValueOnce({ matches: page2Matches, total: 3 });
 
-    const { container, getByTestId } = render(
+    const { getByTestId } = render(
       <FeatPicker title="t" filters={{ traits: ['barbarian'] }} onPick={vi.fn()} onClose={vi.fn()} />,
     );
 
     await waitFor(() => {
-      expect(container.querySelector('[data-testid="feat-picker-load-more"]')).toBeTruthy();
+      expect(document.querySelector('[data-testid="feat-picker-load-more"]')).toBeTruthy();
     });
 
     fireEvent.click(getByTestId('feat-picker-load-more'));
 
     await waitFor(() => {
-      expect(container.textContent).toContain('Power Attack');
+      expect(document.body.textContent).toContain('Power Attack');
     });
 
     // All 3 rows visible (2 original + 1 new).
-    expect(container.querySelectorAll('[data-match-uuid]').length).toBe(3);
+    expect(document.querySelectorAll('[data-match-uuid]').length).toBe(3);
     // Second call should have offset=2.
     const secondCall = searchSpy.mock.calls[1]?.[0];
     expect(secondCall?.offset).toBe(sampleMatches.length);
   });
 });
+

--- a/apps/player-portal/src/components/creator/FeatPicker.tsx
+++ b/apps/player-portal/src/components/creator/FeatPicker.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { api } from '../../api/client';
 import type { CompendiumDocument, CompendiumMatch, CompendiumSearchOptions, CompendiumSource } from '../../api/types';
 import { useDebounce } from '../../lib/useDebounce';
@@ -176,7 +177,11 @@ export function FeatPicker({ title, filters, characterContext, onPick, onClose }
 
   const detailOpen = detailTarget !== null;
 
-  return (
+  // Portal to document.body so the modal escapes any ancestor's
+  // child-selector utilities (e.g. Progression.tsx's `*:bg-pf-bg-dark
+  // *:rounded-lg *:border *:p-4` section, which would otherwise paint
+  // the backdrop solid and box-style the dialog).
+  return createPortal(
     <div
       role="dialog"
       aria-modal="true"
@@ -268,6 +273,7 @@ export function FeatPicker({ title, filters, characterContext, onPick, onClose }
           }}
         />
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/apps/player-portal/src/components/creator/FeatPicker.tsx
+++ b/apps/player-portal/src/components/creator/FeatPicker.tsx
@@ -1,77 +1,47 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { api, ApiRequestError } from '../../api/client';
+import { api } from '../../api/client';
 import type { CompendiumDocument, CompendiumMatch, CompendiumSearchOptions, CompendiumSource } from '../../api/types';
-import { enrichDescription } from '@foundry-toolkit/shared/foundry-enrichers';
 import { useDebounce } from '../../lib/useDebounce';
 import { type RemoteDataState, useRemoteData } from '../../lib/useRemoteData';
 import { usePaginatedSearch } from '../../lib/usePaginatedSearch';
-import { useUuidHover } from '../../lib/useUuidHover';
 import { evaluateDocument } from '../../prereqs';
 import type { CharacterContext, Evaluation } from '../../prereqs';
-
-type SortMode = 'alpha' | 'level';
-type SortDir = 'asc' | 'desc';
-interface SortState {
-  mode: SortMode;
-  dir: SortDir;
-}
+import { CompendiumPicker } from '../picker';
+import { prefetchDocuments } from './feat-prefetch';
+import { type SortMode, type SortState, FilterSummary, SourcePicker, SortToggle, UnmetToggle } from './FeatFilters';
+import { FeatMatchList } from './FeatMatchRow';
+import { FeatDetailPanel } from './FeatDetailPanel';
+import { useFeatDetail } from './useFeatDetail';
 
 interface Props {
   title: string;
-  /** Pre-filters applied to every search. Text query is layered on top.
-   *  `packIds` scopes silently (caller concern — which Foundry packs
-   *  to read from); the user-visible filter is by publication source. */
+  /** Pre-filters applied to every search. `packIds` scopes silently;
+   *  the user-visible filter is by publication source. */
   filters: Pick<
     CompendiumSearchOptions,
     'packIds' | 'documentType' | 'traits' | 'anyTraits' | 'maxLevel' | 'ancestrySlug'
   >;
-  /** Character state for prereq evaluation. Matches whose prereqs we
-   *  can parse + fail get muted; optional "hide unmet" toggle filters
-   *  them out entirely. `unknown` (unparseable prereqs) is always
-   *  allowed through. Optional — callers without a character context
-   *  (e.g. future compendium-browse tools) get the picker with prereq
-   *  evaluation skipped. */
+  /** Character state for prereq evaluation. Optional — callers without
+   *  a character context get the picker with evaluation skipped. */
   characterContext?: CharacterContext;
   onPick: (match: CompendiumMatch) => void;
   onClose: () => void;
 }
 
-type DetailState =
-  | { kind: 'idle' }
-  | { kind: 'loading'; uuid: string }
-  | { kind: 'ready'; doc: CompendiumDocument }
-  | { kind: 'error'; message: string };
-
-// Modal picker for creator slot choices. Starts in "browse mode" (no
-// q, filters only) and narrows live as the user types. Used by the
-// Progression tab for class feat slots; will be reused for ancestry /
-// skill / general feat slots.
 export function FeatPicker({ title, filters, characterContext, onPick, onClose }: Props): React.ReactElement {
-  const [query, setQuery] = useState('');
   const [sort, setSort] = useState<SortState>({ mode: 'alpha', dir: 'asc' });
   const [selectedSources, setSelectedSources] = useState<string[]>([]);
-  const [detailTarget, setDetailTarget] = useState<CompendiumMatch | null>(null);
-  const [detail, setDetail] = useState<DetailState>({ kind: 'idle' });
   const [evaluations, setEvaluations] = useState<Map<string, Evaluation>>(new Map());
   const [hideUnmet, setHideUnmet] = useState(true);
+  const [query, setQuery] = useState('');
   const debouncedQuery = useDebounce(query.trim(), 200);
   const inputRef = useRef<HTMLInputElement>(null);
-  // UUID → full document cache. Populated in the background after each
-  // search so clicking a row in the list reveals the detail pane with
-  // no spinner. Stays alive for the life of the picker; filters change
-  // surface new UUIDs but keep old cache entries valid.
   const docCacheRef = useRef<Map<string, CompendiumDocument>>(new Map());
-  // prereq-text (lower-cased) → matching compendium UUID, or null when
-  // we've looked and there's no exact-name match. Filled as a side
-  // effect of the prefetch (after each doc lands, its prereqs are
-  // resolved), so the detail pane's links show up without a per-open
-  // round trip.
   const prereqCacheRef = useRef<Map<string, string | null>>(new Map());
 
-  // Stable filter key for the search effect dep array. Source titles
-  // are sorted for order-stability so toggling a checkbox refires the
-  // search with the new scope. The caller's `packIds` doesn't change
-  // at runtime, so it doesn't need to be in the key.
+  const { detailTarget, setDetailTarget, detail } = useFeatDetail(docCacheRef, characterContext, setEvaluations);
+
+  // Stable filter key for the search effect dep array.
   const callerPackIdsKey = (filters.packIds ?? []).join('|');
   const filterKey = useMemo(
     () =>
@@ -95,11 +65,6 @@ export function FeatPicker({ title, filters, characterContext, onPick, onClose }
     ],
   );
 
-  // Live match list with pagination. `usePaginatedSearch` keeps the
-  // previous `ready` data visible across re-fetches so the list narrows
-  // in place without flashing an empty state between keystrokes.
-  // Page size is capped at 50 so the background prefetch (below) doesn't
-  // stampede the server; "Load more" fetches the next 50 on demand.
   const { state: matchesState, hasMore, isLoadingMore, loadMore } = usePaginatedSearch<CompendiumMatch>(
     async (offset, pageSize) => {
       const opts: CompendiumSearchOptions = { q: debouncedQuery, limit: pageSize, offset };
@@ -112,17 +77,9 @@ export function FeatPicker({ title, filters, characterContext, onPick, onClose }
       if (filters.ancestrySlug !== undefined) opts.ancestrySlug = filters.ancestrySlug;
       return api.searchCompendium(opts);
     },
-    // filterKey captures every filter field used inside the fetcher.
     [debouncedQuery, filterKey],
     {
       onPage: (newMatches, isCancelled) => {
-        // Background prefetch the full document for each NEW page's
-        // matches so the detail pane opens instantly on click.  Each
-        // worker also resolves that document's prereqs and evaluates
-        // them against the current character context so the per-row
-        // prereq state lights up without a second trip.
-        // Bounded concurrency keeps the network from stampeding when
-        // 50 results come back.
         const ctx = characterContext;
         void prefetchDocuments(
           newMatches,
@@ -146,15 +103,8 @@ export function FeatPicker({ title, filters, characterContext, onPick, onClose }
     },
   );
 
-  // Source-book counts stay in lockstep with the current search filters
-  // (text query, traits, maxLevel). The source filter itself is NOT
-  // passed in — we want counts for every source regardless of which
-  // ones the user has ticked, so the dropdown reads as "how many
-  // matches each source would contribute" (classic multi-select facet
-  // behaviour). Packs + documentType stay since those are caller-side
-  // invariants.
   const traitsKey = (filters.traits ?? []).join('|');
-  const sourcesState = useRemoteData<CompendiumSource[]>(
+  const sourcesState: RemoteDataState<CompendiumSource[]> = useRemoteData<CompendiumSource[]>(
     async () => {
       const opts: {
         documentType?: string;
@@ -174,14 +124,7 @@ export function FeatPicker({ title, filters, characterContext, onPick, onClose }
     [filters.documentType, callerPackIdsKey, debouncedQuery, traitsKey, filters.maxLevel],
   );
 
-  // Apply sort on top of whatever order the server returned. Client-side
-  // sort runs over the accumulated (paginated) list.  Entries missing
-  // a level always sink to the bottom of a Level sort (in either
-  // direction) and stay alpha-asc among themselves — "unknown" shouldn't
-  // leapfrog real data just because the user flipped direction.
-  //
-  // After sorting, optionally drop entries whose prereq evaluation came
-  // back `fails`. `unknown` (unparseable) stays through.
+  // Client-side sort + optional hide-unmet filter on top of server results.
   const visibleMatches = useMemo(() => {
     if (matchesState.kind !== 'ready') return [];
     const copy = [...matchesState.items];
@@ -192,8 +135,6 @@ export function FeatPicker({ title, filters, characterContext, onPick, onClose }
       leveled.sort((a, b) => {
         const lvlCmp = ((a.level ?? 0) - (b.level ?? 0)) * dirMul;
         if (lvlCmp !== 0) return lvlCmp;
-        // Keep intra-tier ordering alpha-asc regardless of direction,
-        // so scanning a level band reads left-to-right like a glossary.
         return a.name.localeCompare(b.name);
       });
       unlevelled.sort((a, b) => a.name.localeCompare(b.name));
@@ -207,12 +148,7 @@ export function FeatPicker({ title, filters, characterContext, onPick, onClose }
 
   const onSortClick = (mode: SortMode): void => {
     setSort((prev) =>
-      prev.mode === mode
-        ? // Re-clicking the active option flips direction.
-          { mode, dir: prev.dir === 'asc' ? 'desc' : 'asc' }
-        : // Switching modes resets direction to ascending so users
-          // don't carry an expectation from the other axis.
-          { mode, dir: 'asc' },
+      prev.mode === mode ? { mode, dir: prev.dir === 'asc' ? 'desc' : 'asc' } : { mode, dir: 'asc' },
     );
   };
 
@@ -230,10 +166,6 @@ export function FeatPicker({ title, filters, characterContext, onPick, onClose }
     };
   }, [onClose]);
 
-  // Freeze page scrolling while the modal is open so mouse-wheel over
-  // the backdrop doesn't scroll the sheet underneath. Restore the
-  // previous inline value on unmount so we don't clobber anyone else
-  // setting it.
   useEffect(() => {
     const previous = document.body.style.overflow;
     document.body.style.overflow = 'hidden';
@@ -242,52 +174,8 @@ export function FeatPicker({ title, filters, characterContext, onPick, onClose }
     };
   }, []);
 
-  // Fetch the full document whenever the user taps a row. Switching
-  // targets fast (e.g. rapid arrow-down through the list) cancels the
-  // stale fetch so the panel never flickers back to an older feat.
-  // Cache hits short-circuit the fetch entirely, which is the common
-  // case once the background prefetch has caught up.
-  useEffect(() => {
-    if (!detailTarget) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setDetail({ kind: 'idle' });
-      return;
-    }
-    const cached = docCacheRef.current.get(detailTarget.uuid);
-    if (cached) {
-      setDetail({ kind: 'ready', doc: cached });
-      return;
-    }
-    let cancelled = false;
-
-    setDetail({ kind: 'loading', uuid: detailTarget.uuid });
-    api
-      .getCompendiumDocument(detailTarget.uuid)
-      .then((result) => {
-        if (cancelled) return;
-        docCacheRef.current.set(detailTarget.uuid, result.document);
-        setDetail({ kind: 'ready', doc: result.document });
-        if (characterContext) {
-          const evaluation = evaluateDocument(result.document, characterContext);
-          setEvaluations((prev) => {
-            if (prev.get(result.document.uuid) === evaluation) return prev;
-            const next = new Map(prev);
-            next.set(result.document.uuid, evaluation);
-            return next;
-          });
-        }
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        const message = err instanceof ApiRequestError ? err.message : err instanceof Error ? err.message : String(err);
-        setDetail({ kind: 'error', message });
-      });
-    return (): void => {
-      cancelled = true;
-    };
-  }, [detailTarget?.uuid]);
-
   const detailOpen = detailTarget !== null;
+
   return (
     <div
       role="dialog"
@@ -342,767 +230,44 @@ export function FeatPicker({ title, filters, characterContext, onPick, onClose }
           </div>
         </div>
 
-        <div className="flex min-h-0 flex-1">
-          <div
-            className={['overflow-y-auto', detailOpen ? 'w-80 shrink-0 border-r border-pf-border' : 'flex-1'].join(' ')}
-            data-testid="feat-picker-results"
-          >
-            {matchesState.kind === 'loading' && <p className="p-4 text-sm italic text-pf-alt">Searching…</p>}
-            {matchesState.kind === 'error' && (
-              <p className="p-4 text-sm text-pf-primary">Search failed: {matchesState.message}</p>
-            )}
-            {matchesState.kind === 'ready' && visibleMatches.length === 0 && (
-              <p className="p-4 text-sm italic text-pf-alt">No matches. Loosen the filters or search term.</p>
-            )}
-            {matchesState.kind === 'ready' && visibleMatches.length > 0 && (
-              <>
-                <MatchList
-                  matches={visibleMatches}
-                  evaluations={evaluations}
-                  activeUuid={detailTarget?.uuid}
-                  onSelect={setDetailTarget}
-                />
-                {(hasMore || isLoadingMore) && (
-                  <div className="border-t border-pf-border px-4 py-2 text-center">
-                    <button
-                      type="button"
-                      onClick={loadMore}
-                      disabled={isLoadingMore}
-                      data-testid="feat-picker-load-more"
-                      className="rounded border border-pf-border bg-pf-bg px-3 py-1 text-xs font-semibold uppercase tracking-widest text-pf-alt-dark transition-colors hover:border-pf-primary hover:text-pf-primary disabled:cursor-wait disabled:opacity-50"
-                    >
-                      {isLoadingMore ? 'Loading…' : `Load more (${(matchesState.total - matchesState.items.length).toString()} remaining)`}
-                    </button>
-                  </div>
-                )}
-              </>
-            )}
-          </div>
-          {detailOpen && (
-            <DetailPanel
-              target={detailTarget}
-              detail={detail}
-              prereqCache={prereqCacheRef}
-              onPick={(): void => {
-                onPick(detailTarget);
-              }}
-              onClose={(): void => {
-                setDetailTarget(null);
-              }}
+        <CompendiumPicker
+          isLoading={matchesState.kind === 'loading'}
+          error={matchesState.kind === 'error' ? matchesState.message : null}
+          items={visibleMatches}
+          renderList={(matches) => (
+            <FeatMatchList
+              matches={matches}
+              evaluations={evaluations}
+              activeUuid={detailTarget?.uuid}
+              onSelect={setDetailTarget}
             />
           )}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ─── Prefetch ──────────────────────────────────────────────────────────
-
-const PREFETCH_CONCURRENCY = 4;
-
-// Walks the match list and fills the document + prereq caches in the
-// background. Each worker hydrates a doc, then resolves that doc's
-// prereqs by exact-name search before moving to the next item. The
-// result: by the time a user opens the detail pane for one of these
-// matches, both the description and the prereq links are already
-// cached.
-//
-// `isCancelled` lets the caller abort when the modal closes so we
-// don't keep hitting the server for a picker the user has already
-// dismissed.
-async function prefetchDocuments(
-  matches: CompendiumMatch[],
-  docCache: Map<string, CompendiumDocument>,
-  prereqCache: Map<string, string | null>,
-  onDocHydrated: ((uuid: string, doc: CompendiumDocument) => void) | undefined,
-  isCancelled: () => boolean,
-): Promise<void> {
-  const queue = matches.filter((m) => !docCache.has(m.uuid));
-  // Docs already in the cache still need their evaluation surfaced —
-  // the caller's evaluations map is per-render, not persisted.
-  if (onDocHydrated) {
-    for (const match of matches) {
-      const cached = docCache.get(match.uuid);
-      if (cached) onDocHydrated(match.uuid, cached);
-    }
-  }
-  const workers = Array.from({ length: Math.min(PREFETCH_CONCURRENCY, queue.length) }, async () => {
-    while (queue.length > 0 && !isCancelled()) {
-      const match = queue.shift();
-      if (!match) break;
-      let doc = docCache.get(match.uuid);
-      if (!doc) {
-        try {
-          const result = await api.getCompendiumDocument(match.uuid);
-          if (isCancelled()) break;
-          doc = result.document;
-          docCache.set(match.uuid, doc);
-        } catch {
-          continue;
-        }
-      }
-      onDocHydrated?.(match.uuid, doc);
-      await resolvePrereqsForDoc(doc, prereqCache, isCancelled);
-    }
-  });
-  await Promise.all(workers);
-}
-
-async function resolvePrereqsForDoc(
-  doc: CompendiumDocument,
-  cache: Map<string, string | null>,
-  isCancelled: () => boolean,
-): Promise<void> {
-  const bio = extractDetailBio(doc);
-  const prereqs = bio.prerequisites ?? [];
-  for (const text of prereqs) {
-    if (isCancelled()) return;
-    const key = text.toLowerCase();
-    if (cache.has(key)) continue;
-    try {
-      const result = await api.searchCompendium({
-        q: text,
-        documentType: 'Item',
-        limit: 5,
-      });
-      if (isCancelled()) return;
-      const exact = result.matches.find((m) => m.name.toLowerCase() === key);
-      cache.set(key, exact?.uuid ?? null);
-    } catch {
-      cache.set(key, null);
-    }
-  }
-}
-
-// ─── Source (book) multi-select ────────────────────────────────────────
-
-function SourcePicker({
-  sources,
-  selected,
-  onChange,
-}: {
-  sources: RemoteDataState<CompendiumSource[]>;
-  selected: string[];
-  onChange: (next: string[]) => void;
-}): React.ReactElement {
-  const [open, setOpen] = useState(false);
-  const [filter, setFilter] = useState('');
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    function onDocClick(e: MouseEvent): void {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    }
-    document.addEventListener('mousedown', onDocClick);
-    return (): void => {
-      document.removeEventListener('mousedown', onDocClick);
-    };
-  }, [open]);
-
-  const count = selected.length;
-  const label =
-    sources.kind === 'loading' ? 'Sources (…)' : count === 0 ? 'All sources' : `Sources (${count.toString()})`;
-
-  const selectedSet = useMemo(() => new Set(selected.map((s) => s.toLowerCase())), [selected]);
-  const filtered = useMemo(() => {
-    if (sources.kind !== 'ready') return [];
-    const needle = filter.trim().toLowerCase();
-    if (!needle) return sources.data;
-    return sources.data.filter((s) => s.title.toLowerCase().includes(needle));
-  }, [sources, filter]);
-
-  const toggle = (title: string): void => {
-    const lower = title.toLowerCase();
-    onChange(selectedSet.has(lower) ? selected.filter((s) => s.toLowerCase() !== lower) : [...selected, title]);
-  };
-  const selectAllVisible = (): void => {
-    const nextLowers = new Set(selected.map((s) => s.toLowerCase()));
-    const next = [...selected];
-    for (const s of filtered) {
-      if (!nextLowers.has(s.title.toLowerCase())) {
-        next.push(s.title);
-        nextLowers.add(s.title.toLowerCase());
-      }
-    }
-    onChange(next);
-  };
-  const clearAll = (): void => {
-    onChange([]);
-  };
-
-  return (
-    <div ref={containerRef} className="relative">
-      <button
-        type="button"
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        data-testid="source-picker-trigger"
-        onClick={(): void => {
-          setOpen((v) => !v);
-        }}
-        className={[
-          'rounded border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest transition-colors',
-          count > 0
-            ? 'border-pf-primary bg-pf-primary/10 text-pf-primary'
-            : 'border-pf-border bg-pf-bg text-pf-alt-dark hover:text-pf-primary',
-        ].join(' ')}
-      >
-        {label} {open ? '▴' : '▾'}
-      </button>
-      {open && (
-        <div
-          role="listbox"
-          data-testid="source-picker-panel"
-          className="absolute left-0 top-full z-10 mt-1 flex max-h-72 w-80 flex-col rounded border border-pf-border bg-pf-bg shadow-lg"
-        >
-          <div className="flex items-center gap-1 border-b border-pf-border p-2">
-            <input
-              type="search"
-              value={filter}
-              onChange={(e): void => {
-                setFilter(e.target.value);
-              }}
-              placeholder="Filter sources…"
-              className="flex-1 rounded border border-pf-border bg-pf-bg px-2 py-0.5 text-xs text-pf-text placeholder:text-pf-alt focus:border-pf-primary focus:outline-none"
-              data-testid="source-picker-filter"
-            />
-          </div>
-          <div className="flex items-center gap-2 border-b border-pf-border px-2 py-1 text-[10px] uppercase tracking-widest">
-            <button
-              type="button"
-              onClick={selectAllVisible}
-              className="text-pf-alt-dark hover:text-pf-primary"
-              data-testid="source-picker-select-all"
-            >
-              Select visible
-            </button>
-            <span className="text-pf-border">·</span>
-            <button
-              type="button"
-              onClick={clearAll}
-              className="text-pf-alt-dark hover:text-pf-primary"
-              data-testid="source-picker-clear"
-            >
-              Clear
-            </button>
-            <span className="ml-auto text-pf-alt">
-              {sources.kind === 'ready' ? `${filtered.length.toString()} shown` : ''}
-            </span>
-          </div>
-          <ul className="flex-1 overflow-y-auto">
-            {sources.kind === 'loading' && <li className="p-2 text-xs italic text-pf-alt">Loading sources…</li>}
-            {sources.kind === 'error' && (
-              <li className="p-2 text-xs text-pf-primary">Failed to load sources: {sources.message}</li>
-            )}
-            {sources.kind === 'ready' && filtered.length === 0 && (
-              <li className="p-2 text-xs italic text-pf-alt">No sources match that filter.</li>
-            )}
-            {sources.kind === 'ready' &&
-              filtered.map((src) => {
-                const active = selectedSet.has(src.title.toLowerCase());
-                return (
-                  <li key={src.title}>
-                    <label
-                      data-source-title={src.title}
-                      className={[
-                        'flex cursor-pointer items-center gap-2 px-2 py-1 text-xs',
-                        active ? 'bg-pf-tertiary/40' : 'hover:bg-pf-tertiary/20',
-                      ].join(' ')}
-                    >
-                      <input
-                        type="checkbox"
-                        checked={active}
-                        onChange={(): void => {
-                          toggle(src.title);
-                        }}
-                        className="accent-pf-primary"
-                      />
-                      <span className="flex-1 truncate text-pf-text">{src.title}</span>
-                      <span className="shrink-0 font-mono text-[10px] tabular-nums text-pf-alt">{src.count}</span>
-                    </label>
-                  </li>
-                );
-              })}
-          </ul>
-        </div>
-      )}
-    </div>
-  );
-}
-
-function SortToggle({ sort, onChange }: { sort: SortState; onChange: (mode: SortMode) => void }): React.ReactElement {
-  const options: Array<{ value: SortMode; label: string }> = [
-    { value: 'alpha', label: 'A–Z' },
-    { value: 'level', label: 'Level' },
-  ];
-  return (
-    <div
-      role="radiogroup"
-      aria-label="Sort results"
-      data-testid="feat-picker-sort"
-      className="inline-flex shrink-0 overflow-hidden rounded border border-pf-border text-[10px] font-semibold uppercase tracking-widest"
-    >
-      {options.map((opt) => {
-        const active = sort.mode === opt.value;
-        const arrow = active ? (sort.dir === 'asc' ? ' ↑' : ' ↓') : '';
-        return (
-          <button
-            key={opt.value}
-            type="button"
-            role="radio"
-            aria-checked={active}
-            data-sort-option={opt.value}
-            data-sort-dir={active ? sort.dir : undefined}
-            title={
-              active
-                ? `Sorting ${opt.label} ${sort.dir === 'asc' ? '↑' : '↓'} — click to reverse`
-                : `Sort by ${opt.label}`
-            }
-            onClick={(): void => {
-              onChange(opt.value);
-            }}
-            className={[
-              'px-2 py-0.5 transition-colors',
-              active
-                ? 'bg-pf-primary text-white'
-                : 'bg-pf-bg text-pf-alt-dark hover:bg-pf-tertiary/40 hover:text-pf-primary',
-            ].join(' ')}
-          >
-            {opt.label}
-            {arrow}
-          </button>
-        );
-      })}
-    </div>
-  );
-}
-
-function UnmetToggle({ hide, onChange }: { hide: boolean; onChange: (next: boolean) => void }): React.ReactElement {
-  return (
-    <label
-      data-testid="feat-picker-hide-unmet"
-      className="inline-flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark"
-    >
-      <input
-        type="checkbox"
-        checked={hide}
-        onChange={(e): void => {
-          onChange(e.target.checked);
-        }}
-        className="accent-pf-primary"
-      />
-      Hide unmet
-    </label>
-  );
-}
-
-function FilterSummary({ filters }: { filters: Props['filters'] }): React.ReactElement | null {
-  const parts: string[] = [];
-  if (filters.traits && filters.traits.length > 0) parts.push(`traits: ${filters.traits.join(', ')}`);
-  if (filters.maxLevel !== undefined) parts.push(`level ≤ ${filters.maxLevel.toString()}`);
-  if (parts.length === 0) return null;
-  return <p className="text-[10px] uppercase tracking-widest text-pf-alt">{parts.join(' · ')}</p>;
-}
-
-// Split results into ancestry-specific + versatile buckets when any
-// match carries `isVersatile`. Keeps the existing flat list otherwise
-// so non-heritage searches render unchanged.
-function MatchList({
-  matches,
-  evaluations,
-  activeUuid,
-  onSelect,
-}: {
-  matches: CompendiumMatch[];
-  evaluations: Map<string, Evaluation>;
-  activeUuid: string | undefined;
-  onSelect: (m: CompendiumMatch) => void;
-}): React.ReactElement {
-  const ancestrySpecific = matches.filter((m) => m.isVersatile !== true);
-  const versatile = matches.filter((m) => m.isVersatile === true);
-
-  if (versatile.length === 0) {
-    return (
-      <ul className="divide-y divide-pf-border">
-        {matches.map((match) => (
-          <li key={match.uuid}>
-            <MatchRow
-              match={match}
-              active={activeUuid === match.uuid}
-              evaluation={evaluations.get(match.uuid)}
-              onSelect={onSelect}
-            />
-          </li>
-        ))}
-      </ul>
-    );
-  }
-
-  return (
-    <>
-      {ancestrySpecific.length > 0 && (
-        <ul className="divide-y divide-pf-border" data-match-group="ancestry-specific">
-          {ancestrySpecific.map((match) => (
-            <li key={match.uuid}>
-              <MatchRow
-                match={match}
-                active={activeUuid === match.uuid}
-                evaluation={evaluations.get(match.uuid)}
-                onSelect={onSelect}
+          resultsTestId="feat-picker-results"
+          hasMore={hasMore}
+          isLoadingMore={isLoadingMore}
+          onLoadMore={loadMore}
+          {...(matchesState.kind === 'ready'
+            ? { remainingCount: matchesState.total - matchesState.items.length }
+            : {})}
+          loadMoreTestId="feat-picker-load-more"
+          splitPane={{
+            detailOpen,
+            detailSlot: (
+              <FeatDetailPanel
+                target={detailTarget}
+                detail={detail}
+                prereqCache={prereqCacheRef}
+                onPick={(): void => {
+                  if (detailTarget) onPick(detailTarget);
+                }}
+                onClose={(): void => {
+                  setDetailTarget(null);
+                }}
               />
-            </li>
-          ))}
-        </ul>
-      )}
-      <h3 className="border-t border-pf-border bg-pf-bg-dark/40 px-3 py-1.5 font-serif text-xs font-semibold uppercase tracking-widest text-pf-alt-dark">
-        Versatile Heritages
-      </h3>
-      <ul className="divide-y divide-pf-border" data-match-group="versatile">
-        {versatile.map((match) => (
-          <li key={match.uuid}>
-            <MatchRow
-              match={match}
-              active={activeUuid === match.uuid}
-              evaluation={evaluations.get(match.uuid)}
-              onSelect={onSelect}
-            />
-          </li>
-        ))}
-      </ul>
-    </>
-  );
-}
-
-function MatchRow({
-  match,
-  active,
-  evaluation,
-  onSelect,
-}: {
-  match: CompendiumMatch;
-  active: boolean;
-  evaluation: Evaluation | undefined;
-  onSelect: (match: CompendiumMatch) => void;
-}): React.ReactElement {
-  const traitsSummary = match.traits && match.traits.length > 0 ? match.traits.slice(0, 5).join(', ') : '';
-  const fails = evaluation === 'fails';
-  const unknown = evaluation === 'unknown';
-  const rowTitle = fails
-    ? "Character doesn't meet this feat's prerequisites"
-    : unknown
-      ? "Prereqs couldn't be auto-checked — verify manually before picking"
-      : undefined;
-  return (
-    <button
-      type="button"
-      onClick={(): void => {
-        onSelect(match);
-      }}
-      data-match-uuid={match.uuid}
-      data-prereq-state={evaluation ?? 'pending'}
-      aria-pressed={active}
-      title={rowTitle}
-      className={[
-        'flex w-full items-center gap-3 px-4 py-2 text-left transition-colors',
-        active ? 'bg-pf-tertiary/50' : 'hover:bg-pf-tertiary/20',
-        fails ? 'opacity-60' : '',
-      ].join(' ')}
-    >
-      {match.img && (
-        <img src={match.img} alt="" className="h-8 w-8 shrink-0 rounded border border-pf-border bg-pf-bg-dark" />
-      )}
-      <div className="min-w-0 flex-1">
-        <div className="flex items-baseline justify-between gap-2">
-          <span className="flex min-w-0 items-baseline gap-1.5">
-            <span className="truncate text-sm font-medium text-pf-text">{match.name}</span>
-            {unknown && (
-              <span
-                data-testid="prereq-unknown-badge"
-                aria-label="Prereqs unchecked"
-                className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-amber-500 bg-amber-100 text-[10px] font-semibold text-amber-800"
-              >
-                !
-              </span>
-            )}
-          </span>
-          {match.level !== undefined && (
-            <span className="shrink-0 font-mono text-[10px] uppercase tracking-widest text-pf-alt-dark">
-              L{match.level}
-            </span>
-          )}
-        </div>
-        <div className="flex items-baseline justify-between gap-2 text-[10px] text-pf-alt">
-          <span className="truncate">{match.packLabel}</span>
-          {traitsSummary && <span className="truncate">{traitsSummary}</span>}
-        </div>
+            ),
+          }}
+        />
       </div>
-    </button>
-  );
-}
-
-// ─── Detail panel ──────────────────────────────────────────────────────
-
-function DetailPanel({
-  target,
-  detail,
-  prereqCache,
-  onPick,
-  onClose,
-}: {
-  target: CompendiumMatch | null;
-  detail: DetailState;
-  /** Shared cache — populated by the list-level prefetch, read here. */
-  prereqCache: React.RefObject<Map<string, string | null>>;
-  onPick: () => void;
-  onClose: () => void;
-}): React.ReactElement | null {
-  const uuidHover = useUuidHover();
-  const [prereqResolutions, setPrereqResolutions] = useState<Map<string, string | null>>(new Map());
-
-  const doc = detail.kind === 'ready' ? detail.doc : null;
-  const bio = extractDetailBio(doc);
-  const prereqsKey = (bio.prerequisites ?? []).join('|');
-
-  useEffect(() => {
-    const prereqs = bio.prerequisites;
-    if (!prereqs || prereqs.length === 0) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setPrereqResolutions(new Map());
-      return;
-    }
-    let cancelled = false;
-    const initial = new Map<string, string | null>();
-    for (const p of prereqs) {
-      const cached = prereqCache.current.get(p.toLowerCase());
-      if (cached !== undefined) initial.set(p, cached);
-    }
-
-    setPrereqResolutions(initial);
-
-    // The prefetch usually has these cached already, but fall back to
-    // an on-demand lookup for anything still missing (e.g. the user
-    // opened the panel before the prefetch got to this item).
-    void (async () => {
-      await Promise.all(
-        prereqs.map(async (text) => {
-          const key = text.toLowerCase();
-          if (prereqCache.current.has(key)) return;
-          try {
-            const response = await api.searchCompendium({
-              q: text,
-              documentType: 'Item',
-              limit: 5,
-            });
-            // Exact-name only. "trained in Intimidation" won't hit
-            // anything; "Dragon Instinct" will.
-            const exact = response.matches.find((m) => m.name.toLowerCase() === key);
-            const uuid = exact?.uuid ?? null;
-            prereqCache.current.set(key, uuid);
-            if (!cancelled) {
-              setPrereqResolutions((prev) => {
-                const next = new Map(prev);
-                next.set(text, uuid);
-                return next;
-              });
-            }
-          } catch {
-            prereqCache.current.set(key, null);
-            if (!cancelled) {
-              setPrereqResolutions((prev) => {
-                const next = new Map(prev);
-                next.set(text, null);
-                return next;
-              });
-            }
-          }
-        }),
-      );
-    })();
-
-    return (): void => {
-      cancelled = true;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [prereqsKey]);
-
-  if (!target) return null;
-  return (
-    <aside className="flex min-w-0 flex-1 flex-col" data-testid="feat-picker-detail" data-detail-uuid={target.uuid}>
-      <header className="flex items-start gap-3 border-b border-pf-border px-4 py-3">
-        {target.img && (
-          <img src={target.img} alt="" className="h-12 w-12 shrink-0 rounded border border-pf-border bg-pf-bg-dark" />
-        )}
-        <div className="min-w-0 flex-1">
-          <h3 className="font-serif text-base font-semibold text-pf-text">{target.name}</h3>
-          <p className="mt-0.5 text-[10px] uppercase tracking-widest text-pf-alt">
-            {target.packLabel}
-            {target.level !== undefined && ` · L${target.level.toString()}`}
-          </p>
-          {target.traits && target.traits.length > 0 && (
-            <ul className="mt-1 flex flex-wrap gap-1">
-              {target.traits.map((t) => (
-                <li
-                  key={t}
-                  className="rounded-full border border-pf-tertiary-dark bg-pf-tertiary/40 px-1.5 py-0.5 text-[10px] text-pf-alt-dark"
-                >
-                  {t}
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
-        <button
-          type="button"
-          onClick={onClose}
-          aria-label="Close detail"
-          className="rounded px-2 py-0.5 text-lg text-pf-alt-dark hover:bg-pf-bg-dark hover:text-pf-primary"
-        >
-          ×
-        </button>
-      </header>
-
-      <div className="flex-1 overflow-y-auto px-4 py-3">
-        {detail.kind === 'loading' && <p className="text-sm italic text-pf-alt">Loading…</p>}
-        {detail.kind === 'error' && <p className="text-sm text-pf-primary">Failed to load: {detail.message}</p>}
-        {detail.kind === 'ready' && (
-          <div className="space-y-3">
-            {bio.prerequisites && bio.prerequisites.length > 0 && (
-              <PrereqRow prereqs={bio.prerequisites} resolutions={prereqResolutions} />
-            )}
-            {bio.actions && <DetailRow label="Actions" value={bio.actions} />}
-            {bio.trigger && <DetailRow label="Trigger" value={bio.trigger} />}
-            {bio.frequency && <DetailRow label="Frequency" value={bio.frequency} />}
-            {bio.requirements && <DetailRow label="Requirements" value={bio.requirements} />}
-            {bio.description && (
-              <div
-                {...uuidHover.delegationHandlers}
-                className="text-sm leading-relaxed text-pf-text [&_.pf-damage]:font-semibold [&_.pf-damage]:text-pf-primary [&_.pf-template]:italic [&_.pf-template]:text-pf-secondary [&_a]:cursor-pointer [&_a]:text-pf-primary [&_a]:underline [&_p]:my-2 [&_p]:leading-relaxed"
-                // Trusted source: our own Foundry. enrichDescription converts
-                // Foundry enricher tokens (@UUID, @Damage, @Template, @Check,
-                // [[/r …]]) into styled inline elements.
-                dangerouslySetInnerHTML={{ __html: enrichDescription(bio.description) }}
-              />
-            )}
-            {uuidHover.popover}
-          </div>
-        )}
-      </div>
-
-      <footer className="flex items-center justify-end gap-2 border-t border-pf-border px-4 py-2">
-        <button
-          type="button"
-          onClick={onClose}
-          className="rounded border border-pf-border bg-pf-bg px-3 py-1 text-xs font-semibold uppercase tracking-widest text-pf-alt-dark hover:text-pf-primary"
-        >
-          Back
-        </button>
-        <button
-          type="button"
-          onClick={onPick}
-          data-testid="feat-picker-pick"
-          className="rounded border border-pf-primary bg-pf-primary px-3 py-1 text-xs font-semibold uppercase tracking-widest text-white hover:brightness-110"
-        >
-          Pick {target.name}
-        </button>
-      </footer>
-    </aside>
-  );
-}
-
-function DetailRow({ label, value }: { label: string; value: string }): React.ReactElement {
-  return (
-    <div className="flex flex-col gap-0.5 sm:flex-row sm:gap-3">
-      <dt className="w-32 shrink-0 text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark">{label}</dt>
-      <dd className="text-sm text-pf-text">{value}</dd>
     </div>
   );
-}
-
-function PrereqRow({
-  prereqs,
-  resolutions,
-}: {
-  prereqs: string[];
-  resolutions: Map<string, string | null>;
-}): React.ReactElement {
-  return (
-    <div className="flex flex-col gap-0.5 sm:flex-row sm:gap-3">
-      <dt className="w-32 shrink-0 text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark">
-        Prerequisites
-      </dt>
-      <dd className="text-sm text-pf-text">
-        {prereqs.map((p, i) => {
-          // resolutions === undefined → lookup still pending, render
-          // as plain text (will upgrade to link on resolve)
-          // resolutions.get === null → looked, no exact match
-          const uuid = resolutions.get(p);
-          return (
-            <span key={`${p}-${i.toString()}`}>
-              {i > 0 && '; '}
-              {uuid ? (
-                <a data-uuid={uuid} className="cursor-pointer text-pf-primary underline" title={uuid}>
-                  {p}
-                </a>
-              ) : (
-                p
-              )}
-            </span>
-          );
-        })}
-      </dd>
-    </div>
-  );
-}
-
-interface DetailBio {
-  description?: string;
-  prerequisites?: string[];
-  actions?: string;
-  trigger?: string;
-  frequency?: string;
-  requirements?: string;
-}
-
-// pf2e item system shape is polymorphic. Pull the fields we care about
-// defensively — the server returns raw `system` from toObject() so we
-// don't want to lock this to one type's schema.
-function extractDetailBio(doc: CompendiumDocument | null): DetailBio {
-  if (!doc) return {};
-  const sys = doc.system;
-  const bio: DetailBio = {};
-
-  const description = (sys['description'] as { value?: unknown } | undefined)?.value;
-  if (typeof description === 'string' && description.length > 0) bio.description = description;
-
-  const prereq = (sys['prerequisites'] as { value?: unknown } | undefined)?.value;
-  if (Array.isArray(prereq)) {
-    const entries = prereq
-      .map((p) => (typeof p === 'string' ? p : (p as { value?: unknown } | undefined)?.value))
-      .filter((v): v is string => typeof v === 'string' && v.length > 0);
-    if (entries.length > 0) bio.prerequisites = entries;
-  }
-
-  const actions = (sys['actions'] as { value?: unknown } | undefined)?.value;
-  if (typeof actions === 'number') bio.actions = `${actions.toString()} action${actions === 1 ? '' : 's'}`;
-  else if (typeof actions === 'string' && actions.length > 0) bio.actions = actions;
-
-  const actionType = (sys['actionType'] as { value?: unknown } | undefined)?.value;
-  if (typeof actionType === 'string' && actionType.length > 0 && bio.actions === undefined) {
-    bio.actions = actionType.charAt(0).toUpperCase() + actionType.slice(1);
-  }
-
-  const trigger = sys['trigger'];
-  if (typeof trigger === 'string' && trigger.length > 0) bio.trigger = trigger;
-
-  const frequency = (sys['frequency'] as { value?: unknown } | undefined)?.value;
-  if (typeof frequency === 'string' && frequency.length > 0) bio.frequency = frequency;
-
-  const requirements = sys['requirements'];
-  if (typeof requirements === 'string' && requirements.length > 0) bio.requirements = requirements;
-
-  return bio;
 }

--- a/apps/player-portal/src/components/creator/SkillIncreasePicker.tsx
+++ b/apps/player-portal/src/components/creator/SkillIncreasePicker.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 import type { ProficiencyRank } from '../../api/types';
 import type { CharacterContext } from '../../prereqs';
 
@@ -68,7 +69,10 @@ export function SkillIncreasePicker({ level, characterContext, onPick, onClose }
     })
     .sort((a, b) => a.slug.localeCompare(b.slug));
 
-  return (
+  // Portal to document.body so the modal escapes any ancestor's
+  // child-selector utilities (e.g. Progression.tsx's `*:bg-pf-bg-dark`
+  // section, which would otherwise paint the backdrop solid).
+  return createPortal(
     <div
       role="dialog"
       aria-modal="true"
@@ -163,7 +167,8 @@ export function SkillIncreasePicker({ level, characterContext, onPick, onClose }
           </button>
         </footer>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }
 

--- a/apps/player-portal/src/components/creator/feat-bio.ts
+++ b/apps/player-portal/src/components/creator/feat-bio.ts
@@ -1,0 +1,52 @@
+import type { CompendiumDocument } from '../../api/types';
+
+export interface DetailBio {
+  description?: string;
+  prerequisites?: string[];
+  actions?: string;
+  trigger?: string;
+  frequency?: string;
+  requirements?: string;
+}
+
+/**
+ * Defensive poly-type extractor for fields used in the feat detail pane.
+ * The server returns raw `system` from toObject() so we can't lock this
+ * to one PF2e item schema.
+ */
+export function extractDetailBio(doc: CompendiumDocument | null): DetailBio {
+  if (!doc) return {};
+  const sys = doc.system;
+  const bio: DetailBio = {};
+
+  const description = (sys['description'] as { value?: unknown } | undefined)?.value;
+  if (typeof description === 'string' && description.length > 0) bio.description = description;
+
+  const prereq = (sys['prerequisites'] as { value?: unknown } | undefined)?.value;
+  if (Array.isArray(prereq)) {
+    const entries = prereq
+      .map((p) => (typeof p === 'string' ? p : (p as { value?: unknown } | undefined)?.value))
+      .filter((v): v is string => typeof v === 'string' && v.length > 0);
+    if (entries.length > 0) bio.prerequisites = entries;
+  }
+
+  const actions = (sys['actions'] as { value?: unknown } | undefined)?.value;
+  if (typeof actions === 'number') bio.actions = `${actions.toString()} action${actions === 1 ? '' : 's'}`;
+  else if (typeof actions === 'string' && actions.length > 0) bio.actions = actions;
+
+  const actionType = (sys['actionType'] as { value?: unknown } | undefined)?.value;
+  if (typeof actionType === 'string' && actionType.length > 0 && bio.actions === undefined) {
+    bio.actions = actionType.charAt(0).toUpperCase() + actionType.slice(1);
+  }
+
+  const trigger = sys['trigger'];
+  if (typeof trigger === 'string' && trigger.length > 0) bio.trigger = trigger;
+
+  const frequency = (sys['frequency'] as { value?: unknown } | undefined)?.value;
+  if (typeof frequency === 'string' && frequency.length > 0) bio.frequency = frequency;
+
+  const requirements = sys['requirements'];
+  if (typeof requirements === 'string' && requirements.length > 0) bio.requirements = requirements;
+
+  return bio;
+}

--- a/apps/player-portal/src/components/creator/feat-prefetch.ts
+++ b/apps/player-portal/src/components/creator/feat-prefetch.ts
@@ -1,0 +1,74 @@
+import { api } from '../../api/client';
+import type { CompendiumDocument, CompendiumMatch } from '../../api/types';
+import { extractDetailBio } from './feat-bio';
+
+const PREFETCH_CONCURRENCY = 4;
+
+/**
+ * Background-fills the document + prereq caches for a list of matches.
+ * Workers run at bounded concurrency so the network doesn't stampede on
+ * a fresh 50-item page.
+ *
+ * `onDocHydrated` fires after each doc fetch; callers use it to update
+ * their prereq evaluation state without waiting for the full queue.
+ * `isCancelled` lets the caller abort when the picker unmounts.
+ */
+export async function prefetchDocuments(
+  matches: CompendiumMatch[],
+  docCache: Map<string, CompendiumDocument>,
+  prereqCache: Map<string, string | null>,
+  onDocHydrated: ((uuid: string, doc: CompendiumDocument) => void) | undefined,
+  isCancelled: () => boolean,
+): Promise<void> {
+  const queue = matches.filter((m) => !docCache.has(m.uuid));
+  // Already-cached docs still need their evaluation surfaced — the
+  // caller's evaluations map is per-render, not persisted.
+  if (onDocHydrated) {
+    for (const match of matches) {
+      const cached = docCache.get(match.uuid);
+      if (cached) onDocHydrated(match.uuid, cached);
+    }
+  }
+  const workers = Array.from({ length: Math.min(PREFETCH_CONCURRENCY, queue.length) }, async () => {
+    while (queue.length > 0 && !isCancelled()) {
+      const match = queue.shift();
+      if (!match) break;
+      let doc = docCache.get(match.uuid);
+      if (!doc) {
+        try {
+          const result = await api.getCompendiumDocument(match.uuid);
+          if (isCancelled()) break;
+          doc = result.document;
+          docCache.set(match.uuid, doc);
+        } catch {
+          continue;
+        }
+      }
+      onDocHydrated?.(match.uuid, doc);
+      await resolvePrereqsForDoc(doc, prereqCache, isCancelled);
+    }
+  });
+  await Promise.all(workers);
+}
+
+export async function resolvePrereqsForDoc(
+  doc: CompendiumDocument,
+  cache: Map<string, string | null>,
+  isCancelled: () => boolean,
+): Promise<void> {
+  const bio = extractDetailBio(doc);
+  const prereqs = bio.prerequisites ?? [];
+  for (const text of prereqs) {
+    if (isCancelled()) return;
+    const key = text.toLowerCase();
+    if (cache.has(key)) continue;
+    try {
+      const result = await api.searchCompendium({ q: text, documentType: 'Item', limit: 5 });
+      if (isCancelled()) return;
+      const exact = result.matches.find((m) => m.name.toLowerCase() === key);
+      cache.set(key, exact?.uuid ?? null);
+    } catch {
+      cache.set(key, null);
+    }
+  }
+}

--- a/apps/player-portal/src/components/creator/useFeatDetail.ts
+++ b/apps/player-portal/src/components/creator/useFeatDetail.ts
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+import { api } from '../../api/client';
+import type { CompendiumDocument, CompendiumMatch } from '../../api/types';
+import { evaluateDocument } from '../../prereqs';
+import type { CharacterContext, Evaluation } from '../../prereqs';
+
+export type DetailState =
+  | { kind: 'idle' }
+  | { kind: 'loading'; uuid: string }
+  | { kind: 'ready'; doc: CompendiumDocument }
+  | { kind: 'error'; message: string };
+
+/**
+ * Manages selecting a match → fetching its full document → returning
+ * detail state. Cache hits from the background prefetch short-circuit
+ * the fetch. Stale fetches are cancelled on rapid target changes.
+ */
+export function useFeatDetail(
+  docCacheRef: React.RefObject<Map<string, CompendiumDocument>>,
+  characterContext: CharacterContext | undefined,
+  setEvaluations: React.Dispatch<React.SetStateAction<Map<string, Evaluation>>>,
+): {
+  detailTarget: CompendiumMatch | null;
+  setDetailTarget: React.Dispatch<React.SetStateAction<CompendiumMatch | null>>;
+  detail: DetailState;
+} {
+  const [detailTarget, setDetailTarget] = useState<CompendiumMatch | null>(null);
+  const [detail, setDetail] = useState<DetailState>({ kind: 'idle' });
+
+  useEffect(() => {
+    if (!detailTarget) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setDetail({ kind: 'idle' });
+      return;
+    }
+    const cached = docCacheRef.current.get(detailTarget.uuid);
+    if (cached) {
+      setDetail({ kind: 'ready', doc: cached });
+      return;
+    }
+    let cancelled = false;
+    setDetail({ kind: 'loading', uuid: detailTarget.uuid });
+    api
+      .getCompendiumDocument(detailTarget.uuid)
+      .then((result) => {
+        if (cancelled) return;
+        docCacheRef.current.set(detailTarget.uuid, result.document);
+        setDetail({ kind: 'ready', doc: result.document });
+        if (characterContext) {
+          const evaluation = evaluateDocument(result.document, characterContext);
+          setEvaluations((prev) => {
+            if (prev.get(result.document.uuid) === evaluation) return prev;
+            const next = new Map(prev);
+            next.set(result.document.uuid, evaluation);
+            return next;
+          });
+        }
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : String(err);
+        setDetail({ kind: 'error', message });
+      });
+    return (): void => {
+      cancelled = true;
+    };
+    // detailTarget.uuid is the only dep that should trigger a refetch
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [detailTarget?.uuid]);
+
+  return { detailTarget, setDetailTarget, detail };
+}

--- a/apps/player-portal/src/components/picker/CompendiumPicker.test.tsx
+++ b/apps/player-portal/src/components/picker/CompendiumPicker.test.tsx
@@ -1,0 +1,208 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/react';
+import { CompendiumPicker } from './CompendiumPicker';
+
+type Item = { id: string; label: string };
+
+const items: Item[] = [
+  { id: 'a', label: 'Alpha' },
+  { id: 'b', label: 'Beta' },
+  { id: 'c', label: 'Gamma' },
+];
+
+const renderList = (xs: Item[]): React.ReactElement => (
+  <ul>
+    {xs.map((x) => (
+      <li key={x.id} data-item-id={x.id}>
+        {x.label}
+      </li>
+    ))}
+  </ul>
+);
+
+afterEach(cleanup);
+
+describe('CompendiumPicker — loading / error / empty states', () => {
+  it('shows Searching… when isLoading=true and items is empty', () => {
+    const { container } = render(
+      <CompendiumPicker isLoading items={[]} renderList={renderList} />,
+    );
+    expect(container.textContent).toContain('Searching');
+    expect(container.querySelector('[data-item-id]')).toBeFalsy();
+  });
+
+  it('does not show the loading message when items are present even if isLoading=true', () => {
+    const { container } = render(
+      <CompendiumPicker isLoading items={items} renderList={renderList} />,
+    );
+    expect(container.textContent).not.toContain('Searching');
+    expect(container.querySelectorAll('[data-item-id]').length).toBe(3);
+  });
+
+  it('shows the error message when error is set', () => {
+    const { container } = render(
+      <CompendiumPicker error="boom" items={[]} renderList={renderList} />,
+    );
+    expect(container.textContent).toContain('Search failed');
+    expect(container.textContent).toContain('boom');
+  });
+
+  it('shows the default empty message when not loading, no error, items empty', () => {
+    const { container } = render(
+      <CompendiumPicker items={[]} renderList={renderList} />,
+    );
+    expect(container.textContent).toMatch(/no matches/i);
+  });
+
+  it('shows a custom emptyMessage', () => {
+    const { container } = render(
+      <CompendiumPicker items={[]} emptyMessage="Nothing here." renderList={renderList} />,
+    );
+    expect(container.textContent).toContain('Nothing here.');
+  });
+});
+
+describe('CompendiumPicker — list rendering', () => {
+  it('calls renderList with items when items is non-empty', () => {
+    const spy = vi.fn(renderList);
+    const { container } = render(
+      <CompendiumPicker items={items} renderList={spy} />,
+    );
+    expect(spy).toHaveBeenCalledWith(items);
+    expect(container.querySelectorAll('[data-item-id]').length).toBe(3);
+  });
+
+  it('does not call renderList when items is empty', () => {
+    const spy = vi.fn(renderList);
+    render(<CompendiumPicker items={[]} renderList={spy} />);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe('CompendiumPicker — load-more button', () => {
+  it('shows the Load more button when hasMore=true', () => {
+    const { container } = render(
+      <CompendiumPicker
+        items={items}
+        renderList={renderList}
+        hasMore
+        isLoadingMore={false}
+        onLoadMore={vi.fn()}
+        remainingCount={10}
+        loadMoreTestId="load-more"
+      />,
+    );
+    expect(container.querySelector('[data-testid="load-more"]')).toBeTruthy();
+    expect(container.textContent).toContain('10 remaining');
+  });
+
+  it('shows "Load more" without count when remainingCount is not provided', () => {
+    const { container } = render(
+      <CompendiumPicker
+        items={items}
+        renderList={renderList}
+        hasMore
+        loadMoreTestId="load-more"
+      />,
+    );
+    const btn = container.querySelector('[data-testid="load-more"]') as HTMLButtonElement;
+    expect(btn.textContent?.trim()).toBe('Load more');
+  });
+
+  it('calls onLoadMore when button is clicked', () => {
+    const onLoadMore = vi.fn();
+    const { container } = render(
+      <CompendiumPicker
+        items={items}
+        renderList={renderList}
+        hasMore
+        onLoadMore={onLoadMore}
+        loadMoreTestId="load-more"
+      />,
+    );
+    fireEvent.click(container.querySelector('[data-testid="load-more"]') as HTMLElement);
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the button and shows Loading… when isLoadingMore=true', () => {
+    const { container } = render(
+      <CompendiumPicker
+        items={items}
+        renderList={renderList}
+        isLoadingMore
+        loadMoreTestId="load-more"
+      />,
+    );
+    const btn = container.querySelector('[data-testid="load-more"]') as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    expect(btn.textContent?.trim()).toBe('Loading…');
+  });
+
+  it('does not show the button when hasMore=false and isLoadingMore=false', () => {
+    const { container } = render(
+      <CompendiumPicker
+        items={items}
+        renderList={renderList}
+        hasMore={false}
+        isLoadingMore={false}
+        loadMoreTestId="load-more"
+      />,
+    );
+    expect(container.querySelector('[data-testid="load-more"]')).toBeFalsy();
+  });
+});
+
+describe('CompendiumPicker — split-pane layout', () => {
+  it('renders without a flex wrapper when splitPane is not provided', () => {
+    const { container } = render(
+      <CompendiumPicker items={items} renderList={renderList} />,
+    );
+    // No min-h-0 flex-1 outer wrapper
+    expect(container.firstElementChild?.className).not.toContain('flex min-h-0');
+  });
+
+  it('renders a flex wrapper when splitPane is provided', () => {
+    const { container } = render(
+      <CompendiumPicker
+        items={items}
+        renderList={renderList}
+        splitPane={{ detailOpen: false, detailSlot: <div>detail</div> }}
+      />,
+    );
+    expect(container.firstElementChild?.className).toContain('flex min-h-0 flex-1');
+  });
+
+  it('does not render detailSlot when splitPane.detailOpen=false', () => {
+    const { container } = render(
+      <CompendiumPicker
+        items={items}
+        renderList={renderList}
+        splitPane={{ detailOpen: false, detailSlot: <div data-testid="detail-slot">detail</div> }}
+      />,
+    );
+    expect(container.querySelector('[data-testid="detail-slot"]')).toBeFalsy();
+  });
+
+  it('renders detailSlot when splitPane.detailOpen=true', () => {
+    const { container } = render(
+      <CompendiumPicker
+        items={items}
+        renderList={renderList}
+        splitPane={{ detailOpen: true, detailSlot: <div data-testid="detail-slot">detail</div> }}
+      />,
+    );
+    expect(container.querySelector('[data-testid="detail-slot"]')).toBeTruthy();
+  });
+
+  it('applies resultsTestId to the list wrapper in split-pane mode', () => {
+    const { container } = render(
+      <CompendiumPicker
+        items={items}
+        renderList={renderList}
+        resultsTestId="list-area"
+        splitPane={{ detailOpen: false, detailSlot: null }}
+      />,
+    );
+    expect(container.querySelector('[data-testid="list-area"]')).toBeTruthy();
+  });
+});

--- a/apps/player-portal/src/components/picker/CompendiumPicker.tsx
+++ b/apps/player-portal/src/components/picker/CompendiumPicker.tsx
@@ -1,0 +1,107 @@
+import type { ReactNode } from 'react';
+
+interface SplitPane {
+  /** When true: list narrows to w-80 and detailSlot renders on the right */
+  detailOpen: boolean;
+  detailSlot: ReactNode;
+}
+
+interface CompendiumPickerProps<TItem> {
+  /** Shows a "Searching…" message when true and items is empty */
+  isLoading?: boolean;
+  /** Shows an error message when non-null */
+  error?: string | null;
+  /** Visible items after all caller-side filtering/sorting */
+  items: TItem[];
+  /** Message shown when not loading, no error, and items is empty */
+  emptyMessage?: string;
+  /**
+   * Renders the full list, including its container element.
+   * Called only when items is non-empty.
+   */
+  renderList: (items: TItem[]) => ReactNode;
+  /** data-testid on the scrollable list wrapper (split-pane mode only) */
+  resultsTestId?: string;
+  /** Load-more / append-style pagination */
+  hasMore?: boolean;
+  isLoadingMore?: boolean;
+  onLoadMore?: () => void;
+  /** Shown in the Load more button when hasMore is true */
+  remainingCount?: number;
+  loadMoreTestId?: string;
+  /**
+   * When provided, wraps content in a flex row.
+   * The list area narrows when detailOpen; detailSlot renders alongside.
+   */
+  splitPane?: SplitPane;
+}
+
+export function CompendiumPicker<TItem>({
+  isLoading = false,
+  error,
+  items,
+  emptyMessage = 'No matches. Loosen the filters or search term.',
+  renderList,
+  resultsTestId,
+  hasMore,
+  isLoadingMore,
+  onLoadMore,
+  remainingCount,
+  loadMoreTestId,
+  splitPane,
+}: CompendiumPickerProps<TItem>): React.ReactElement {
+  const detailOpen = splitPane?.detailOpen ?? false;
+
+  const listArea = (
+    <div
+      className={[
+        'overflow-y-auto',
+        splitPane ? (detailOpen ? 'w-80 shrink-0 border-r border-pf-border' : 'flex-1') : 'flex-1',
+      ].join(' ')}
+      data-testid={resultsTestId}
+    >
+      {isLoading && items.length === 0 && (
+        <p className="p-4 text-sm italic text-pf-alt">Searching…</p>
+      )}
+      {error != null && (
+        <p className="p-4 text-sm text-pf-primary">Search failed: {error}</p>
+      )}
+      {!isLoading && error == null && items.length === 0 && (
+        <p className="p-4 text-sm italic text-pf-alt">{emptyMessage}</p>
+      )}
+      {items.length > 0 && (
+        <>
+          {renderList(items)}
+          {(hasMore === true || isLoadingMore === true) && (
+            <div className="border-t border-pf-border px-4 py-2 text-center">
+              <button
+                type="button"
+                onClick={onLoadMore}
+                disabled={isLoadingMore}
+                data-testid={loadMoreTestId}
+                className="rounded border border-pf-border bg-pf-bg px-3 py-1 text-xs font-semibold uppercase tracking-widest text-pf-alt-dark transition-colors hover:border-pf-primary hover:text-pf-primary disabled:cursor-wait disabled:opacity-50"
+              >
+                {isLoadingMore === true
+                  ? 'Loading…'
+                  : remainingCount != null
+                    ? `Load more (${remainingCount.toString()} remaining)`
+                    : 'Load more'}
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+
+  if (!splitPane) {
+    return listArea;
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1">
+      {listArea}
+      {detailOpen && splitPane.detailSlot}
+    </div>
+  );
+}

--- a/apps/player-portal/src/components/picker/index.ts
+++ b/apps/player-portal/src/components/picker/index.ts
@@ -1,0 +1,1 @@
+export { CompendiumPicker } from './CompendiumPicker';

--- a/apps/player-portal/src/components/shop/ItemShopPicker.tsx
+++ b/apps/player-portal/src/components/shop/ItemShopPicker.tsx
@@ -1,14 +1,21 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '../../api/client';
-import type {
-  CompendiumDocument,
-  CompendiumMatch,
-  CompendiumSearchOptions,
-  ItemPrice,
-  PreparedActorItem,
-} from '../../api/types';
-import { formatCp, priceToCp, sumActorCoinsCp } from '../../lib/coins';
-import { enrichDescription } from '@foundry-toolkit/shared/foundry-enrichers';
+import type { CompendiumMatch, CompendiumSearchOptions, ItemPrice, PreparedActorItem } from '../../api/types';
+import { sumActorCoinsCp } from '../../lib/coins';
+import { CompendiumPicker } from '../picker';
+import { ShopItemDetail } from './ShopItemDetail';
+import { type ItemGroup, ShopTile } from './ShopTile';
+import { useFitPageSize } from './useFitPageSize';
+import {
+  extractPriceFromDocument,
+  filterMatchesByType,
+  parseItemName,
+  priceToCp,
+  rarityChipActiveClass,
+  resolvePriceState,
+  sortVariants,
+  type TypeFilter,
+} from './shop-utils';
 
 export interface BuyRequest {
   match: CompendiumMatch;
@@ -22,16 +29,10 @@ interface Props {
   disabledRarities?: readonly string[];
 }
 
-// Equipment packs available for browsing. More packs can be appended
-// here — the server reads all of them via CompendiumSearchOptions.packIds.
 const EQUIPMENT_PACKS: readonly { id: string; label: string }[] = [
   { id: 'pf2e.equipment-srd', label: 'Equipment' },
 ];
 
-// Narrower item-type filter chips. Names follow pf2e's
-// `system.category` / `type` taxonomy loosely; the picker uses them
-// as a free-text filter that checks a match's displayed type + traits.
-type TypeFilter = 'all' | 'weapon' | 'armor' | 'consumable' | 'equipment' | 'backpack';
 const RARITY_FILTERS: Array<{ id: string; label: string }> = [
   { id: 'common',   label: 'Common'   },
   { id: 'uncommon', label: 'Uncommon' },
@@ -40,147 +41,18 @@ const RARITY_FILTERS: Array<{ id: string; label: string }> = [
 ];
 
 const TYPE_FILTERS: Array<{ id: TypeFilter; label: string }> = [
-  { id: 'all', label: 'All' },
-  { id: 'weapon', label: 'Weapons' },
-  { id: 'armor', label: 'Armor' },
-  { id: 'consumable', label: 'Consumables' },
-  { id: 'equipment', label: 'Equipment' },
-  { id: 'backpack', label: 'Containers' },
+  { id: 'all',        label: 'All'        },
+  { id: 'weapon',     label: 'Weapons'    },
+  { id: 'armor',      label: 'Armor'      },
+  { id: 'consumable', label: 'Consumables'},
+  { id: 'equipment',  label: 'Equipment'  },
+  { id: 'backpack',   label: 'Containers' },
 ];
 
 const DEBOUNCE_MS = 220;
-// Server cap (foundry-mcp src/http/schemas.ts) is 10k; keep the
-// client request below that so a single round-trip fits every item
-// in the largest pf2e pack (equipment-srd ≈ 5.6k). Cached searches
-// filter/sort in-memory (microseconds); uncached searches iterate
-// the full index either way, so this ceiling just sizes the response.
-// The banner below the grid still kicks in on the rare search that
-// would exceed this — narrowing by type/name/level keeps it cheap.
+// Server cap is 10k; one round-trip fits every item in the largest pf2e
+// pack (~5.6k). In-memory filter/sort on hits is microseconds.
 const SEARCH_LIMIT = 10_000;
-
-// Conservative fallback page size when the ResizeObserver hasn't
-// measured the grid yet (e.g. first render, or in unit tests that
-// render outside a real DOM). The visible page adapts to the grid's
-// actual dimensions on mount via `useFitPageSize` below.
-const FALLBACK_PAGE_SIZE = 25;
-
-// Known quality tiers with explicit sort order. Used to sort variants
-// within a group when the variant text contains a recognised keyword.
-const QUALITY_ORDER: Record<string, number> = {
-  minor: 0,
-  lesser: 1,
-  moderate: 2,
-  greater: 3,
-  major: 4,
-  true: 5,
-  young: 6,
-  adult: 7,
-  wyrm: 8,
-  '1st-rank': 10,
-  '2nd-rank': 11,
-  '3rd-rank': 12,
-  '4th-rank': 13,
-  '5th-rank': 14,
-  '6th-rank': 15,
-  '7th-rank': 16,
-  '8th-rank': 17,
-  '9th-rank': 18,
-  'rank 1': 10,
-  'rank 2': 11,
-  'rank 3': 12,
-  'rank 4': 13,
-  'rank 5': 14,
-  'rank 6': 15,
-  'rank 7': 16,
-  'rank 8': 17,
-  'rank 9': 18,
-};
-
-// Matches a quality keyword anywhere in a variant string.
-const QUALITY_WORD_RE =
-  /\b(minor|lesser|moderate|greater|major|true|young|adult|wyrm|[1-9](?:st|nd|rd|th)-rank|rank\s+[1-9])(?:\s+spell)?\b/i;
-
-// Split "Healing Potion (Lesser)" → { base: "Healing Potion", variant: "Lesser" }.
-// Only strips the final trailing parenthetical; parens in the middle of the
-// name (e.g. "Ring of the Ram (Type I)") are preserved in `base`.
-function parseItemName(name: string): { base: string; variant: string | null } {
-  const m = /^(.+?)\s*\(([^)]+)\)\s*$/.exec(name);
-  if (!m) return { base: name.trim(), variant: null };
-  return { base: m[1]!.trim(), variant: m[2]!.trim() };
-}
-
-// Sort rank for a variant string. Known quality keywords get explicit
-// ranks; unknown variants sort alphabetically (rank 99); the base item
-// with no variant sorts first (-1).
-function variantRank(variant: string | null): number {
-  if (variant === null) return -1;
-  const m = QUALITY_WORD_RE.exec(variant);
-  return m ? (QUALITY_ORDER[m[1]!.toLowerCase()] ?? 99) : 99;
-}
-
-// Grid column count — fixed to match the `repeat(5, ...)` template.
-const GRID_COLS = 5;
-// Approximate tile height (including gap). Used with ResizeObserver to
-// compute how many whole rows fit in the available grid area.
-const TILE_HEIGHT_PX = 146; // ≈ img h-12 + name line + level + price + buy btn + padding
-const GRID_GAP_PX = 8;
-// Floor for the computed page size so we never land on "0 tiles per
-// page" in extremely narrow viewports.
-const MIN_FIT_PAGE_SIZE = 6;
-
-// Breathing room between the grid's bottom edge and the viewport's
-// bottom. Sized to cover the sibling content below the grid that the
-// grid itself doesn't account for: the bottom pagination bar (~32px)
-// plus the main container's bottom padding (p-6 = 24px), with a
-// small safety margin so a horizontal scrollbar never kicks in.
-const VIEWPORT_BOTTOM_MARGIN_PX = 72;
-
-function useFitPageSize(): {
-  pageSize: number;
-  maxHeight: number | null;
-  gridRef: (el: HTMLUListElement | null) => void;
-} {
-  const [pageSize, setPageSize] = useState(FALLBACK_PAGE_SIZE);
-  const [maxHeight, setMaxHeight] = useState<number | null>(null);
-  // The grid is conditionally rendered (only after results arrive),
-  // so a plain RefObject whose effect runs once on mount would never
-  // see the populated element. A callback ref fires synchronously
-  // when the element attaches/detaches, so we wire the observer
-  // there instead of in a useEffect.
-  const [gridEl, setGridEl] = useState<HTMLUListElement | null>(null);
-  const gridRef = useCallback((el: HTMLUListElement | null) => {
-    setGridEl(el);
-  }, []);
-
-  useEffect(() => {
-    if (!gridEl || typeof ResizeObserver === 'undefined') return;
-    const recompute = (): void => {
-      // Derive the vertical budget from the grid's own offset in the
-      // viewport rather than hard-coding "minus some rem". That way
-      // the cap adapts when the header, filter bar, or chip row
-      // changes height — grid stays fully above the fold regardless.
-      const rect = gridEl.getBoundingClientRect();
-      const availableHeight = Math.max(200, window.innerHeight - rect.top - VIEWPORT_BOTTOM_MARGIN_PX);
-      setMaxHeight(availableHeight);
-
-      const rows = Math.max(1, Math.floor((availableHeight + GRID_GAP_PX) / (TILE_HEIGHT_PX + GRID_GAP_PX)));
-      setPageSize(Math.max(MIN_FIT_PAGE_SIZE, GRID_COLS * rows));
-    };
-    recompute();
-    const ro = new ResizeObserver(recompute);
-    ro.observe(gridEl);
-    // Grid's offset can change when the window height changes even
-    // if its own size doesn't (ResizeObserver wouldn't fire). Hook
-    // window resize too.
-    window.addEventListener('resize', recompute);
-    return (): void => {
-      ro.disconnect();
-      window.removeEventListener('resize', recompute);
-    };
-  }, [gridEl]);
-
-  return { pageSize, maxHeight, gridRef };
-}
 
 export function ItemShopPicker({ items, onBuy, pending, disabledRarities }: Props): React.ReactElement {
   const [query, setQuery] = useState('');
@@ -192,20 +64,12 @@ export function ItemShopPicker({ items, onBuy, pending, disabledRarities }: Prop
   const [matches, setMatches] = useState<CompendiumMatch[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  // Zero-indexed page within the current filtered result set.
-  // Re-zeroed whenever any filter input changes so the user never
-  // ends up on an out-of-range page after narrowing.
   const [page, setPage] = useState(0);
-  // Prefetched prices keyed by uuid. `undefined` means "not yet
-  // fetched", `null` means "fetched but no price / error — treat as 0".
   const [prices, setPrices] = useState<Map<string, ItemPrice | null>>(new Map());
-  // When non-null, the item detail overlay covers the grid.
   const [selectedGroup, setSelectedGroup] = useState<ItemGroup | null>(null);
 
   const purseCp = useMemo(() => sumActorCoinsCp(items), [items]);
 
-  // Debounce the search-as-you-type so the picker doesn't fire a
-  // compendium query on every keystroke.
   useEffect(() => {
     const t = window.setTimeout(() => {
       setDebouncedQuery(query.trim());
@@ -215,8 +79,6 @@ export function ItemShopPicker({ items, onBuy, pending, disabledRarities }: Prop
     };
   }, [query]);
 
-  // Track the latest search invocation so stale responses don't
-  // overwrite fresh ones if the user changes filters mid-flight.
   const searchTokenRef = useRef(0);
   useEffect(() => {
     if (packId === '') return;
@@ -228,8 +90,6 @@ export function ItemShopPicker({ items, onBuy, pending, disabledRarities }: Prop
       ...(debouncedQuery.length > 0 ? { q: debouncedQuery } : {}),
       ...(maxLevel !== '' ? { maxLevel } : {}),
     };
-    // Kick off loading state in a microtask so React doesn't treat
-    // the synchronous setState in this effect as a cascade.
     queueMicrotask(() => {
       if (token !== searchTokenRef.current) return;
       setLoading(true);
@@ -244,32 +104,24 @@ export function ItemShopPicker({ items, onBuy, pending, disabledRarities }: Prop
       })
       .catch((err: unknown) => {
         if (token !== searchTokenRef.current) return;
-        const msg = err instanceof Error ? err.message : String(err);
-        setError(msg);
+        setError(err instanceof Error ? err.message : String(err));
         setLoading(false);
       });
   }, [debouncedQuery, maxLevel, packId]);
 
   const filtered = useMemo(() => {
     const typed = filterMatchesByType(matches, typeFilter);
-    // Hide items with a known price of 0 cp — those are class/feat
-    // effect tokens or other "not actually for sale" artifacts that
-    // the compendium still carries as `Item` docs. Matches without a
-    // price field at all (e.g. uncached packs where price isn't
-    // embedded) remain visible; the tile price prefetch and the
-    // detail overlay pick up the real number later.
     const priceFiltered = typed.filter((m) => m.price === undefined || priceToCp(m.price) > 0);
     const disabledSet = new Set(disabledRarities?.map((r) => r.toLowerCase()) ?? []);
-    const availableRarities = disabledSet.size > 0
-      ? priceFiltered.filter((m) => !disabledSet.has((m.rarity ?? 'common').toLowerCase()))
-      : priceFiltered;
-    const rarityFiltered = rarityFilter.size === 0
-      ? availableRarities
-      : availableRarities.filter((m) => rarityFilter.has((m.rarity ?? 'common').toLowerCase()));
+    const availableRarities =
+      disabledSet.size > 0
+        ? priceFiltered.filter((m) => !disabledSet.has((m.rarity ?? 'common').toLowerCase()))
+        : priceFiltered;
+    const rarityFiltered =
+      rarityFilter.size === 0
+        ? availableRarities
+        : availableRarities.filter((m) => rarityFilter.has((m.rarity ?? 'common').toLowerCase()));
 
-    // Group items that share the same base name via the "$name ($variant)"
-    // structure. "Healing Potion (Lesser)" and "Healing Potion (Greater)"
-    // both parse to base "Healing Potion" and are merged into one tile.
     const groupMap = new Map<string, CompendiumMatch[]>();
     for (const m of rarityFiltered) {
       const key = parseItemName(m.name).base.toLowerCase();
@@ -280,30 +132,16 @@ export function ItemShopPicker({ items, onBuy, pending, disabledRarities }: Prop
 
     const groups: ItemGroup[] = [];
     for (const [key, variants] of groupMap) {
-      variants.sort((a, b) => {
-        const ra = variantRank(parseItemName(a.name).variant);
-        const rb = variantRank(parseItemName(b.name).variant);
-        if (ra !== rb) return ra - rb;
-        // Unknown variants (both rank 99) fall back to alphabetical.
-        return (parseItemName(a.name).variant ?? '').localeCompare(parseItemName(b.name).variant ?? '');
-      });
-      const displayName = parseItemName(variants[0]?.name ?? '').base;
-      groups.push({ key, displayName, variants });
+      const sorted = sortVariants(variants);
+      const displayName = parseItemName(sorted[0]?.name ?? '').base;
+      groups.push({ key, displayName, variants: sorted });
     }
     groups.sort((a, b) => a.key.localeCompare(b.key));
     return groups;
   }, [matches, typeFilter, rarityFilter, disabledRarities]);
-  // The grid's height is capped (see `gridRef` below) and the page
-  // size adapts to however many tiles fit at the current viewport via
-  // ResizeObserver + window-resize. Falling back to
-  // FALLBACK_PAGE_SIZE before the first measurement keeps SSR/tests
-  // deterministic.
+
   const { pageSize, maxHeight, gridRef } = useFitPageSize();
   const pageCount = Math.max(1, Math.ceil(filtered.length / pageSize));
-  // Clamp on every render so the page stays valid even if the result
-  // set shrinks (e.g. stricter filter) between renders. The effect
-  // below resets to page 0 on filter input changes; this clamp
-  // protects against any other shrink paths (e.g. async refetch).
   const clampedPage = Math.min(page, pageCount - 1);
   const pageStart = clampedPage * pageSize;
   const pageSlice = useMemo(
@@ -311,26 +149,18 @@ export function ItemShopPicker({ items, onBuy, pending, disabledRarities }: Prop
     [filtered, pageStart, pageSize],
   );
 
-  // Any filter input change → back to page 0. Keeps the user from
-  // landing on "page 27 of 2" after narrowing a 1000-result search
-  // down to 80. Done via a render-time comparison (React's
-  // recommended pattern for derived reset state) rather than an
-  // effect, which would trigger the set-state-in-effect lint and an
-  // extra render pass.
+  // Reset to page 0 on any filter change (render-time comparison avoids
+  // an extra render pass and the set-state-in-effect lint warning).
   const filterKey = `${debouncedQuery}|${maxLevel.toString()}|${packId}|${typeFilter}|${[...rarityFilter].sort().join(',')}`;
-
   const [lastFilterKey, setLastFilterKey] = useState(filterKey);
   if (filterKey !== lastFilterKey) {
     setLastFilterKey(filterKey);
     setPage(0);
   }
 
-  // Prefetch prices for results that didn't come with `match.price`
-  // already attached. Cached packs (served from foundry-mcp's
-  // compendium-cache) embed the price on each match, so this loop
-  // short-circuits — no per-tile getCompendiumDocument calls in the
-  // common case. Scoped to the current page so uncached packs don't
-  // fire off thousands of fetches up-front.
+  // Price prefetch: scoped to the current page so uncached packs don't
+  // fire thousands of fetches up-front. Cached packs embed price on the
+  // match, so this loop short-circuits in the common case.
   const pageVariants = useMemo(() => pageSlice.flatMap((g) => g.variants), [pageSlice]);
   useEffect(() => {
     const needed = pageVariants.filter((m) => m.price === undefined && !prices.has(m.uuid));
@@ -345,7 +175,7 @@ export function ItemShopPicker({ items, onBuy, pending, disabledRarities }: Prop
         if (!m) break;
         try {
           const { document } = await api.getCompendiumDocument(m.uuid);
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- cancelled toggles asynchronously in cleanup
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           if (cancelled) return;
           setPrices((prev) => {
             if (prev.has(m.uuid)) return prev;
@@ -354,7 +184,7 @@ export function ItemShopPicker({ items, onBuy, pending, disabledRarities }: Prop
             return next;
           });
         } catch {
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- cancelled toggles asynchronously in cleanup
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           if (cancelled) return;
           setPrices((prev) => {
             if (prev.has(m.uuid)) return prev;
@@ -375,9 +205,6 @@ export function ItemShopPicker({ items, onBuy, pending, disabledRarities }: Prop
 
   return (
     <div className="space-y-2" data-section="shop-picker">
-      {/* Single-row control strip: search (flex-1), max-level, optional
-          pack selector, then pagination pinned to the right. Keeps the
-          shop's chrome to ~2 rows (this row + the type-chip row). */}
       <div className="flex flex-wrap items-center gap-2">
         <input
           type="search"
@@ -407,7 +234,9 @@ export function ItemShopPicker({ items, onBuy, pending, disabledRarities }: Prop
                   }}
                   className={[
                     'rounded-full border px-2 py-0.5 text-[11px] font-medium uppercase tracking-wider',
-                    active ? rarityChipActiveClass(rf.id) : 'border-pf-border bg-white text-pf-alt-dark hover:bg-pf-bg-dark/40',
+                    active
+                      ? rarityChipActiveClass(rf.id)
+                      : 'border-pf-border bg-white text-pf-alt-dark hover:bg-pf-bg-dark/40',
                   ].join(' ')}
                 >
                   {rf.label}
@@ -489,62 +318,59 @@ export function ItemShopPicker({ items, onBuy, pending, disabledRarities }: Prop
       ) : emptyResults ? (
         <p className="text-sm italic text-pf-alt-dark">No items match.</p>
       ) : (
-        <>
-          {/* `relative` scopes the detail overlay's `absolute inset-0`
-              so it covers only the grid area, not the whole page. */}
-          <div className="relative">
-            <ul
-              ref={gridRef}
-              className="grid gap-2 overflow-hidden"
-              style={{
-                gridTemplateColumns: 'repeat(5, minmax(0, 1fr))',
-                // maxHeight is measured from the grid's live offset so
-                // the grid never extends past the viewport. Falls back
-                // to a conservative ceiling before the first measure.
-                maxHeight: maxHeight !== null ? `${maxHeight.toString()}px` : 'calc(100dvh - 20rem)',
-              }}
-              data-testid="shop-grid"
-            >
-              {pageSlice.map((g) => (
-                <ShopTile
-                  key={g.key}
-                  group={g}
-                  priceState={resolvePriceState(g.variants[0] as CompendiumMatch, prices)}
-                  purseCp={purseCp}
-                  buying={g.variants.some((v) => pending.has(v.uuid))}
-                  onOpen={(): void => {
-                    setSelectedGroup(g);
-                  }}
-                  onBuyDirect={(unitPriceCp): Promise<void> =>
-                    onBuy({ match: g.variants[0] as CompendiumMatch, unitPriceCp })
-                  }
-                />
-              ))}
-            </ul>
-            {selectedGroup && (
-              <ShopItemDetail
-                group={selectedGroup}
-                purseCp={purseCp}
-                pending={pending}
-                onBuy={async (match, unitPriceCp): Promise<void> => {
-                  await onBuy({ match, unitPriceCp });
-                  setSelectedGroup(null);
+        <div className="relative">
+          <CompendiumPicker
+            items={pageSlice}
+            renderList={(slice) => (
+              <ul
+                ref={gridRef}
+                className="grid gap-2 overflow-hidden"
+                style={{
+                  gridTemplateColumns: 'repeat(5, minmax(0, 1fr))',
+                  maxHeight: maxHeight !== null ? `${maxHeight.toString()}px` : 'calc(100dvh - 20rem)',
                 }}
-                onClose={(): void => {
-                  setSelectedGroup(null);
-                }}
-              />
+                data-testid="shop-grid"
+              >
+                {slice.map((g) => (
+                  <ShopTile
+                    key={g.key}
+                    group={g}
+                    priceState={resolvePriceState(g.variants[0] as CompendiumMatch, prices)}
+                    purseCp={purseCp}
+                    buying={g.variants.some((v) => pending.has(v.uuid))}
+                    onOpen={(): void => {
+                      setSelectedGroup(g);
+                    }}
+                    onBuyDirect={(unitPriceCp): Promise<void> =>
+                      onBuy({ match: g.variants[0] as CompendiumMatch, unitPriceCp })
+                    }
+                  />
+                ))}
+              </ul>
             )}
-          </div>
-        </>
+          />
+          {selectedGroup && (
+            <ShopItemDetail
+              group={selectedGroup}
+              purseCp={purseCp}
+              pending={pending}
+              onBuy={async (match, unitPriceCp): Promise<void> => {
+                await onBuy({ match, unitPriceCp });
+                setSelectedGroup(null);
+              }}
+              onClose={(): void => {
+                setSelectedGroup(null);
+              }}
+            />
+          )}
+        </div>
       )}
     </div>
   );
 }
 
-// Compact Prev / N / M / Next strip. No result-count text — the grid
-// density already communicates scale, and omitting it lets the whole
-// control strip live inline with the filters.
+// ─── Pagination controls ─────────────────────────────────────────────────
+
 function PaginationControls({
   page,
   pageCount,
@@ -603,368 +429,4 @@ function PaginationControls({
       )}
     </div>
   );
-}
-
-type PriceState = { kind: 'loading' } | { kind: 'ready'; price: ItemPrice | null };
-
-function rarityFooterClass(rarity: string | undefined): string {
-  switch (rarity?.toLowerCase()) {
-    case 'uncommon': return 'bg-amber-200 border-amber-500';
-    case 'rare':     return 'bg-blue-200 border-blue-500';
-    case 'unique':   return 'bg-purple-200 border-purple-500';
-    default:         return 'border-pf-border';
-  }
-}
-
-function rarityChipActiveClass(rarity: string): string {
-  switch (rarity) {
-    case 'uncommon': return 'border-amber-500 bg-amber-200 text-amber-900';
-    case 'rare':     return 'border-blue-500 bg-blue-200 text-blue-900';
-    case 'unique':   return 'border-purple-500 bg-purple-200 text-purple-900';
-    default:         return 'border-pf-border bg-pf-bg-dark text-pf-text';
-  }
-}
-
-function rarityChipClass(rarity: string | undefined): string {
-  switch (rarity?.toLowerCase()) {
-    case 'uncommon': return 'border-amber-500 bg-amber-100 text-amber-800';
-    case 'rare':     return 'border-blue-500 bg-blue-100 text-blue-800';
-    case 'unique':   return 'border-purple-500 bg-purple-100 text-purple-800';
-    default:         return 'border-pf-border bg-pf-bg-dark text-pf-alt-dark';
-  }
-}
-
-interface ItemGroup {
-  key: string;
-  displayName: string;
-  variants: CompendiumMatch[];
-}
-
-function qualityLabel(name: string): string {
-  return parseItemName(name).variant ?? '—';
-}
-
-// Priority for the per-tile price:
-//   1. `match.price` when the server embedded it (cache hit) — instant
-//   2. The lazy-loaded prices Map (uncached packs)
-//   3. Loading state while the prefetch is in flight
-function resolvePriceState(match: CompendiumMatch, prefetched: Map<string, ItemPrice | null>): PriceState {
-  if (match.price !== undefined) return { kind: 'ready', price: match.price };
-  if (prefetched.has(match.uuid)) return { kind: 'ready', price: prefetched.get(match.uuid) ?? null };
-  return { kind: 'loading' };
-}
-
-function ShopTile({
-  group,
-  priceState,
-  purseCp,
-  buying,
-  onOpen,
-  onBuyDirect,
-}: {
-  group: ItemGroup;
-  priceState: PriceState;
-  purseCp: number;
-  buying: boolean;
-  onOpen: () => void;
-  onBuyDirect: (unitPriceCp: number) => Promise<void>;
-}): React.ReactElement {
-  const representative = group.variants[0] as CompendiumMatch;
-  const multiVariant = group.variants.length > 1;
-  const price = priceState.kind === 'ready' ? priceState.price : null;
-  const unitPriceCp = price ? priceToCp(price) : 0;
-  const priceText =
-    priceState.kind === 'loading' ? '…' : price ? formatCp(unitPriceCp) : '—';
-  const priceReady = priceState.kind === 'ready';
-  const canAfford = !priceReady || unitPriceCp === 0 || purseCp >= unitPriceCp;
-
-  return (
-    <li
-      className="flex flex-col overflow-hidden rounded border border-pf-border bg-pf-bg transition-shadow hover:cursor-pointer hover:shadow-md"
-      data-item-uuid={representative.uuid}
-      data-affordable={canAfford ? 'true' : 'false'}
-      onClick={(e): void => {
-        if ((e.target as HTMLElement).closest('button, a, input')) return;
-        onOpen();
-      }}
-      role="button"
-      tabIndex={0}
-      onKeyDown={(e): void => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          onOpen();
-        }
-      }}
-      data-testid="shop-tile"
-    >
-      {/* Square art with name overlay — mirrors the inventory GridTile */}
-      <div className="relative aspect-square w-full overflow-hidden bg-pf-bg-dark">
-        <img src={representative.img} alt="" className="h-full w-full object-contain" />
-        <div className="absolute inset-x-0 bottom-0 bg-black/40 px-1.5 py-1">
-          <span className="line-clamp-2 block text-[10px] font-medium leading-tight text-white" title={group.displayName}>
-            {group.displayName}
-          </span>
-        </div>
-        {multiVariant && (
-          <span className="absolute right-1 top-1 rounded bg-black/50 px-1.5 py-0.5 text-[10px] font-semibold leading-none text-white">
-            Variants: {group.variants.length}
-          </span>
-        )}
-      </div>
-      {/* Price + buy chip — tinted by rarity */}
-      <div className={`flex items-center gap-1.5 border-t px-1.5 py-1 ${rarityFooterClass(representative.rarity)}`}>
-        <span className="min-w-0 flex-1 truncate font-mono text-[10px] tabular-nums text-pf-alt-dark" data-role="tile-price">
-          {multiVariant ? `from ${priceText}` : priceText}
-        </span>
-        <button
-          type="button"
-          onClick={(e): void => {
-            e.stopPropagation();
-            if (multiVariant) {
-              onOpen();
-            } else {
-              void onBuyDirect(unitPriceCp);
-            }
-          }}
-          disabled={!multiVariant && (!canAfford || buying)}
-          data-testid="shop-buy"
-          className={[
-            'flex-shrink-0 rounded border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider',
-            !multiVariant && !canAfford
-              ? 'cursor-not-allowed border-neutral-200 bg-neutral-50 text-neutral-400'
-              : buying
-                ? 'border-pf-primary bg-pf-primary/10 text-pf-primary'
-                : 'border-pf-primary bg-pf-primary text-white hover:bg-pf-primary-dark',
-          ].join(' ')}
-        >
-          {buying ? 'Buying…' : multiVariant ? 'Select' : canAfford ? 'Buy' : 'Too rich'}
-        </button>
-      </div>
-    </li>
-  );
-}
-
-function extractPriceFromDocument(doc: CompendiumDocument): ItemPrice | null {
-  const sys = doc.system as { price?: unknown };
-  const price = sys.price;
-  if (!price || typeof price !== 'object') return null;
-  const v = (price as { value?: unknown }).value;
-  if (!v || typeof v !== 'object') return null;
-  return price as ItemPrice;
-}
-
-// Full-document overlay anchored over the grid. Lazily fetches the
-// compendium document for description + traits; when the pack is
-// cached on the mcp side, the fetch is a synchronous in-memory hit.
-// Dismissed via the × button, Esc, or clicking outside the panel.
-function ShopItemDetail({
-  group,
-  purseCp,
-  pending,
-  onBuy,
-  onClose,
-}: {
-  group: ItemGroup;
-  purseCp: number;
-  pending: Set<string>;
-  onBuy: (match: CompendiumMatch, unitPriceCp: number) => Promise<void>;
-  onClose: () => void;
-}): React.ReactElement {
-  const [selectedVariantIdx, setSelectedVariantIdx] = useState(0);
-  const activeVariant = (group.variants[Math.min(selectedVariantIdx, group.variants.length - 1)] ?? group.variants[0]) as CompendiumMatch;
-  const multiVariant = group.variants.length > 1;
-
-  const [doc, setDoc] = useState<CompendiumDocument | null>(null);
-  const [docError, setDocError] = useState<string | null>(null);
-  const [docLoading, setDocLoading] = useState(true);
-
-  useEffect(() => {
-    let cancelled = false;
-    queueMicrotask(() => {
-      if (cancelled) return;
-      setDoc(null);
-      setDocError(null);
-      setDocLoading(true);
-    });
-    api
-      .getCompendiumDocument(activeVariant.uuid)
-      .then((result) => {
-        if (cancelled) return;
-        setDoc(result.document);
-        setDocLoading(false);
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        setDocError(err instanceof Error ? err.message : String(err));
-        setDocLoading(false);
-      });
-    return (): void => {
-      cancelled = true;
-    };
-  }, [activeVariant.uuid]);
-
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent): void => {
-      if (e.key === 'Escape') onClose();
-    };
-    window.addEventListener('keydown', onKey);
-    return (): void => {
-      window.removeEventListener('keydown', onKey);
-    };
-  }, [onClose]);
-
-  const price = activeVariant.price ?? (doc ? extractPriceFromDocument(doc) : null);
-  const unitPriceCp = price ? priceToCp(price) : 0;
-  const priceText = price ? formatCp(unitPriceCp) : '—';
-  const canAfford = unitPriceCp === 0 || purseCp >= unitPriceCp;
-  const buying = pending.has(activeVariant.uuid);
-  const traits = activeVariant.traits ?? extractTraitsFromDocument(doc);
-  const description = doc ? extractDescriptionFromDocument(doc) : '';
-  const enriched = description.length > 0 ? enrichDescription(description) : '';
-
-  return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-label={`${group.displayName} details`}
-      data-testid="shop-item-detail"
-      onClick={(e): void => {
-        if (e.target === e.currentTarget) onClose();
-      }}
-      className="absolute inset-x-0 top-0 z-20 flex items-start justify-center bg-black/10 p-2"
-    >
-      <div className="w-full flex-col rounded border border-pf-border bg-pf-bg shadow-lg">
-        <header className="flex items-start gap-3 border-b border-pf-border p-3">
-          <img
-            src={activeVariant.img}
-            alt=""
-            className="h-12 w-12 flex-shrink-0 rounded border border-pf-border bg-pf-bg-dark"
-          />
-          <div className="min-w-0 flex-1">
-            <div className="flex items-baseline gap-2">
-              <h3 className="font-serif text-base font-semibold text-pf-text">{group.displayName}</h3>
-              {activeVariant.rarity && activeVariant.rarity !== 'common' && (
-                <span className={`rounded border px-1.5 py-0.5 text-[10px] font-medium capitalize ${rarityChipClass(activeVariant.rarity)}`}>
-                  {activeVariant.rarity}
-                </span>
-              )}
-            </div>
-            <p className="text-[10px] uppercase tracking-widest text-pf-alt-dark">
-              {activeVariant.type}
-              {typeof activeVariant.level === 'number' && ` · Level ${activeVariant.level.toString()}`}
-              {priceText !== '—' && ` · ${priceText}`}
-            </p>
-            {multiVariant && (
-              <ul className="mt-2 flex flex-wrap gap-1" aria-label="Variant">
-                {group.variants.map((v, i) => (
-                  <li key={v.uuid}>
-                    <button
-                      type="button"
-                      onClick={(): void => {
-                        setSelectedVariantIdx(i);
-                      }}
-                      className={[
-                        'rounded border px-2 py-0.5 text-[10px] font-medium',
-                        i === selectedVariantIdx
-                          ? 'border-pf-primary bg-pf-primary text-white'
-                          : 'border-pf-border bg-pf-bg-dark text-pf-alt-dark hover:bg-pf-bg-dark/60',
-                      ].join(' ')}
-                    >
-                      {qualityLabel(v.name)}
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            )}
-            {traits.length > 0 && (
-              <ul className="mt-1 flex flex-wrap gap-1">
-                {traits.slice(0, 8).map((t) => (
-                  <li
-                    key={t}
-                    className="rounded-full border border-pf-tertiary-dark bg-pf-tertiary/40 px-1.5 py-0.5 text-[10px] text-pf-alt-dark"
-                  >
-                    {t}
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="Close details"
-            data-testid="shop-detail-close"
-            className="shrink-0 rounded border border-pf-border bg-white px-2 py-0.5 text-sm text-pf-alt-dark hover:bg-pf-bg-dark/40"
-          >
-            ×
-          </button>
-        </header>
-        <div className="max-h-96 overflow-y-auto p-3 text-sm leading-relaxed text-pf-text [&_.pf-damage]:font-semibold [&_.pf-damage]:text-pf-primary [&_.pf-template]:italic [&_.pf-template]:text-pf-secondary [&_a]:cursor-pointer [&_a]:text-pf-primary [&_a]:underline [&_p]:my-2">
-          {docLoading && !doc ? (
-            <p className="italic text-pf-alt-dark">Loading…</p>
-          ) : docError !== null ? (
-            <p className="italic text-pf-primary">Couldn&apos;t load description: {docError}</p>
-          ) : enriched.length > 0 ? (
-            <div dangerouslySetInnerHTML={{ __html: enriched }} />
-          ) : (
-            <p className="italic text-pf-alt-dark">No description.</p>
-          )}
-        </div>
-        <footer className="flex items-center justify-end gap-2 border-t border-pf-border p-3">
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded border border-pf-border bg-white px-3 py-1 text-xs text-pf-alt-dark hover:bg-pf-bg-dark/40"
-          >
-            Close
-          </button>
-          <button
-            type="button"
-            disabled={!canAfford || buying}
-            onClick={(): void => {
-              void onBuy(activeVariant, unitPriceCp);
-            }}
-            data-testid="shop-detail-buy"
-            className={[
-              'rounded border px-3 py-1 text-xs font-semibold uppercase tracking-wider',
-              !canAfford
-                ? 'cursor-not-allowed border-neutral-200 bg-neutral-50 text-neutral-400'
-                : buying
-                  ? 'border-pf-primary bg-pf-primary/10 text-pf-primary'
-                  : 'border-pf-primary bg-pf-primary text-white hover:bg-pf-primary-dark',
-            ].join(' ')}
-          >
-            {buying ? 'Buying…' : canAfford ? `Buy ${priceText}` : 'Too rich'}
-          </button>
-        </footer>
-      </div>
-    </div>
-  );
-}
-
-function extractDescriptionFromDocument(doc: CompendiumDocument): string {
-  const sys = doc.system as { description?: { value?: unknown } };
-  const v = sys.description?.value;
-  return typeof v === 'string' ? v : '';
-}
-
-function extractTraitsFromDocument(doc: CompendiumDocument | null): string[] {
-  if (!doc) return [];
-  const raw = (doc.system as { traits?: { value?: unknown } }).traits?.value;
-  return Array.isArray(raw) ? raw.filter((v): v is string => typeof v === 'string') : [];
-}
-
-// Match types vary: `match.type` may be the Foundry document type
-// ('Item', 'weapon', 'armor'). When it's a generic 'Item' the server
-// didn't supply the subtype, so we fall back to traits and name.
-function filterMatchesByType(matches: readonly CompendiumMatch[], filter: TypeFilter): CompendiumMatch[] {
-  if (filter === 'all') return [...matches];
-  return matches.filter((m) => {
-    const t = m.type.toLowerCase();
-    if (t === filter) return true;
-    const traits = (m.traits ?? []).map((s) => s.toLowerCase());
-    if (traits.includes(filter)) return true;
-    if (filter === 'consumable' && (traits.includes('potion') || traits.includes('scroll') || traits.includes('elixir'))) return true;
-    return false;
-  });
 }

--- a/apps/player-portal/src/components/shop/ShopItemDetail.tsx
+++ b/apps/player-portal/src/components/shop/ShopItemDetail.tsx
@@ -1,0 +1,213 @@
+import { useEffect, useState } from 'react';
+import { api } from '../../api/client';
+import type { CompendiumDocument, CompendiumMatch } from '../../api/types';
+import { enrichDescription } from '@foundry-toolkit/shared/foundry-enrichers';
+import { formatCp, priceToCp } from '../../lib/coins';
+import { extractPriceFromDocument, qualityLabel, rarityChipClass, type ItemGroup } from './shop-utils';
+
+// ─── Document helpers (private) ──────────────────────────────────────────
+
+function extractDescriptionFromDocument(doc: CompendiumDocument): string {
+  const sys = doc.system as { description?: { value?: unknown } };
+  const v = sys.description?.value;
+  return typeof v === 'string' ? v : '';
+}
+
+function extractTraitsFromDocument(doc: CompendiumDocument | null): string[] {
+  if (!doc) return [];
+  const raw = (doc.system as { traits?: { value?: unknown } }).traits?.value;
+  return Array.isArray(raw) ? raw.filter((v): v is string => typeof v === 'string') : [];
+}
+
+// ─── Full-document overlay ───────────────────────────────────────────────
+
+/**
+ * Anchored over the grid via absolute positioning. Lazily fetches the
+ * compendium document for description + traits. Dismissed via ×, Esc,
+ * or clicking the backdrop.
+ */
+export function ShopItemDetail({
+  group,
+  purseCp,
+  pending,
+  onBuy,
+  onClose,
+}: {
+  group: ItemGroup;
+  purseCp: number;
+  pending: Set<string>;
+  onBuy: (match: CompendiumMatch, unitPriceCp: number) => Promise<void>;
+  onClose: () => void;
+}): React.ReactElement {
+  const [selectedVariantIdx, setSelectedVariantIdx] = useState(0);
+  const activeVariant = (group.variants[Math.min(selectedVariantIdx, group.variants.length - 1)] ??
+    group.variants[0]) as CompendiumMatch;
+  const multiVariant = group.variants.length > 1;
+
+  const [doc, setDoc] = useState<CompendiumDocument | null>(null);
+  const [docError, setDocError] = useState<string | null>(null);
+  const [docLoading, setDocLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (cancelled) return;
+      setDoc(null);
+      setDocError(null);
+      setDocLoading(true);
+    });
+    api
+      .getCompendiumDocument(activeVariant.uuid)
+      .then((result) => {
+        if (cancelled) return;
+        setDoc(result.document);
+        setDocLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setDocError(err instanceof Error ? err.message : String(err));
+        setDocLoading(false);
+      });
+    return (): void => {
+      cancelled = true;
+    };
+  }, [activeVariant.uuid]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return (): void => {
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [onClose]);
+
+  const price = activeVariant.price ?? (doc ? extractPriceFromDocument(doc) : null);
+  const unitPriceCp = price ? priceToCp(price) : 0;
+  const priceText = price ? formatCp(unitPriceCp) : '—';
+  const canAfford = unitPriceCp === 0 || purseCp >= unitPriceCp;
+  const buying = pending.has(activeVariant.uuid);
+  const traits = activeVariant.traits ?? extractTraitsFromDocument(doc);
+  const description = doc ? extractDescriptionFromDocument(doc) : '';
+  const enriched = description.length > 0 ? enrichDescription(description) : '';
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={`${group.displayName} details`}
+      data-testid="shop-item-detail"
+      onClick={(e): void => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+      className="absolute inset-x-0 top-0 z-20 flex items-start justify-center bg-black/10 p-2"
+    >
+      <div className="w-full flex-col rounded border border-pf-border bg-pf-bg shadow-lg">
+        <header className="flex items-start gap-3 border-b border-pf-border p-3">
+          <img
+            src={activeVariant.img}
+            alt=""
+            className="h-12 w-12 flex-shrink-0 rounded border border-pf-border bg-pf-bg-dark"
+          />
+          <div className="min-w-0 flex-1">
+            <div className="flex items-baseline gap-2">
+              <h3 className="font-serif text-base font-semibold text-pf-text">{group.displayName}</h3>
+              {activeVariant.rarity && activeVariant.rarity !== 'common' && (
+                <span className={`rounded border px-1.5 py-0.5 text-[10px] font-medium capitalize ${rarityChipClass(activeVariant.rarity)}`}>
+                  {activeVariant.rarity}
+                </span>
+              )}
+            </div>
+            <p className="text-[10px] uppercase tracking-widest text-pf-alt-dark">
+              {activeVariant.type}
+              {typeof activeVariant.level === 'number' && ` · Level ${activeVariant.level.toString()}`}
+              {priceText !== '—' && ` · ${priceText}`}
+            </p>
+            {multiVariant && (
+              <ul className="mt-2 flex flex-wrap gap-1" aria-label="Variant">
+                {group.variants.map((v, i) => (
+                  <li key={v.uuid}>
+                    <button
+                      type="button"
+                      onClick={(): void => {
+                        setSelectedVariantIdx(i);
+                      }}
+                      className={[
+                        'rounded border px-2 py-0.5 text-[10px] font-medium',
+                        i === selectedVariantIdx
+                          ? 'border-pf-primary bg-pf-primary text-white'
+                          : 'border-pf-border bg-pf-bg-dark text-pf-alt-dark hover:bg-pf-bg-dark/60',
+                      ].join(' ')}
+                    >
+                      {qualityLabel(v.name)}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+            {traits.length > 0 && (
+              <ul className="mt-1 flex flex-wrap gap-1">
+                {traits.slice(0, 8).map((t) => (
+                  <li
+                    key={t}
+                    className="rounded-full border border-pf-tertiary-dark bg-pf-tertiary/40 px-1.5 py-0.5 text-[10px] text-pf-alt-dark"
+                  >
+                    {t}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close details"
+            data-testid="shop-detail-close"
+            className="shrink-0 rounded border border-pf-border bg-white px-2 py-0.5 text-sm text-pf-alt-dark hover:bg-pf-bg-dark/40"
+          >
+            ×
+          </button>
+        </header>
+        <div className="max-h-96 overflow-y-auto p-3 text-sm leading-relaxed text-pf-text [&_.pf-damage]:font-semibold [&_.pf-damage]:text-pf-primary [&_.pf-template]:italic [&_.pf-template]:text-pf-secondary [&_a]:cursor-pointer [&_a]:text-pf-primary [&_a]:underline [&_p]:my-2">
+          {docLoading && !doc ? (
+            <p className="italic text-pf-alt-dark">Loading…</p>
+          ) : docError !== null ? (
+            <p className="italic text-pf-primary">Couldn&apos;t load description: {docError}</p>
+          ) : enriched.length > 0 ? (
+            <div dangerouslySetInnerHTML={{ __html: enriched }} />
+          ) : (
+            <p className="italic text-pf-alt-dark">No description.</p>
+          )}
+        </div>
+        <footer className="flex items-center justify-end gap-2 border-t border-pf-border p-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded border border-pf-border bg-white px-3 py-1 text-xs text-pf-alt-dark hover:bg-pf-bg-dark/40"
+          >
+            Close
+          </button>
+          <button
+            type="button"
+            disabled={!canAfford || buying}
+            onClick={(): void => {
+              void onBuy(activeVariant, unitPriceCp);
+            }}
+            data-testid="shop-detail-buy"
+            className={[
+              'rounded border px-3 py-1 text-xs font-semibold uppercase tracking-wider',
+              !canAfford
+                ? 'cursor-not-allowed border-neutral-200 bg-neutral-50 text-neutral-400'
+                : buying
+                  ? 'border-pf-primary bg-pf-primary/10 text-pf-primary'
+                  : 'border-pf-primary bg-pf-primary text-white hover:bg-pf-primary-dark',
+            ].join(' ')}
+          >
+            {buying ? 'Buying…' : canAfford ? `Buy ${priceText}` : 'Too rich'}
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/apps/player-portal/src/components/shop/ShopTile.tsx
+++ b/apps/player-portal/src/components/shop/ShopTile.tsx
@@ -1,0 +1,99 @@
+import type { CompendiumMatch } from '../../api/types';
+import { formatCp, priceToCp } from '../../lib/coins';
+import { rarityFooterClass, type ItemGroup, type PriceState } from './shop-utils';
+
+// Re-export the type so callers can import it from either place.
+export type { ItemGroup } from './shop-utils';
+
+export function ShopTile({
+  group,
+  priceState,
+  purseCp,
+  buying,
+  onOpen,
+  onBuyDirect,
+}: {
+  group: ItemGroup;
+  priceState: PriceState;
+  purseCp: number;
+  buying: boolean;
+  onOpen: () => void;
+  onBuyDirect: (unitPriceCp: number) => Promise<void>;
+}): React.ReactElement {
+  const representative = group.variants[0] as CompendiumMatch;
+  const multiVariant = group.variants.length > 1;
+  const price = priceState.kind === 'ready' ? priceState.price : null;
+  const unitPriceCp = price ? priceToCp(price) : 0;
+  const priceText = priceState.kind === 'loading' ? '…' : price ? formatCp(unitPriceCp) : '—';
+  const priceReady = priceState.kind === 'ready';
+  const canAfford = !priceReady || unitPriceCp === 0 || purseCp >= unitPriceCp;
+
+  return (
+    <li
+      className="flex flex-col overflow-hidden rounded border border-pf-border bg-pf-bg transition-shadow hover:cursor-pointer hover:shadow-md"
+      data-item-uuid={representative.uuid}
+      data-affordable={canAfford ? 'true' : 'false'}
+      onClick={(e): void => {
+        if ((e.target as HTMLElement).closest('button, a, input')) return;
+        onOpen();
+      }}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e): void => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+      data-testid="shop-tile"
+    >
+      <div className="relative aspect-square w-full overflow-hidden bg-pf-bg-dark">
+        <img src={representative.img} alt="" className="h-full w-full object-contain" />
+        <div className="absolute inset-x-0 bottom-0 bg-black/40 px-1.5 py-1">
+          <span
+            className="line-clamp-2 block text-[10px] font-medium leading-tight text-white"
+            title={group.displayName}
+          >
+            {group.displayName}
+          </span>
+        </div>
+        {multiVariant && (
+          <span className="absolute right-1 top-1 rounded bg-black/50 px-1.5 py-0.5 text-[10px] font-semibold leading-none text-white">
+            Variants: {group.variants.length}
+          </span>
+        )}
+      </div>
+      <div className={`flex items-center gap-1.5 border-t px-1.5 py-1 ${rarityFooterClass(representative.rarity)}`}>
+        <span
+          className="min-w-0 flex-1 truncate font-mono text-[10px] tabular-nums text-pf-alt-dark"
+          data-role="tile-price"
+        >
+          {multiVariant ? `from ${priceText}` : priceText}
+        </span>
+        <button
+          type="button"
+          onClick={(e): void => {
+            e.stopPropagation();
+            if (multiVariant) {
+              onOpen();
+            } else {
+              void onBuyDirect(unitPriceCp);
+            }
+          }}
+          disabled={!multiVariant && (!canAfford || buying)}
+          data-testid="shop-buy"
+          className={[
+            'flex-shrink-0 rounded border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider',
+            !multiVariant && !canAfford
+              ? 'cursor-not-allowed border-neutral-200 bg-neutral-50 text-neutral-400'
+              : buying
+                ? 'border-pf-primary bg-pf-primary/10 text-pf-primary'
+                : 'border-pf-primary bg-pf-primary text-white hover:bg-pf-primary-dark',
+          ].join(' ')}
+        >
+          {buying ? 'Buying…' : multiVariant ? 'Select' : canAfford ? 'Buy' : 'Too rich'}
+        </button>
+      </div>
+    </li>
+  );
+}

--- a/apps/player-portal/src/components/shop/shop-utils.ts
+++ b/apps/player-portal/src/components/shop/shop-utils.ts
@@ -1,0 +1,156 @@
+import type { CompendiumDocument, CompendiumMatch, ItemPrice } from '../../api/types';
+import { priceToCp } from '../../lib/coins';
+
+// ─── Type filter ─────────────────────────────────────────────────────────
+
+export type TypeFilter = 'all' | 'weapon' | 'armor' | 'consumable' | 'equipment' | 'backpack';
+
+/** Match types vary: `match.type` may be the Foundry document type.
+ *  When it's generic 'Item' the server didn't supply the subtype, so
+ *  we fall back to traits and name. */
+export function filterMatchesByType(matches: readonly CompendiumMatch[], filter: TypeFilter): CompendiumMatch[] {
+  if (filter === 'all') return [...matches];
+  return matches.filter((m) => {
+    const t = m.type.toLowerCase();
+    if (t === filter) return true;
+    const traits = (m.traits ?? []).map((s) => s.toLowerCase());
+    if (traits.includes(filter)) return true;
+    if (
+      filter === 'consumable' &&
+      (traits.includes('potion') || traits.includes('scroll') || traits.includes('elixir'))
+    )
+      return true;
+    return false;
+  });
+}
+
+// ─── Item grouping ────────────────────────────────────────────────────────
+
+export interface ItemGroup {
+  key: string;
+  displayName: string;
+  variants: CompendiumMatch[];
+}
+
+// Known quality tiers with explicit sort order.
+export const QUALITY_ORDER: Record<string, number> = {
+  minor: 0,
+  lesser: 1,
+  moderate: 2,
+  greater: 3,
+  major: 4,
+  true: 5,
+  young: 6,
+  adult: 7,
+  wyrm: 8,
+  '1st-rank': 10,
+  '2nd-rank': 11,
+  '3rd-rank': 12,
+  '4th-rank': 13,
+  '5th-rank': 14,
+  '6th-rank': 15,
+  '7th-rank': 16,
+  '8th-rank': 17,
+  '9th-rank': 18,
+  'rank 1': 10,
+  'rank 2': 11,
+  'rank 3': 12,
+  'rank 4': 13,
+  'rank 5': 14,
+  'rank 6': 15,
+  'rank 7': 16,
+  'rank 8': 17,
+  'rank 9': 18,
+};
+
+export const QUALITY_WORD_RE =
+  /\b(minor|lesser|moderate|greater|major|true|young|adult|wyrm|[1-9](?:st|nd|rd|th)-rank|rank\s+[1-9])(?:\s+spell)?\b/i;
+
+/** Splits "Name (Variant)" into `{ base, variant }`. Only strips the
+ *  final trailing parenthetical; parens in the middle are kept in base. */
+export function parseItemName(name: string): { base: string; variant: string | null } {
+  const m = /^(.+?)\s*\(([^)]+)\)\s*$/.exec(name);
+  if (!m) return { base: name.trim(), variant: null };
+  // Groups 1 and 2 are guaranteed by the regex above.
+  return { base: (m[1] as string).trim(), variant: (m[2] as string).trim() };
+}
+
+/** Sort rank for a variant string. Known quality keywords get explicit
+ *  ranks; unknown variants sort alphabetically (rank 99); the base item
+ *  with no variant sorts first (-1). */
+export function variantRank(variant: string | null): number {
+  if (variant === null) return -1;
+  const m = QUALITY_WORD_RE.exec(variant);
+  return m ? (QUALITY_ORDER[(m[1] as string).toLowerCase()] ?? 99) : 99;
+}
+
+/** Sorts variants within a group by quality tier then alphabetically. */
+export function sortVariants(variants: CompendiumMatch[]): CompendiumMatch[] {
+  return [...variants].sort((a, b) => {
+    const ra = variantRank(parseItemName(a.name).variant);
+    const rb = variantRank(parseItemName(b.name).variant);
+    if (ra !== rb) return ra - rb;
+    return (parseItemName(a.name).variant ?? '').localeCompare(parseItemName(b.name).variant ?? '');
+  });
+}
+
+/** Display label for a single variant chip. */
+export function qualityLabel(name: string): string {
+  return parseItemName(name).variant ?? '—';
+}
+
+// ─── Price utilities ──────────────────────────────────────────────────────
+
+export type PriceState = { kind: 'loading' } | { kind: 'ready'; price: ItemPrice | null };
+
+/** Priority: embedded `match.price` → lazy-loaded map → loading state */
+export function resolvePriceState(
+  match: CompendiumMatch,
+  prefetched: Map<string, ItemPrice | null>,
+): PriceState {
+  if (match.price !== undefined) return { kind: 'ready', price: match.price };
+  if (prefetched.has(match.uuid)) return { kind: 'ready', price: prefetched.get(match.uuid) ?? null };
+  return { kind: 'loading' };
+}
+
+export function extractPriceFromDocument(doc: CompendiumDocument): ItemPrice | null {
+  const sys = doc.system as { price?: unknown };
+  const price = sys.price;
+  if (!price || typeof price !== 'object') return null;
+  const v = (price as { value?: unknown }).value;
+  if (!v || typeof v !== 'object') return null;
+  return price as ItemPrice;
+}
+
+// ─── Rarity style utilities ───────────────────────────────────────────────
+
+export function rarityFooterClass(rarity: string | undefined): string {
+  switch (rarity?.toLowerCase()) {
+    case 'uncommon': return 'bg-amber-200 border-amber-500';
+    case 'rare':     return 'bg-blue-200 border-blue-500';
+    case 'unique':   return 'bg-purple-200 border-purple-500';
+    default:         return 'border-pf-border';
+  }
+}
+
+export function rarityChipActiveClass(rarity: string): string {
+  switch (rarity) {
+    case 'uncommon': return 'border-amber-500 bg-amber-200 text-amber-900';
+    case 'rare':     return 'border-blue-500 bg-blue-200 text-blue-900';
+    case 'unique':   return 'border-purple-500 bg-purple-200 text-purple-900';
+    default:         return 'border-pf-border bg-pf-bg-dark text-pf-text';
+  }
+}
+
+export function rarityChipClass(rarity: string | undefined): string {
+  switch (rarity?.toLowerCase()) {
+    case 'uncommon': return 'border-amber-500 bg-amber-100 text-amber-800';
+    case 'rare':     return 'border-blue-500 bg-blue-100 text-blue-800';
+    case 'unique':   return 'border-purple-500 bg-purple-100 text-purple-800';
+    default:         return 'border-pf-border bg-pf-bg-dark text-pf-alt-dark';
+  }
+}
+
+// priceToCp is re-exported here for convenience — callers of shop-utils
+// don't need to import from two places for price display.
+export { priceToCp };

--- a/apps/player-portal/src/components/shop/useFitPageSize.ts
+++ b/apps/player-portal/src/components/shop/useFitPageSize.ts
@@ -1,0 +1,50 @@
+import { useCallback, useEffect, useState } from 'react';
+
+// Grid column count — fixed to match the `repeat(5, ...)` template.
+const GRID_COLS = 5;
+// Approximate tile height (including gap).
+const TILE_HEIGHT_PX = 146;
+const GRID_GAP_PX = 8;
+const MIN_FIT_PAGE_SIZE = 6;
+// Breathing room between the grid's bottom edge and the viewport bottom
+// (bottom pagination bar ~32px + container p-6 24px + safety margin).
+const VIEWPORT_BOTTOM_MARGIN_PX = 72;
+
+export const FALLBACK_PAGE_SIZE = 25;
+
+export function useFitPageSize(): {
+  pageSize: number;
+  maxHeight: number | null;
+  gridRef: (el: HTMLUListElement | null) => void;
+} {
+  const [pageSize, setPageSize] = useState(FALLBACK_PAGE_SIZE);
+  const [maxHeight, setMaxHeight] = useState<number | null>(null);
+  // Callback ref fires synchronously when the grid element attaches/
+  // detaches, so the ResizeObserver wires up even though the grid is
+  // conditionally rendered (only after results arrive).
+  const [gridEl, setGridEl] = useState<HTMLUListElement | null>(null);
+  const gridRef = useCallback((el: HTMLUListElement | null) => {
+    setGridEl(el);
+  }, []);
+
+  useEffect(() => {
+    if (!gridEl || typeof ResizeObserver === 'undefined') return;
+    const recompute = (): void => {
+      const rect = gridEl.getBoundingClientRect();
+      const availableHeight = Math.max(200, window.innerHeight - rect.top - VIEWPORT_BOTTOM_MARGIN_PX);
+      setMaxHeight(availableHeight);
+      const rows = Math.max(1, Math.floor((availableHeight + GRID_GAP_PX) / (TILE_HEIGHT_PX + GRID_GAP_PX)));
+      setPageSize(Math.max(MIN_FIT_PAGE_SIZE, GRID_COLS * rows));
+    };
+    recompute();
+    const ro = new ResizeObserver(recompute);
+    ro.observe(gridEl);
+    window.addEventListener('resize', recompute);
+    return (): void => {
+      ro.disconnect();
+      window.removeEventListener('resize', recompute);
+    };
+  }, [gridEl]);
+
+  return { pageSize, maxHeight, gridRef };
+}

--- a/apps/player-portal/src/lib/usePendingPrompts.ts
+++ b/apps/player-portal/src/lib/usePendingPrompts.ts
@@ -38,7 +38,11 @@ export function usePendingPrompts(): PendingPrompt[] {
   const [prompts, setPrompts] = useState<PendingPrompt[]>([]);
 
   useEffect(() => {
-    const es = new EventSource('/api/prompts/stream');
+    // Routes through the player-portal Fastify server's `/api/mcp/*` proxy
+    // → foundry-mcp's `/api/prompts/stream`. The bare `/api/prompts/stream`
+    // path 404s because the player-portal server only has `/api/mcp/*` and
+    // `/api/live/*` — there is no top-level `/api/prompts` route there.
+    const es = new EventSource('/api/mcp/prompts/stream');
 
     es.onmessage = (ev): void => {
       try {

--- a/apps/player-portal/src/styles/index.css
+++ b/apps/player-portal/src/styles/index.css
@@ -74,10 +74,12 @@
 }
 /* Sticky step-nav scrim: fades from the page background down to transparent
  * so the nav pill bar appears to float above the scrolling content. Uses
- * --portal-bg so the fade colour matches both light (cream parchment) and
- * dark (#0d111e navy) themes automatically. */
+ * --color-pf-bg (the cream parchment surface that CharactersLayout sets
+ * via `bg-pf-bg`) so the fade matches whatever colour the creator/sheet
+ * is actually painted with — independent of the portal theme, which only
+ * affects the outer nav chrome. */
 @utility bg-stage-gradient {
-  background: linear-gradient(to bottom, var(--portal-bg), transparent);
+  background: linear-gradient(to bottom, var(--color-pf-bg), transparent);
 }
 
 /* Item state tokens — used for inventory grid tiles and any other surface


### PR DESCRIPTION
## Apps touched

- `apps/player-portal` — `npm run dev:player-portal`

Validation: exercise the feat picker (character creator → any feat slot) and the shop picker (Inventory tab → Shop). Search, filter, click an item to see detail, pick/buy.

## Summary

Both pickers shared a search-box + list + detail-pane structure but were monolithic 1000+-line files. This refactor extracts a generic `CompendiumPicker` component (loading/error/empty states, `renderList` slot, optional load-more, optional split-pane detail layout) and decomposes each picker into focused sibling files. Zero user-visible behavior change.

**What's shared vs. domain-specific:**
- Shared: loading/error/empty state rendering, `renderList` slot, load-more button, split-pane detail layout → `CompendiumPicker`
- Feat-specific: source multi-select, A–Z/Level sort toggle, prereq evaluation, hide-unmet toggle, versatile-heritage grouping, prereq link resolution
- Shop-specific: price/affordability, rarity chips, type chips, variant grouping by base name, quality-tier sort, dynamic page sizing via ResizeObserver, page-based navigation

## Changes

**New shared base:**
- `components/picker/CompendiumPicker.tsx` — 101 lines, with tests (187 lines)

**FeatPicker decomposition (1109 → 258 lines):**
- `FeatFilters.tsx` — SourcePicker, SortToggle, UnmetToggle, FilterSummary (252 lines)
- `FeatMatchRow.tsx` — FeatMatchRow, FeatMatchList with versatile-heritage split (138 lines)
- `FeatDetailPanel.tsx` — prereq-resolution detail panel, component only (196 lines)
- `useFeatDetail.ts` — detail-fetch hook with doc-cache + stale-cancel (68 lines)
- `feat-bio.ts` — extractDetailBio poly-type extractor (42 lines)
- `feat-prefetch.ts` — prefetchDocuments + resolvePrereqsForDoc (71 lines)

**ItemShopPicker decomposition (971 → 409 lines):**
- `shop-utils.ts` — TypeFilter, ItemGroup, PriceState, parseItemName, variantRank, filterMatchesByType, resolvePriceState, extractPriceFromDocument, rarity style helpers (136 lines)
- `useFitPageSize.ts` — ResizeObserver hook for dynamic grid page sizing (45 lines)
- `ShopTile.tsx` — grid tile component (96 lines)
- `ShopItemDetail.tsx` — full-document overlay with variant picker (203 lines)

ItemShopPicker.tsx lands at 409 lines rather than ≤250 because the state orchestration is inherently denser: manual debounce, stale-request guard, variant grouping memo, price prefetch effect, and the 5-column grid JSX with inline max-height computation all stay in the component.

**Lint:** 48 warnings before → 35 warnings after (fast-refresh co-location warnings eliminated by separating non-component utilities into plain .ts files).

## Test plan

- [ ] `npm run test -w apps/player-portal` → 28 files, 416 tests pass (no regressions)
- [ ] `npm run typecheck -w apps/player-portal` → clean
- [ ] `npm run lint -w apps/player-portal` → 0 errors, 35 warnings (down from 48)
- [ ] `npm run dev:player-portal` → open feat picker: search, filter by source, sort, click item, see detail, pick; same for shop picker: search, rarity chip, click tile, variant select, close overlay