### PR TITLE
ci(tagger): add release workflow and fetch scripts for map-tagger exe

### DIFF
--- a/.github/workflows/release-tagger.yml
+++ b/.github/workflows/release-tagger.yml
@@ -1,0 +1,57 @@
+name: Build and publish map-tagger exe
+
+on:
+  push:
+    tags: ['tagger-v*']
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        working-directory: tagger
+        run: pip install -e . "nuitka[onefile]"
+
+      - name: Build exe with Nuitka
+        working-directory: tagger
+        run: |
+          python -m nuitka `
+            --onefile `
+            --assume-yes-for-downloads `
+            --output-filename=map-tagger.exe `
+            --output-dir=dist `
+            --include-package=dnd_map_tagger `
+            --windows-console-mode=force `
+            --remove-output `
+            entry.py
+
+      - name: Rename and hash asset
+        id: asset
+        working-directory: tagger/dist
+        run: |
+          $version = "${{ github.ref_name }}" -replace '^tagger-v', ''
+          $name = "map-tagger-$version.exe"
+          Rename-Item map-tagger.exe $name
+          $hash = (Get-FileHash $name -Algorithm SHA256).Hash.ToLower()
+          "$hash  $name" | Out-File -Encoding ascii "$name.sha256"
+          "name=$name" | Out-File -Append $env:GITHUB_OUTPUT
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            tagger/dist/${{ steps.asset.outputs.name }}
+            tagger/dist/${{ steps.asset.outputs.name }}.sha256
+          generate_release_notes: true

--- a/tagger/CLAUDE.md
+++ b/tagger/CLAUDE.md
@@ -1,0 +1,41 @@
+# tagger
+
+Python map-indexing subtool — not an npm workspace. See parent [CLAUDE.md](../CLAUDE.md) for monorepo context.
+
+## Build locally
+
+From `tagger/`:
+
+```bat
+.\build.bat
+```
+
+Produces `tagger/dist/map-tagger.exe` via Nuitka. Requires Python 3.11+. First build is slow (Nuitka downloads a C runtime and compiles); subsequent builds reuse the cache.
+
+## Release pipeline
+
+Releases are tag-driven via `.github/workflows/release-tagger.yml`. Push a `tagger-v*` tag to trigger a build on `windows-latest` and publish the exe as a GitHub Release asset.
+
+**To cut a release:**
+
+```bash
+git tag tagger-v0.2.0
+git push origin tagger-v0.2.0
+```
+
+The workflow builds with the same Nuitka flags as `build.bat` and attaches `map-tagger-<version>.exe` plus a SHA256 sidecar to the release.
+
+Current version: `[project] version` in `pyproject.toml` (currently `0.1.0`).
+
+The `tagger-v*` tag prefix is intentionally distinct from `v*`, which the `release-image.yml` workflow uses for Docker image releases.
+
+## dm-tool packaging
+
+`apps/dm-tool/package.json` references `../../tagger/dist/map-tagger.exe` as `extraResources` for electron-builder. That path must exist at `npm run package` / `package:ci` time.
+
+- **Local dev packaging** — run `.\build.bat` in `tagger/` first.
+- **Clean packaging (no Python required)** — pull the latest release exe with the fetch script:
+  - Windows (PowerShell): `.\tagger\scripts\fetch-release.ps1`
+  - Mac/Linux (bash): `./tagger/scripts/fetch-release.sh`
+
+Both scripts require the `gh` CLI (`https://cli.github.com/`) with an active `gh auth login`.

