### PR TITLE
feat(player-portal): sync PF2e status effects from Foundry to sheet

### DIFF
--- a/apps/foundry-api-bridge/src/commands/handlers/actor/GetPreparedActorHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/GetPreparedActorHandler.ts
@@ -1,4 +1,4 @@
-import type { GetActorParams, PreparedActorResult, ItemSummary } from '@/commands/types';
+import type { GetActorParams, PreparedActorResult, ItemSummary, StatusEffectEntry } from '@/commands/types';
 
 interface ToObjectable {
   toObject(source: boolean): { system: Record<string, unknown>; flags?: Record<string, Record<string, unknown>> };
@@ -36,6 +36,49 @@ function getGame(): FoundryGame {
   return (globalThis as unknown as { game: FoundryGame }).game;
 }
 
+// Conditions with dedicated steppers — excluded from statusEffects.
+const STEPPER_CONDITIONS = new Set(['dying', 'wounded', 'doomed']);
+
+function normalizeStatusEffect(item: ActorItem, sys: Record<string, unknown>): StatusEffectEntry | null {
+  if (item.type !== 'condition' && item.type !== 'effect') return null;
+
+  const slug = typeof sys['slug'] === 'string' ? sys['slug'] : '';
+
+  if (item.type === 'condition' && STEPPER_CONDITIONS.has(slug)) return null;
+
+  const entry: StatusEffectEntry = {
+    id: item.id,
+    name: item.name,
+    slug,
+    img: item.img ?? '',
+    fromSpell: item.type === 'effect' && (sys['fromSpell'] as boolean | undefined) === true,
+  };
+
+  const rawBadge: unknown = sys['badge'];
+  if (rawBadge !== null && typeof rawBadge === 'object' && !Array.isArray(rawBadge)) {
+    const badge = rawBadge as Record<string, unknown>;
+    const bType = badge['type'];
+    const bValue = badge['value'];
+    if ((bType === 'value' || bType === 'counter') && typeof bValue === 'number') {
+      entry.badge = { type: bType, value: bValue };
+    }
+  }
+
+  const rawDesc: unknown = sys['description'];
+  if (rawDesc !== null && typeof rawDesc === 'object' && !Array.isArray(rawDesc)) {
+    const descObj = rawDesc as Record<string, unknown>;
+    const descValue: unknown = descObj['value'];
+    if (typeof descValue === 'string' && descValue.length > 0) {
+      // Replace line-break tags with a space before stripping other tags so
+      // adjacent sentences don't run together (e.g. "foo.<br/>bar" → "foo. bar").
+      const plain = descValue.replace(/<br\s*\/?>/gi, ' ').replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+      if (plain.length > 0) entry.description = plain;
+    }
+  }
+
+  return entry;
+}
+
 // Returns the actor post-prepareData, with derived state merged into `system`
 // (final AC value, save modifiers, skill totals, etc.). `toObject(false)` is
 // the Foundry API that returns a snapshot including prepared/derived data,
@@ -48,14 +91,19 @@ export function getPreparedActorHandler(params: GetActorParams): Promise<Prepare
   }
 
   const items: ItemSummary[] = [];
+  const statusEffects: StatusEffectEntry[] = [];
+
   actor.items.forEach((item) => {
+    const obj = item.toObject(false);
     items.push({
       id: item.id,
       name: item.name,
       type: item.type,
       img: item.img ?? '',
-      system: item.toObject(false).system,
+      system: obj.system,
     });
+    const effect = normalizeStatusEffect(item, obj.system);
+    if (effect !== null) statusEffects.push(effect);
   });
 
   const snapshot = actor.toObject(false);
@@ -68,6 +116,7 @@ export function getPreparedActorHandler(params: GetActorParams): Promise<Prepare
     img: actor.img ?? '',
     system: snapshot.system,
     items,
