### PR TITLE
fix(deploy): use glibc runtime for player-portal to fix sodium-native

### DIFF
--- a/deploy/Dockerfile.player-portal
+++ b/deploy/Dockerfile.player-portal
@@ -36,8 +36,13 @@ RUN npm --workspace @foundry-toolkit/player-portal run build:client
 
 ###############################################################################
 # Stage 2 — Runtime (tsx serves TypeScript server source + built Vite SPA)
+#
+# Must be glibc-based (bookworm, not Alpine/musl) because @fastify/secure-session
+# pulls in sodium-native, which ships prebuilt .node binaries for linux-x64
+# (glibc) but not for linux-x64-musl.  Alpine would require compiling from
+# source, which needs python3/make/g++ and is slower.
 ###############################################################################
-FROM node:22-alpine AS runtime
+FROM node:22-bookworm-slim AS runtime
 WORKDIR /app
 
 COPY package.json package-lock.json tsconfig.base.json ./


### PR DESCRIPTION
## Summary

The player-portal container crashed on startup because `@fastify/secure-session` (added in the auth PR #162) pulls in `sodium-native`, a native Node.js addon. `sodium-native` ships prebuilt `.node` binaries for `linux-x64` (glibc) but has no prebuilds for `linux-x64-musl` (Alpine). The Alpine runtime stage therefore failed to find the addon and crashed immediately.

Fix: change the player-portal runtime stage base from `node:22-alpine` to `node:22-bookworm-slim`. The build stage stays Alpine — Vite doesn't touch native addons, so that stage is unaffected.

## Apps touched

- `deploy/Dockerfile.player-portal` — runtime stage base image only

No dev server needed; validate via `docker compose up` and confirming the portal starts without the `ADDON_NOT_FOUND` error.

## Test plan

- [ ] `docker compose -f deploy/compose.yaml -f deploy/compose.override.yaml build player-portal` succeeds
- [ ] `docker compose -f deploy/compose.yaml -f deploy/compose.override.yaml up -d` — player-portal starts and stays up (no restart loop)
- [ ] `curl http://localhost:3000/health` → `{"ok":true}`
- [ ] No `ADDON_NOT_FOUND` / `sodium-native` errors in `docker compose logs player-portal`