### PR TITLE
fix(player-portal): scope creator backdrop to actor flag; fix Windows path separator

### DIFF
--- a/apps/foundry-mcp/src/http/routes/uploads.ts
+++ b/apps/foundry-mcp/src/http/routes/uploads.ts
@@ -17,13 +17,14 @@ import { uploadAssetBody } from '../schemas.js';
 // while keeping a lid on accidental giant-file uploads.
 const UPLOAD_BODY_LIMIT = 16 * 1024 * 1024;
 
-export function registerUploadRoutes(app: FastifyInstance): void {
+export function registerUploadRoutes(app: FastifyInstance, opts: { dataDir?: string } = {}): void {
+  const dataDir = opts.dataDir ?? FOUNDRY_DATA_DIR;
   app.post('/api/uploads', { bodyLimit: UPLOAD_BODY_LIMIT }, async (req, reply) => {
     const body = uploadAssetBody.parse(req.body);
 
     // Reject any path that tries to escape the Data dir — either via a
     // leading `..`, a mid-path `..`, or an absolute path that resolves
-    // outside FOUNDRY_DATA_DIR after normalisation.
+    // outside dataDir after normalisation.
     const safeRel = normalize(body.path);
     if (safeRel.startsWith('..') || safeRel.includes('/..') || safeRel.includes('\\..')) {
       reply.code(400).send({
@@ -32,8 +33,8 @@ export function registerUploadRoutes(app: FastifyInstance): void {
       });
       return;
     }
-    const absPath = resolve(FOUNDRY_DATA_DIR, safeRel);
-    if (!absPath.startsWith(FOUNDRY_DATA_DIR)) {
+    const absPath = resolve(dataDir, safeRel);
+    if (!absPath.startsWith(dataDir)) {
       reply.code(400).send({ error: 'path must resolve inside the Data directory' });
       return;
     }
@@ -49,6 +50,8 @@ export function registerUploadRoutes(app: FastifyInstance): void {
     await mkdir(dirname(absPath), { recursive: true });
     await writeFile(absPath, buf);
 
-    return { path: safeRel, bytes: buf.length };
+    // Always return forward slashes regardless of platform so the stored
+    // path is a valid URL segment on every OS.
+    return { path: safeRel.replace(/\\/g, '/'), bytes: buf.length };
   });
 }

--- a/apps/foundry-mcp/test/upload-routes.test.ts
+++ b/apps/foundry-mcp/test/upload-routes.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { ZodError } from 'zod/v4';
+import { registerUploadRoutes } from '../src/http/routes/uploads.js';
+
+function makeApp(dataDir: string): FastifyInstance {
+  const app = Fastify({ logger: false });
+  app.setErrorHandler((err, _req, reply) => {
+    if (err instanceof ZodError) {
+      reply.code(400).send({ error: 'Invalid request parameters' });
+      return;
+    }
+    reply.code(500).send({ error: err instanceof Error ? err.message : String(err) });
+  });
+  registerUploadRoutes(app, { dataDir });
+  return app;
+}
+
+const PNG_1PX_B64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+describe('POST /api/uploads — path separator', () => {
+  let tmpDir: string;
+  let app: FastifyInstance;
+
+  before(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'upload-routes-test-'));
+    app = makeApp(tmpDir);
+  });
+
+  after(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns forward-slash path regardless of platform', async () => {
+    // Regression: path.normalize on Windows converts forward slashes to
+    // backslashes. The returned path was stored verbatim in the actor flag
+    // and rendered as a broken background URL on the sheet.
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/uploads',
+      headers: { 'Content-Type': 'application/json' },
+      payload: JSON.stringify({
+        path: 'modules/character-creator-bg/actor-123-1234567890.png',
+        dataBase64: PNG_1PX_B64,
+      }),
+    });
+    assert.equal(res.statusCode, 200);
+    const body = JSON.parse(res.payload) as { path: string; bytes: number };
+    assert.ok(!body.path.includes('\\'), `path must not contain backslashes, got: ${body.path}`);
+    assert.match(body.path, /^modules\/character-creator-bg\//);
+  });
+
+  it('rejects paths that escape the data directory', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/uploads',
+      headers: { 'Content-Type': 'application/json' },
+      payload: JSON.stringify({
+        path: '../escape/evil.png',
+        dataBase64: PNG_1PX_B64,
+      }),
+    });
+    assert.equal(res.statusCode, 400);
+  });
+
+  it('rejects missing path field', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/uploads',
+      headers: { 'Content-Type': 'application/json' },
+      payload: JSON.stringify({ dataBase64: PNG_1PX_B64 }),
+    });
+    assert.equal(res.statusCode, 400);
+  });
+});