+    statusEffects,
     flags: snapshot.flags ?? {},
   });
 }

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/__tests__/GetPreparedActorHandler.test.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/__tests__/GetPreparedActorHandler.test.ts
@@ -1,0 +1,166 @@
+import { getPreparedActorHandler } from '../GetPreparedActorHandler';
+
+interface MockItem {
+  id: string;
+  name: string;
+  type: string;
+  img: string | undefined;
+  toObject: jest.Mock;
+}
+
+function makeItem(overrides: Partial<MockItem> & { id: string; type: string }): MockItem {
+  return {
+    name: 'Test Item',
+    img: 'icons/test.webp',
+    toObject: jest.fn().mockReturnValue({ system: {} }),
+    ...overrides,
+  };
+}
+
+function setGame(items: MockItem[]): void {
+  (globalThis as Record<string, unknown>)['game'] = {
+    actors: {
+      get: jest.fn((_id: string) => ({
+        id: 'actor-1',
+        uuid: 'Actor.actor-1',
+        name: 'Test Actor',
+        type: 'character',
+        img: 'tokens/test.webp',
+        items: {
+          forEach: jest.fn((fn: (item: MockItem) => void) => {
+            items.forEach(fn);
+          }),
+        },
+        toObject: jest.fn().mockReturnValue({ system: { hp: 20 }, flags: {} }),
+      })),
+    },
+  };
+}
+
+function clearGame(): void {
+  delete (globalThis as Record<string, unknown>)['game'];
+}
+
+describe('getPreparedActorHandler', () => {
+  afterEach(clearGame);
+
+  it('rejects when actor not found', async () => {
+    (globalThis as Record<string, unknown>)['game'] = {
+      actors: { get: jest.fn().mockReturnValue(undefined) },
+    };
+    await expect(getPreparedActorHandler({ actorId: 'missing' })).rejects.toThrow('Actor not found: missing');
+  });
+
+  it('returns statusEffects as empty array when actor has no conditions or effects', async () => {
+    setGame([makeItem({ id: 'i1', type: 'weapon', toObject: jest.fn().mockReturnValue({ system: {} }) })]);
+    const result = await getPreparedActorHandler({ actorId: 'actor-1' });
+    expect(result.statusEffects).toEqual([]);
+  });
+
+  it('includes a valued condition (frightened-2) with badge', async () => {
+    setGame([
+      makeItem({
+        id: 'c1',
+        name: 'Frightened',
+        type: 'condition',
+        img: 'icons/frightened.webp',
+        toObject: jest.fn().mockReturnValue({
+          system: {
+            slug: 'frightened',
+            badge: { type: 'value', value: 2 },
+            description: { value: '<p>You are afraid.</p>' },
+          },
+        }),
+      }),
+    ]);
+    const result = await getPreparedActorHandler({ actorId: 'actor-1' });
+    expect(result.statusEffects).toHaveLength(1);
+    expect(result.statusEffects[0]).toMatchObject({
+      id: 'c1',
+      name: 'Frightened',
+      slug: 'frightened',
+      img: 'icons/frightened.webp',
+      badge: { type: 'value', value: 2 },
+      description: 'You are afraid.',
+      fromSpell: false,
+    });
+  });
+
+  it('excludes dying, wounded, and doomed conditions', async () => {
+    setGame(
+      ['dying', 'wounded', 'doomed'].map((slug, i) =>
+        makeItem({
+          id: `skip-${i.toString()}`,
+          name: slug,
+          type: 'condition',
+          toObject: jest.fn().mockReturnValue({ system: { slug } }),
+        }),
+      ),
+    );
+    const result = await getPreparedActorHandler({ actorId: 'actor-1' });
+    expect(result.statusEffects).toHaveLength(0);
+  });
+
+  it('includes an effect with fromSpell=true', async () => {
+    setGame([
+      makeItem({
+        id: 'e1',
+        name: 'Bless',
+        type: 'effect',
+        img: 'icons/bless.webp',
+        toObject: jest.fn().mockReturnValue({
+          system: {
+            slug: 'bless',
+            fromSpell: true,
+            description: { value: '<p>Allies gain +1 to attack rolls.</p>' },
+          },
+        }),
+      }),
+    ]);
+    const result = await getPreparedActorHandler({ actorId: 'actor-1' });
+    expect(result.statusEffects).toHaveLength(1);
+    expect(result.statusEffects[0]).toMatchObject({
+      id: 'e1',
+      name: 'Bless',
+      slug: 'bless',
+      fromSpell: true,
+      description: 'Allies gain +1 to attack rolls.',
+    });
+    expect(result.statusEffects[0]?.badge).toBeUndefined();
+  });
+
+  it('strips HTML from descriptions', async () => {
+    setGame([
+      makeItem({
+        id: 'c2',
+        name: 'Sickened',
+        type: 'condition',
+        toObject: jest.fn().mockReturnValue({
+          system: {
+            slug: 'sickened',
+            badge: { type: 'value', value: 1 },
+            description: { value: '<p>You are <b>sickened</b>.<br/>Apply a −1 penalty.</p>' },
+          },
+        }),
+      }),
+    ]);
+    const result = await getPreparedActorHandler({ actorId: 'actor-1' });
+    expect(result.statusEffects[0]?.description).toBe('You are sickened. Apply a −1 penalty.');
+  });
+
+  it('includes non-skippped conditions alongside regular items', async () => {
+    setGame([
+      makeItem({ id: 'w1', type: 'weapon', toObject: jest.fn().mockReturnValue({ system: {} }) }),
+      makeItem({
+        id: 'c3',
+        name: 'Off-Guard',
+        type: 'condition',
+        toObject: jest.fn().mockReturnValue({ system: { slug: 'off-guard' } }),
+      }),
+    ]);
+    const result = await getPreparedActorHandler({ actorId: 'actor-1' });
+    expect(result.items).toHaveLength(2);
+    expect(result.statusEffects).toHaveLength(1);
+    expect(result.statusEffects[0]?.slug).toBe('off-guard');
+  });
+});

