### PR TITLE
style(player-portal): hide rarity and alliance badges from sheet header

### DIFF
--- a/apps/player-portal/src/components/sheet/SheetHeader.test.tsx
+++ b/apps/player-portal/src/components/sheet/SheetHeader.test.tsx
@@ -32,43 +32,6 @@ describe('SheetHeader', () => {
     expect(container.querySelector('[data-section="identity"]')?.textContent).not.toContain('Hunter');
   });
 
-  it('renders rarity badge when non-common (Amiri is unique)', () => {
-    const { container } = render(<SheetHeader character={character} actorId="test-actor" onActorChanged={() => undefined} />);
-    const badge = container.querySelector('[data-badge="rarity"]');
-    expect(badge, 'rarity badge').toBeTruthy();
-    expect(badge?.textContent).toBe('Unique');
-  });
-
-  it('renders alliance badge for party members', () => {
-    const { container } = render(<SheetHeader character={character} actorId="test-actor" onActorChanged={() => undefined} />);
-    const badge = container.querySelector('[data-badge="alliance"]');
-    expect(badge, 'alliance badge').toBeTruthy();
-    expect(badge?.textContent).toBe('Party');
-  });
-
-  it('omits rarity badge when rarity is common', () => {
-    const common: PreparedCharacter = {
-      ...character,
-      system: {
-        ...character.system,
-        traits: { ...character.system.traits, rarity: 'common' },
-      },
-    };
-    const { container } = render(<SheetHeader character={common} actorId="test-actor" onActorChanged={() => undefined} />);
-    expect(container.querySelector('[data-badge="rarity"]')).toBeNull();
-  });
-
-  it('omits alliance badge when alliance is null', () => {
-    const neutral: PreparedCharacter = {
-      ...character,
-      system: {
-        ...character.system,
-        details: { ...character.system.details, alliance: null },
-      },
-    };
-    const { container } = render(<SheetHeader character={neutral} actorId="test-actor" onActorChanged={() => undefined} />);
-    expect(container.querySelector('[data-badge="alliance"]')).toBeNull();
-  });
 
   it('does not duplicate ancestry when heritage already contains it', () => {
     // Regression: "Venom-Resistant Vishkanya Vishkanya" was produced before

--- a/apps/player-portal/src/components/sheet/SheetHeader.tsx
+++ b/apps/player-portal/src/components/sheet/SheetHeader.tsx
@@ -17,17 +17,6 @@ interface Props {
   onSettingsOpen?: () => void;
 }
 
-const RARITY_CLASSES: Record<string, string> = {
-  uncommon: 'border-pf-rarity-uncommon bg-pf-rarity-uncommon/10 text-pf-rarity-uncommon',
-  rare: 'border-pf-rarity-rare bg-pf-rarity-rare/10 text-pf-rarity-rare',
-  unique: 'border-pf-rarity-unique bg-pf-rarity-unique/10 text-pf-rarity-unique',
-};
-
-const ALLIANCE_CLASSES: Record<string, string> = {
-  party: 'border-emerald-400 bg-emerald-50 text-emerald-800',
-  opposition: 'border-pf-primary bg-pf-primary/10 text-pf-primary',
-};
-
 export function SheetHeader({
   character,
   actorId,
@@ -41,8 +30,6 @@ export function SheetHeader({
   const heritage = system.details.heritage?.name;
   const cls = system.details.class?.name;
   const background = items.find((i) => i.type === 'background')?.name;
-  const rarity = system.traits.rarity;
-  const alliance = system.details.alliance;
   const xp = system.details.xp;
   const heroPoints = system.resources.heroPoints;
 
@@ -60,16 +47,6 @@ export function SheetHeader({
           <div className="min-w-0 flex-1">
             <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
               <h1 className="font-serif text-2xl font-bold text-pf-text">{name}</h1>
-              {rarity && rarity !== 'common' && (
-                <Badge data-badge="rarity" label={capitalise(rarity)} className={RARITY_CLASSES[rarity] ?? ''} />
-              )}
-              {alliance && (
-                <Badge
-                  data-badge="alliance"
-                  label={capitalise(alliance)}
-                  className={ALLIANCE_CLASSES[alliance] ?? ''}
-                />
-              )}
             </div>
             {subtitle && (
               <p className="mt-0.5 font-sans text-sm text-pf-alt" data-section="identity">
@@ -311,31 +288,6 @@ function PortraitLightbox({
       />
     </div>
   );
-}
-
-// ─── Badges ────────────────────────────────────────────────────────────
-
-function Badge({
-  label,
-  className,
-  ...rest
-}: {
-  label: string;
-  className: string;
-  'data-badge'?: string;
-}): React.ReactElement {
-  return (
-    <span
-      className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest ${className}`}
-      {...rest}
-    >
-      {label}
-    </span>
-  );
-}
-
-function capitalise(s: string): string {
-  return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
 // ─── Icons ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Removed the rarity and alliance trait badges that rendered to the right of the character name in the sheet header. The underlying actor metadata and constants remain for use by other components.

## Changes
- Removed JSX rendering badges for rarity and alliance traits
- Removed unused `Badge` component and `capitalise` helper function
- Removed tests asserting on badge presence

## Test plan
- [x] SheetHeader tests pass (5 tests remain after removing 4 badge-related tests)
- [x] Component renders character name without badges

## Apps touched
- `apps/player-portal`