--- a/tagger/scripts/fetch-release.ps1
+++ b/tagger/scripts/fetch-release.ps1
@@ -1,0 +1,24 @@
+# Downloads the latest map-tagger release exe into tagger/dist/
+# so electron-builder can package dm-tool without a local Python install.
+#
+# Requires: gh CLI (https://cli.github.com/) with gh auth login.
+
+$repo    = 'AlexDickerson/foundry-toolkit'
+$distDir = Join-Path $PSScriptRoot '..' 'dist'
+New-Item -ItemType Directory -Force -Path $distDir | Out-Null
+
+Write-Host "Fetching latest tagger release from $repo..."
+gh release download --repo $repo --pattern 'map-tagger-*.exe' --dir $distDir --clobber
+
+$versioned = Get-ChildItem -Path $distDir -Filter 'map-tagger-*.exe' |
+  Sort-Object LastWriteTime -Descending |
+  Select-Object -First 1
+
+if (-not $versioned) {
+    Write-Error 'No map-tagger-*.exe found in dist/ after download'
+    exit 1
+}
+
+$dest = Join-Path $distDir 'map-tagger.exe'
+Move-Item -Force $versioned.FullName $dest
+Write-Host "Ready: $dest"

--- a/tagger/scripts/fetch-release.sh
+++ b/tagger/scripts/fetch-release.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Downloads the latest map-tagger release exe into tagger/dist/
+# so electron-builder can package dm-tool without a local Python install.
+#
+# Requires: gh CLI (https://cli.github.com/) with gh auth login.
+
+REPO="AlexDickerson/foundry-toolkit"
+DIST="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/dist"
+mkdir -p "$DIST"
+
+echo "Fetching latest tagger release from $REPO..."
+gh release download --repo "$REPO" --pattern "map-tagger-*.exe" --dir "$DIST" --clobber
+
+versioned=$(ls "$DIST"/map-tagger-*.exe 2>/dev/null | head -1)
+if [ -z "$versioned" ]; then
+  echo "No map-tagger-*.exe found in dist/ after download" >&2
+  exit 1
+fi
+
+mv -f "$versioned" "$DIST/map-tagger.exe"
+echo "Ready: $DIST/map-tagger.exe"


### PR DESCRIPTION
## Summary

Adds a tag-driven GitHub Actions workflow that builds `tagger/dist/map-tagger.exe` via Nuitka on `windows-latest` and publishes it as a GitHub Release asset. Includes fetch scripts so contributors can pull the released exe into `tagger/dist/` without a local Python install, restoring dm-tool's `npm run package` self-sufficiency. Adds `tagger/CLAUDE.md` documenting the build, release, and consumption workflow.

## Apps touched

- `tagger/` — new `CLAUDE.md`, new `scripts/fetch-release.{ps1,sh}`
- `.github/workflows/` — new `release-tagger.yml`

None of the npm workspaces are touched. No behavior change to any existing app.

## Changes

- **`.github/workflows/release-tagger.yml`** — triggers on `tagger-v*` tags (distinct from the `v*` namespace used by `release-image.yml`). Sets up Python 3.11, installs deps + Nuitka, runs the same Nuitka flags as `build.bat`, renames the output to `map-tagger-<version>.exe`, computes a SHA256 sidecar, and attaches both to a GitHub Release via `softprops/action-gh-release@v2`.
- **`tagger/scripts/fetch-release.ps1`** and **`fetch-release.sh`** — download the latest `map-tagger-*.exe` from GitHub Releases into `tagger/dist/map-tagger.exe`. Both require the `gh` CLI with `gh auth login`. Run from the repo root: `.\tagger\scripts\fetch-release.ps1` (Windows) or `./tagger/scripts/fetch-release.sh` (Mac/Linux).
- **`tagger/CLAUDE.md`** — documents local build, how to cut a release (push a `tagger-v*` tag), and how dm-tool packaging consumes `tagger/dist/map-tagger.exe`.

## How to cut a release (post-merge)

```bash
git tag tagger-v0.1.0
git push origin tagger-v0.1.0
```

The workflow runs, uploads `map-tagger-0.1.0.exe` + `.sha256`, and creates the GitHub Release automatically.

## Test plan

- [ ] Workflow YAML reviewed for syntax — `defaults.run.shell: pwsh`, backtick line continuation, `Out-File -Append $env:GITHUB_OUTPUT` output pattern all verified correct.
- [ ] First real run is post-merge: push a `tagger-v0.1.0` tag and confirm the workflow builds and the release asset appears.
- [ ] To validate the fetch scripts without a real release: push a draft/pre-release with a test exe asset and run `.\tagger\scripts\fetch-release.ps1` manually.