### PR TITLE
feat(player-portal): chat feed sort toggle and improved card formatting

### DIFF
--- a/apps/player-portal/src/components/chat/MessageBubble.tsx
+++ b/apps/player-portal/src/components/chat/MessageBubble.tsx
@@ -1,8 +1,9 @@
 import type { ChatMessageSnapshot, ChatRoll } from '@foundry-toolkit/shared/rpc';
 
-// Foundry ChatMessage type constants. We only distinguish roll vs. OOC
-// vs. IC for styling; everything else renders as plain content.
+// Foundry ChatMessage type constants.
 const MSG_OOC = 1;
+// Type 5 = emote in Foundry v14.
+const MSG_EMOTE = 5;
 
 function formatTime(timestamp: number | null): string | null {
   if (timestamp === null) return null;
@@ -11,21 +12,26 @@ function formatTime(timestamp: number | null): string | null {
 
 function RollResult({ roll }: { roll: ChatRoll }): React.ReactElement {
   return (
-    <div className="mb-1 flex items-center gap-2">
-      <span className="font-mono text-xs text-pf-alt-dark">{roll.formula}</span>
+    <div className="flex items-center gap-2 py-0.5">
+      <span className="font-mono text-[11px] text-pf-alt-dark">{roll.formula}</span>
+      <span className="text-pf-border">→</span>
       <span
         className={[
-          'text-lg font-bold tabular-nums',
+          'text-base font-bold tabular-nums leading-none',
           roll.isCritical ? 'text-green-600' : roll.isFumble ? 'text-red-500' : 'text-pf-primary',
         ].join(' ')}
       >
         {roll.total}
       </span>
       {roll.isCritical && (
-        <span className="rounded bg-green-100 px-1 py-0.5 text-xs font-medium text-green-700">Critical!</span>
+        <span className="rounded bg-green-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-green-700">
+          Crit
+        </span>
       )}
       {roll.isFumble && (
-        <span className="rounded bg-red-100 px-1 py-0.5 text-xs font-medium text-red-700">Fumble</span>
+        <span className="rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-red-700">
+          Fumble
+        </span>
       )}
     </div>
   );
@@ -38,62 +44,80 @@ interface Props {
 export function MessageBubble({ message }: Props): React.ReactElement {
   const isWhisper = message.whisper.length > 0;
   const isOoc = message.type === MSG_OOC;
+  const isEmote = message.type === MSG_EMOTE;
+  const isRoll = message.isRoll;
   const time = formatTime(message.timestamp);
 
-  // IC: show character alias; OOC or roll with no alias: fall back to author name.
+  // IC: show character alias; OOC or roll with no alias: fall back to author.
   const speakerLabel = message.speaker?.alias ?? message.author?.name ?? null;
 
-  return (
-    <div
-      className={[
-        'rounded border p-2 text-sm',
-        isWhisper
-          ? 'border-pf-alt/40 bg-pf-alt/5'
-          : isOoc
-            ? 'border-pf-border bg-pf-bg'
+  const cardClass = [
+    'rounded border text-sm',
+    isRoll
+      ? 'border-pf-border/70 bg-pf-bg-dark border-l-2 border-l-pf-primary/60'
+      : isWhisper
+        ? 'border-pf-alt/40 bg-pf-alt/5'
+        : isOoc
+          ? 'border-pf-border/50 bg-pf-bg'
+          : isEmote
+            ? 'border-pf-border/40 bg-pf-bg/50 italic'
             : 'border-pf-border bg-pf-bg-dark',
-      ].join(' ')}
-    >
-      {/* Header row: speaker · badges · timestamp */}
-      <div className="mb-1 flex flex-wrap items-center gap-1.5">
+  ].join(' ');
+
+  return (
+    <div className={cardClass}>
+      {/* Header: speaker · badges · timestamp */}
+      <div className="flex flex-wrap items-center gap-1.5 border-b border-pf-border/30 px-2 py-1.5">
         {speakerLabel !== null && (
-          <span className={`font-medium ${isOoc ? 'text-pf-alt-dark' : 'text-pf-primary'}`}>{speakerLabel}</span>
+          <span
+            className={`text-[11px] font-semibold leading-none ${isOoc ? 'text-pf-alt-dark' : 'text-pf-primary'}`}
+          >
+            {speakerLabel}
+          </span>
         )}
         {isWhisper && (
-          <span className="rounded bg-pf-alt px-1 py-0.5 text-xs text-white">Whisper</span>
+          <span className="rounded bg-pf-alt px-1 py-0.5 text-[10px] font-medium text-white">
+            Whisper
+          </span>
         )}
-        {message.isRoll && (
-          <span className="rounded border border-pf-border bg-pf-bg px-1 py-0.5 text-xs text-pf-alt-dark">
+        {isRoll && (
+          <span className="rounded border border-pf-border/60 bg-pf-bg px-1 py-0.5 text-[10px] text-pf-alt-dark">
             Roll
           </span>
         )}
         {time !== null && (
-          <span className="ml-auto text-xs tabular-nums text-pf-alt-dark">{time}</span>
+          <span className="ml-auto text-[10px] tabular-nums text-pf-alt-dark/70">{time}</span>
         )}
       </div>
 
-      {/* Roll flavor (e.g. "Perception Check") — clamp action-cost icons */}
-      {message.isRoll && message.flavor.length > 0 && (
-        <div
-          className="mb-1 text-xs text-pf-alt-dark [&_img]:!max-h-4 [&_img]:!w-auto [&_img]:inline-block [&_img]:align-middle"
-          dangerouslySetInnerHTML={{ __html: message.flavor }}
-        />
-      )}
+      {/* Card body */}
+      <div className="space-y-1 px-2 py-1.5">
+        {/* Roll flavor (e.g. "Perception Check") */}
+        {isRoll && message.flavor.length > 0 && (
+          <div
+            className="text-[11px] italic text-pf-alt-dark [&_img]:!max-h-3.5 [&_img]:!w-auto [&_img]:inline-block [&_img]:align-middle"
+            dangerouslySetInnerHTML={{ __html: message.flavor }}
+          />
+        )}
 
-      {/* Roll result summary */}
-      {message.isRoll && message.rolls[0] !== undefined && (
-        <RollResult roll={message.rolls[0]} />
-      )}
+        {/* Roll result summary */}
+        {isRoll && message.rolls[0] !== undefined && <RollResult roll={message.rolls[0]} />}
 
-      {/* Message content (HTML from Foundry — trusted source).
-          Cap embedded images: PF2e cards include action icons and item
-          art with inline size attributes that would overflow the sidebar. */}
-      {message.content.length > 0 && (
-        <div
-          className="prose-sm max-w-none text-pf-text [&_a]:text-pf-primary [&_a]:underline [&_img]:!max-h-6 [&_img]:!w-auto [&_img]:inline-block [&_img]:align-middle"
-          dangerouslySetInnerHTML={{ __html: message.content }}
-        />
-      )}
+        {/* Message content (PF2e-rendered HTML — trusted source).
+            PF2e action chips (<button> elements) have no live handlers in the portal;
+            pointer-events-none prevents accidental interaction. */}
+        {message.content.length > 0 && (
+          <div
+            className={[
+              'prose-sm max-w-none text-pf-text',
+              '[&_a]:text-pf-primary [&_a]:underline',
+              '[&_img]:!max-h-5 [&_img]:!w-auto [&_img]:inline-block [&_img]:align-middle',
+              '[&_button]:cursor-not-allowed [&_button]:opacity-50 [&_button]:select-none [&_button]:pointer-events-none',
+            ].join(' ')}
+            dangerouslySetInnerHTML={{ __html: message.content }}
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/player-portal/src/components/tabs/Chat.test.tsx
+++ b/apps/player-portal/src/components/tabs/Chat.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/react';
+import type { ChatMessageSnapshot } from '@foundry-toolkit/shared/rpc';
+
+vi.mock('../../lib/useLiveChat', () => ({
+  useLiveChat: vi.fn(),
+}));
+
+import { useLiveChat } from '../../lib/useLiveChat';
+import { Chat } from './Chat';
+
+function makeMsg(id: string, content: string, timestamp: number): ChatMessageSnapshot {
+  return {
+    id,
+    uuid: null,
+    type: null,
+    author: { id: 'user-1', name: 'Alice' },
+    timestamp,
+    flavor: '',
+    content,
+    speaker: { alias: 'Alice' },
+    speakerOwnerIds: [],
+    whisper: [],
+    isRoll: false,
+    rolls: [],
+    flags: {},
+  };
+}
+
+const OLDER = makeMsg('msg-1', 'First', 1000);
+const NEWER = makeMsg('msg-2', 'Second', 2000);
+
+const SORT_KEY = 'chat-feed:sort-order';
+
+beforeEach(() => {
+  vi.mocked(useLiveChat).mockReturnValue({
+    messages: [OLDER, NEWER],
+    status: 'connected',
+    truncated: false,
+  });
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('Chat sort toggle', () => {
+  it('defaults to newest-first (descending) when no preference stored', () => {
+    const { container } = render(<Chat actorId="actor-1" />);
+    // Content order: NEWER text should appear before OLDER text in the DOM.
+    const text = container.textContent ?? '';
+    const idxFirst = text.indexOf('First');
+    const idxSecond = text.indexOf('Second');
+    expect(idxSecond).toBeLessThan(idxFirst);
+  });
+
+  it('shows the toggle button with correct label for descending', () => {
+    const { getByTitle } = render(<Chat actorId="actor-1" />);
+    const btn = getByTitle(/Showing newest first/i);
+    expect(btn).toBeTruthy();
+    expect(btn.textContent).toMatch(/Newest first/i);
+  });
+
+  it('toggles to oldest-first on click', () => {
+    const { getByTitle, container } = render(<Chat actorId="actor-1" />);
+    const btn = getByTitle(/Showing newest first/i);
+    fireEvent.click(btn);
+
+    // After toggle: OLDER text should appear before NEWER.
+    const text = container.textContent ?? '';
+    const idxFirst = text.indexOf('First');
+    const idxSecond = text.indexOf('Second');
+    expect(idxFirst).toBeLessThan(idxSecond);
+  });
+
+  it('updates the button label after toggle', () => {
+    const { getByTitle } = render(<Chat actorId="actor-1" />);
+    const btn = getByTitle(/Showing newest first/i);
+    fireEvent.click(btn);
+    expect(btn.textContent).toMatch(/Oldest first/i);
+    expect(btn.title).toMatch(/Showing oldest first/i);
+  });
+
+  it('persists sort order to localStorage', () => {
+    const { getByTitle } = render(<Chat actorId="actor-1" />);
+    const btn = getByTitle(/Showing newest first/i);
+    fireEvent.click(btn);
+    expect(window.localStorage.getItem(SORT_KEY)).toBe('asc');
+  });
+
+  it('reads initial sort order from localStorage', () => {
+    window.localStorage.setItem(SORT_KEY, 'asc');
+    const { container } = render(<Chat actorId="actor-1" />);
+    // Oldest-first: OLDER should appear before NEWER.
+    const text = container.textContent ?? '';
+    expect(text.indexOf('First')).toBeLessThan(text.indexOf('Second'));
+  });
+
+  it('can toggle back to descending', () => {
+    const { getByTitle } = render(<Chat actorId="actor-1" />);
+    const btn = getByTitle(/Showing newest first/i);
+    fireEvent.click(btn); // → asc
+    fireEvent.click(btn); // → desc again
+    expect(window.localStorage.getItem(SORT_KEY)).toBe('desc');
+    expect(btn.textContent).toMatch(/Newest first/i);
+  });
+
+  it('renders empty state when no messages', () => {
+    vi.mocked(useLiveChat).mockReturnValue({
+      messages: [],
+      status: 'connected',
+      truncated: false,
+    });
+    const { getByText } = render(<Chat actorId="actor-1" />);
+    expect(getByText(/No messages yet/i)).toBeTruthy();
+  });
+
+  it('renders loading state', () => {
+    vi.mocked(useLiveChat).mockReturnValue({
+      messages: [],
+      status: 'loading',
+      truncated: false,
+    });
+    const { getByText } = render(<Chat actorId="actor-1" />);
+    expect(getByText(/Connecting/i)).toBeTruthy();
+  });
+});

--- a/apps/player-portal/src/components/tabs/Chat.tsx
+++ b/apps/player-portal/src/components/tabs/Chat.tsx
@@ -38,39 +38,49 @@ export function Chat({ actorId }: Props): React.ReactElement {
   const sorted = sortOrder === 'desc' ? [...messages].reverse() : messages;
 
   return (
-    <div className="flex flex-col gap-2">
-      {/* Header: sort toggle */}
-      <div className="flex items-center justify-between pb-1">
+    <div className="flex min-h-0 flex-1 flex-col">
+      {/* Header row: "Chat" label (left) + sort toggle (right) */}
+      <div className="mb-2 flex shrink-0 items-center justify-between">
+        <p className="text-xs font-medium uppercase tracking-wide text-pf-alt-dark">Chat</p>
         <button
           type="button"
           onClick={toggleSort}
-          title={sortOrder === 'desc' ? 'Showing newest first — click for oldest first' : 'Showing oldest first — click for newest first'}
-          className="flex items-center gap-1 rounded px-1 py-0.5 text-xs text-pf-alt-dark hover:bg-pf-bg-dark hover:text-pf-text transition-colors"
+          title={
+            sortOrder === 'desc'
+              ? 'Showing newest first — click for oldest first'
+              : 'Showing oldest first — click for newest first'
+          }
+          className="flex items-center gap-1 rounded px-1 py-0.5 text-xs text-pf-alt-dark transition-colors hover:bg-pf-bg-dark hover:text-pf-text"
         >
           <SortIcon order={sortOrder} />
           {sortOrder === 'desc' ? 'Newest first' : 'Oldest first'}
         </button>
       </div>
 
-      {truncated && (
-        <p className="text-center text-xs text-pf-alt-dark">Showing recent messages only.</p>
-      )}
+      {/* Scrollable messages */}
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <div className="flex flex-col gap-2">
+          {truncated && (
+            <p className="text-center text-xs text-pf-alt-dark">Showing recent messages only.</p>
+          )}
 
-      {messages.length === 0 && status !== 'loading' && (
-        <p className="py-8 text-center text-sm text-pf-alt-dark">No messages yet.</p>
-      )}
+          {messages.length === 0 && status !== 'loading' && (
+            <p className="py-8 text-center text-sm text-pf-alt-dark">No messages yet.</p>
+          )}
 
-      {messages.length === 0 && status === 'loading' && (
-        <p className="py-8 text-center text-sm text-pf-alt-dark">Connecting…</p>
-      )}
+          {messages.length === 0 && status === 'loading' && (
+            <p className="py-8 text-center text-sm text-pf-alt-dark">Connecting…</p>
+          )}
 
-      {sorted.map((m) => (
-        <MessageBubble key={m.id} message={m} />
-      ))}
+          {sorted.map((m) => (
+            <MessageBubble key={m.id} message={m} />
+          ))}
 
-      {status === 'disconnected' && (
-        <p className="text-center text-xs text-amber-600">Reconnecting to chat stream…</p>
-      )}
+          {status === 'disconnected' && (
+            <p className="text-center text-xs text-amber-600">Reconnecting to chat stream…</p>
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/player-portal/src/components/tabs/Chat.tsx
+++ b/apps/player-portal/src/components/tabs/Chat.tsx
@@ -1,5 +1,21 @@
+import { useState } from 'react';
 import { useLiveChat } from '../../lib/useLiveChat';
 import { MessageBubble } from '../chat/MessageBubble';
+
+type SortOrder = 'desc' | 'asc';
+
+const SORT_KEY = 'chat-feed:sort-order';
+const DEFAULT_ORDER: SortOrder = 'desc';
+
+function readStoredOrder(): SortOrder {
+  if (typeof window === 'undefined') return DEFAULT_ORDER;
+  try {
+    const raw = window.localStorage.getItem(SORT_KEY);
+    return raw === 'asc' || raw === 'desc' ? raw : DEFAULT_ORDER;
+  } catch {
+    return DEFAULT_ORDER;
+  }
+}
 
 interface Props {
   actorId: string;
@@ -7,9 +23,35 @@ interface Props {
 
 export function Chat({ actorId }: Props): React.ReactElement {
   const { messages, status, truncated } = useLiveChat(actorId);
+  const [sortOrder, setSortOrder] = useState<SortOrder>(readStoredOrder);
+
+  const toggleSort = (): void => {
+    const next: SortOrder = sortOrder === 'desc' ? 'asc' : 'desc';
+    setSortOrder(next);
+    try {
+      window.localStorage.setItem(SORT_KEY, next);
+    } catch {
+      // ignore — non-persistent fallback works for the session
+    }
+  };
+
+  const sorted = sortOrder === 'desc' ? [...messages].reverse() : messages;
 
   return (
-    <div className="space-y-2">
+    <div className="flex flex-col gap-2">
+      {/* Header: sort toggle */}
+      <div className="flex items-center justify-between pb-1">
+        <button
+          type="button"
+          onClick={toggleSort}
+          title={sortOrder === 'desc' ? 'Showing newest first — click for oldest first' : 'Showing oldest first — click for newest first'}
+          className="flex items-center gap-1 rounded px-1 py-0.5 text-xs text-pf-alt-dark hover:bg-pf-bg-dark hover:text-pf-text transition-colors"
+        >
+          <SortIcon order={sortOrder} />
+          {sortOrder === 'desc' ? 'Newest first' : 'Oldest first'}
+        </button>
+      </div>
+
       {truncated && (
         <p className="text-center text-xs text-pf-alt-dark">Showing recent messages only.</p>
       )}
@@ -22,7 +64,7 @@ export function Chat({ actorId }: Props): React.ReactElement {
         <p className="py-8 text-center text-sm text-pf-alt-dark">Connecting…</p>
       )}
 
-      {messages.map((m) => (
+      {sorted.map((m) => (
         <MessageBubble key={m.id} message={m} />
       ))}
 
@@ -30,5 +72,26 @@ export function Chat({ actorId }: Props): React.ReactElement {
         <p className="text-center text-xs text-amber-600">Reconnecting to chat stream…</p>
       )}
     </div>
+  );
+}
+
+function SortIcon({ order }: { order: SortOrder }): React.ReactElement {
+  // Arrow pointing down = newest first (desc); up = oldest first (asc).
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      style={{ transform: order === 'asc' ? 'rotate(180deg)' : undefined }}
+    >
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <polyline points="19 12 12 19 5 12" />
+    </svg>
   );
 }

--- a/apps/player-portal/src/routes/CharacterSheet.tsx
+++ b/apps/player-portal/src/routes/CharacterSheet.tsx
@@ -273,11 +273,8 @@ function CharacterSheetInner({ actorId, onBack, preferences }: InnerProps): Reac
           independently so the sheet and chat can be read in parallel. */}
       {state.kind === 'ready' && (
         <aside className="hidden w-[230px] shrink-0 pr-3 lg:flex lg:flex-col">
-          <div className="sticky top-6 flex max-h-[calc(100svh-3rem)] flex-col">
-            <p className="mb-2 text-xs font-medium uppercase tracking-wide text-pf-alt-dark">Chat</p>
-            <div className="min-h-0 flex-1 overflow-y-auto">
-              <Chat actorId={actorId} />
-            </div>
+          <div className="sticky top-6 flex min-h-0 max-h-[calc(100svh-3rem)] flex-col">
+            <Chat actorId={actorId} />
           </div>
         </aside>
       )}

--- a/apps/player-portal/src/routes/CharacterSheet.tsx
+++ b/apps/player-portal/src/routes/CharacterSheet.tsx
@@ -273,7 +273,7 @@ function CharacterSheetInner({ actorId, onBack, preferences }: InnerProps): Reac
           independently so the sheet and chat can be read in parallel. */}
       {state.kind === 'ready' && (
         <aside className="hidden w-[230px] shrink-0 pr-3 lg:flex lg:flex-col">
-          <div className="sticky top-6 flex min-h-0 max-h-[calc(100svh-3rem)] flex-col">
+          <div className="sticky top-6 flex h-[calc(100svh-3rem)] flex-col overflow-hidden">
             <Chat actorId={actorId} />
           </div>
         </aside>


### PR DESCRIPTION
## Summary

Adds a sort-direction toggle to the chat sidebar so players can switch between newest-first (default, persisted in `localStorage`) and oldest-first. Tightens up `MessageBubble` card layout — separates the header row from body content, makes roll cards visually distinct with a coloured left border, italicises flavor text, and cleans up font sizes/spacing. PF2e action chips (\"Roll Damage\", \"Saving Throw\", etc.) are styled as inert with `pointer-events-none` and a disabled appearance; wire-up is tracked in #160.

## Apps touched

- `apps/player-portal` — `npm run dev:player-portal` or `npm run dev:player-portal:mock`

## Changes

- `Chat.tsx`: sort toggle button with inline SVG arrow, `localStorage` persistence under `chat-feed:sort-order`, defaults to descending (newest first)
- `MessageBubble.tsx`: header/body separation via border-bottom; roll cards get `border-l-2 border-l-pf-primary/60` left accent; flavor text is `text-[11px] italic`; RollResult uses `→` separator; font sizes tightened to `text-[11px]` / `text-[10px]`; PF2e `<button>` chips disabled via CSS
- `Chat.test.tsx`: 9 tests for sort toggle, localStorage persistence, empty/loading states

## Per-ask outcome

1. **Sort toggle** — shipped. Default: newest first. Persisted in localStorage.
2. **Card formatting** — shipped. Header row with subtle separator, roll card left-border accent, italicised flavor, cleaned-up spacing.
3. **Interactive chips** — deferred. Chips are visually inert (disabled appearance). Wire-protocol for dispatching chip actions needs new api-bridge + MCP work; tracked in #160.

## Test plan

- [ ] Sort toggle: click toggles label and arrow; scroll confirms message order flips; reload confirms preference survives
- [ ] Formatting: open mock mode (`npm run dev:player-portal:mock`) and scroll through chat — roll cards have left accent, flavor is italic, header is separated, timestamps are readable
- [ ] Chips: clicking a PF2e chip button does nothing (pointer-events-none); cursor shows not-allowed

## Follow-ups

- #160 — interactive PF2e action chips (Roll Damage, Saving Throw, etc.)