### PR TITLE
fix(shared): serialize all CompendiumSearchOptions fields in buildCompendiumQuery

### DIFF
--- a/packages/shared/src/http.test.ts
+++ b/packages/shared/src/http.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { buildCompendiumQuery } from './http';
+import { compendiumSearchQuery } from './rpc/schemas';
+
+function roundTrip(qs: string) {
+  return compendiumSearchQuery.parse(Object.fromEntries(new URLSearchParams(qs)));
+}
+
+describe('buildCompendiumQuery', () => {
+  it('round-trips all 26 CompendiumSearchOptions fields through the Zod schema', () => {
+    const qs = buildCompendiumQuery({
+      q: 'goblin',
+      packIds: ['pf2e.bestiary-family-ability-glossary', 'pf2e.feats-srd'],
+      documentType: 'Actor',
+      traits: ['humanoid', 'goblin'],
+      anyTraits: ['orc'],
+      sources: ['Core Rulebook'],
+      ancestrySlug: 'goblin',
+      minLevel: 2,
+      maxLevel: 10,
+      rarities: ['common', 'uncommon'],
+      sizes: ['sm', 'med'],
+      creatureTypes: ['humanoid'],
+      usageCategories: ['held', 'worn'],
+      isMagical: true,
+      hpMin: 10,
+      hpMax: 100,
+      acMin: 15,
+      acMax: 25,
+      fortMin: 5,
+      fortMax: 15,
+      refMin: 3,
+      refMax: 12,
+      willMin: 2,
+      willMax: 10,
+      limit: 50,
+      offset: 100,
+    });
+
+    const parsed = roundTrip(qs);
+    expect(parsed.q).toBe('goblin');
+    expect(parsed.packId).toEqual(['pf2e.bestiary-family-ability-glossary', 'pf2e.feats-srd']);
+    expect(parsed.documentType).toBe('Actor');
+    expect(parsed.traits).toEqual(['humanoid', 'goblin']);
+    expect(parsed.anyTraits).toEqual(['orc']);
+    expect(parsed.sources).toEqual(['Core Rulebook']);
+    expect(parsed.ancestrySlug).toBe('goblin');
+    expect(parsed.minLevel).toBe(2);
+    expect(parsed.maxLevel).toBe(10);
+    expect(parsed.rarities).toEqual(['common', 'uncommon']);
+    expect(parsed.sizes).toEqual(['sm', 'med']);
+    expect(parsed.creatureTypes).toEqual(['humanoid']);
+    expect(parsed.usageCategories).toEqual(['held', 'worn']);
+    expect(parsed.isMagical).toBe(true);
+    expect(parsed.hpMin).toBe(10);
+    expect(parsed.hpMax).toBe(100);
+    expect(parsed.acMin).toBe(15);
+    expect(parsed.acMax).toBe(25);
+    expect(parsed.fortMin).toBe(5);
+    expect(parsed.fortMax).toBe(15);
+    expect(parsed.refMin).toBe(3);
+    expect(parsed.refMax).toBe(12);
+    expect(parsed.willMin).toBe(2);
+    expect(parsed.willMax).toBe(10);
+    expect(parsed.limit).toBe(50);
+    expect(parsed.offset).toBe(100);
+  });
+
+  it('omits empty arrays from the query string', () => {
+    const qs = buildCompendiumQuery({
+      q: 'goblin',
+      rarities: [],
+      sizes: [],
+      creatureTypes: [],
+      usageCategories: [],
+    });
+    const params = new URLSearchParams(qs);
+    expect(params.has('rarities')).toBe(false);
+    expect(params.has('sizes')).toBe(false);
+    expect(params.has('creatureTypes')).toBe(false);
+    expect(params.has('usageCategories')).toBe(false);
+  });
+
+  it('encodes falsy number offset=0', () => {
+    const qs = buildCompendiumQuery({ q: 'x', offset: 0 });
+    expect(new URLSearchParams(qs).get('offset')).toBe('0');
+    expect(roundTrip(qs).offset).toBe(0);
+  });
+
+  it('encodes falsy number hpMin=0', () => {
+    const qs = buildCompendiumQuery({ q: 'x', hpMin: 0 });
+    expect(new URLSearchParams(qs).get('hpMin')).toBe('0');
+    expect(roundTrip(qs).hpMin).toBe(0);
+  });
+
+  it('encodes isMagical=true as the string "true"', () => {
+    const qs = buildCompendiumQuery({ q: 'x', isMagical: true });
+    expect(new URLSearchParams(qs).get('isMagical')).toBe('true');
+    expect(roundTrip(qs).isMagical).toBe(true);
+  });
+
+  it('encodes isMagical=false as the string "false"', () => {
+    const qs = buildCompendiumQuery({ q: 'x', isMagical: false });
+    expect(new URLSearchParams(qs).get('isMagical')).toBe('false');
+    expect(roundTrip(qs).isMagical).toBe(false);
+  });
+});

