### PR TITLE
feat(dm-tool): add monster-art hover chip to detail view

### DIFF
--- a/apps/dm-tool/electron/compendium/projection/monster.ts
+++ b/apps/dm-tool/electron/compendium/projection/monster.ts
@@ -5,6 +5,7 @@ import type { MonsterDetail, MonsterSpellGroup, MonsterSpellInfo, MonsterSummary
 import type { CompendiumDocument, CompendiumEmbeddedItem, CompendiumMatch } from '../types.js';
 import {
   cleanDescription,
+  isDefaultIcon,
   isRecord,
   readSystem,
   readPath,
@@ -715,6 +716,7 @@ export function monsterDocToSummary(doc: CompendiumDocument): MonsterSummary {
     traits: monsterTraits(system),
     source: monsterSource(system),
     aonUrl: '',
+    tokenUrl: pickTokenUrl(doc),
   };
 }
 
@@ -740,5 +742,6 @@ export function monsterMatchToSummary(m: CompendiumMatch): MonsterSummary {
     traits: m.traits ?? [],
     source: m.source ?? '',
     aonUrl: '',
+    tokenUrl: m.img && !isDefaultIcon(m.img) ? m.img : null,
   };
 }

--- a/apps/dm-tool/electron/ipc/monsters.ts
+++ b/apps/dm-tool/electron/ipc/monsters.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron';
-import type { MonsterDetail, MonsterSearchParams } from '@foundry-toolkit/shared/types';
+import type { MonsterDetail, MonsterSearchParams, MonsterSummary } from '@foundry-toolkit/shared/types';
 import { getPreparedCompendium } from '../compendium/singleton.js';
 import { toMonsterFileUrl } from '../compendium/image-url.js';
 
@@ -12,7 +12,7 @@ import { toMonsterFileUrl } from '../compendium/image-url.js';
  *  them. When foundryMcpUrl is configured the image is served through
  *  foundry-mcp's asset proxy (preferred). Otherwise falls back to the
  *  monster-file:// Electron protocol. */