--- a/apps/foundry-api-bridge/src/commands/types/actor.ts
+++ b/apps/foundry-api-bridge/src/commands/types/actor.ts
@@ -89,6 +89,16 @@ export interface ActorDetailResult {
   items: ItemSummary[];
 }
 
+export interface StatusEffectEntry {
+  id: string;
+  name: string;
+  slug: string;
+  img: string;
+  badge?: { type: 'value' | 'counter'; value: number };
+  description?: string;
+  fromSpell: boolean;
+}
+
 export interface PreparedActorResult {
   id: string;
   uuid: string;
@@ -97,6 +107,7 @@ export interface PreparedActorResult {
   img: string;
   system: Record<string, unknown>;
   items: ItemSummary[];
+  statusEffects: StatusEffectEntry[];
   flags?: Record<string, Record<string, unknown>>;
 }
 

--- a/apps/foundry-api-bridge/src/events/EventChannelController.ts
+++ b/apps/foundry-api-bridge/src/events/EventChannelController.ts
@@ -198,6 +198,32 @@ export class EventChannelController {
             this.publisher.pushEvent('actors', { actorId: rawActor.id, changedPaths });
           }),
         );
+        // PF2e conditions and effects are embedded items. createItem/deleteItem
+        // fire when they are added or removed; updateItem fires when a valued
+        // condition's badge changes (e.g. Frightened 2 → 1). None of these
+        // trigger updateActor directly, so we hook them here to push an actors
+        // event so the portal refetches the prepared actor.
+        handles.push(
+          this.reg('createItem', (...args: unknown[]) => {
+            const actorId = getConditionOrEffectActorId(args[0]);
+            if (actorId === null) return;
+            this.publisher.pushEvent('actors', { actorId, changedPaths: ['items'] });
+          }),
+        );
+        handles.push(
+          this.reg('deleteItem', (...args: unknown[]) => {
+            const actorId = getConditionOrEffectActorId(args[0]);
+            if (actorId === null) return;
+            this.publisher.pushEvent('actors', { actorId, changedPaths: ['items'] });
+          }),
+        );
+        handles.push(
+          this.reg('updateItem', (...args: unknown[]) => {
+            const actorId = getConditionOrEffectActorId(args[0]);
+            if (actorId === null) return;
+            this.publisher.pushEvent('actors', { actorId, changedPaths: ['items'] });
+          }),
+        );
         break;
 
       case 'combat': {
@@ -396,6 +422,22 @@ function serializeCombatant(cb: CombatantForEvent): Record<string, unknown> {
     initiative: cb.initiative,
     defeated: cb.defeated,
   };
+}
+
+// ---- Helpers ------------------------------------------------------------
+
+// Returns the actor id if `raw` is a PF2e condition or effect embedded on an
+// actor; null otherwise. Used by the createItem/deleteItem/updateItem hooks
+// in the actors channel so only status-effect changes trigger a push.
+function getConditionOrEffectActorId(raw: unknown): string | null {
+  if (typeof raw !== 'object' || raw === null) return null;
+  const item = raw as Record<string, unknown>;
+  if (item['type'] !== 'condition' && item['type'] !== 'effect') return null;
+  const parent = item['parent'];
+  if (typeof parent !== 'object' || parent === null) return null;
+  const p = parent as Record<string, unknown>;
+  if (p['documentName'] !== 'Actor' || typeof p['id'] !== 'string') return null;
+  return p['id'];
 }
 
 // ---- Type guards --------------------------------------------------------