--- a/apps/player-portal/src/lib/sheetBackground.test.ts
+++ b/apps/player-portal/src/lib/sheetBackground.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { readBackgroundPath, buildSheetSurfaceStyle } from './sheetBackground';
+import type { PreparedCharacter } from '../api/types';
+
+function makeCharacter(flags?: Record<string, Record<string, unknown>>): PreparedCharacter {
+  return {
+    id: 'test-id',
+    uuid: 'Actor.test-id',
+    name: 'Test',
+    type: 'character',
+    img: '',
+    system: {} as PreparedCharacter['system'],
+    items: [],
+    ...(flags !== undefined ? { flags } : {}),
+  };
+}
+
+describe('readBackgroundPath', () => {
+  it('returns null when flags are absent', () => {
+    expect(readBackgroundPath(makeCharacter())).toBeNull();
+  });
+
+  it('returns null when the character-creator scope is missing', () => {
+    expect(readBackgroundPath(makeCharacter({ other: { foo: 'bar' } }))).toBeNull();
+  });
+
+  it('returns null when backgroundImage is null', () => {
+    expect(readBackgroundPath(makeCharacter({ 'character-creator': { backgroundImage: null } }))).toBeNull();
+  });
+
+  it('returns null when backgroundImage is an empty string', () => {
+    expect(readBackgroundPath(makeCharacter({ 'character-creator': { backgroundImage: '' } }))).toBeNull();
+  });
+
+  it('returns the path as-is when it already uses forward slashes', () => {
+    const path = 'modules/character-creator-bg/actor123-1234567890.jpeg';
+    expect(readBackgroundPath(makeCharacter({ 'character-creator': { backgroundImage: path } }))).toBe(path);
+  });
+
+  it('normalizes Windows backslash paths stored by an older upload on Windows', () => {
+    // Regression: path.normalize on Windows emits backslashes; these were
+    // stored verbatim in actor flags and rendered as broken background URLs.
+    const stored = 'modules\\character-creator-bg\\actor123-1234567890.jpeg';
+    const result = readBackgroundPath(makeCharacter({ 'character-creator': { backgroundImage: stored } }));
+    expect(result).toBe('modules/character-creator-bg/actor123-1234567890.jpeg');
+  });
+});
+
+describe('buildSheetSurfaceStyle', () => {
+  it('returns undefined for null path', () => {
+    expect(buildSheetSurfaceStyle(null)).toBeUndefined();
+  });
+
+  it('prepends a leading slash when the path is relative', () => {
+    const style = buildSheetSurfaceStyle('modules/character-creator-bg/actor-ts.jpeg');
+    expect(style?.backgroundImage).toContain('url(/modules/character-creator-bg/actor-ts.jpeg)');
+  });
+
+  it('does not double-prepend when the path already starts with /', () => {
+    const style = buildSheetSurfaceStyle('/modules/character-creator-bg/actor-ts.jpeg');
+    expect(style?.backgroundImage).toContain('url(/modules/character-creator-bg/actor-ts.jpeg)');
+    expect(style?.backgroundImage).not.toContain('url(//');
+  });
+
+  it('includes the overlay gradient', () => {
+    const style = buildSheetSurfaceStyle('modules/character-creator-bg/actor.png');
+    expect(style?.backgroundImage).toMatch(/^linear-gradient\(var\(--pf-bg-overlay\)/);
+  });
+});

--- a/apps/player-portal/src/lib/sheetBackground.ts
+++ b/apps/player-portal/src/lib/sheetBackground.ts
@@ -1,0 +1,26 @@
+import type { CSSProperties } from 'react';
+import type { PreparedCharacter } from '../api/types';
+
+export function readBackgroundPath(character: PreparedCharacter): string | null {
+  const raw = character.flags?.['character-creator']?.['backgroundImage'];
+  if (typeof raw !== 'string' || raw.length === 0) return null;
+  // Normalize Windows-style backslashes that may have been stored by an
+  // older upload on a Windows host (path.normalize produced \ separators).
+  return raw.replace(/\\/g, '/');
+}
+
+// Layers a semi-transparent overlay on top of the user's image so arbitrary
+// artwork (dark, busy, saturated) stays readable behind the sheet content.
+// Uses var(--pf-bg-overlay) so the overlay colour follows the portal theme
+// toggle (light: cream parchment at 88%, dark: navy at 88%).
+export function buildSheetSurfaceStyle(bgPath: string | null): CSSProperties | undefined {
+  if (!bgPath) return undefined;
+  const url = bgPath.startsWith('/') ? bgPath : `/${bgPath}`;
+  return {
+    backgroundImage: `linear-gradient(var(--pf-bg-overlay), var(--pf-bg-overlay)), url(${url})`,
+    backgroundSize: 'auto, cover',
+    backgroundPosition: 'center, center',
+    backgroundRepeat: 'no-repeat, no-repeat',
+    backgroundAttachment: 'local, local',
+  };
+}

--- a/apps/player-portal/src/routes/CharacterSheet.tsx
+++ b/apps/player-portal/src/routes/CharacterSheet.tsx
@@ -28,6 +28,7 @@ import type { TabId } from '../lib/tabUtils';
 import { useShopMode } from '../lib/useShopMode';
 import { PartyRail } from '../components/sheet/PartyRail';
 import { MemberCard } from '../components/sheet/MemberCard';
+import { readBackgroundPath, buildSheetSurfaceStyle } from '../lib/sheetBackground';
 
 type State =
   | { kind: 'loading' }
@@ -285,23 +286,3 @@ function CharacterSheetInner({ actorId, onBack, preferences }: InnerProps): Reac
   );
 }
 
