### PR TITLE
fix(player-portal): correct upward-flip popover offset

### DIFF
--- a/apps/player-portal/src/components/tabs/Progression.tsx
+++ b/apps/player-portal/src/components/tabs/Progression.tsx
@@ -724,7 +724,7 @@ function FeatureChip({
   failed: boolean;
 }): React.ReactElement {
   const [open, setOpen] = useState(false);
-  const [pos, setPos] = useState<{ top?: number; bottom?: number; left: number; maxHeight: number } | null>(null);
+  const [pos, setPos] = useState<{ top: number; transform?: string; left: number; maxHeight: number } | null>(null);
   const chipRef = useRef<HTMLLIElement>(null);
   const closeTimerRef = useRef<number | null>(null);
   const openTimerRef = useRef<number | null>(null);
@@ -798,11 +798,11 @@ function FeatureChip({
             style={{
               position: 'fixed',
               top: pos.top,
-              bottom: pos.bottom,
               left: pos.left,
               width: FEATURE_POPOVER_WIDTH,
               maxHeight: pos.maxHeight,
               overflowY: 'auto',
+              transform: pos.transform,
             }}
             className="z-50 rounded border border-pf-border bg-pf-bg p-4 text-left shadow-xl"
           >
@@ -843,9 +843,9 @@ function extractDescription(doc: CompendiumDocument): string {
 // Choose below vs above the anchor based on available viewport space,
 // and return a `maxHeight` so the popover caps itself to the space it
 // has and scrolls inside rather than overflowing the viewport.
-// Above cases return `bottom` instead of `top` so a short popover stays
-// adjacent to the trigger — maxHeight is a cap, not the rendered height.
-function pickFeaturePopoverVerticalSlot(anchor: DOMRect): { top?: number; bottom?: number; maxHeight: number } {
+// Above cases pair `top: anchor.top - GAP` with `transform: translateY(-100%)`
+// so the popover bottom always kisses the trigger with exactly GAP separation.
+function pickFeaturePopoverVerticalSlot(anchor: DOMRect): { top: number; transform?: string; maxHeight: number } {
   const viewportH = window.innerHeight;
   const spaceBelow = viewportH - anchor.bottom - FEATURE_POPOVER_GAP - FEATURE_POPOVER_VIEWPORT_MARGIN;
   const spaceAbove = anchor.top - FEATURE_POPOVER_GAP - FEATURE_POPOVER_VIEWPORT_MARGIN;
@@ -854,13 +854,17 @@ function pickFeaturePopoverVerticalSlot(anchor: DOMRect): { top?: number; bottom
     return { top: anchor.bottom + FEATURE_POPOVER_GAP, maxHeight: FEATURE_POPOVER_PREFERRED_HEIGHT };
   }
   if (spaceAbove >= FEATURE_POPOVER_PREFERRED_HEIGHT) {
-    return { bottom: viewportH - anchor.top + FEATURE_POPOVER_GAP, maxHeight: FEATURE_POPOVER_PREFERRED_HEIGHT };
+    return {
+      top: anchor.top - FEATURE_POPOVER_GAP,
+      transform: 'translateY(-100%)',
+      maxHeight: FEATURE_POPOVER_PREFERRED_HEIGHT,
+    };
   }
   if (spaceBelow >= spaceAbove) {
     return { top: anchor.bottom + FEATURE_POPOVER_GAP, maxHeight: Math.max(120, spaceBelow) };
   }
   const h = Math.max(120, spaceAbove);
-  return { bottom: viewportH - anchor.top + FEATURE_POPOVER_GAP, maxHeight: h };
+  return { top: anchor.top - FEATURE_POPOVER_GAP, transform: 'translateY(-100%)', maxHeight: h };
 }
 
 // ─── Slot chips ────────────────────────────────────────────────────────

--- a/apps/player-portal/src/components/tabs/Progression.tsx
+++ b/apps/player-portal/src/components/tabs/Progression.tsx
@@ -724,7 +724,7 @@ function FeatureChip({
   failed: boolean;
 }): React.ReactElement {
   const [open, setOpen] = useState(false);
-  const [pos, setPos] = useState<{ top: number; left: number; maxHeight: number } | null>(null);
+  const [pos, setPos] = useState<{ top?: number; bottom?: number; left: number; maxHeight: number } | null>(null);
   const chipRef = useRef<HTMLLIElement>(null);
   const closeTimerRef = useRef<number | null>(null);
   const openTimerRef = useRef<number | null>(null);
@@ -763,7 +763,7 @@ function FeatureChip({
       const maxLeft = window.innerWidth - FEATURE_POPOVER_WIDTH - FEATURE_POPOVER_VIEWPORT_MARGIN;
       const left = Math.max(FEATURE_POPOVER_VIEWPORT_MARGIN, Math.min(rect.left, maxLeft));
       const vertical = pickFeaturePopoverVerticalSlot(rect);
-      setPos({ top: vertical.top, left, maxHeight: vertical.maxHeight });
+      setPos({ ...vertical, left });
       setOpen(true);
     }, HOVER_OPEN_DELAY_MS);
   };
@@ -798,6 +798,7 @@ function FeatureChip({
             style={{
               position: 'fixed',
               top: pos.top,
+              bottom: pos.bottom,
               left: pos.left,
               width: FEATURE_POPOVER_WIDTH,
               maxHeight: pos.maxHeight,
@@ -842,7 +843,9 @@ function extractDescription(doc: CompendiumDocument): string {
 // Choose below vs above the anchor based on available viewport space,
 // and return a `maxHeight` so the popover caps itself to the space it
 // has and scrolls inside rather than overflowing the viewport.
-function pickFeaturePopoverVerticalSlot(anchor: DOMRect): { top: number; maxHeight: number } {
+// Above cases return `bottom` instead of `top` so a short popover stays
+// adjacent to the trigger — maxHeight is a cap, not the rendered height.
+function pickFeaturePopoverVerticalSlot(anchor: DOMRect): { top?: number; bottom?: number; maxHeight: number } {
   const viewportH = window.innerHeight;
   const spaceBelow = viewportH - anchor.bottom - FEATURE_POPOVER_GAP - FEATURE_POPOVER_VIEWPORT_MARGIN;
   const spaceAbove = anchor.top - FEATURE_POPOVER_GAP - FEATURE_POPOVER_VIEWPORT_MARGIN;
@@ -851,16 +854,13 @@ function pickFeaturePopoverVerticalSlot(anchor: DOMRect): { top: number; maxHeig
     return { top: anchor.bottom + FEATURE_POPOVER_GAP, maxHeight: FEATURE_POPOVER_PREFERRED_HEIGHT };
   }
   if (spaceAbove >= FEATURE_POPOVER_PREFERRED_HEIGHT) {
-    return {
-      top: anchor.top - FEATURE_POPOVER_GAP - FEATURE_POPOVER_PREFERRED_HEIGHT,
-      maxHeight: FEATURE_POPOVER_PREFERRED_HEIGHT,
-    };
+    return { bottom: viewportH - anchor.top + FEATURE_POPOVER_GAP, maxHeight: FEATURE_POPOVER_PREFERRED_HEIGHT };
   }
   if (spaceBelow >= spaceAbove) {
     return { top: anchor.bottom + FEATURE_POPOVER_GAP, maxHeight: Math.max(120, spaceBelow) };
   }
   const h = Math.max(120, spaceAbove);
-  return { top: Math.max(FEATURE_POPOVER_VIEWPORT_MARGIN, anchor.top - FEATURE_POPOVER_GAP - h), maxHeight: h };
+  return { bottom: viewportH - anchor.top + FEATURE_POPOVER_GAP, maxHeight: h };
 }
 
 // ─── Slot chips ────────────────────────────────────────────────────────

--- a/apps/player-portal/src/lib/useUuidHover.test.ts
+++ b/apps/player-portal/src/lib/useUuidHover.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+import { pickVerticalSlot } from './useUuidHover';
+
+// Helpers to build a minimal DOMRect for pickVerticalSlot.
+const makeRect = (top: number, bottom: number): DOMRect =>
+  ({ top, bottom, left: 0, right: 0, width: 0, height: bottom - top, x: 0, y: top, toJSON: () => ({}) }) as DOMRect;
+
+const POPOVER_GAP = 6;
+const PREFERRED_HEIGHT = 520;
+const VIEWPORT_EDGE_MARGIN = 12;
+
+describe('pickVerticalSlot', () => {
+  it('renders below when there is preferred height below', () => {
+    vi.stubGlobal('innerHeight', 900);
+    // Anchor near the top — plenty of space below.
+    const anchor = makeRect(50, 70);
+    const slot = pickVerticalSlot(anchor);
+    expect(slot.top).toBe(70 + POPOVER_GAP);
+    expect(slot.bottom).toBeUndefined();
+    expect(slot.maxHeight).toBe(PREFERRED_HEIGHT);
+  });
+
+  it('flips above using bottom-anchor when space below is insufficient', () => {
+    vi.stubGlobal('innerHeight', 900);
+    // Anchor near the bottom — not enough space below, plenty above.
+    const anchor = makeRect(700, 720);
+    const slot = pickVerticalSlot(anchor);
+
+    // Must use bottom, not top, so a short popover stays adjacent to the trigger.
+    expect(slot.top).toBeUndefined();
+    expect(slot.bottom).toBe(900 - 700 + POPOVER_GAP); // viewportH - anchor.top + GAP
+    expect(slot.maxHeight).toBe(PREFERRED_HEIGHT);
+  });
+
+  it('bottom-anchor places the popover bottom POPOVER_GAP above the trigger (regression)', () => {
+    vi.stubGlobal('innerHeight', 900);
+    const anchor = makeRect(700, 720);
+    const slot = pickVerticalSlot(anchor);
+
+    // With fixed bottom-anchoring, the rendered bottom of the popover is at:
+    //   viewportH - slot.bottom  =  900 - (900 - 700 + 6)  =  694  =  anchor.top - GAP
+    // Regardless of how short the actual content is, the gap is always exactly POPOVER_GAP.
+    const popoverBottom = 900 - (slot.bottom ?? 0);
+    expect(popoverBottom).toBe(anchor.top - POPOVER_GAP);
+  });
+
+  it('fallback below when neither side has preferred height', () => {
+    vi.stubGlobal('innerHeight', 400);
+    // Anchor in the middle of a short viewport.
+    const anchor = makeRect(180, 200);
+    // spaceBelow = 400-200-6-12 = 182; spaceAbove = 180-6-12 = 162 → below wins
+    const slot = pickVerticalSlot(anchor);
+    expect(slot.top).toBe(200 + POPOVER_GAP);
+    expect(slot.bottom).toBeUndefined();
+    expect(slot.maxHeight).toBeGreaterThanOrEqual(120);
+  });
+
+  it('fallback above uses bottom-anchor when above has more space', () => {
+    vi.stubGlobal('innerHeight', 400);
+    // Anchor near bottom of a short viewport.
+    const anchor = makeRect(250, 270);
+    // spaceBelow = 400-270-6-12 = 112; spaceAbove = 250-6-12 = 232 → above wins
+    const slot = pickVerticalSlot(anchor);
+    expect(slot.top).toBeUndefined();
+    expect(slot.bottom).toBe(400 - 250 + POPOVER_GAP);
+    expect(slot.maxHeight).toBe(250 - POPOVER_GAP - VIEWPORT_EDGE_MARGIN); // = spaceAbove
+  });
+
+  it('below gap is consistent with above gap', () => {
+    // Verify the gap constant is applied symmetrically.
+    vi.stubGlobal('innerHeight', 900);
+
+    const anchorBelow = makeRect(50, 70);
+    const slotBelow = pickVerticalSlot(anchorBelow);
+    const belowGap = (slotBelow.top ?? 0) - anchorBelow.bottom;
+
+    const anchorAbove = makeRect(700, 720);
+    const slotAbove = pickVerticalSlot(anchorAbove);
+    const popoverBottomAbove = 900 - (slotAbove.bottom ?? 0);
+    const aboveGap = anchorAbove.top - popoverBottomAbove;
+
+    expect(belowGap).toBe(aboveGap);
+    expect(belowGap).toBe(POPOVER_GAP);
+  });
+});

--- a/apps/player-portal/src/lib/useUuidHover.test.ts
+++ b/apps/player-portal/src/lib/useUuidHover.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { pickVerticalSlot } from './useUuidHover';
 
-// Helpers to build a minimal DOMRect for pickVerticalSlot.
 const makeRect = (top: number, bottom: number): DOMRect =>
   ({ top, bottom, left: 0, right: 0, width: 0, height: bottom - top, x: 0, y: top, toJSON: () => ({}) }) as DOMRect;
 
@@ -12,72 +11,71 @@ const VIEWPORT_EDGE_MARGIN = 12;
 describe('pickVerticalSlot', () => {
   it('renders below when there is preferred height below', () => {
     vi.stubGlobal('innerHeight', 900);
-    // Anchor near the top — plenty of space below.
     const anchor = makeRect(50, 70);
     const slot = pickVerticalSlot(anchor);
     expect(slot.top).toBe(70 + POPOVER_GAP);
-    expect(slot.bottom).toBeUndefined();
+    expect(slot.transform).toBeUndefined();
     expect(slot.maxHeight).toBe(PREFERRED_HEIGHT);
   });
 
-  it('flips above using bottom-anchor when space below is insufficient', () => {
+  it('flips above using translateY(-100%) when space below is insufficient', () => {
     vi.stubGlobal('innerHeight', 900);
     // Anchor near the bottom — not enough space below, plenty above.
     const anchor = makeRect(700, 720);
     const slot = pickVerticalSlot(anchor);
 
-    // Must use bottom, not top, so a short popover stays adjacent to the trigger.
-    expect(slot.top).toBeUndefined();
-    expect(slot.bottom).toBe(900 - 700 + POPOVER_GAP); // viewportH - anchor.top + GAP
+    expect(slot.top).toBe(700 - POPOVER_GAP);
+    expect(slot.transform).toBe('translateY(-100%)');
     expect(slot.maxHeight).toBe(PREFERRED_HEIGHT);
   });
 
-  it('bottom-anchor places the popover bottom POPOVER_GAP above the trigger (regression)', () => {
+  it('translateY(-100%) places the popover bottom POPOVER_GAP above the trigger (regression)', () => {
     vi.stubGlobal('innerHeight', 900);
     const anchor = makeRect(700, 720);
     const slot = pickVerticalSlot(anchor);
 
-    // With fixed bottom-anchoring, the rendered bottom of the popover is at:
-    //   viewportH - slot.bottom  =  900 - (900 - 700 + 6)  =  694  =  anchor.top - GAP
-    // Regardless of how short the actual content is, the gap is always exactly POPOVER_GAP.
-    const popoverBottom = 900 - (slot.bottom ?? 0);
-    expect(popoverBottom).toBe(anchor.top - POPOVER_GAP);
+    // `top` is the CSS top edge before the transform. The transform shifts
+    // the element up by its own rendered height. Regardless of content height,
+    // the bottom of the element will always be at `top` — i.e. anchor.top - GAP.
+    // So the gap is always exactly POPOVER_GAP.
+    expect(slot.top).toBe(anchor.top - POPOVER_GAP);
+    // Visual bottom = slot.top (since translateY(-100%) shifts by rendered height,
+    // making visual_bottom = css_top + rendered_height - rendered_height = css_top).
+    const visualBottom = slot.top; // after translateY(-100%), bottom == top in CSS space
+    expect(anchor.top - visualBottom).toBe(POPOVER_GAP);
   });
 
   it('fallback below when neither side has preferred height', () => {
     vi.stubGlobal('innerHeight', 400);
-    // Anchor in the middle of a short viewport.
+    // spaceBelow = 400-200-6-12=182; spaceAbove = 180-6-12=162 → below wins
     const anchor = makeRect(180, 200);
-    // spaceBelow = 400-200-6-12 = 182; spaceAbove = 180-6-12 = 162 → below wins
     const slot = pickVerticalSlot(anchor);
     expect(slot.top).toBe(200 + POPOVER_GAP);
-    expect(slot.bottom).toBeUndefined();
+    expect(slot.transform).toBeUndefined();
     expect(slot.maxHeight).toBeGreaterThanOrEqual(120);
   });
 
-  it('fallback above uses bottom-anchor when above has more space', () => {
+  it('fallback above uses translateY(-100%) when above has more space', () => {
     vi.stubGlobal('innerHeight', 400);
-    // Anchor near bottom of a short viewport.
+    // spaceBelow = 400-270-6-12=112; spaceAbove = 250-6-12=232 → above wins
     const anchor = makeRect(250, 270);
-    // spaceBelow = 400-270-6-12 = 112; spaceAbove = 250-6-12 = 232 → above wins
     const slot = pickVerticalSlot(anchor);
-    expect(slot.top).toBeUndefined();
-    expect(slot.bottom).toBe(400 - 250 + POPOVER_GAP);
-    expect(slot.maxHeight).toBe(250 - POPOVER_GAP - VIEWPORT_EDGE_MARGIN); // = spaceAbove
+    expect(slot.top).toBe(250 - POPOVER_GAP);
+    expect(slot.transform).toBe('translateY(-100%)');
+    expect(slot.maxHeight).toBe(250 - POPOVER_GAP - VIEWPORT_EDGE_MARGIN);
   });
 
   it('below gap is consistent with above gap', () => {
-    // Verify the gap constant is applied symmetrically.
     vi.stubGlobal('innerHeight', 900);
 
     const anchorBelow = makeRect(50, 70);
     const slotBelow = pickVerticalSlot(anchorBelow);
-    const belowGap = (slotBelow.top ?? 0) - anchorBelow.bottom;
+    const belowGap = slotBelow.top - anchorBelow.bottom;
 
     const anchorAbove = makeRect(700, 720);
     const slotAbove = pickVerticalSlot(anchorAbove);
-    const popoverBottomAbove = 900 - (slotAbove.bottom ?? 0);
-    const aboveGap = anchorAbove.top - popoverBottomAbove;
+    // For above: visual bottom = css top (after translateY(-100%)), gap = anchor.top - css.top
+    const aboveGap = anchorAbove.top - slotAbove.top;
 
     expect(belowGap).toBe(aboveGap);
     expect(belowGap).toBe(POPOVER_GAP);

--- a/apps/player-portal/src/lib/useUuidHover.tsx
+++ b/apps/player-portal/src/lib/useUuidHover.tsx
@@ -205,35 +205,33 @@ export function useUuidHover(opts?: UseUuidHoverOptions): {
     handleMouseOut(e.target as Element, (e.relatedTarget as Element | null) ?? null);
   };
 
-  const positions = stack.reduce<Array<{ top: number; left: number; maxHeight: number }>>((acc, level, idx) => {
-    const maxLeft = window.innerWidth - POPOVER_WIDTH - VIEWPORT_EDGE_MARGIN;
-    if (idx === 0) {
-      const v = pickVerticalSlot(level.anchorRect);
-      acc.push({
-        top: v.top,
-        left: Math.max(VIEWPORT_EDGE_MARGIN, Math.min(level.anchorRect.left, maxLeft)),
-        maxHeight: v.maxHeight,
-      });
+  const positions = stack.reduce<Array<{ top?: number; bottom?: number; left: number; maxHeight: number }>>(
+    (acc, level, idx) => {
+      const maxLeft = window.innerWidth - POPOVER_WIDTH - VIEWPORT_EDGE_MARGIN;
+      if (idx === 0) {
+        const v = pickVerticalSlot(level.anchorRect);
+        acc.push({ ...v, left: Math.max(VIEWPORT_EDGE_MARGIN, Math.min(level.anchorRect.left, maxLeft)) });
+        return acc;
+      }
+      const parent = acc[idx - 1];
+      if (parent === undefined) {
+        const v = pickVerticalSlot(level.anchorRect);
+        acc.push({ ...v, left: Math.max(VIEWPORT_EDGE_MARGIN, Math.min(level.anchorRect.left, maxLeft)) });
+        return acc;
+      }
+      // Prefer right of the parent; if that overflows the viewport,
+      // fall back to the left side so the preview stays reachable.
+      const rightOfParent = parent.left + POPOVER_WIDTH + POPOVER_GAP;
+      const leftOfParent = parent.left - POPOVER_WIDTH - POPOVER_GAP;
+      const left = rightOfParent <= maxLeft ? rightOfParent : Math.max(VIEWPORT_EDGE_MARGIN, leftOfParent);
+      // When the parent used bottom-anchoring (above flip), derive a top for
+      // the sibling popover from the parent's bottom anchor and maxHeight.
+      const nestTop = parent.top ?? window.innerHeight - (parent.bottom ?? 0) - parent.maxHeight;
+      acc.push({ top: nestTop, left, maxHeight: parent.maxHeight });
       return acc;
-    }
-    const parent = acc[idx - 1];
-    if (parent === undefined) {
-      const v = pickVerticalSlot(level.anchorRect);
-      acc.push({
-        top: v.top,
-        left: Math.max(VIEWPORT_EDGE_MARGIN, Math.min(level.anchorRect.left, maxLeft)),
-        maxHeight: v.maxHeight,
-      });
-      return acc;
-    }
-    // Prefer right of the parent; if that overflows the viewport,
-    // fall back to the left side so the preview stays reachable.
-    const rightOfParent = parent.left + POPOVER_WIDTH + POPOVER_GAP;
-    const leftOfParent = parent.left - POPOVER_WIDTH - POPOVER_GAP;
-    const left = rightOfParent <= maxLeft ? rightOfParent : Math.max(VIEWPORT_EDGE_MARGIN, leftOfParent);
-    acc.push({ top: parent.top, left, maxHeight: parent.maxHeight });
-    return acc;
-  }, []);
+    },
+    [],
+  );
 
   const popover =
     stack.length > 0 ? (
@@ -269,6 +267,7 @@ export function useUuidHover(opts?: UseUuidHoverOptions): {
               style={{
                 position: 'fixed',
                 top: pos.top,
+                bottom: pos.bottom,
                 left: pos.left,
                 width: POPOVER_WIDTH,
                 maxHeight: pos.maxHeight,
@@ -294,7 +293,11 @@ export function useUuidHover(opts?: UseUuidHoverOptions): {
 // when there isn't enough room, and how tall the popover can be before
 // it should scroll internally. Falls back to the side with the most
 // room when neither fits the preferred height.
-function pickVerticalSlot(anchor: DOMRect): { top: number; maxHeight: number } {
+//
+// "Above" cases return `bottom` (distance from viewport bottom) instead
+// of `top` so a short popover stays kissing the trigger rather than
+// floating away from it — maxHeight is a cap, not the rendered height.
+export function pickVerticalSlot(anchor: DOMRect): { top?: number; bottom?: number; maxHeight: number } {
   const viewportH = window.innerHeight;
   const spaceBelow = viewportH - anchor.bottom - POPOVER_GAP - VIEWPORT_EDGE_MARGIN;
   const spaceAbove = anchor.top - POPOVER_GAP - VIEWPORT_EDGE_MARGIN;
@@ -303,7 +306,7 @@ function pickVerticalSlot(anchor: DOMRect): { top: number; maxHeight: number } {
     return { top: anchor.bottom + POPOVER_GAP, maxHeight: POPOVER_PREFERRED_HEIGHT };
   }
   if (spaceAbove >= POPOVER_PREFERRED_HEIGHT) {
-    return { top: anchor.top - POPOVER_GAP - POPOVER_PREFERRED_HEIGHT, maxHeight: POPOVER_PREFERRED_HEIGHT };
+    return { bottom: viewportH - anchor.top + POPOVER_GAP, maxHeight: POPOVER_PREFERRED_HEIGHT };
   }
   // Neither side has preferred height — open on whichever side has
   // more space and cap the popover to that space so the content
@@ -312,7 +315,7 @@ function pickVerticalSlot(anchor: DOMRect): { top: number; maxHeight: number } {
     return { top: anchor.bottom + POPOVER_GAP, maxHeight: Math.max(120, spaceBelow) };
   }
   const h = Math.max(120, spaceAbove);
-  return { top: Math.max(VIEWPORT_EDGE_MARGIN, anchor.top - POPOVER_GAP - h), maxHeight: h };
+  return { bottom: viewportH - anchor.top + POPOVER_GAP, maxHeight: h };
 }
 
 function PopoverBody({ state }: { state: DocState | undefined }): React.ReactElement {

--- a/apps/player-portal/src/lib/useUuidHover.tsx
+++ b/apps/player-portal/src/lib/useUuidHover.tsx
@@ -205,7 +205,7 @@ export function useUuidHover(opts?: UseUuidHoverOptions): {
     handleMouseOut(e.target as Element, (e.relatedTarget as Element | null) ?? null);
   };
 
-  const positions = stack.reduce<Array<{ top?: number; bottom?: number; left: number; maxHeight: number }>>(
+  const positions = stack.reduce<Array<{ top: number; transform?: string; left: number; maxHeight: number }>>(
     (acc, level, idx) => {
       const maxLeft = window.innerWidth - POPOVER_WIDTH - VIEWPORT_EDGE_MARGIN;
       if (idx === 0) {
@@ -224,9 +224,10 @@ export function useUuidHover(opts?: UseUuidHoverOptions): {
       const rightOfParent = parent.left + POPOVER_WIDTH + POPOVER_GAP;
       const leftOfParent = parent.left - POPOVER_WIDTH - POPOVER_GAP;
       const left = rightOfParent <= maxLeft ? rightOfParent : Math.max(VIEWPORT_EDGE_MARGIN, leftOfParent);
-      // When the parent used bottom-anchoring (above flip), derive a top for
-      // the sibling popover from the parent's bottom anchor and maxHeight.
-      const nestTop = parent.top ?? window.innerHeight - (parent.bottom ?? 0) - parent.maxHeight;
+      // For above-flipped parents the CSS `top` is the trigger's top edge
+      // (before the translateY shift). Subtract maxHeight to approximate
+      // where the parent's visual top is so nested popovers align with it.
+      const nestTop = parent.transform !== undefined ? parent.top - parent.maxHeight : parent.top;
       acc.push({ top: nestTop, left, maxHeight: parent.maxHeight });
       return acc;
     },
@@ -267,11 +268,11 @@ export function useUuidHover(opts?: UseUuidHoverOptions): {
               style={{
                 position: 'fixed',
                 top: pos.top,
-                bottom: pos.bottom,
                 left: pos.left,
                 width: POPOVER_WIDTH,
                 maxHeight: pos.maxHeight,
                 overflowY: 'auto',
+                transform: pos.transform,
               }}
               className="z-50 rounded border border-pf-border bg-pf-bg p-4 text-left shadow-xl"
             >
@@ -294,10 +295,13 @@ export function useUuidHover(opts?: UseUuidHoverOptions): {
 // it should scroll internally. Falls back to the side with the most
 // room when neither fits the preferred height.
 //
-// "Above" cases return `bottom` (distance from viewport bottom) instead
-// of `top` so a short popover stays kissing the trigger rather than
-// floating away from it — maxHeight is a cap, not the rendered height.
-export function pickVerticalSlot(anchor: DOMRect): { top?: number; bottom?: number; maxHeight: number } {
+// Above cases set `top` to the anchor's top edge minus the gap and pair
+// it with `transform: translateY(-100%)` — this shifts the element up by
+// its own actual rendered height, so the popover bottom always kisses the
+// trigger with exactly POPOVER_GAP separation regardless of content length.
+// Using CSS `bottom` alone fails when a short popover is inside a subtree
+// whose ancestor has a transform/filter (which overrides fixed positioning).
+export function pickVerticalSlot(anchor: DOMRect): { top: number; transform?: string; maxHeight: number } {
   const viewportH = window.innerHeight;
   const spaceBelow = viewportH - anchor.bottom - POPOVER_GAP - VIEWPORT_EDGE_MARGIN;
   const spaceAbove = anchor.top - POPOVER_GAP - VIEWPORT_EDGE_MARGIN;
@@ -306,7 +310,7 @@ export function pickVerticalSlot(anchor: DOMRect): { top?: number; bottom?: numb
     return { top: anchor.bottom + POPOVER_GAP, maxHeight: POPOVER_PREFERRED_HEIGHT };
   }
   if (spaceAbove >= POPOVER_PREFERRED_HEIGHT) {
-    return { bottom: viewportH - anchor.top + POPOVER_GAP, maxHeight: POPOVER_PREFERRED_HEIGHT };
+    return { top: anchor.top - POPOVER_GAP, transform: 'translateY(-100%)', maxHeight: POPOVER_PREFERRED_HEIGHT };
   }
   // Neither side has preferred height — open on whichever side has
   // more space and cap the popover to that space so the content
@@ -315,7 +319,7 @@ export function pickVerticalSlot(anchor: DOMRect): { top?: number; bottom?: numb
     return { top: anchor.bottom + POPOVER_GAP, maxHeight: Math.max(120, spaceBelow) };
   }
   const h = Math.max(120, spaceAbove);
-  return { bottom: viewportH - anchor.top + POPOVER_GAP, maxHeight: h };
+  return { top: anchor.top - POPOVER_GAP, transform: 'translateY(-100%)', maxHeight: h };
 }
 
 function PopoverBody({ state }: { state: DocState | undefined }): React.ReactElement {


### PR DESCRIPTION
## Summary

When a hover popover flips above its trigger, short popovers appeared with a large gap instead of the expected 6px separation. Root cause: the positioning math assumed the popover would fill its `maxHeight`, but `maxHeight` is a cap — a 200px popover placed with `top = anchor.top - 6 - 520` has its bottom 326px above the trigger.

Two implementations had the same bug: `pickVerticalSlot` in `useUuidHover` (enricher link hovers) and `pickFeaturePopoverVerticalSlot` in `Progression.tsx` (class/ancestry feature chips).

The fix uses `top: anchor.top - GAP` + `transform: translateY(-100%)` for above-flip cases. `translateY(-100%)` shifts the element up by its own **actual rendered height**, so the bottom edge is always at `anchor.top - GAP` regardless of content length. Using CSS `bottom` alone failed because a transformed ancestor overrides the containing block for `position: fixed`.

## Changes

- `pickVerticalSlot` (`useUuidHover.tsx`): above cases return `top: anchor.top - GAP, transform: 'translateY(-100%)'` instead of a `bottom` value
- `pickFeaturePopoverVerticalSlot` (`Progression.tsx`): same fix
- Nested-popover `nestTop` derivation updated to account for the transform shift
- `useUuidHover.test.ts`: regression tests updated to assert the `transform` approach and verify the gap invariant

## Surfaces fixed

- All `@UUID[...]` enricher link hovers (feats, spells, items, conditions in descriptions)
- `FeatureChip` tooltips on the Progression tab (class/ancestry/skill features)

## Test plan

- [ ] Hover a feat/spell/item link near the **bottom** of the viewport — popover flips above, gap is 6px for both short content (loading state) and long content (scrolling)
- [ ] Hover a class/ancestry feature chip near the bottom of the viewport — same result
- [ ] Hover near the top — downward render unchanged, no gap change

**Apps touched**
- `apps/player-portal` — `npm run dev:player-portal` (or `dev:player-portal:mock`)