--- a/apps/player-portal/src/features/characters/sheet/CharacterSheet.tsx
+++ b/apps/player-portal/src/features/characters/sheet/CharacterSheet.tsx
@@ -195,6 +195,7 @@ function CharacterSheetInner({ actorId, onBack, preferences }: InnerProps): Reac
                 system={state.actor.system}
                 actorId={actorId}
                 items={state.actor.items}
+                statusEffects={state.actor.statusEffects ?? []}
                 characterLevel={state.actor.system.details.level.value}
                 onActorChanged={reloadActor}
               />

--- a/apps/player-portal/src/features/characters/sheet/tabs/character/Character.test.tsx
+++ b/apps/player-portal/src/features/characters/sheet/tabs/character/Character.test.tsx
@@ -26,7 +26,7 @@ describe('Character tab', () => {
   });
 
   it('renders the six ability modifiers with correct signs', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} characterLevel={1} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} statusEffects={[]} characterLevel={1} />);
     const expected: Record<string, string> = {
       str: '+4', dex: '+2', con: '+2', int: '+0', wis: '+0', cha: '+1',
     };
@@ -38,7 +38,7 @@ describe('Character tab', () => {
   });
 
   it("marks the character's key ability", () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} characterLevel={1} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} statusEffects={[]} characterLevel={1} />);
     const strRow = container.querySelector('[data-attribute="str"]');
     expect(strRow?.textContent).toContain('KEY');
     const dexRow = container.querySelector('[data-attribute="dex"]');
@@ -46,7 +46,7 @@ describe('Character tab', () => {
   });
 
   it('renders the headline stats (AC, HP, Perception)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} characterLevel={1} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} statusEffects={[]} characterLevel={1} />);
     expect(container.querySelector('[data-stat="hp"]')?.textContent).toContain('22');
     expect(container.querySelector('[data-stat="perception"]')?.textContent).toContain('+5');
     const acLabel = Array.from(container.querySelectorAll('span')).find((el) => el.textContent === 'AC');
@@ -54,26 +54,26 @@ describe('Character tab', () => {
   });
 
   it('renders the three saves with correct modifiers', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} characterLevel={1} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} statusEffects={[]} characterLevel={1} />);
     expect(container.querySelector('[data-stat="save-fortitude"]')?.textContent).toContain('+7');
     expect(container.querySelector('[data-stat="save-reflex"]')?.textContent).toContain('+5');
     expect(container.querySelector('[data-stat="save-will"]')?.textContent).toContain('+5');
   });
 
   it('renders the class DC (Barbarian @ 17)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} characterLevel={1} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} statusEffects={[]} characterLevel={1} />);
     const dc = container.querySelector('[data-stat="class-dc"]');
     expect(dc, 'class DC tile').toBeTruthy();
     expect(dc?.textContent).toContain('17');
   });
 
   it("renders Amiri's land speed", () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} characterLevel={1} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} statusEffects={[]} characterLevel={1} />);
     expect(container.textContent).toContain('25 ft');
   });
 
   it('renders the conditions row (Dying/Wounded/Doomed)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} characterLevel={1} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} statusEffects={[]} characterLevel={1} />);
     const row = container.querySelector('[data-section="conditions"]');
     expect(row, 'conditions row').toBeTruthy();
     for (const stat of ['dying', 'wounded', 'doomed']) {
@@ -83,19 +83,37 @@ describe('Character tab', () => {
     }
   });
 
+  it('renders status effect chips when statusEffects are provided', () => {
+    const effects = [
+      { id: 'e1', name: 'Frightened', slug: 'frightened', img: '', badge: { type: 'value' as const, value: 2 }, fromSpell: false },
+      { id: 'e2', name: 'Bless', slug: 'bless', img: '', fromSpell: true, description: 'Allies gain +1.' },
+    ];
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} statusEffects={effects} characterLevel={1} />);
+    const block = container.querySelector('[data-section="status-effects"]');
+    expect(block, 'status-effects block').toBeTruthy();
+    expect(block?.textContent).toContain('Frightened');
+    expect(block?.textContent).toContain('2');
+    expect(block?.textContent).toContain('Bless');
+  });
+
+  it('omits the status effects block when statusEffects is empty', () => {
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} statusEffects={[]} characterLevel={1} />);
+    expect(container.querySelector('[data-section="status-effects"]')).toBeNull();
+  });
+
   it('does not render an investiture counter (moved to Inventory tab)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} characterLevel={1} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} statusEffects={[]} characterLevel={1} />);
     expect(container.querySelector('[data-stat="investiture"]')).toBeNull();
   });
 
   it('omits Focus and Mythic resources when max is zero', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} characterLevel={1} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} statusEffects={[]} characterLevel={1} />);
     expect(container.querySelector('[data-stat="focus"]')).toBeNull();
     expect(container.querySelector('[data-stat="mythic-points"]')).toBeNull();
   });
 
   it('hides the Defenses block when IWR are all empty (Amiri)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} characterLevel={1} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} statusEffects={[]} characterLevel={1} />);
     expect(container.querySelector('[data-section="iwr"]')).toBeNull();
   });
 