-function readBackgroundPath(character: PreparedCharacter): string | null {
-  const raw = character.flags?.['character-creator']?.['backgroundImage'];
-  return typeof raw === 'string' && raw.length > 0 ? raw : null;
-}
-
-// Layers a semi-transparent overlay on top of the user's image so arbitrary
-// artwork (dark, busy, saturated) stays readable behind the sheet content.
-// Uses var(--pf-bg-overlay) so the overlay colour follows the portal theme
-// toggle (light: cream parchment at 88%, dark: navy at 88%).
-function buildSheetSurfaceStyle(bgPath: string | null): React.CSSProperties | undefined {
-  if (!bgPath) return undefined;
-  const url = bgPath.startsWith('/') ? bgPath : `/${bgPath}`;
-  return {
-    backgroundImage: `linear-gradient(var(--pf-bg-overlay), var(--pf-bg-overlay)), url(${url})`,
-    backgroundSize: 'auto, cover',
-    backgroundPosition: 'center, center',
-    backgroundRepeat: 'no-repeat, no-repeat',
-    backgroundAttachment: 'local, local',
-  };
-}


### PR DESCRIPTION
## Summary

The sheet-surface backdrop styling (inline `background-image` + `-mx-4 rounded-lg px-4 py2` classes) was appearing on saved actor sheets where it shouldn't — Broccoli showed the styled surface while Lutharion (and actors without a set background) did not.

Root cause (two-part):

1. **`foundry-mcp` `POST /api/uploads`** uses `path.normalize` from `node:path`, which on Windows converts forward-slash input paths to backslash paths. The normalized Windows path (`modules\character-creator-bg\...`) was returned to the client and stored verbatim in the actor's `character-creator.backgroundImage` flag.
2. **`CharacterSheet.tsx`** applies the backdrop style block whenever `readBackgroundPath` returns a non-empty string. A Windows backslash path is a non-empty string — so the styles fired (making the layout visibly different) even though the `url()` reference was broken and the image never loaded.

This is not a creator-state leak; the backdrop is an intentional per-actor feature. The bug was that a Windows-normalized path string was stored on the actor, causing it to appear for an actor whose background image had been uploaded on Windows.

## Changes

- **`apps/foundry-mcp/src/http/routes/uploads.ts`**: append `.replace(/\/g, '/')` to the returned `path` so it is always a forward-slash URL segment regardless of server OS. Added an optional `dataDir` parameter to `registerUploadRoutes` to enable integration testing without touching the real Foundry data dir.
- **`apps/player-portal/src/lib/sheetBackground.ts`** (new): extracted `readBackgroundPath` and `buildSheetSurfaceStyle` from `CharacterSheet.tsx`. `readBackgroundPath` now normalizes any legacy backslash paths already stored on actor flags via `.replace(/\/g, '/')`.
- **`apps/player-portal/src/routes/CharacterSheet.tsx`**: imports from the new module; no behavior change for actors without a stored background path.
- **`apps/foundry-mcp/test/upload-routes.test.ts`** (new): regression — verifies the returned path never contains backslashes, and that traversal-escape and missing-field inputs are rejected.
- **`apps/player-portal/src/lib/sheetBackground.test.ts`** (new): covers `readBackgroundPath` (null cases, forward-slash passthrough, backslash normalization) and `buildSheetSurfaceStyle` (undefined for null, slash prepend, gradient inclusion).

## Apps touched

- `apps/player-portal` — `npm run dev:player-portal`
- `apps/foundry-mcp` — `npm run dev:mcp`

## Test plan

- [ ] `npm run test -w @foundry-toolkit/player-portal` — all pass (includes 10 new `sheetBackground` tests)
- [ ] `npm run test -w @foundry-toolkit/mcp` — all pass (includes 3 new `upload-routes` tests)
- [ ] `npm run typecheck -w @foundry-toolkit/player-portal` — clean
- [ ] `npm run lint -w @foundry-toolkit/player-portal` — 0 errors (pre-existing warnings unchanged)
- [ ] Manual: open Broccoli's sheet — `sheet-surface` div has empty `style` and no extra classes
- [ ] Manual: open the character creator — themed backdrop still renders
- [ ] Manual: upload a new background image → save → open sheet → backdrop appears with correct forward-slash URL, image loads
- [ ] Manual: open Lutharion's sheet — no regression