--- a/packages/shared/src/http.ts
+++ b/packages/shared/src/http.ts
@@ -75,7 +75,25 @@ export function buildCompendiumQuery(opts: CompendiumSearchOptions): string {
   if (opts.anyTraits !== undefined && opts.anyTraits.length > 0) params.set('anyTraits', opts.anyTraits.join(','));
   if (opts.sources !== undefined && opts.sources.length > 0) params.set('sources', opts.sources.join(','));
   if (opts.ancestrySlug !== undefined && opts.ancestrySlug.length > 0) params.set('ancestrySlug', opts.ancestrySlug);
+  if (opts.minLevel !== undefined) params.set('minLevel', opts.minLevel.toString());
   if (opts.maxLevel !== undefined) params.set('maxLevel', opts.maxLevel.toString());
+  if (opts.rarities !== undefined && opts.rarities.length > 0) params.set('rarities', opts.rarities.join(','));
+  if (opts.sizes !== undefined && opts.sizes.length > 0) params.set('sizes', opts.sizes.join(','));
+  if (opts.creatureTypes !== undefined && opts.creatureTypes.length > 0)
+    params.set('creatureTypes', opts.creatureTypes.join(','));
+  if (opts.usageCategories !== undefined && opts.usageCategories.length > 0)
+    params.set('usageCategories', opts.usageCategories.join(','));
+  if (opts.isMagical !== undefined) params.set('isMagical', opts.isMagical.toString());
+  if (opts.hpMin !== undefined) params.set('hpMin', opts.hpMin.toString());
+  if (opts.hpMax !== undefined) params.set('hpMax', opts.hpMax.toString());
+  if (opts.acMin !== undefined) params.set('acMin', opts.acMin.toString());
+  if (opts.acMax !== undefined) params.set('acMax', opts.acMax.toString());
+  if (opts.fortMin !== undefined) params.set('fortMin', opts.fortMin.toString());
+  if (opts.fortMax !== undefined) params.set('fortMax', opts.fortMax.toString());
+  if (opts.refMin !== undefined) params.set('refMin', opts.refMin.toString());
+  if (opts.refMax !== undefined) params.set('refMax', opts.refMax.toString());
+  if (opts.willMin !== undefined) params.set('willMin', opts.willMin.toString());
+  if (opts.willMax !== undefined) params.set('willMax', opts.willMax.toString());
   if (opts.limit !== undefined) params.set('limit', opts.limit.toString());
   if (opts.offset !== undefined) params.set('offset', opts.offset.toString());
   return params.toString();


### PR DESCRIPTION
## Summary

`buildCompendiumQuery` in `packages/shared/src/http.ts` was encoding only 10 of the 26 fields declared on `CompendiumSearchOptions`, silently dropping `minLevel`, `rarities`, `sizes`, `creatureTypes`, `usageCategories`, `isMagical`, and all ten combat-stat range params (`hpMin`/`Max`, `acMin`/`Max`, `fortMin`/`Max`, `refMin`/`Max`, `willMin`/`Max`). The server-side Zod schema (`compendiumSearchQuery`) already accepts every field; filters were simply discarded at the wire boundary instead of reaching the server.

This is **audit finding F1** from `docs/REFACTOR-AUDIT-2026-04-30.md`. Before: 10 fields serialized. After: all 26 fields serialized.

Note: dm-tool's client-side workarounds in `apps/dm-tool/electron/compendium/prepared.ts` (inline `minLevel` filter comment at line 485, facet filters at lines 204–224 and 409–419) are intentionally left for a follow-up PR as called out by the audit.

## Changes

- `packages/shared/src/http.ts`: add 16 missing param encodings to `buildCompendiumQuery` — CSV join for array fields, `.toString()` for numbers (including `0`), `.toString()` for booleans (`'true'`/`'false'`)
- `packages/shared/src/http.test.ts` (new): Vitest round-trip suite — pipes a fully-populated `CompendiumSearchOptions` through `buildCompendiumQuery` → `compendiumSearchQuery.parse()` and asserts every field survives; plus edge cases for empty-array omission, falsy-zero encoding, and boolean string encoding

## Test plan

- [x] `npm run test -w @foundry-toolkit/shared` — 215 tests pass (14 files)
- [x] `npm run typecheck` — clean across all workspaces (both consumers `dm-tool` and `player-portal` typecheck without changes)
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npm run format:check` — clean

## Apps touched

Only `packages/shared` changed. Both consumers receive the fix transitively:
- `apps/dm-tool` — `npm run dev:dm-tool`
- `apps/player-portal` — `npm run dev:player-portal`

No app needs to be spun up to validate this PR — the behavior change is that server-side filters now receive the params they were already declared to accept. The existing consumer call sites (`apps/dm-tool/electron/compendium/client.ts:52`, `apps/player-portal/src/api/client.ts:71`) are unchanged.

## Follow-ups

Retire dm-tool's client-side workarounds once this lands (audit F1 explicit suggestion):
- `prepared.ts:485` — inline `minLevel` comment noting the wire contract gap
- `prepared.ts:204–224`, `409–419` — client-side facet filters for rarities/creatureTypes