-function rewriteImageUrls(detail: MonsterDetail, mcpBaseUrl: string | undefined): MonsterDetail {
+function rewriteDetailImageUrls(detail: MonsterDetail, mcpBaseUrl: string | undefined): MonsterDetail {
   return {
     ...detail,
     imageUrl: toMonsterFileUrl(detail.imageUrl, mcpBaseUrl),
@@ -20,9 +20,15 @@ function rewriteImageUrls(detail: MonsterDetail, mcpBaseUrl: string | undefined)
   };
 }
 
+function rewriteSummaryImageUrls(summary: MonsterSummary, mcpBaseUrl: string | undefined): MonsterSummary {
+  return { ...summary, tokenUrl: toMonsterFileUrl(summary.tokenUrl, mcpBaseUrl) };
+}
+
 export function registerMonsterHandlers(foundryMcpUrl?: string): void {
   ipcMain.handle('monstersSearch', (_e, params: MonsterSearchParams) => {
-    return getPreparedCompendium().listMonsters(params ?? {});
+    return getPreparedCompendium()
+      .listMonsters(params ?? {})
+      .then((summaries) => summaries.map((s) => rewriteSummaryImageUrls(s, foundryMcpUrl)));
   });
 
   ipcMain.handle('monstersFacets', () => {
@@ -32,6 +38,6 @@ export function registerMonsterHandlers(foundryMcpUrl?: string): void {
   ipcMain.handle('monstersGetDetail', (_e, name: string) => {
     return getPreparedCompendium()
       .getMonsterByName(name)
-      .then((d) => (d ? rewriteImageUrls(d, foundryMcpUrl) : null));
+      .then((d) => (d ? rewriteDetailImageUrls(d, foundryMcpUrl) : null));
   });
 }

--- a/apps/dm-tool/src/App.tsx
+++ b/apps/dm-tool/src/App.tsx
@@ -63,6 +63,8 @@ function MainApp() {
     setToolFavicons,
     partyLevel,
     setPartyLevel,
+    monsterCardSize,
+    setMonsterCardSize,
   } = usePreferences();
 
   const [activeTab, setActiveTab] = useState<ActiveTab>('maps');
@@ -172,6 +174,8 @@ function MainApp() {
             onToolFaviconsChange={setToolFavicons}
             partyLevel={partyLevel}
             onPartyLevelChange={setPartyLevel}
+            monsterCardSize={monsterCardSize}
+            onMonsterCardSizeChange={setMonsterCardSize}
           />
         </div>
       </header>
@@ -197,7 +201,7 @@ function MainApp() {
           )}
           {activeTab === 'books' && <BookBrowser keywords={keywords} />}
           {activeTab === 'combat' && <CombatTab partyLevel={partyLevel} anthropicApiKey={anthropicApiKey} />}
-          {activeTab === 'monsters' && <MonsterBrowser keywords={keywords} />}
+          {activeTab === 'monsters' && <MonsterBrowser keywords={keywords} cardSize={monsterCardSize} />}
           {activeTab === 'items' && <ItemBrowser keywords={keywords} />}
           {activeTab === 'globe' && <GlobeViewer />}
           {activeTab === 'inventory' && <InventoryTab />}

--- a/apps/dm-tool/src/features/creatures/CreatureDetailPane.tsx
+++ b/apps/dm-tool/src/features/creatures/CreatureDetailPane.tsx
@@ -1,7 +1,7 @@
 // Shared creature stat-block layout used by both the monster browser detail
-// overlay and the combat tracker sidebar. Renders the two-column content area
-// only: left stat column (defenses + saves + abilities) and right scrollable
-// section (speed, skills, attacks, abilities, spells, portrait, AoN link).
+// overlay and the combat tracker sidebar. Renders a single scrollable content
+// area: stats row (defenses, saves, abilities), then speed/skills, attacks,
+// abilities, spells, and AoN link.
 //
 // Identity chrome (name, level/rarity/size/traits, close button) and
 // combat chrome (HP bar, conditions) are the responsibility of each caller.
@@ -25,104 +25,113 @@ export function CreatureDetailPane({ detail, onOpenExternal }: Props) {
   const formattedSkills = formatSkills(detail.skills);
 
   return (
-    <div className="flex min-h-0 flex-1">
-      {/* Left stat column */}
-      <div className="flex w-16 shrink-0 flex-col items-center gap-3 border-r border-border py-3 text-[10px]">
-        <StatCell label="AC" value={String(detail.ac)} />
-        <StatCell label="HP" value={String(detail.hp)} />
-        <Separator className="w-8" />
-        <StatCell label="Fort" value={mod(detail.fort)} />
-        <StatCell label="Ref" value={mod(detail.ref)} />
-        <StatCell label="Will" value={mod(detail.will)} />
-        <StatCell label="Perc" value={mod(detail.perception)} />
-        <Separator className="w-8" />
-        {(['str', 'dex', 'con', 'int', 'wis', 'cha'] as const).map((a) => (
-          <StatCell key={a} label={a.toUpperCase()} value={mod(detail[a])} />
-        ))}
-      </div>
-
-      {/* Right scrollable content */}
-      <ScrollArea className="min-h-0 min-w-0 flex-1">
-        <div className="space-y-4 p-4">
-          {/* Speed, Skills, Immunities / Weaknesses / Resistances */}
-          <div className="space-y-1 text-xs">
-            <Stat label="Speed" value={detail.speed} />
-            {formattedSkills && <Stat label="Skills" value={formattedSkills} />}
-            {detail.immunities && <Stat label="Immunities" value={detail.immunities} />}
-            {detail.weaknesses && <Stat label="Weaknesses" value={detail.weaknesses} />}
-            {detail.resistances && <Stat label="Resistances" value={detail.resistances} />}
+    <ScrollArea className="min-h-0 min-w-0 flex-1">
+      <div className="space-y-4 p-4">
+        {/* Stats + token two-column layout */}
+        <div className="flex items-start gap-4">
+          {/* Stats column */}
+          <div className="flex flex-col gap-2 text-[10px]">
+            <div className="flex gap-4">
+              <StatCell label="AC" value={String(detail.ac)} />
+              <StatCell label="HP" value={String(detail.hp)} />
+            </div>
+            <div className="flex gap-4">
+              <StatCell label="Fort" value={mod(detail.fort)} />
+              <StatCell label="Ref" value={mod(detail.ref)} />
+              <StatCell label="Will" value={mod(detail.will)} />
+              <StatCell label="Perc" value={mod(detail.perception)} />
+            </div>
+            <div className="flex gap-4">
+              {(['str', 'dex', 'con', 'int', 'wis', 'cha'] as const).map((a) => (
+                <StatCell key={a} label={a.toUpperCase()} value={mod(detail[a])} />
+              ))}
+            </div>
           </div>
 
-          {/* Attacks */}
-          {(detail.melee || detail.ranged) && (
-            <>
-              <Separator />
-              <section>
-                <SectionLabel>Attacks</SectionLabel>
-                <div className="space-y-1.5 text-xs">
-                  {detail.melee &&
-                    cleanFoundryMarkup(detail.melee)
-                      .split(';')
-                      .map((a) => a.trim())
-                      .filter(Boolean)
-                      .map((a, i) => (
-                        <div key={`m${i}`}>
-                          <span className="font-semibold text-muted-foreground">Melee </span>
-                          {a}
-                        </div>
-                      ))}
-                  {detail.ranged &&
-                    cleanFoundryMarkup(detail.ranged)
-                      .split(';')
-                      .map((a) => a.trim())
-                      .filter(Boolean)
-                      .map((a, i) => (
-                        <div key={`r${i}`}>
-                          <span className="font-semibold text-muted-foreground">Ranged </span>
-                          {a}
-                        </div>
-                      ))}
-                </div>
-              </section>
-            </>
-          )}
-
-          {/* Abilities */}
-          {detail.abilities && (
-            <>
-              <Separator />
-              <section>
-                <SectionLabel>Abilities</SectionLabel>
-                <AbilityBlock text={detail.abilities} />
-              </section>
-            </>
-          )}
-
-          {/* Spells */}
-          {detail.spells.length > 0 && (
-            <>
-              <Separator />
-              <section>
-                <SectionLabel>Spells</SectionLabel>
-                <SpellsSection groups={detail.spells} />
-              </section>
-            </>
-          )}
-
-          {/* Archives of Nethys link — opens in the system browser */}
-          {detail.aonUrl && (
-            <button
-              type="button"
-              onClick={() => onOpenExternal(detail.aonUrl)}
-              className="flex items-center gap-1.5 self-start text-xs text-primary hover:underline"
-            >
-              <ExternalLink className="h-3 w-3" />
-              Archives of Nethys
-            </button>
-          )}
+          {/* Full art column */}
+          {detail.imageUrl && <img src={detail.imageUrl} alt="" className="ml-auto h-40 w-40 rounded object-contain" />}
         </div>
-      </ScrollArea>
-    </div>
+
+        <Separator />
+
+        {/* Speed, Skills, Immunities / Weaknesses / Resistances */}
+        <div className="space-y-1 text-xs">
+          <Stat label="Speed" value={detail.speed} />
+          {formattedSkills && <Stat label="Skills" value={formattedSkills} />}
+          {detail.immunities && <Stat label="Immunities" value={detail.immunities} />}
+          {detail.weaknesses && <Stat label="Weaknesses" value={detail.weaknesses} />}
+          {detail.resistances && <Stat label="Resistances" value={detail.resistances} />}
+        </div>
+
+        {/* Attacks */}
+        {(detail.melee || detail.ranged) && (
+          <>
+            <Separator />
+            <section>
+              <SectionLabel>Attacks</SectionLabel>
+              <div className="space-y-1.5 text-xs">
+                {detail.melee &&
+                  cleanFoundryMarkup(detail.melee)
+                    .split(';')
+                    .map((a) => a.trim())
+                    .filter(Boolean)
+                    .map((a, i) => (
+                      <div key={`m${i}`}>
+                        <span className="font-semibold text-muted-foreground">Melee </span>
+                        {a}
+                      </div>
+                    ))}
+                {detail.ranged &&
+                  cleanFoundryMarkup(detail.ranged)
+                    .split(';')
+                    .map((a) => a.trim())
+                    .filter(Boolean)
+                    .map((a, i) => (
+                      <div key={`r${i}`}>
+                        <span className="font-semibold text-muted-foreground">Ranged </span>
+                        {a}
+                      </div>
+                    ))}
+              </div>
+            </section>
+          </>
+        )}
+
+        {/* Abilities */}
+        {detail.abilities && (
+          <>
+            <Separator />
+            <section>
+              <SectionLabel>Abilities</SectionLabel>
+              <AbilityBlock text={detail.abilities} />
+            </section>
+          </>
+        )}
+
+        {/* Spells */}
+        {detail.spells.length > 0 && (
+          <>
+            <Separator />
+            <section>
+              <SectionLabel>Spells</SectionLabel>
+              <SpellsSection groups={detail.spells} />
+            </section>
+          </>
+        )}
+
+        {/* Archives of Nethys link — opens in the system browser */}
+        {detail.aonUrl && (
+          <button
+            type="button"
+            onClick={() => onOpenExternal(detail.aonUrl)}
+            className="flex items-center gap-1.5 self-start text-xs text-primary hover:underline"
+          >
+            <ExternalLink className="h-3 w-3" />
+            Archives of Nethys
+          </button>
+        )}
+      </div>
+    </ScrollArea>
   );
 }
 

--- a/apps/dm-tool/src/features/creatures/CreatureDetailPane.tsx
+++ b/apps/dm-tool/src/features/creatures/CreatureDetailPane.tsx
@@ -109,14 +109,6 @@ export function CreatureDetailPane({ detail, onOpenExternal }: Props) {
             </>
           )}
 
-          {/* Full portrait art */}
-          {detail.imageUrl && (
-            <>
-              <Separator />
-              <img src={detail.imageUrl} alt={detail.name} className="w-full rounded-md object-contain" />
-            </>
-          )}
-
           {/* Archives of Nethys link — opens in the system browser */}
           {detail.aonUrl && (
             <button

--- a/apps/dm-tool/src/features/monsters/MonsterBrowser.tsx
+++ b/apps/dm-tool/src/features/monsters/MonsterBrowser.tsx
@@ -8,7 +8,7 @@ import { MonsterDetailPane } from './MonsterDetailPane';
 import { useMonsterSearch, useMonsterFacets, useMonsterDetail, useOpenExternal } from './useMonsters';
 import type { MonsterSearchParams } from '@foundry-toolkit/shared/types';
 
-export function MonsterBrowser({ keywords = '' }: { keywords?: string }) {
+export function MonsterBrowser({ keywords = '', cardSize }: { keywords?: string; cardSize?: number }) {
   const [filters, setFilters] = useState<MonsterSearchParams>({});
   const [selectedMonster, setSelectedMonster] = useState<string | null>(null);
   const [closing, setClosing] = useState(false);
@@ -57,7 +57,13 @@ export function MonsterBrowser({ keywords = '' }: { keywords?: string }) {
         </ResizableSidebar>
 
         <div className="relative flex min-w-0 flex-1 flex-col overflow-hidden">
-          <MonsterCardGrid monsters={monsters ?? []} error={error} selected={selectedMonster} onSelect={handleSelect} />
+          <MonsterCardGrid
+            monsters={monsters ?? []}
+            error={error}
+            selected={selectedMonster}
+            onSelect={handleSelect}
+            cardSize={cardSize}
+          />
 
           {selectedMonster && detail && (
             <DetailOverlay storageKey="dmtool.detail.monsters" closing={closing} onClosed={handleClosed}>

--- a/apps/dm-tool/src/features/monsters/MonsterCardGrid.tsx
+++ b/apps/dm-tool/src/features/monsters/MonsterCardGrid.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { cn } from '@/lib/utils';
+import { MONSTER_CARD_SIZE } from '@/lib/constants';
 import type { MonsterSummary } from '@foundry-toolkit/shared/types';
 
-const CARD_W = 200;
-const CARD_H = 108;
+const CARD_ASPECT = 200 / 108;
 const GAP = 8;
 
 const RARITY_BORDER: Record<string, string> = {
@@ -19,9 +19,13 @@ interface Props {
   error: string | null;
   selected: string | null;
   onSelect: (name: string) => void;
+  cardSize?: number;
 }
 
-export function MonsterCardGrid({ monsters, error, selected, onSelect }: Props) {
+export function MonsterCardGrid({ monsters, error, selected, onSelect, cardSize }: Props) {
+  const cardW = cardSize ?? MONSTER_CARD_SIZE.default;
+  const cardH = Math.round(cardW * CARD_ASPECT);
+
   const parentRef = useRef<HTMLDivElement>(null);
   const [columnCount, setColumnCount] = useState(4);
 
@@ -30,20 +34,20 @@ export function MonsterCardGrid({ monsters, error, selected, onSelect }: Props) 
     if (!el) return;
     const update = () => {
       const w = el.clientWidth;
-      setColumnCount(Math.max(1, Math.floor((w + GAP) / (CARD_W + GAP))));
+      setColumnCount(Math.max(1, Math.floor((w + GAP) / (cardW + GAP))));
     };
     update();
     const ro = new ResizeObserver(update);
     ro.observe(el);
     return () => ro.disconnect();
-  }, []);
+  }, [cardW]);
 
   const rowCount = Math.ceil(monsters.length / columnCount);
 
   const virtualizer = useVirtualizer({
     count: rowCount,
     getScrollElement: () => parentRef.current,
-    estimateSize: () => CARD_H + GAP,
+    estimateSize: () => cardH + GAP,
     overscan: 5,
   });
 
@@ -56,8 +60,6 @@ export function MonsterCardGrid({ monsters, error, selected, onSelect }: Props) 
     }),
     [columnCount],
   );
-
-  const mod = (n: number) => (n >= 0 ? `+${n}` : `${n}`);
 
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col">
@@ -87,60 +89,37 @@ export function MonsterCardGrid({ monsters, error, selected, onSelect }: Props) 
                         type="button"
                         onClick={() => onSelect(m.name)}
                         className={cn(
-                          'flex flex-col rounded-md border border-l-[3px] p-2 text-left text-xs transition-colors',
+                          'relative overflow-hidden rounded-md border border-l-[3px] text-left text-xs transition-colors',
                           RARITY_BORDER[m.rarity.toLowerCase()] ?? 'border-l-border',
-                          isSelected ? 'border-primary/50 bg-primary/10' : 'border-border bg-card hover:bg-accent/40',
+                          isSelected ? 'border-primary/50' : 'border-border',
                         )}
-                        style={{ height: CARD_H }}
+                        style={{ height: cardH }}
                       >
-                        {/* Name + level */}
-                        <div className="flex items-start justify-between gap-1">
-                          <span className="min-w-0 truncate font-medium leading-tight">{m.name}</span>
-                          <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-bold tabular-nums leading-none">
-                            {m.level}
-                          </span>
-                        </div>
-
-                        {/* Creature type + size */}
-                        <span className="mt-0.5 truncate text-[10px] capitalize text-muted-foreground">
-                          {m.size} {m.creatureType}
-                        </span>
-
-                        {/* Stats row */}
-                        <div className="mt-auto flex items-center gap-2 text-[10px] tabular-nums text-muted-foreground">
-                          <span>
-                            <b className="text-foreground/80">HP</b> {m.hp}
-                          </span>
-                          <span>
-                            <b className="text-foreground/80">AC</b> {m.ac}
-                          </span>
-                          <span>
-                            <b className="text-foreground/80">F</b> {mod(m.fort)}
-                          </span>
-                          <span>
-                            <b className="text-foreground/80">R</b> {mod(m.ref)}
-                          </span>
-                          <span>
-                            <b className="text-foreground/80">W</b> {mod(m.will)}
-                          </span>
-                        </div>
-
-                        {/* Traits */}
-                        {m.traits.length > 0 && (
-                          <div className="mt-1 flex items-center gap-1 overflow-hidden">
-                            {m.traits.slice(0, 3).map((t) => (
-                              <span
-                                key={t}
-                                className="shrink-0 rounded bg-accent/60 px-1 py-0.5 text-[9px] leading-none text-foreground/70"
-                              >
-                                {t.toLowerCase()}
-                              </span>
-                            ))}
-                            {m.traits.length > 3 && (
-                              <span className="text-[9px] text-muted-foreground">+{m.traits.length - 3}</span>
-                            )}
-                          </div>
+                        {/* Token art — full-card background */}
+                        {m.tokenUrl && (
+                          <img src={m.tokenUrl} alt="" className="absolute inset-0 h-full w-full object-contain" />
                         )}
+
+                        {/* Content — sits above the art */}
+                        <div className="relative flex h-full flex-col justify-between p-2">
+                          {/* Name + level */}
+                          <div className="flex items-start justify-between gap-1">
+                            <span className="min-w-0 font-medium leading-tight drop-shadow-sm">{m.name}</span>
+                            <span className="shrink-0 rounded bg-muted/80 px-1.5 py-0.5 text-[10px] font-bold tabular-nums leading-none">
+                              {m.level}
+                            </span>
+                          </div>
+
+                          {/* Stats row */}
+                          <div className="flex items-center gap-2 text-[10px] tabular-nums">
+                            <span className="rounded bg-muted/80 px-1 py-0.5">
+                              <b>HP</b> {m.hp}
+                            </span>
+                            <span className="rounded bg-muted/80 px-1 py-0.5">
+                              <b>AC</b> {m.ac}
+                            </span>
+                          </div>
+                        </div>
                       </button>
                     );
                   })}

--- a/apps/dm-tool/src/features/monsters/MonsterDetailPane.tsx
+++ b/apps/dm-tool/src/features/monsters/MonsterDetailPane.tsx
@@ -1,4 +1,3 @@
-import * as HoverCard from '@radix-ui/react-hover-card';
 import { Image as ImageIcon, Info, X } from 'lucide-react';
 import { useState } from 'react';
 import { cn } from '@/lib/utils';
@@ -22,13 +21,13 @@ interface Props {
 
 export function MonsterDetailPane({ detail, loading, onOpenExternal, onClose }: Props) {
   const [loreOpen, setLoreOpen] = useState(false);
+  const [artOpen, setArtOpen] = useState(false);
   const artAssets = resolveMonsterArtAssets(detail.tokenUrl, detail.imageUrl);
 
   return (
     <>
       {/* Header: identity chrome — name, badges, traits, lore toggle, close */}
       <div className="flex shrink-0 items-center gap-2 border-b border-border px-4 py-2">
-        <ArtHoverCard name={detail.name} portraitSrc={artAssets.portraitSrc} artSrc={artAssets.artSrc} />
         <h2 className="shrink-0 text-sm font-semibold">{detail.name}</h2>
         <span className="shrink-0 rounded bg-accent px-1.5 py-0.5 text-[11px] font-medium tabular-nums">
           Lvl {detail.level}
@@ -49,7 +48,15 @@ export function MonsterDetailPane({ detail, loading, onOpenExternal, onClose }: 
         ))}
         <div className="flex-1" />
         {(artAssets.artSrc ?? artAssets.portraitSrc) && (
-          <MonsterArtChip name={detail.name} imageSrc={artAssets.artSrc ?? artAssets.portraitSrc!} />
+          <button
+            type="button"
+            aria-label="Show full art"
+            onMouseEnter={() => setArtOpen(true)}
+            onMouseLeave={() => setArtOpen(false)}
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          >
+            <ImageIcon className="h-4 w-4" />
+          </button>
         )}
         {detail.description && (
           <button
@@ -77,6 +84,21 @@ export function MonsterDetailPane({ detail, loading, onOpenExternal, onClose }: 
         <div className="relative flex min-h-0 flex-1">
           <CreatureDetailPane detail={detail} onOpenExternal={onOpenExternal} />
 
+          {/* Art overlay — covers the content area on art-button hover */}
+          {artOpen && (artAssets.artSrc ?? artAssets.portraitSrc) && (
+            <div
+              className="absolute inset-0 z-10 flex items-center justify-center bg-background/50 backdrop-blur-sm"
+              onMouseEnter={() => setArtOpen(true)}
+              onMouseLeave={() => setArtOpen(false)}
+            >
+              <img
+                src={(artAssets.artSrc ?? artAssets.portraitSrc)!}
+                alt={detail.name}
+                className="max-h-full max-w-full object-contain p-4"
+              />
+            </div>
+          )}
+
           {/* Lore overlay — covers the content area on info-button hover */}
           {loreOpen && detail.description && (
             <div
@@ -97,77 +119,5 @@ export function MonsterDetailPane({ detail, loading, onOpenExternal, onClose }: 
         </div>
       )}
     </>
-  );
-}
-
-/** Chip button in the header controls; hovering reveals the full monster art in a popover. */
-function MonsterArtChip({ name, imageSrc }: { name: string; imageSrc: string }) {
-  return (
-    <HoverCard.Root openDelay={400} closeDelay={200}>
-      <HoverCard.Trigger asChild>
-        <button
-          type="button"
-          aria-label="Show full art"
-          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-        >
-          <ImageIcon className="h-4 w-4" />
-        </button>
-      </HoverCard.Trigger>
-      <HoverCard.Portal>
-        <HoverCard.Content
-          side="bottom"
-          align="end"
-          sideOffset={4}
-          avoidCollisions
-          collisionPadding={8}
-          className="z-50 overflow-hidden rounded-md border border-border bg-popover shadow-lg"
-          style={{ width: '240px' }}
-        >
-          <img src={imageSrc} alt={name} className="w-full object-contain" />
-        </HoverCard.Content>
-      </HoverCard.Portal>
-    </HoverCard.Root>
-  );
-}
-
-/** Small inline portrait; hovering reveals the full monster art. */
-function ArtHoverCard({
-  name,
-  portraitSrc,
-  artSrc,
-}: {
-  name: string;
-  portraitSrc: string | null;
-  artSrc: string | null;
-}) {
-  const portrait = portraitSrc ? (
-    <img src={portraitSrc} alt="" className="h-8 w-8 shrink-0 rounded object-cover" />
-  ) : (
-    <div className="h-8 w-8 shrink-0 rounded bg-muted" />
-  );
-
-  if (!artSrc) {
-    return portrait;
-  }
-
-  return (
-    <HoverCard.Root openDelay={400} closeDelay={200}>
-      <HoverCard.Trigger asChild>
-        <span className="shrink-0 cursor-default">{portrait}</span>
-      </HoverCard.Trigger>
-      <HoverCard.Portal>
-        <HoverCard.Content
-          side="bottom"
-          align="start"
-          sideOffset={4}
-          avoidCollisions
-          collisionPadding={8}
-          className="z-50 overflow-hidden rounded-md border border-border bg-popover shadow-lg"
-          style={{ width: '240px' }}
-        >
-          <img src={artSrc} alt={name} className="w-full object-contain" />
-        </HoverCard.Content>
-      </HoverCard.Portal>
-    </HoverCard.Root>
   );
 }

--- a/apps/dm-tool/src/features/monsters/MonsterDetailPane.tsx
+++ b/apps/dm-tool/src/features/monsters/MonsterDetailPane.tsx
@@ -1,5 +1,5 @@
 import * as HoverCard from '@radix-ui/react-hover-card';
-import { Info, X } from 'lucide-react';
+import { Image as ImageIcon, Info, X } from 'lucide-react';
 import { useState } from 'react';
 import { cn } from '@/lib/utils';
 import type { MonsterDetail } from '@foundry-toolkit/shared/types';
@@ -48,6 +48,9 @@ export function MonsterDetailPane({ detail, loading, onOpenExternal, onClose }: 
           </span>
         ))}
         <div className="flex-1" />
+        {(artAssets.artSrc ?? artAssets.portraitSrc) && (
+          <MonsterArtChip name={detail.name} imageSrc={artAssets.artSrc ?? artAssets.portraitSrc!} />
+        )}
         {detail.description && (
           <button
             type="button"
@@ -94,6 +97,36 @@ export function MonsterDetailPane({ detail, loading, onOpenExternal, onClose }: 
         </div>
       )}
     </>
+  );
+}
+
+/** Chip button in the header controls; hovering reveals the full monster art in a popover. */
+function MonsterArtChip({ name, imageSrc }: { name: string; imageSrc: string }) {
+  return (
+    <HoverCard.Root openDelay={400} closeDelay={200}>
+      <HoverCard.Trigger asChild>
+        <button
+          type="button"
+          aria-label="Show full art"
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+        >
+          <ImageIcon className="h-4 w-4" />
+        </button>
+      </HoverCard.Trigger>
+      <HoverCard.Portal>
+        <HoverCard.Content
+          side="bottom"
+          align="end"
+          sideOffset={4}
+          avoidCollisions
+          collisionPadding={8}
+          className="z-50 overflow-hidden rounded-md border border-border bg-popover shadow-lg"
+          style={{ width: '240px' }}
+        >
+          <img src={imageSrc} alt={name} className="w-full object-contain" />
+        </HoverCard.Content>
+      </HoverCard.Portal>
+    </HoverCard.Root>
   );
 }
 

--- a/apps/dm-tool/src/features/settings/SettingsDialog.tsx
+++ b/apps/dm-tool/src/features/settings/SettingsDialog.tsx
@@ -23,6 +23,7 @@ import {
   THEMES,
   CHAT_MODELS,
   PARTY_LEVEL,
+  MONSTER_CARD_SIZE,
   type FontFamily,
   type ThemeId,
   type ToolEntry,
@@ -50,6 +51,8 @@ export interface SettingsDialogProps {
   onToolFaviconsChange: (v: boolean) => void;
   partyLevel: number;
   onPartyLevelChange: (n: number) => void;
+  monsterCardSize: number;
+  onMonsterCardSizeChange: (n: number) => void;
 }
 
 export function SettingsDialog({
@@ -72,6 +75,8 @@ export function SettingsDialog({
   onToolFaviconsChange,
   partyLevel,
   onPartyLevelChange,
+  monsterCardSize,
+  onMonsterCardSizeChange,
 }: SettingsDialogProps) {
   const [open, setOpen] = useState(false);
   const [tab, setTab] = useState<SettingsTab>('maps');
@@ -481,7 +486,30 @@ export function SettingsDialog({
                 </div>
               )}
 
-              {tab === 'monsters' && <MonsterPacksSettings />}
+              {tab === 'monsters' && (
+                <>
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between">
+                      <Label htmlFor="monster-card-size" className="text-xs font-medium">
+                        Card Size
+                      </Label>
+                      <span className="text-xs tabular-nums text-muted-foreground">{monsterCardSize}px</span>
+                    </div>
+                    <Slider
+                      id="monster-card-size"
+                      min={MONSTER_CARD_SIZE.min}
+                      max={MONSTER_CARD_SIZE.max}
+                      step={4}
+                      value={[monsterCardSize]}
+                      onValueChange={(v) => onMonsterCardSizeChange(v[0] ?? monsterCardSize)}
+                    />
+                    <p className="pt-0.5 text-[11px] leading-snug text-muted-foreground">
+                      Width of each card in the monster browser grid. Height scales proportionally.
+                    </p>
+                  </div>
+                  <MonsterPacksSettings />
+                </>
+              )}
 
               {tab === 'items' && <p className="text-xs text-muted-foreground">No item settings yet.</p>}
 

--- a/apps/dm-tool/src/hooks/usePreferences.ts
+++ b/apps/dm-tool/src/hooks/usePreferences.ts
@@ -13,6 +13,7 @@ import {
   DEFAULT_CHAT_MODEL,
   DEFAULT_TOOLS,
   PARTY_LEVEL,
+  MONSTER_CARD_SIZE,
   type FontFamily,
   type ThemeId,
   type ToolEntry,
@@ -38,6 +39,8 @@ export interface Preferences {
   setToolFavicons: React.Dispatch<React.SetStateAction<boolean>>;
   partyLevel: number;
   setPartyLevel: React.Dispatch<React.SetStateAction<number>>;
+  monsterCardSize: number;
+  setMonsterCardSize: React.Dispatch<React.SetStateAction<number>>;
 }
 
 export function usePreferences(): Preferences {
@@ -59,6 +62,9 @@ export function usePreferences(): Preferences {
   const [toolFavicons, setToolFavicons] = useState<boolean>(() => readString(STORAGE_KEYS.toolFavicons) === 'true');
   const [partyLevel, setPartyLevel] = useState<number>(() =>
     readNumber(STORAGE_KEYS.partyLevel, PARTY_LEVEL.default, PARTY_LEVEL.min, PARTY_LEVEL.max),
+  );
+  const [monsterCardSize, setMonsterCardSize] = useState<number>(() =>
+    readNumber(STORAGE_KEYS.monsterCardSize, MONSTER_CARD_SIZE.default, MONSTER_CARD_SIZE.min, MONSTER_CARD_SIZE.max),
   );
 
   // Load API key from secure storage on mount
@@ -135,6 +141,10 @@ export function usePreferences(): Preferences {
     writeString(STORAGE_KEYS.partyLevel, String(partyLevel));
   }, [partyLevel]);
 
+  useEffect(() => {
+    writeString(STORAGE_KEYS.monsterCardSize, String(monsterCardSize));
+  }, [monsterCardSize]);
+
   return {
     uiScale,
     setUiScale,
@@ -154,5 +164,7 @@ export function usePreferences(): Preferences {
     setToolFavicons,
     partyLevel,
     setPartyLevel,
+    monsterCardSize,
+    setMonsterCardSize,
   };
 }

--- a/apps/dm-tool/src/lib/constants.ts
+++ b/apps/dm-tool/src/lib/constants.ts
@@ -18,6 +18,7 @@ export const STORAGE_KEYS = {
   toolUrls: 'dmtool.toolUrls',
   toolFavicons: 'dmtool.toolFavicons',
   partyLevel: 'dmtool.partyLevel',
+  monsterCardSize: 'dmtool.monsterCardSize',
 } as const;
 
 // --- Party level (global) ----------------------------------------------------
@@ -46,6 +47,11 @@ export const HEADER_REMS = 3;
 // --- Thumbnail scale ---------------------------------------------------------
 
 export const THUMB_SCALE = { default: 1, min: 0.7, max: 2 } as const;
+
+// --- Monster card size -------------------------------------------------------
+
+/** Width of a monster browser card in px. Height scales at a fixed 108:200 ratio. */
+export const MONSTER_CARD_SIZE = { default: 108, min: 72, max: 200 } as const;
 
 // --- Font families -----------------------------------------------------------
 

--- a/packages/shared/src/compendium/types.ts
+++ b/packages/shared/src/compendium/types.ts
@@ -118,6 +118,8 @@ export interface MonsterSummary {
   traits: string[];
   source: string;
   aonUrl: string;
+  /** Token image URL, rewritten to monster-file:// or mcp proxy. Null when unavailable. */
+  tokenUrl: string | null;
 }
 
 export interface MonsterSpellInfo {


### PR DESCRIPTION
## Summary

Redesigns the monster browser card grid and detail panel as part of an ongoing visual iteration. Cards are now portrait-oriented with monster art as the full-card background. The detail panel stats are moved inline and the full art appears beside them. All changes are in `apps/dm-tool` only.

## Apps touched

- `apps/dm-tool` — `npm run dev:dm-tool`

## Changes

**Monster browser cards**
- Art rendered as full-card background (`object-contain`) behind name and stats
- Token image added to `MonsterSummary` type and surfaced through the search IPC (URL-rewritten via `toMonsterFileUrl`, same as detail)
- Card aspect ratio flipped to portrait — default 108×200 px
- Card size slider added to Settings → Monsters (72–200 px, persisted in localStorage)
- Removed trait chips, F/R/W saves, and size/type subtitle from cards
- Monster name wraps instead of truncating

**Monster detail panel**
- Stats (AC/HP · Fort/Ref/Will/Perc · ability mods) moved from left column to inline section above Speed
- Full art shown in a two-column layout beside the stats (160×160)
- Full art section below attacks/spells removed
- Art hover chip (Image icon) uses the same `onMouseEnter` overlay pattern as the Info (lore) chip — blurred overlay over the content area
- Inline portrait (`ArtHoverCard`) removed from the header; token art now lives on the cards in the grid

## Test plan

- [ ] Open Monsters tab — cards show portrait art as background, name wraps, HP/AC visible
- [ ] Settings → Monsters → Card Size slider resizes the grid live and persists on reload
- [ ] Pick any monster → detail panel shows stats inline beside the full art, then Speed/Skills/Attacks/Abilities/Spells below
- [ ] Hover Image chip → full art overlay appears; hover Info chip → lore overlay appears; both dismiss on mouse-out
- [ ] Monster with no art → card shows plain card background; detail art column absent
- [ ] `npm run typecheck -w @foundry-toolkit/dm-tool` passes
- [ ] `npm run test -w @foundry-toolkit/dm-tool` passes (405 tests)