@@ -109,7 +127,7 @@ describe('Character tab', () => {
         resistances: [{ type: 'physical', value: 2, exceptions: ['adamantine'] }],
       },
     } as CharacterSystem;
-    const { container } = render(<Character system={custom} actorId="test-actor" onActorChanged={() => undefined} items={[]} characterLevel={1} />);
+    const { container } = render(<Character system={custom} actorId="test-actor" onActorChanged={() => undefined} items={[]} statusEffects={[]} characterLevel={1} />);
     expect(container.querySelector('[data-section="iwr"]')).toBeTruthy();
     expect(container.querySelector('[data-iwr="immunities"]')?.textContent).toContain('Fire');
     expect(container.querySelector('[data-iwr="weaknesses"]')?.textContent).toContain('Cold 5');
@@ -117,7 +135,7 @@ describe('Character tab', () => {
   });
 
   it('hides Shield tile when no shield is equipped (Amiri)', () => {
-    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} characterLevel={1} />);
+    const { container } = render(<Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} statusEffects={[]} characterLevel={1} />);
     expect(container.querySelector('[data-stat="shield"]')).toBeNull();
   });
 
@@ -140,7 +158,7 @@ describe('Character tab', () => {
         },
       },
     };
-    const { container } = render(<Character system={shielded} actorId="test-actor" onActorChanged={() => undefined} items={[]} characterLevel={1} />);
+    const { container } = render(<Character system={shielded} actorId="test-actor" onActorChanged={() => undefined} items={[]} statusEffects={[]} characterLevel={1} />);
     const tile = container.querySelector('[data-stat="shield"]');
     expect(tile, 'shield tile').toBeTruthy();
     expect(tile?.textContent).toContain('Steel Shield');
@@ -168,7 +186,7 @@ describe('Character tab — saves wired through dispatcher', () => {
     ['save-will', 'saves.will.roll'],
   ])('clicking the %s tile dispatches method=%s', async (dataStat, expectedMethod) => {
     const { container } = render(
-      <Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} characterLevel={1} />,
+      <Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} statusEffects={[]} characterLevel={1} />,
     );
 
     const tile = container.querySelector(`[data-stat="${dataStat}"]`) as HTMLButtonElement;
