### PR TITLE
feat(deploy): add docker-compose demo pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,38 @@
+# Monorepo-root .dockerignore
+# Applies when Docker build context is the repo root (deploy/Dockerfile.*).
+
+# Dependencies — installed fresh inside each image
+**/node_modules/
+
+# Version control and local tooling
+.git
+.github
+.claude
+
+# Secrets — must never enter an image layer
+.env
+
+# Build artifacts — each Dockerfile rebuilds what it needs
+**/dist/
+**/out/
+**/server-dist/
+**/release/
+
+# Electron builder outputs
+apps/dm-tool/out/
+apps/dm-tool/release/
+
+# Python subtool — not part of JS workspace builds
+tagger/
+
+# Prebuilt Win32 binary — not relevant to Linux container builds
+auto-wall-bin/
+
+# Logs and coverage
+**/*.log
+**/npm-debug.log*
+**/coverage/
+
+# OS artifacts
+**/.DS_Store
+**/Thumbs.db

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,42 @@
+# foundry-toolkit demo stack — environment variables
+# Copy this file to .env and fill in values before running docker compose.
+# Never commit .env — it contains credentials.
+
+# ── Foundry VTT ─────────────────────────────────────────────────────────────
+# felddy/foundryvtt uses these to download a licensed Foundry copy from Paizo
+# on first boot.  Required.
+FOUNDRY_USERNAME=your-foundry-username
+FOUNDRY_PASSWORD=your-foundry-password
+
+# Admin console password set at startup.  Strongly recommended: without it,
+# anyone on the network can claim admin access before you do.
+FOUNDRY_ADMIN_KEY=change-me-to-something-random
+
+# ── OpenAI ───────────────────────────────────────────────────────────────────
+# Required only for the edit_image MCP tool (GPT-image-1 map editing).
+# All other tools — actor browsing, compendium search, rolls, chat stream —
+# work without it.  Leave blank to disable edit_image.
+OPENAI_API_KEY=sk-your-openai-api-key
+
+# ── Shared auth token ────────────────────────────────────────────────────────
+# Bearer token for player-portal's /api/live/* POST endpoints (inventory,
+# globe, Aurus leaderboard pushes from dm-tool).  player-portal refuses to
+# start without this set, even though dm-tool is not part of this stack.
+# Generate one with:   openssl rand -hex 32
+SHARED_SECRET=change-me-to-something-random
+
+# ── /api/eval gate ───────────────────────────────────────────────────────────
+# Set to 1 to enable the /api/eval debug endpoint on foundry-mcp.  This is a
+# dev-time escape hatch for running arbitrary scripts inside Foundry's page
+# context (see root CLAUDE.md "API eval — dev escape hatch").  Off by default.
+# Never enable in a publicly reachable deployment.
+ALLOW_EVAL=0
+
+# ── Ports ────────────────────────────────────────────────────────────────────
+# Host port for player-portal.  Change if 3000 conflicts with another service
+# on your host (e.g. homepage dashboard, other dev servers).  The container
+# always listens on port 3000 internally; only the host-side mapping changes.
+PLAYER_PORTAL_PORT=3000
+
+# Foundry is always on host port 30000.  To remap it, edit the ports: entry in
+# compose.yaml directly (Foundry's own settings also need to reflect the change).

