### PR TITLE
refactor(player-portal): fold party stash into inventory selector

### DIFF
--- a/apps/player-portal/package.json
+++ b/apps/player-portal/package.json
@@ -25,6 +25,7 @@
     "@fastify/static": "^9.1.1",
     "dotenv": "^16.6.1",
     "fastify": "^5.3.2",
+    "lucide-react": "^1.14.0",
     "maplibre-gl": "^5.24.0",
     "pmtiles": "^4.4.1",
     "react": "^19.2.5",

--- a/apps/player-portal/src/components/sheet/SheetHeader.tsx
+++ b/apps/player-portal/src/components/sheet/SheetHeader.tsx
@@ -1,4 +1,4 @@
-import { Cog } from 'lucide-react';
+import { Settings } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import type { PreparedCharacter } from '../../api/types';
@@ -95,7 +95,7 @@ export function SheetHeader({
                     title="Settings"
                     className="flex h-7 w-7 items-center justify-center rounded border border-pf-border bg-pf-bg text-pf-text hover:bg-pf-bg-dark"
                   >
-                    <Cog size={14} aria-hidden="true" />
+                    <Settings size={14} aria-hidden="true" />
                   </button>
                 )}
                 {onBack && (

--- a/apps/player-portal/src/components/sheet/SheetHeader.tsx
+++ b/apps/player-portal/src/components/sheet/SheetHeader.tsx
@@ -1,3 +1,4 @@
+import { Cog } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import type { PreparedCharacter } from '../../api/types';
@@ -94,7 +95,7 @@ export function SheetHeader({
                     title="Settings"
                     className="flex h-7 w-7 items-center justify-center rounded border border-pf-border bg-pf-bg text-pf-text hover:bg-pf-bg-dark"
                   >
-                    <GearIcon />
+                    <Cog size={14} aria-hidden="true" />
                   </button>
                 )}
                 {onBack && (
@@ -338,25 +339,6 @@ function capitalise(s: string): string {
 }
 
 // ─── Icons ─────────────────────────────────────────────────────────────
-
-function GearIcon(): React.ReactElement {
-  return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden
-    >
-      <circle cx="12" cy="12" r="3" />
-      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
-    </svg>
-  );
-}
 
 function PersonIcon(): React.ReactElement {
   return (

--- a/apps/player-portal/src/components/tabs/Inventory.test.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.test.tsx
@@ -14,7 +14,7 @@ const BACKPACK_ID = 'l25ZlJJVpWamk5Ye';
 // (backpack-with-contents) run in list view, so they flip the toggle
 // first. This helper finds the List button and clicks it.
 function selectListView(container: HTMLElement): void {
-  const listBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === 'List');
+  const listBtn = container.querySelector<HTMLButtonElement>('button[aria-label="List view"]');
   if (!listBtn) throw new Error('List toggle button not found');
   fireEvent.click(listBtn);
 }

--- a/apps/player-portal/src/components/tabs/Inventory.test.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.test.tsx
@@ -167,33 +167,33 @@ describe('Inventory tab — party stash selector', () => {
     MockEventSourceClass.mockClear();
   });
 
-  it('shows "Party Stash" button in selector when partyId is provided', () => {
+  it('shows "Party" button in selector when partyId is provided', () => {
     const { container } = render(<Inventory items={items} partyId="party-1" />);
     const buttons = Array.from(container.querySelectorAll('[role="group"] button')).map((b) => b.textContent);
-    expect(buttons).toContain('My Inventory');
-    expect(buttons).toContain('Party Stash');
+    expect(buttons).toContain('Player');
+    expect(buttons).toContain('Party');
   });
 
-  it('does not show "Party Stash" button when no partyId', () => {
+  it('does not show "Party" button when no partyId', () => {
     const { container } = render(<Inventory items={items} />);
     const allButtons = Array.from(container.querySelectorAll('button')).map((b) => b.textContent);
-    expect(allButtons).not.toContain('Party Stash');
+    expect(allButtons).not.toContain('Party');
   });
 
   it('does not show "Shop" in selector when shop mode is off', () => {
     const { container } = render(<Inventory items={items} partyId="party-1" actorId="actor-1" onActorChanged={vi.fn()} />);
     const buttons = Array.from(container.querySelectorAll('[role="group"] button')).map((b) => b.textContent);
-    expect(buttons).toContain('My Inventory');
+    expect(buttons).toContain('Player');
     expect(buttons).not.toContain('Shop');
-    expect(buttons).toContain('Party Stash');
+    expect(buttons).toContain('Party');
   });
 
-  it('renders PartyStash panel when "Party Stash" tab is clicked', async () => {
+  it('renders PartyStash panel when "Party" tab is clicked', async () => {
     const { container } = render(<Inventory items={items} partyId="party-1" />);
     const stashBtn = Array.from(container.querySelectorAll('[role="group"] button')).find(
-      (b) => b.textContent === 'Party Stash',
+      (b) => b.textContent === 'Party',
     );
-    expect(stashBtn, 'Party Stash button').toBeTruthy();
+    expect(stashBtn, 'Party button').toBeTruthy();
     fireEvent.click(stashBtn!);
     await waitFor(() => {
       expect(api.getPartyStash).toHaveBeenCalledWith('party-1');

--- a/apps/player-portal/src/components/tabs/Inventory.test.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.test.tsx
@@ -189,7 +189,7 @@ describe('Inventory tab — party stash selector', () => {
   });
 
   it('renders PartyStash panel when "Party Stash" tab is clicked', async () => {
-    const { container } = render(<Inventory items={items} partyId="party-1" partyName="Test Party" />);
+    const { container } = render(<Inventory items={items} partyId="party-1" />);
     const stashBtn = Array.from(container.querySelectorAll('[role="group"] button')).find(
       (b) => b.textContent === 'Party Stash',
     );

--- a/apps/player-portal/src/components/tabs/Inventory.test.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import { render, cleanup, fireEvent } from '@testing-library/react';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { render, cleanup, fireEvent, waitFor } from '@testing-library/react';
 import amiri from '../../fixtures/amiri-prepared.json';
 import type { PreparedActorItem } from '../../api/types';
+import { api } from '../../api/client';
 import { Inventory } from './Inventory';
 
 const items = (amiri as unknown as { items: PreparedActorItem[] }).items;
@@ -144,5 +145,73 @@ describe('Inventory tab', () => {
     expect(weapons?.textContent).not.toContain('Hide Armor');
     expect(armor?.textContent).toContain('Hide Armor');
     expect(armor?.textContent).not.toContain('Bastard Sword');
+  });
+});
+
+describe('Inventory tab — party stash selector', () => {
+  const MockEventSourceClass = vi.fn(function (this: Record<string, unknown>) {
+    this.close = vi.fn();
+    this.onmessage = null;
+    this.onerror = null;
+  });
+
+  beforeEach(() => {
+    vi.stubGlobal('EventSource', MockEventSourceClass);
+    vi.spyOn(api, 'getPartyStash').mockResolvedValue({ items: [] });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    MockEventSourceClass.mockClear();
+  });
+
+  it('shows "Party Stash" button in selector when partyId is provided', () => {
+    const { container } = render(<Inventory items={items} partyId="party-1" />);
+    const buttons = Array.from(container.querySelectorAll('[role="group"] button')).map((b) => b.textContent);
+    expect(buttons).toContain('My Inventory');
+    expect(buttons).toContain('Party Stash');
+  });
+
+  it('does not show "Party Stash" button when no partyId', () => {
+    const { container } = render(<Inventory items={items} />);
+    const allButtons = Array.from(container.querySelectorAll('button')).map((b) => b.textContent);
+    expect(allButtons).not.toContain('Party Stash');
+  });
+
+  it('does not show "Shop" in selector when shop mode is off', () => {
+    const { container } = render(<Inventory items={items} partyId="party-1" actorId="actor-1" onActorChanged={vi.fn()} />);
+    const buttons = Array.from(container.querySelectorAll('[role="group"] button')).map((b) => b.textContent);
+    expect(buttons).toContain('My Inventory');
+    expect(buttons).not.toContain('Shop');
+    expect(buttons).toContain('Party Stash');
+  });
+
+  it('renders PartyStash panel when "Party Stash" tab is clicked', async () => {
+    const { container } = render(<Inventory items={items} partyId="party-1" partyName="Test Party" />);
+    const stashBtn = Array.from(container.querySelectorAll('[role="group"] button')).find(
+      (b) => b.textContent === 'Party Stash',
+    );
+    expect(stashBtn, 'Party Stash button').toBeTruthy();
+    fireEvent.click(stashBtn!);
+    await waitFor(() => {
+      expect(api.getPartyStash).toHaveBeenCalledWith('party-1');
+    });
+    expect(container.textContent).toContain('stash is empty');
+  });
+
+  it('does not render the party stash section above the inventory controls', () => {
+    render(<Inventory items={items} partyId="party-1" />);
+    // PartyStash should not be mounted in inventory view (only when tab is active).
+    // Verify the stash API was not called on initial render (inventory tab is default).
+    expect(api.getPartyStash).not.toHaveBeenCalled();
+  });
+
+  it('shows selector with only "My Inventory" when no partyId and no shop mode', () => {
+    const { container } = render(<Inventory items={items} />);
+    // No selector group should be rendered at all (no shop mode, no party).
+    const group = container.querySelector('[role="group"][aria-label="Shop view"]');
+    expect(group).toBeNull();
   });
 });

--- a/apps/player-portal/src/components/tabs/Inventory.test.tsx
+++ b/apps/player-portal/src/components/tabs/Inventory.test.tsx
@@ -167,33 +167,31 @@ describe('Inventory tab — party stash selector', () => {
     MockEventSourceClass.mockClear();
   });
 
-  it('shows "Party" button in selector when partyId is provided', () => {
+  it('shows Player and Party buttons in selector when partyId is provided', () => {
     const { container } = render(<Inventory items={items} partyId="party-1" />);
-    const buttons = Array.from(container.querySelectorAll('[role="group"] button')).map((b) => b.textContent);
-    expect(buttons).toContain('Player');
-    expect(buttons).toContain('Party');
+    const labels = Array.from(container.querySelectorAll('[role="group"] button')).map((b) => b.getAttribute('aria-label'));
+    expect(labels).toContain('Player inventory');
+    expect(labels).toContain('Party stash');
   });
 
-  it('does not show "Party" button when no partyId', () => {
+  it('does not show Party button when no partyId', () => {
     const { container } = render(<Inventory items={items} />);
-    const allButtons = Array.from(container.querySelectorAll('button')).map((b) => b.textContent);
-    expect(allButtons).not.toContain('Party');
+    const labels = Array.from(container.querySelectorAll('button')).map((b) => b.getAttribute('aria-label'));
+    expect(labels).not.toContain('Party stash');
   });
 
-  it('does not show "Shop" in selector when shop mode is off', () => {
+  it('does not show Shop button in selector when shop mode is off', () => {
     const { container } = render(<Inventory items={items} partyId="party-1" actorId="actor-1" onActorChanged={vi.fn()} />);
-    const buttons = Array.from(container.querySelectorAll('[role="group"] button')).map((b) => b.textContent);
-    expect(buttons).toContain('Player');
-    expect(buttons).not.toContain('Shop');
-    expect(buttons).toContain('Party');
+    const labels = Array.from(container.querySelectorAll('[role="group"] button')).map((b) => b.getAttribute('aria-label'));
+    expect(labels).toContain('Player inventory');
+    expect(labels).not.toContain('Shop');
+    expect(labels).toContain('Party stash');
   });
 
-  it('renders PartyStash panel when "Party" tab is clicked', async () => {
+  it('renders PartyStash panel when Party button is clicked', async () => {
     const { container } = render(<Inventory items={items} partyId="party-1" />);
-    const stashBtn = Array.from(container.querySelectorAll('[role="group"] button')).find(
-      (b) => b.textContent === 'Party',
-    );
-    expect(stashBtn, 'Party button').toBeTruthy();
+    const stashBtn = container.querySelector<HTMLButtonElement>('button[aria-label="Party stash"]');
+    expect(stashBtn, 'Party stash button').toBeTruthy();
     fireEvent.click(stashBtn!);
     await waitFor(() => {
       expect(api.getPartyStash).toHaveBeenCalledWith('party-1');

--- a/apps/player-portal/src/components/tabs/inventory/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/inventory/Inventory.tsx
@@ -27,10 +27,9 @@ interface Props {
   onActorChanged?: () => void;
   investiture?: PointPool;
   /** Party actor ID, when the character is a member of a party. Drives the
-   *  stash section rendered above personal inventory. Undefined = no party
-   *  (or lookup still in flight) — stash section is hidden. */
+   *  Party Stash tab. Undefined = no party (or lookup still in flight) —
+   *  Party Stash tab is hidden. */
   partyId?: string;
-  partyName?: string;
 }
 
 // Inventory tab — reads `items[]`, filters to physical item types
@@ -44,7 +43,7 @@ interface Props {
 // inventory.hbs, but flattened — our read-only viewer doesn't need
 // stow/carry/drop controls or quantity adjusters.
 //
-export function Inventory({ items, actorId, onActorChanged, investiture, partyId, partyName }: Props): React.ReactElement {
+export function Inventory({ items, actorId, onActorChanged, investiture, partyId }: Props): React.ReactElement {
   // One uuid-hover instance for every expanded item description —
   // event delegation on the section picks up anchors produced by
   // `enrichDescription` regardless of which item was expanded.
@@ -234,7 +233,6 @@ export function Inventory({ items, actorId, onActorChanged, investiture, partyId
           {effectiveShopView === 'party-stash' && partyId !== undefined ? (
             <PartyStash
               partyId={partyId}
-              partyName={partyName}
               refreshKey={stashNonce}
               {...(actorId !== undefined ? { actorId } : {})}
               {...(onActorChanged !== undefined ? { onActorChanged } : {})}

--- a/apps/player-portal/src/components/tabs/inventory/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/inventory/Inventory.tsx
@@ -213,22 +213,20 @@ export function Inventory({ items, actorId, onActorChanged, investiture, partyId
                   showPartyStash={partyId !== undefined}
                 />
               )}
+              {effectiveShopView === 'inventory' && <ViewToggle view={view} onChange={setView} />}
               <ShopGearMenu shopMode={shopMode} tileColumns={tileColumns} onTileColumnsChange={setTileColumns} />
             </div>
-            <div className="flex items-center gap-4">
-              {investiture !== undefined && investiture.max > 0 && (
-                <div className="flex items-center gap-2" data-stat="investiture">
-                  <span className="text-[11px] font-semibold uppercase tracking-widest text-pf-text-muted">
-                    Invested
-                  </span>
-                  <span className="font-mono text-sm tabular-nums text-pf-text">
-                    {investedCount}
-                    <span className="text-pf-text-muted">/{investiture.max}</span>
-                  </span>
-                </div>
-              )}
-              {effectiveShopView === 'inventory' && <ViewToggle view={view} onChange={setView} />}
-            </div>
+            {investiture !== undefined && investiture.max > 0 && effectiveShopView !== 'party-stash' && (
+              <div className="flex items-center gap-2" data-stat="investiture">
+                <span className="text-[11px] font-semibold uppercase tracking-widest text-pf-text-muted">
+                  Invested
+                </span>
+                <span className="font-mono text-sm tabular-nums text-pf-text">
+                  {investedCount}
+                  <span className="text-pf-text-muted">/{investiture.max}</span>
+                </span>
+              </div>
+            )}
           </div>
           {effectiveShopView === 'party-stash' && partyId !== undefined ? (
             <PartyStash

--- a/apps/player-portal/src/components/tabs/inventory/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/inventory/Inventory.tsx
@@ -175,10 +175,18 @@ export function Inventory({ items, actorId, onActorChanged, investiture, partyId
   const topLevelByCategory = groupByCategory(topLevel);
   const allByCategory = groupByCategory(nonCoin);
 
-  // When shop mode is off or we can't transact, force back to the
-  // inventory pane so the toggle doesn't strand the user on an empty
-  // shop tab.
-  const effectiveShopView: ShopView = shopMode.enabled && canTransact ? shopView : 'inventory';
+  // Force back to 'inventory' when the chosen pane's prerequisite is gone:
+  // - 'shop' requires shop mode + transact rights
+  // - 'party-stash' requires a known party actor
+  const effectiveShopView: ShopView =
+    shopView === 'party-stash' && partyId !== undefined
+      ? 'party-stash'
+      : shopMode.enabled && canTransact && shopView === 'shop'
+        ? 'shop'
+        : 'inventory';
+
+  // Whether the segmented selector is rendered at all.
+  const hasSelector = (shopMode.enabled && canTransact) || partyId !== undefined;
 
   return (
     <section
@@ -186,28 +194,26 @@ export function Inventory({ items, actorId, onActorChanged, investiture, partyId
       onMouseOver={uuidHover.delegationHandlers.onMouseOver}
       onMouseOut={uuidHover.delegationHandlers.onMouseOut}
     >
-      {partyId !== undefined && (
-        <PartyStash
-          partyId={partyId}
-          partyName={partyName}
-          refreshKey={stashNonce}
-          {...(actorId !== undefined ? { actorId } : {})}
-          {...(onActorChanged !== undefined ? { onActorChanged } : {})}
-        />
-      )}
       {txError !== null && (
         <p className="rounded border border-red-200 bg-red-50 px-2 py-1 text-xs text-red-800" data-role="tx-error">
           {txError}
         </p>
       )}
-      {physical.length === 0 && effectiveShopView === 'inventory' ? (
+      {physical.length === 0 && effectiveShopView === 'inventory' && !hasSelector ? (
         <p className="text-sm text-pf-text-muted">No items yet.</p>
       ) : (
         <>
           <div className="flex flex-wrap items-center justify-between gap-4">
             <div className="flex items-center gap-3">
               {coins.length > 0 && <CoinStrip coins={coins} />}
-              {shopMode.enabled && canTransact && <ShopViewToggle view={effectiveShopView} onChange={setShopView} />}
+              {hasSelector && (
+                <ShopViewToggle
+                  view={effectiveShopView}
+                  onChange={setShopView}
+                  showShop={shopMode.enabled && canTransact}
+                  showPartyStash={partyId !== undefined}
+                />
+              )}
               <ShopGearMenu shopMode={shopMode} tileColumns={tileColumns} onTileColumnsChange={setTileColumns} />
             </div>
             <div className="flex items-center gap-4">
@@ -225,13 +231,23 @@ export function Inventory({ items, actorId, onActorChanged, investiture, partyId
               {effectiveShopView === 'inventory' && <ViewToggle view={view} onChange={setView} />}
             </div>
           </div>
-          {effectiveShopView === 'shop' && canTransact ? (
+          {effectiveShopView === 'party-stash' && partyId !== undefined ? (
+            <PartyStash
+              partyId={partyId}
+              partyName={partyName}
+              refreshKey={stashNonce}
+              {...(actorId !== undefined ? { actorId } : {})}
+              {...(onActorChanged !== undefined ? { onActorChanged } : {})}
+            />
+          ) : effectiveShopView === 'shop' && canTransact ? (
             <ItemShopPicker
               items={items}
               onBuy={handleBuy}
               pending={pendingBuys}
               disabledRarities={shopMode.disabledRarities}
             />
+          ) : physical.length === 0 ? (
+            <p className="text-sm text-pf-text-muted">No items yet.</p>
           ) : (
             <CategorizedInventory
               view={view}

--- a/apps/player-portal/src/components/tabs/inventory/Inventory.tsx
+++ b/apps/player-portal/src/components/tabs/inventory/Inventory.tsx
@@ -202,21 +202,19 @@ export function Inventory({ items, actorId, onActorChanged, investiture, partyId
         <p className="text-sm text-pf-text-muted">No items yet.</p>
       ) : (
         <>
-          <div className="flex flex-wrap items-center justify-between gap-4">
-            <div className="flex items-center gap-3">
-              {coins.length > 0 && <CoinStrip coins={coins} />}
-              {hasSelector && (
-                <ShopViewToggle
-                  view={effectiveShopView}
-                  onChange={setShopView}
-                  showShop={shopMode.enabled && canTransact}
-                  showPartyStash={partyId !== undefined}
-                />
-              )}
-              {effectiveShopView === 'inventory' && <ViewToggle view={view} onChange={setView} />}
-              <ShopGearMenu shopMode={shopMode} tileColumns={tileColumns} onTileColumnsChange={setTileColumns} />
-            </div>
-            {investiture !== undefined && investiture.max > 0 && effectiveShopView !== 'party-stash' && (
+          <div className="flex flex-wrap items-center gap-3">
+            {coins.length > 0 && <CoinStrip coins={coins} />}
+            {hasSelector && (
+              <ShopViewToggle
+                view={effectiveShopView}
+                onChange={setShopView}
+                showShop={shopMode.enabled && canTransact}
+                showPartyStash={partyId !== undefined}
+              />
+            )}
+            {effectiveShopView !== 'shop' && <ViewToggle view={view} onChange={setView} />}
+            <ShopGearMenu shopMode={shopMode} tileColumns={tileColumns} onTileColumnsChange={setTileColumns} />
+            {investiture !== undefined && investiture.max > 0 && (
               <div className="flex items-center gap-2" data-stat="investiture">
                 <span className="text-[11px] font-semibold uppercase tracking-widest text-pf-text-muted">
                   Invested

--- a/apps/player-portal/src/components/tabs/inventory/InventoryControls.tsx
+++ b/apps/player-portal/src/components/tabs/inventory/InventoryControls.tsx
@@ -51,7 +51,7 @@ export function ViewToggle({
   view: ViewMode;
   onChange: (v: ViewMode) => void;
 }): React.ReactElement {
-  const base = 'flex items-center justify-center px-2 py-1 transition-colors';
+  const base = 'flex items-center justify-center px-2 py-2 transition-colors';
   const active = 'bg-pf-primary text-white';
   const inactive = 'text-pf-alt-dark hover:bg-pf-bg-dark/60';
   return (
@@ -98,7 +98,7 @@ export function ShopViewToggle({
   showShop?: boolean;
   showPartyStash?: boolean;
 }): React.ReactElement {
-  const base = 'flex items-center justify-center px-2 py-1 transition-colors';
+  const base = 'flex items-center justify-center px-2 py-2 transition-colors';
   const active = 'bg-pf-primary text-white';
   const inactive = 'text-pf-alt-dark hover:bg-pf-bg-dark/60';
   return (
@@ -166,7 +166,7 @@ export function ShopGearMenu({
   return (
     <details className="relative" data-section="shop-debug">
       <summary
-        className="flex h-8 w-8 cursor-pointer list-none items-center justify-center rounded border border-pf-border bg-pf-bg text-base leading-none text-pf-alt-dark hover:bg-pf-bg-dark/40"
+        className="flex h-9 w-9 cursor-pointer list-none items-center justify-center rounded border border-pf-border bg-pf-bg text-base leading-none text-pf-alt-dark hover:bg-pf-bg-dark/40"
         title="Shop settings"
         aria-label="Shop settings"
         data-testid="shop-gear"

--- a/apps/player-portal/src/components/tabs/inventory/InventoryControls.tsx
+++ b/apps/player-portal/src/components/tabs/inventory/InventoryControls.tsx
@@ -115,18 +115,6 @@ export function ShopViewToggle({
       >
         My Inventory
       </button>
-      {showShop && (
-        <button
-          type="button"
-          className={`${base} border-l border-pf-border ${view === 'shop' ? active : inactive}`}
-          aria-pressed={view === 'shop'}
-          onClick={(): void => {
-            onChange('shop');
-          }}
-        >
-          Shop
-        </button>
-      )}
       {showPartyStash && (
         <button
           type="button"
@@ -137,6 +125,18 @@ export function ShopViewToggle({
           }}
         >
           Party Stash
+        </button>
+      )}
+      {showShop && (
+        <button
+          type="button"
+          className={`${base} border-l border-pf-border ${view === 'shop' ? active : inactive}`}
+          aria-pressed={view === 'shop'}
+          onClick={(): void => {
+            onChange('shop');
+          }}
+        >
+          Shop
         </button>
       )}
     </div>

--- a/apps/player-portal/src/components/tabs/inventory/InventoryControls.tsx
+++ b/apps/player-portal/src/components/tabs/inventory/InventoryControls.tsx
@@ -1,4 +1,4 @@
-import { LayoutGrid, List, Settings, ShoppingBag, User, UsersRound } from 'lucide-react';
+import { LayoutGrid, List, Settings, ShoppingBag, UserRound, UsersRound } from 'lucide-react';
 import type { PhysicalItem } from '../../../api/types';
 import { useShopMode } from '../../../lib/useShopMode';
 import type { ViewMode, ShopView } from './inventory-categories';
@@ -117,7 +117,7 @@ export function ShopViewToggle({
           onChange('inventory');
         }}
       >
-        <User size={14} aria-hidden="true" />
+        <UserRound size={14} aria-hidden="true" />
       </button>
       {showPartyStash && (
         <button

--- a/apps/player-portal/src/components/tabs/inventory/InventoryControls.tsx
+++ b/apps/player-portal/src/components/tabs/inventory/InventoryControls.tsx
@@ -1,4 +1,4 @@
-import { CircleUserRound, LayoutGrid, List, Vault } from 'lucide-react';
+import { CircleUserRound, LayoutGrid, List, ShoppingBag, Vault } from 'lucide-react';
 import type { PhysicalItem } from '../../../api/types';
 import { useShopMode } from '../../../lib/useShopMode';
 import type { ViewMode, ShopView } from './inventory-categories';
@@ -98,7 +98,7 @@ export function ShopViewToggle({
   showShop?: boolean;
   showPartyStash?: boolean;
 }): React.ReactElement {
-  const base = 'flex items-center gap-1.5 px-2 py-1 text-xs font-medium uppercase tracking-widest transition-colors';
+  const base = 'flex items-center justify-center px-2 py-1 transition-colors';
   const active = 'bg-pf-primary text-white';
   const inactive = 'text-pf-alt-dark hover:bg-pf-bg-dark/60';
   return (
@@ -117,8 +117,7 @@ export function ShopViewToggle({
           onChange('inventory');
         }}
       >
-        <CircleUserRound size={13} aria-hidden="true" />
-        Player
+        <CircleUserRound size={14} aria-hidden="true" />
       </button>
       {showPartyStash && (
         <button
@@ -130,8 +129,7 @@ export function ShopViewToggle({
             onChange('party-stash');
           }}
         >
-          <Vault size={13} aria-hidden="true" />
-          Party
+          <Vault size={14} aria-hidden="true" />
         </button>
       )}
       {showShop && (
@@ -139,11 +137,12 @@ export function ShopViewToggle({
           type="button"
           className={`${base} border-l border-pf-border ${view === 'shop' ? active : inactive}`}
           aria-pressed={view === 'shop'}
+          aria-label="Shop"
           onClick={(): void => {
             onChange('shop');
           }}
         >
-          Shop
+          <ShoppingBag size={14} aria-hidden="true" />
         </button>
       )}
     </div>

--- a/apps/player-portal/src/components/tabs/inventory/InventoryControls.tsx
+++ b/apps/player-portal/src/components/tabs/inventory/InventoryControls.tsx
@@ -1,4 +1,4 @@
-import { LayoutGrid, List } from 'lucide-react';
+import { CircleUserRound, LayoutGrid, List, Vault } from 'lucide-react';
 import type { PhysicalItem } from '../../../api/types';
 import { useShopMode } from '../../../lib/useShopMode';
 import type { ViewMode, ShopView } from './inventory-categories';
@@ -98,7 +98,7 @@ export function ShopViewToggle({
   showShop?: boolean;
   showPartyStash?: boolean;
 }): React.ReactElement {
-  const base = 'px-2 py-1 text-xs font-medium uppercase tracking-widest transition-colors';
+  const base = 'flex items-center gap-1.5 px-2 py-1 text-xs font-medium uppercase tracking-widest transition-colors';
   const active = 'bg-pf-primary text-white';
   const inactive = 'text-pf-alt-dark hover:bg-pf-bg-dark/60';
   return (
@@ -112,10 +112,12 @@ export function ShopViewToggle({
         type="button"
         className={`${base} ${view === 'inventory' ? active : inactive}`}
         aria-pressed={view === 'inventory'}
+        aria-label="Player inventory"
         onClick={(): void => {
           onChange('inventory');
         }}
       >
+        <CircleUserRound size={13} aria-hidden="true" />
         Player
       </button>
       {showPartyStash && (
@@ -123,10 +125,12 @@ export function ShopViewToggle({
           type="button"
           className={`${base} border-l border-pf-border ${view === 'party-stash' ? active : inactive}`}
           aria-pressed={view === 'party-stash'}
+          aria-label="Party stash"
           onClick={(): void => {
             onChange('party-stash');
           }}
         >
+          <Vault size={13} aria-hidden="true" />
           Party
         </button>
       )}

--- a/apps/player-portal/src/components/tabs/inventory/InventoryControls.tsx
+++ b/apps/player-portal/src/components/tabs/inventory/InventoryControls.tsx
@@ -113,7 +113,7 @@ export function ShopViewToggle({
           onChange('inventory');
         }}
       >
-        My Inventory
+        Player
       </button>
       {showPartyStash && (
         <button
@@ -124,7 +124,7 @@ export function ShopViewToggle({
             onChange('party-stash');
           }}
         >
-          Party Stash
+          Party
         </button>
       )}
       {showShop && (

--- a/apps/player-portal/src/components/tabs/inventory/InventoryControls.tsx
+++ b/apps/player-portal/src/components/tabs/inventory/InventoryControls.tsx
@@ -87,9 +87,13 @@ export function ViewToggle({
 export function ShopViewToggle({
   view,
   onChange,
+  showShop = true,
+  showPartyStash = false,
 }: {
   view: ShopView;
   onChange: (v: ShopView) => void;
+  showShop?: boolean;
+  showPartyStash?: boolean;
 }): React.ReactElement {
   const base = 'px-2 py-1 text-xs font-medium uppercase tracking-widest transition-colors';
   const active = 'bg-pf-primary text-white';
@@ -111,16 +115,30 @@ export function ShopViewToggle({
       >
         My Inventory
       </button>
-      <button
-        type="button"
-        className={`${base} border-l border-pf-border ${view === 'shop' ? active : inactive}`}
-        aria-pressed={view === 'shop'}
-        onClick={(): void => {
-          onChange('shop');
-        }}
-      >
-        Shop
-      </button>
+      {showShop && (
+        <button
+          type="button"
+          className={`${base} border-l border-pf-border ${view === 'shop' ? active : inactive}`}
+          aria-pressed={view === 'shop'}
+          onClick={(): void => {
+            onChange('shop');
+          }}
+        >
+          Shop
+        </button>
+      )}
+      {showPartyStash && (
+        <button
+          type="button"
+          className={`${base} border-l border-pf-border ${view === 'party-stash' ? active : inactive}`}
+          aria-pressed={view === 'party-stash'}
+          onClick={(): void => {
+            onChange('party-stash');
+          }}
+        >
+          Party Stash
+        </button>
+      )}
     </div>
   );
 }

--- a/apps/player-portal/src/components/tabs/inventory/InventoryControls.tsx
+++ b/apps/player-portal/src/components/tabs/inventory/InventoryControls.tsx
@@ -1,4 +1,4 @@
-import { CircleUserRound, LayoutGrid, List, ShoppingBag, Vault } from 'lucide-react';
+import { CircleUserRound, LayoutGrid, List, Settings, ShoppingBag, Vault } from 'lucide-react';
 import type { PhysicalItem } from '../../../api/types';
 import { useShopMode } from '../../../lib/useShopMode';
 import type { ViewMode, ShopView } from './inventory-categories';
@@ -171,7 +171,7 @@ export function ShopGearMenu({
         aria-label="Shop settings"
         data-testid="shop-gear"
       >
-        <span aria-hidden="true">⚙</span>
+        <Settings size={14} aria-hidden="true" />
       </summary>
       <div
         className="absolute right-0 top-full z-20 mt-1 w-64 rounded border border-pf-border bg-pf-bg p-3 text-xs text-pf-text shadow-lg"

--- a/apps/player-portal/src/components/tabs/inventory/InventoryControls.tsx
+++ b/apps/player-portal/src/components/tabs/inventory/InventoryControls.tsx
@@ -1,4 +1,4 @@
-import { CircleUserRound, LayoutGrid, List, Settings, ShoppingBag, Vault } from 'lucide-react';
+import { LayoutGrid, List, Settings, ShoppingBag, User, UsersRound } from 'lucide-react';
 import type { PhysicalItem } from '../../../api/types';
 import { useShopMode } from '../../../lib/useShopMode';
 import type { ViewMode, ShopView } from './inventory-categories';
@@ -117,7 +117,7 @@ export function ShopViewToggle({
           onChange('inventory');
         }}
       >
-        <CircleUserRound size={14} aria-hidden="true" />
+        <User size={14} aria-hidden="true" />
       </button>
       {showPartyStash && (
         <button
@@ -129,7 +129,7 @@ export function ShopViewToggle({
             onChange('party-stash');
           }}
         >
-          <Vault size={14} aria-hidden="true" />
+          <UsersRound size={14} aria-hidden="true" />
         </button>
       )}
       {showShop && (

--- a/apps/player-portal/src/components/tabs/inventory/InventoryControls.tsx
+++ b/apps/player-portal/src/components/tabs/inventory/InventoryControls.tsx
@@ -1,4 +1,4 @@
-import { CircleUserRound, LayoutGrid, List, Settings, ShoppingBag, Vault } from 'lucide-react';
+import { CircleUserRound, Cog, LayoutGrid, List, ShoppingBag, Vault } from 'lucide-react';
 import type { PhysicalItem } from '../../../api/types';
 import { useShopMode } from '../../../lib/useShopMode';
 import type { ViewMode, ShopView } from './inventory-categories';
@@ -171,7 +171,7 @@ export function ShopGearMenu({
         aria-label="Shop settings"
         data-testid="shop-gear"
       >
-        <Settings size={14} aria-hidden="true" />
+        <Cog size={14} aria-hidden="true" />
       </summary>
       <div
         className="absolute right-0 top-full z-20 mt-1 w-64 rounded border border-pf-border bg-pf-bg p-3 text-xs text-pf-text shadow-lg"

--- a/apps/player-portal/src/components/tabs/inventory/InventoryControls.tsx
+++ b/apps/player-portal/src/components/tabs/inventory/InventoryControls.tsx
@@ -1,3 +1,4 @@
+import { LayoutGrid, List } from 'lucide-react';
 import type { PhysicalItem } from '../../../api/types';
 import { useShopMode } from '../../../lib/useShopMode';
 import type { ViewMode, ShopView } from './inventory-categories';
@@ -50,7 +51,7 @@ export function ViewToggle({
   view: ViewMode;
   onChange: (v: ViewMode) => void;
 }): React.ReactElement {
-  const base = 'px-2 py-1 text-xs font-medium uppercase tracking-widest transition-colors';
+  const base = 'flex items-center justify-center px-2 py-1 transition-colors';
   const active = 'bg-pf-primary text-white';
   const inactive = 'text-pf-alt-dark hover:bg-pf-bg-dark/60';
   return (
@@ -64,21 +65,23 @@ export function ViewToggle({
         type="button"
         className={`${base} ${view === 'grid' ? active : inactive}`}
         aria-pressed={view === 'grid'}
+        aria-label="Grid view"
         onClick={(): void => {
           onChange('grid');
         }}
       >
-        Grid
+        <LayoutGrid size={14} aria-hidden="true" />
       </button>
       <button
         type="button"
         className={`${base} border-l border-pf-border ${view === 'list' ? active : inactive}`}
         aria-pressed={view === 'list'}
+        aria-label="List view"
         onClick={(): void => {
           onChange('list');
         }}
       >
-        List
+        <List size={14} aria-hidden="true" />
       </button>
     </div>
   );

--- a/apps/player-portal/src/components/tabs/inventory/InventoryControls.tsx
+++ b/apps/player-portal/src/components/tabs/inventory/InventoryControls.tsx
@@ -1,4 +1,4 @@
-import { CircleUserRound, Cog, LayoutGrid, List, ShoppingBag, Vault } from 'lucide-react';
+import { CircleUserRound, LayoutGrid, List, Settings, ShoppingBag, Vault } from 'lucide-react';
 import type { PhysicalItem } from '../../../api/types';
 import { useShopMode } from '../../../lib/useShopMode';
 import type { ViewMode, ShopView } from './inventory-categories';
@@ -171,7 +171,7 @@ export function ShopGearMenu({
         aria-label="Shop settings"
         data-testid="shop-gear"
       >
-        <Cog size={14} aria-hidden="true" />
+        <Settings size={14} aria-hidden="true" />
       </summary>
       <div
         className="absolute right-0 top-full z-20 mt-1 w-64 rounded border border-pf-border bg-pf-bg p-3 text-xs text-pf-text shadow-lg"

--- a/apps/player-portal/src/components/tabs/inventory/PartyStash.tsx
+++ b/apps/player-portal/src/components/tabs/inventory/PartyStash.tsx
@@ -7,7 +7,6 @@ import { CATEGORY_ORDER, CATEGORY_LABEL, type InventoryCategory } from './invent
 
 interface Props {
   partyId: string;
-  partyName: string | undefined;
   /** Increment to force an immediate re-fetch (e.g. after a transfer from the
    *  character sheet). transferItemToActor fires createItem hooks, not
    *  updateActor, so the actors-channel SSE won't deliver an event here. */
@@ -148,7 +147,7 @@ function StashTile({
   );
 }
 
-export function PartyStash({ partyId, partyName, refreshKey, actorId, onActorChanged }: Props): React.ReactElement {
+export function PartyStash({ partyId, refreshKey, actorId, onActorChanged }: Props): React.ReactElement {
   const [items, setItems] = useState<PartyStashItem[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [pendingTakes, setPendingTakes] = useState<Set<string>>(new Set());
@@ -205,36 +204,35 @@ export function PartyStash({ partyId, partyName, refreshKey, actorId, onActorCha
   const byCategory = groupByCategory(physical);
   const presentCategories = CATEGORY_ORDER.filter((c) => (byCategory.get(c)?.length ?? 0) > 0);
 
+  if (isLoading) {
+    return <p className="text-sm text-pf-text-muted">Loading…</p>;
+  }
+
+  if (physical.length === 0) {
+    return <p className="text-sm text-pf-text-muted">The stash is empty.</p>;
+  }
+
   return (
-    <div className="mb-4 rounded-lg border border-pf-border bg-pf-bg-dark p-4">
-      <SectionHeader band>{partyName !== undefined ? `${partyName} Stash` : 'Party Stash'}</SectionHeader>
-      {isLoading && <p className="mt-2 text-sm text-pf-text-muted">Loading…</p>}
-      {!isLoading && physical.length === 0 && (
-        <p className="mt-2 text-sm text-pf-text-muted">The stash is empty.</p>
-      )}
-      {!isLoading && presentCategories.length > 0 && (
-        <div className="mt-3 space-y-4">
-          {presentCategories.map((category) => {
-            const bucket = byCategory.get(category) ?? [];
-            return (
-              <div key={category}>
-                <SectionHeader band>{CATEGORY_LABEL[category]}</SectionHeader>
-                <ul className="mt-2 grid grid-cols-6 gap-2">
-                  {bucket.map((item) => (
-                    <StashTile
-                      key={item.id}
-                      item={item}
-                      actorId={actorId}
-                      onTake={handleTake}
-                      pending={pendingTakes.has(item.id)}
-                    />
-                  ))}
-                </ul>
-              </div>
-            );
-          })}
-        </div>
-      )}
+    <div className="space-y-4 *:rounded-lg *:border *:border-pf-border *:bg-pf-bg-dark *:p-4">
+      {presentCategories.map((category) => {
+        const bucket = byCategory.get(category) ?? [];
+        return (
+          <div key={category} data-category={category}>
+            <SectionHeader band>{CATEGORY_LABEL[category]}</SectionHeader>
+            <ul className="mt-2 grid grid-cols-6 gap-2">
+              {bucket.map((item) => (
+                <StashTile
+                  key={item.id}
+                  item={item}
+                  actorId={actorId}
+                  onTake={handleTake}
+                  pending={pendingTakes.has(item.id)}
+                />
+              ))}
+            </ul>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/apps/player-portal/src/components/tabs/inventory/inventory-categories.ts
+++ b/apps/player-portal/src/components/tabs/inventory/inventory-categories.ts
@@ -10,7 +10,7 @@ export type InventoryCategory =
   | 'treasure';
 
 export type ViewMode = 'list' | 'grid';
-export type ShopView = 'inventory' | 'shop';
+export type ShopView = 'inventory' | 'shop' | 'party-stash';
 
 // Category buckets for the inventory separators. Related pf2e item
 // types share a bucket ("Armor & Shields", "Consumables" holds ammo)

--- a/apps/player-portal/src/routes/CharacterSheet.tsx
+++ b/apps/player-portal/src/routes/CharacterSheet.tsx
@@ -224,7 +224,7 @@ function CharacterSheetInner({ actorId, onBack, preferences }: InnerProps): Reac
                   actorId={actorId}
                   onActorChanged={reloadActor}
                   investiture={state.actor.system.resources.investiture}
-                  {...(party !== null ? { partyId: party.id, partyName: party.name } : {})}
+                  {...(party !== null ? { partyId: party.id } : {})}
                 />
                 {!shopMode.enabled && (
                   <div className="mt-10 border-t border-pf-border pt-6">

--- a/package-lock.json
+++ b/package-lock.json
@@ -157,6 +157,7 @@
         "@fastify/static": "^9.1.1",
         "dotenv": "^16.6.1",
         "fastify": "^5.3.2",
+        "lucide-react": "^1.14.0",
         "maplibre-gl": "^5.24.0",
         "pmtiles": "^4.4.1",
         "react": "^19.2.5",
@@ -15627,9 +15628,9 @@
       "license": "ISC"
     },
     "node_modules/lucide-react": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.12.0.tgz",
-      "integrity": "sha512-rTKR3RN6HIAxdNZALoPvqxd64vjL9nTThU0JF9q1Qg8yUnmo1r+d8baN72YNVK3RGxUmzBzbd77IWJq/fkm+Xw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.14.0.tgz",
+      "integrity": "sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"


### PR DESCRIPTION
## Summary

Party Stash moves from a permanent section above personal inventory into a tab in the inventory segmented control. The selector becomes an icon-only strip: **UserRound (Player) | UsersRound (Party) | ShoppingBag (Shop)**, with Shop only appearing when shop mode is active. Switching tabs renders the corresponding content in the same frame — no fork of PartyStash's implementation.

The controls row is also cleaned up: Grid/List toggle uses lucide icons and sits between the tab selector and the gear menu; the Invested counter moves inline after the gear and is always visible. The gear icon (ShopGearMenu + SheetHeader settings button) now both use the lucide `Settings` icon.

**Apps touched**
- `apps/player-portal` — `npm run dev:player-portal` (or `:mock`)

## Changes

**Core integration**
- `inventory-categories.ts` — adds `'party-stash'` to `ShopView` union
- `Inventory.tsx` — removes standalone PartyStash block; selector visible when shop mode OR partyId present; `effectiveShopView` resolves `'party-stash'`; empty-state guard accounts for `hasSelector`
- `PartyStash.tsx` — removes outer card wrapper and named header; each category renders as its own rounded card matching the CategorizedInventory style; drops `partyName` prop
- `CharacterSheet.tsx` — removes `partyName` from the Inventory spread

**Controls polish**
- `InventoryControls.tsx` — `ShopViewToggle` gains `showShop`/`showPartyStash` props; all three tab buttons are icon-only (`UserRound`, `UsersRound`, `ShoppingBag`); `ViewToggle` uses `LayoutGrid`/`List` lucide icons and moves to the left of the gear; gear uses lucide `Settings`; all icon controls height-matched to CoinStrip (`py-2` / `h-9`)
- `SheetHeader.tsx` — replaces handwritten GearIcon SVG with the same lucide `Settings` import

**Dependencies**
- Adds `lucide-react ^1.14.0` to `apps/player-portal`

## Before / After

**Before:** Party Stash was a permanent collapsible section pinned above My Inventory. Controls row had text labels (Grid, List, My Inventory, Shop) and a Unicode ⚙.

**After:** Three icon tabs (Player / Party / Shop). Grid/List toggle is icon-only, left of the gear. Gear is consistent with the sheet header. Invested counter sits inline after the gear, always visible (not hidden in party view).

## Test plan
- [ ] `npm run dev:player-portal:mock` → Inventory tab → icon selector shows UserRound + UsersRound tabs
- [ ] Clicking Party tab renders stash grid; clicking Player returns to personal inventory
- [ ] No Party Stash section above the inventory controls
- [ ] Grid/List toggle visible on Player and Party tabs, hidden on Shop tab
- [ ] Invested counter always visible (when max > 0), to the right of the gear
- [ ] Gear icon matches the sheet header settings button
- [ ] Characters without a party: only UserRound tab shown, no selector group
- [ ] `npm run typecheck -w @foundry-toolkit/player-portal` clean
- [ ] `npm run test -w @foundry-toolkit/player-portal` — 475 tests pass