@@ -188,7 +206,7 @@ describe('Character tab — saves wired through dispatcher', () => {
 
   it('none of the save tiles call rollActorStatistic', async () => {
     const { container } = render(
-      <Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} characterLevel={1} />,
+      <Character system={system} actorId="test-actor" onActorChanged={() => undefined} items={[]} statusEffects={[]} characterLevel={1} />,
     );
 
     for (const stat of ['save-fortitude', 'save-reflex', 'save-will']) {

--- a/apps/player-portal/src/features/characters/sheet/tabs/character/Character.tsx
+++ b/apps/player-portal/src/features/characters/sheet/tabs/character/Character.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import type { CharacterSystem, PreparedActorItem } from '@/features/characters/types';
+import type { CharacterSystem, PreparedActorItem, StatusEffect } from '@/features/characters/types';
 import { SectionHeader } from '@/shared/ui/SectionHeader';
 import { AbilityBlock } from './AbilityBlock';
 import { ConditionsRow, ShieldTile } from './ConditionsBlock';
@@ -7,12 +7,14 @@ import { IWRBlock } from './IWRBlock';
 import { QuickActionsBlock } from './QuickActionsBlock';
 import { SkillsBlock } from './SkillsBlock';
 import { StatsBlock } from './StatsBlock';
+import { StatusEffectsBlock } from './StatusEffectsBlock';
 
 interface Props {
   system: CharacterSystem;
   actorId: string;
   items: PreparedActorItem[];
   characterLevel: number;
+  statusEffects: StatusEffect[];
   /** Fired after any server-acknowledged mutation from this tab — long
    *  rest, HP adjust, hero-point adjust — so the parent can refetch
    *  `/prepared` and redraw. */
@@ -23,7 +25,7 @@ interface Props {
 // stats, hero points, speeds, languages, traits. Ported in structure
 // from pf2e's static/templates/actors/character/tabs/character.hbs, but
 // read-only (no input widgets) and Tailwind-styled.
-export function Character({ system, actorId, items, characterLevel, onActorChanged }: Props): React.ReactElement {
+export function Character({ system, actorId, items, characterLevel, statusEffects, onActorChanged }: Props): React.ReactElement {
   const keyAbility = system.details.keyability.value;
   const skillsCardRef = useRef<HTMLDivElement>(null);
   const [qaMaxHeight, setQaMaxHeight] = useState<number | undefined>(undefined);
@@ -78,6 +80,7 @@ export function Character({ system, actorId, items, characterLevel, onActorChang
             actorId={actorId}
             onActorChanged={onActorChanged}
           />
+          <StatusEffectsBlock effects={statusEffects} />
           {system.attributes.shield.itemId !== null && <ShieldTile shield={system.attributes.shield} />}
         </div>
       </div>

--- a/apps/player-portal/src/features/characters/sheet/tabs/character/StatusEffectsBlock.tsx
+++ b/apps/player-portal/src/features/characters/sheet/tabs/character/StatusEffectsBlock.tsx
@@ -1,0 +1,36 @@
+import type { StatusEffect } from '@/features/characters/types';
+
+export function StatusEffectsBlock({ effects }: { effects: StatusEffect[] }): React.ReactElement | null {
+  if (effects.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-2 pt-1" data-section="status-effects">
+      {effects.map((effect) => (
+        <StatusEffectChip key={effect.id} effect={effect} />
+      ))}
+    </div>
+  );
+}
+
+function StatusEffectChip({ effect }: { effect: StatusEffect }): React.ReactElement {
+  const label = effect.badge !== undefined ? `${effect.name} ${effect.badge.value.toString()}` : effect.name;
+  const tooltip = effect.description !== undefined ? `${label}\n\n${effect.description}` : label;
+
+  return (
+    <div
+      className="flex items-center gap-1.5 rounded-full border border-pf-border bg-pf-bg px-2.5 py-1 text-[11px] text-pf-text"
+      title={tooltip}
+      data-slug={effect.slug}
+    >
+      {effect.img.length > 0 && (
+        <img src={effect.img} alt="" className="h-4 w-4 shrink-0 rounded-sm object-contain" />
+      )}
+      <span className="font-medium leading-none">{effect.name}</span>
+      {effect.badge !== undefined && (
+        <span className="min-w-[1.1rem] rounded-full bg-pf-bg-dark px-1 text-center font-mono font-bold tabular-nums leading-none">
+          {effect.badge.value}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/player-portal/src/features/characters/types/index.ts
+++ b/apps/player-portal/src/features/characters/types/index.ts
@@ -18,6 +18,7 @@ export type {
   ItemPrice,
   PreparedActor,
   PreparedActorItem,
+  StatusEffect,
 } from '@foundry-toolkit/shared/foundry-api';
 
 export * from './primitives';

--- a/apps/player-portal/src/features/characters/types/prepared.ts
+++ b/apps/player-portal/src/features/characters/types/prepared.ts
@@ -1,4 +1,4 @@
-import type { PreparedActorItem } from '@foundry-toolkit/shared/foundry-api';
+import type { PreparedActorItem, StatusEffect } from '@foundry-toolkit/shared/foundry-api';
 
 import type { CharacterSystem } from './character';
 
@@ -10,6 +10,8 @@ export interface PreparedCharacter {
   img: string;
   system: CharacterSystem;
   items: PreparedActorItem[];
+  /** PF2e conditions and active effects (excludes dying/wounded/doomed). */
+  statusEffects?: StatusEffect[];
   /** Mirrors the shared `PreparedActor.flags` field. character-creator
    *  persists sheet-level preferences (e.g. background image path)
    *  under the `character-creator` scope. */

--- a/packages/shared/src/foundry-api.ts
+++ b/packages/shared/src/foundry-api.ts
@@ -56,6 +56,24 @@ export interface PreparedActorItem {
   system: Record<string, unknown>;
 }
 
+/** A single PF2e condition or active effect on an actor, normalized for
+ *  display. Conditions include frightened, sickened, off-guard, etc.;
+ *  effects include spell-applied buffs/debuffs. Dying/wounded/doomed are
+ *  excluded — those have dedicated steppers in the sheet UI. */
+export interface StatusEffect {
+  id: string;
+  name: string;
+  /** PF2e slug (e.g. "frightened", "bless"). Used for keying and data-slug attributes. */
+  slug: string;
+  img: string;
+  /** Valued/counter conditions carry a numeric badge (e.g. Frightened 2). */
+  badge?: { type: 'value' | 'counter'; value: number };
+  /** Plain-text description with HTML stripped. Shown in tooltip. */
+  description?: string;
+  /** True when this effect originated from a spell. */
+  fromSpell: boolean;
+}
+
 export interface PreparedActor {
   id: string;
   uuid: string;
@@ -64,6 +82,8 @@ export interface PreparedActor {
   img: string;
   system: Record<string, unknown>;
   items: PreparedActorItem[];
+  /** PF2e conditions and active effects (excludes dying/wounded/doomed). */
+  statusEffects?: StatusEffect[];
   /** Optional: Foundry module flags (`flags.<scope>.<key>` → value).
    *  character-creator stores its sheet-level preferences (e.g. the
    *  uploaded background image path) under the `character-creator`


### PR DESCRIPTION
## Summary

Adds live status-effect display to the Character tab. When a GM applies a PF2e condition (frightened, sickened, off-guard, etc.) or a spell-sourced active effect to a character in Foundry, it appears on the portal sheet within ~1 second as a badge chip (icon + name + value badge for valued conditions), and disappears just as quickly when removed. Dying/wounded/doomed are excluded — those already have dedicated steppers.

The data flows through the existing `actors` SSE channel, not a new endpoint. Three new Foundry item hooks (`createItem` / `deleteItem` / `updateItem` filtered to `condition` and `effect` types) are wired into the actors channel so it fires even when Foundry doesn't emit `updateActor` for embedded item changes.

## Changes

- `packages/shared/src/foundry-api.ts` — adds `StatusEffect` type; extends `PreparedActor` with `statusEffects?: StatusEffect[]`
- `apps/foundry-api-bridge` — `GetPreparedActorHandler` normalizes `actor.items` conditions and effects into `statusEffects[]` (strips HTML descriptions, maps badge, excludes dying/wounded/doomed); `EventChannelController` adds `createItem` / `deleteItem` / `updateItem` hooks to the `actors` channel; `commands/types/actor.ts` gets `StatusEffectEntry`
- `apps/player-portal` — new `StatusEffectsBlock` chip component; `Character.tsx` and `CharacterSheet.tsx` wired to pass/render; `PreparedCharacter` and the API types barrel updated

## Test plan

- [ ] Apply "Frightened 2" to a character in Foundry → portal sheet shows Frightened chip with "2" badge within ~1 s
- [ ] Reduce to Frightened 1 in Foundry → badge updates live
- [ ] Remove the condition → chip disappears
- [ ] Apply a spell effect (e.g. Bless) → chip appears; hover shows description tooltip
- [ ] Dying/Wounded/Doomed conditions do NOT appear in the effects strip
- [ ] Character with zero conditions/effects: effect strip is absent (not an empty row)
- [ ] Automated: `npm run test -w apps/foundry-api-bridge` — 801 pass; `npm run test -w apps/player-portal` — 517 pass

## Apps touched

- `apps/foundry-api-bridge` — `npm run dev` (Foundry module, loads in browser via Docker)
- `apps/player-portal` — `npm run dev:player-portal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)