--- a/deploy/Dockerfile.foundry-mcp
+++ b/deploy/Dockerfile.foundry-mcp
@@ -1,0 +1,32 @@
+# Build context: monorepo root (compose.yaml build.context: ..).
+#
+# @foundry-toolkit/shared exports raw .ts source files with no build step.
+# Running `tsc && node dist/index.js` would fail at runtime because the compiled
+# JS still imports '@foundry-toolkit/shared/*', which resolves to .ts files that
+# Node can't load.  Instead we run via tsx, which uses esbuild to compile .ts
+# sources on demand — including workspace packages resolved through the
+# package.json exports map.  Slightly larger image, zero build complexity.
+
+FROM node:22-alpine
+WORKDIR /app
+
+# Workspace manifests first — this layer only rebuilds when a manifest changes,
+# not on every source edit.
+COPY package.json package-lock.json tsconfig.base.json ./
+COPY apps/foundry-mcp/package.json apps/foundry-mcp/
+COPY apps/dm-tool/package.json apps/dm-tool/
+COPY packages/shared/package.json packages/shared/
+
+# Includes devDeps so tsx (a devDep of foundry-mcp) is hoisted to the root
+# node_modules.  --ignore-scripts skips husky and any electron-rebuild hooks.
+RUN npm install --ignore-scripts
+
+# Source — only what foundry-mcp imports at runtime.
+COPY packages/shared packages/shared
+COPY apps/foundry-mcp apps/foundry-mcp
+
+EXPOSE 8765
+
+# tsx resolves the workspace symlink node_modules/@foundry-toolkit/shared →
+# packages/shared and compiles .ts files transparently via esbuild.
+CMD ["node_modules/.bin/tsx", "apps/foundry-mcp/src/index.ts"]

--- a/deploy/Dockerfile.player-portal
+++ b/deploy/Dockerfile.player-portal
@@ -1,0 +1,42 @@
+# Build context: monorepo root (compose.yaml build.context: ..).
+# Mirrors apps/player-portal/Dockerfile — kept here so deploy/ is self-contained.
+#
+# Build stage installs workspace deps and builds:
+#   - dist/        Vite SPA (build:client)
+#   - server-dist/ Fastify server (build:server via tsc)
+#
+# @foundry-toolkit/shared is a devDependency of player-portal — the Fastify
+# server imports it for types only; tsc elides those imports from the compiled
+# output.  The runtime stage therefore doesn't need the shared .ts sources.
+
+FROM node:22-alpine AS build
+WORKDIR /repo
+
+# Workspace manifests first — cached independently of source changes.
+COPY package.json package-lock.json tsconfig.base.json ./
+COPY apps/player-portal/package.json apps/player-portal/
+COPY apps/dm-tool/package.json apps/dm-tool/
+COPY packages/shared/package.json packages/shared/
+
+# --ignore-scripts skips husky and electron-rebuild lifecycle hooks.
+RUN npm install --ignore-scripts
+
+# Source — only what the portal build actually needs.
+COPY packages/shared packages/shared
+COPY apps/player-portal apps/player-portal
+
+RUN npm --workspace @foundry-toolkit/player-portal run build
+
+FROM node:22-alpine AS runtime
+WORKDIR /app
+
+COPY --from=build /repo/apps/player-portal/dist ./dist
+COPY --from=build /repo/apps/player-portal/server-dist ./server-dist
+COPY --from=build /repo/apps/player-portal/package.json ./package.json
+# Reuse the hoisted node_modules from the build stage — avoids a second install
+# pass against prod-only deps.  Shared .ts symlinks are unreachable here but
+# the server code doesn't import them at runtime (type-only imports are elided).
+COPY --from=build /repo/node_modules ./node_modules
+
+EXPOSE 3000
+CMD ["node", "server-dist/index.js"]

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,157 @@
+# foundry-toolkit demo stack
+
+Three containers on one internal network:
+
+| Container       | Image / source                  | Exposed                       |
+| --------------- | ------------------------------- | ----------------------------- |
+| `foundry`       | `felddy/foundryvtt:release`     | host port 30000               |
+| `foundry-mcp`   | built from `apps/foundry-mcp`   | internal only (8765)          |
+| `player-portal` | built from `apps/player-portal` | host port 3000 (configurable) |
+
+The `foundry-api-bridge` Foundry module (already deployed in your world) dials out
+from the browser to `ws://foundry-mcp:8765/foundry` over the compose network — no
+extra configuration needed inside the stack itself.
+
+---
+
+## Prerequisites
+
+- Docker with Compose v2 (`docker compose`, not `docker-compose`)
+- A Foundry VTT license (Paizo username + password)
+- The `foundry-api-bridge` module installed and enabled in your Foundry world
+- An OpenAI API key (optional — only needed for the `edit_image` map tool)
+
+---
+
+## Quick start
+
+Run all commands from inside this `deploy/` directory.
+
+```sh
+cd deploy
+cp .env.example .env
+# Fill in at minimum: FOUNDRY_USERNAME, FOUNDRY_PASSWORD, SHARED_SECRET
+$EDITOR .env
+
+docker compose build        # build foundry-mcp and player-portal images
+docker compose up -d        # start all three services
+```
+
+First boot downloads a fresh Foundry install using your Paizo credentials — this
+takes a few minutes. Subsequent starts are instant.
+
+### Verify the stack is up
+
+```sh
+# player-portal health check
+curl http://localhost:3000/health
+# → {"ok":true}
+
+# Foundry setup page (won't fully load without a world, but should serve HTML)
+curl -s -o /dev/null -w "%{http_code}" http://localhost:30000/
+# → 200
+
+# foundry-mcp reachable from inside player-portal container
+docker compose exec player-portal wget -qO- http://foundry-mcp:8765/api/actors
+# → JSON response (empty array or actor list depending on Foundry state)
+```
+
+---
+
+## Configuring foundry-api-bridge
+
+The `foundry-api-bridge` module must be told where foundry-mcp is listening. In
+Foundry's **Module Settings** → **Foundry API Bridge**, set the WebSocket URL to:
+
+```
+ws://foundry-mcp:8765/foundry
+```
+
+This hostname resolves inside the compose network. If you're running Foundry
+**outside** this stack (e.g. a separate host) and still want to use foundry-mcp
+from this compose, set the URL to your Docker host's IP or hostname instead:
+
+```
+ws://<your-host-ip>:8765/foundry
+```
+
+Note: in that case you'll need to expose port 8765 in `compose.yaml` by adding
+a `ports` entry under `foundry-mcp`.
+
+---
+
+## Port layout
+
+| Port  | Service       | Notes                                        |
+| ----- | ------------- | -------------------------------------------- |
+| 30000 | Foundry VTT   | Direct browser access                        |
+| 3000  | player-portal | Override with `PLAYER_PORTAL_PORT`           |
+| 8765  | foundry-mcp   | Internal only — not accessible from the host |
+
+To change the player-portal host port without rebuilding:
+
+```sh
+# In .env:
+PLAYER_PORTAL_PORT=8080
+
+docker compose up -d   # restarts player-portal with the new port mapping
+```
+
+---
+
+## Environment variables
+
+| Variable             | Required    | Default | Purpose                                             |
+| -------------------- | ----------- | ------- | --------------------------------------------------- |
+| `FOUNDRY_USERNAME`   | yes         | —       | Paizo account username for Foundry download         |
+| `FOUNDRY_PASSWORD`   | yes         | —       | Paizo account password                              |
+| `FOUNDRY_ADMIN_KEY`  | recommended | —       | Foundry admin console password                      |
+| `OPENAI_API_KEY`     | no          | —       | GPT-image-1 map editing (`edit_image` tool)         |
+| `SHARED_SECRET`      | yes         | —       | Bearer token for `/api/live/*` POST writes          |
+| `ALLOW_EVAL`         | no          | `0`     | Set to `1` to enable the `/api/eval` debug endpoint |
+| `PLAYER_PORTAL_PORT` | no          | `3000`  | Host port mapping for player-portal                 |
+
+`MCP_URL` and `FOUNDRY_URL` are wired internally via compose service DNS and are
+not read from `.env`.
+
+---
+
+## Stopping, restarting, rebuilding
+
+```sh
+docker compose stop              # pause all containers (volumes preserved)
+docker compose down              # stop + remove containers (volumes preserved)
+docker compose down -v           # also delete foundry-data volume (world data lost)
+
+docker compose build             # rebuild foundry-mcp and player-portal images
+docker compose up -d --build     # rebuild + restart in one step
+```
+
+---
+
+## Data persistence
+
+Foundry world data — systems, modules, worlds, uploads — lives in the
+`foundry-toolkit-demo_foundry-data` named volume. It survives `docker compose
+down` and `docker compose restart`. Only `docker compose down -v` deletes it.
+
+foundry-mcp and player-portal are stateless; player-portal's in-memory live-sync
+state (inventory/globe/aurus snapshots) refills within seconds once dm-tool
+pushes its next update.
+
+---
+
+## TLS / HTTPS
+
+This stack serves plain HTTP. Put nginx, Caddy, or Cloudflare Tunnel in front
+for HTTPS. A minimal Caddy reverse-proxy example:
+
+```
+demo.example.com {
+    reverse_proxy localhost:3000
+}
+
+foundry.example.com {
+    reverse_proxy localhost:30000
+}
+```

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -1,0 +1,83 @@
+# foundry-toolkit demo stack
+# Three services on one internal network: Foundry VTT, foundry-mcp, player-portal.
+#
+# Usage (run from inside this deploy/ directory):
+#   cp .env.example .env   # then fill in credentials
+#   docker compose up -d
+#
+# See README.md for full documentation.
+
+name: foundry-toolkit-demo
+
+services:
+  # ── Foundry VTT ─────────────────────────────────────────────────────────────
+  # felddy/foundryvtt downloads a licensed copy on first boot using your Paizo
+  # credentials.  World data persists in the named volume across restarts.
+  foundry:
+    image: felddy/foundryvtt:release
+    restart: unless-stopped
+    environment:
+      FOUNDRY_USERNAME: ${FOUNDRY_USERNAME}
+      FOUNDRY_PASSWORD: ${FOUNDRY_PASSWORD}
+      FOUNDRY_ADMIN_KEY: ${FOUNDRY_ADMIN_KEY:-}
+    volumes:
+      - foundry-data:/data
+    ports:
+      - '30000:30000'
+    networks:
+      - internal
+
+  # ── foundry-mcp ─────────────────────────────────────────────────────────────
+  # MCP server + Fastify REST surface.  The foundry-api-bridge module (already
+  # deployed inside your Foundry world) dials OUT from the browser tab to
+  # ws://foundry-mcp:8765/foundry over this compose network.
+  # Port 8765 is internal only — not mapped to the host.
+  foundry-mcp:
+    build:
+      context: ..
+      dockerfile: deploy/Dockerfile.foundry-mcp
+    restart: unless-stopped
+    environment:
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      SHARED_SECRET: ${SHARED_SECRET}
+      ALLOW_EVAL: ${ALLOW_EVAL:-0}
+      HOST: 0.0.0.0
+      PORT: '8765'
+      # Give foundry-mcp read access to Foundry's data directory so it can read
+      # compendium pack SQLite files directly (faster than the WS bridge path).
+      FOUNDRY_DATA: /foundry-data
+    volumes:
+      - foundry-data:/foundry-data:ro
+    depends_on:
+      - foundry
+    networks:
+      - internal
+
+  # ── player-portal ────────────────────────────────────────────────────────────
+  # Fastify server that serves the built Vite SPA and reverse-proxies:
+  #   /api/mcp/*              → foundry-mcp (MCP REST surface)
+  #   /icons /systems /worlds → Foundry (asset resolution for prepared actors)
+  player-portal:
+    build:
+      context: ..
+      dockerfile: deploy/Dockerfile.player-portal
+    restart: unless-stopped
+    environment:
+      SHARED_SECRET: ${SHARED_SECRET}
+      # Internal wiring via compose DNS — not overridable from .env.
+      MCP_URL: http://foundry-mcp:8765
+      FOUNDRY_URL: http://foundry:30000
+      PORT: '3000'
+      HOST: 0.0.0.0
+    ports:
+      - '${PLAYER_PORTAL_PORT:-3000}:3000'
+    depends_on:
+      - foundry-mcp
+    networks:
+      - internal
+
+volumes:
+  foundry-data:
+
+networks:
+  internal:

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "tools/*"
       ],
       "devDependencies": {
-        "@electron/rebuild": "^4.0.3",
         "@eslint/js": "^10.0.1",
         "@secretlint/secretlint-rule-anthropic": "^12.3.0",
         "@secretlint/secretlint-rule-aws": "^12.3.0",


### PR DESCRIPTION
## Summary

Adds a self-contained `deploy/` directory with a three-service Docker Compose stack that lets you `docker compose up -d` on any Docker host and demo the AI tooling against a live Foundry instance. The stack wires Foundry VTT, `foundry-mcp`, and `player-portal` on one internal network with service-name DNS for inter-service communication.

## Apps touched

- `deploy/` (**new**) — `docker compose up -d` from inside this directory
  - `deploy/compose.yaml` — three-service stack
  - `deploy/Dockerfile.foundry-mcp` — logs: `docker compose logs -f foundry-mcp`
  - `deploy/Dockerfile.player-portal` — serves on `http://localhost:3000`
  - `deploy/.env.example` — copy to `deploy/.env`, fill in credentials
  - `deploy/README.md` — full usage guide

No app code was changed.

## Changes

- **`deploy/Dockerfile.foundry-mcp`** — single-stage, tsx runner. `@foundry-toolkit/shared` exports raw `.ts` files (no build step), so compiling with `tsc` and running `node dist/index.js` fails at runtime because the compiled JS still imports `@foundry-toolkit/shared/*` which resolves to `.ts` files Node cannot load. Using `tsx` (esbuild under the hood) resolves workspace package exports and compiles `.ts` on demand.
- **`deploy/Dockerfile.player-portal`** — two-stage build mirroring `apps/player-portal/Dockerfile`. The server uses `@foundry-toolkit/shared` for types only (devDep); tsc elides type-only imports so the runtime stage does not need shared's `.ts` sources.
- **`deploy/compose.yaml`** — Foundry on 30000, player-portal on `PLAYER_PORTAL_PORT` (default 3000), foundry-mcp internal-only on 8765. `foundry-data` named volume mounted read-only in foundry-mcp so it can read compendium SQLite packs directly.
- **`.dockerignore`** (repo root) — excludes `node_modules`, `.git`, `.claude`, `.env`, `dist/`, `tagger/`, `auto-wall-bin/` from the monorepo-root build context.
- **`package-lock.json`** — `@electron/rebuild` removed; it was absent from all `package.json` files and was an orphan lockfile entry.

## Test plan

- [ ] `cd deploy && cp .env.example .env` — fill in `FOUNDRY_USERNAME`, `FOUNDRY_PASSWORD`, `SHARED_SECRET`
- [ ] `docker compose build` — both images build without error
- [ ] `docker compose up -d` — all three services start
- [ ] `curl http://localhost:3000/health` returns `{"ok":true}`
- [ ] `curl -s -o /dev/null -w "%{http_code}" http://localhost:30000/` returns `200`
- [ ] `docker compose exec player-portal wget -qO- http://foundry-mcp:8765/healthz` returns `{"ok":true}`
- [ ] In Foundry Module Settings → Foundry API Bridge, set WebSocket URL to `ws://foundry-mcp:8765/foundry` and confirm bridge connects

> **Note:** Docker Desktop was stopped on the dev machine during this session so `docker compose build` could not be validated locally. The compose config validates (`docker compose config` exits 0), Prettier passes on all files, and the Dockerfile logic follows the same pattern as the proven `apps/player-portal/Dockerfile`.