### PR TITLE
feat(chat): emit structured chat-message data for selective rendering

### DIFF
--- a/apps/foundry-api-bridge/src/chat/__tests__/fixtures/damage.json
+++ b/apps/foundry-api-bridge/src/chat/__tests__/fixtures/damage.json
@@ -4,28 +4,28 @@
   "isRoll": true,
   "type": 5,
   "timestamp": 1698765435000,
-  "flavor": "Longsword Damage",
-  "content": "<div class=\"dice-roll\"><div class=\"dice-result\"><div class=\"dice-formula\">2d8[slashing] + 5[slashing]</div><h4 class=\"dice-total\">14</h4></div></div>",
+  "flavor": "<h4 class=\"action\">\n    <strong>Damage Roll: Longsword</strong>\n    </h4>",
+  "content": "9",
   "speaker": { "alias": "Valeros", "actor": "actor001" },
   "whisper": [],
   "author": { "id": "user001", "name": "Player1" },
   "rolls": [
     {
-      "formula": "2d8[slashing] + 5[slashing]",
-      "total": 14,
-      "isCritical": false,
-      "isFumble": false,
-      "dice": [{ "faces": 8, "results": [{ "result": 5, "active": true }, { "result": 4, "active": true }] }]
+      "formula": "1d8 + 5 slashing",
+      "total": 9,
+      "dice": [{ "faces": 8, "results": [{ "result": 4, "active": true }] }]
     }
   ],
   "flags": {
     "pf2e": {
       "context": {
         "type": "damage-roll",
-        "actor": "actor001",
-        "item": "weapon001"
+        "actor": "Actor.actor001",
+        "item": "Item.weapon001",
+        "target": null,
+        "outcome": "success"
       },
-      "origin": { "actor": "actor001", "type": "character" }
+      "origin": { "actor": "Actor.actor001", "type": "weapon" }
     }
   }
 }

--- a/apps/foundry-api-bridge/src/chat/__tests__/fixtures/damage.json
+++ b/apps/foundry-api-bridge/src/chat/__tests__/fixtures/damage.json
@@ -1,0 +1,31 @@
+{
+  "id": "dmgMsg001",
+  "uuid": "ChatMessage.dmgMsg001",
+  "isRoll": true,
+  "type": 5,
+  "timestamp": 1698765435000,
+  "flavor": "Longsword Damage",
+  "content": "<div class=\"dice-roll\"><div class=\"dice-result\"><div class=\"dice-formula\">2d8[slashing] + 5[slashing]</div><h4 class=\"dice-total\">14</h4></div></div>",
+  "speaker": { "alias": "Valeros", "actor": "actor001" },
+  "whisper": [],
+  "author": { "id": "user001", "name": "Player1" },
+  "rolls": [
+    {
+      "formula": "2d8[slashing] + 5[slashing]",
+      "total": 14,
+      "isCritical": false,
+      "isFumble": false,
+      "dice": [{ "faces": 8, "results": [{ "result": 5, "active": true }, { "result": 4, "active": true }] }]
+    }
+  ],
+  "flags": {
+    "pf2e": {
+      "context": {
+        "type": "damage-roll",
+        "actor": "actor001",
+        "item": "weapon001"
+      },
+      "origin": { "actor": "actor001", "type": "character" }
+    }
+  }
+}

--- a/apps/foundry-api-bridge/src/chat/__tests__/fixtures/saving-throw.json
+++ b/apps/foundry-api-bridge/src/chat/__tests__/fixtures/saving-throw.json
@@ -4,8 +4,8 @@
   "isRoll": true,
   "type": 5,
   "timestamp": 1698765445000,
-  "flavor": "Reflex Save",
-  "content": "<div class=\"dice-roll\"><div class=\"dice-result\"><div class=\"dice-formula\">1d20 + 6</div><h4 class=\"dice-total\">8</h4></div></div>",
+  "flavor": "<h4 class=\"action\"><strong>Reflex Saving Throw</strong></h4>",
+  "content": "8",
   "speaker": { "alias": "Valeros", "actor": "actor001" },
   "whisper": [],
   "author": { "id": "user001", "name": "Player1" },
@@ -13,8 +13,6 @@
     {
       "formula": "1d20 + 6",
       "total": 8,
-      "isCritical": false,
-      "isFumble": false,
       "dice": [{ "faces": 20, "results": [{ "result": 2, "active": true }] }]
     }
   ],
@@ -22,11 +20,12 @@
     "pf2e": {
       "context": {
         "type": "saving-throw",
-        "actor": "actor001",
-        "dc": { "value": 22 }
+        "actor": "Actor.actor001",
+        "dc": { "value": 22, "visible": true },
+        "target": { "actor": "Actor.targetActor001", "token": "Scene.scene001.Token.targetToken001" },
+        "outcome": "failure"
       },
-      "origin": { "actor": "actor001", "type": "character" },
-      "outcomePrecise": "failure"
+      "origin": { "actor": "Actor.actor001", "type": "character" }
     }
   }
 }

--- a/apps/foundry-api-bridge/src/chat/__tests__/fixtures/saving-throw.json
+++ b/apps/foundry-api-bridge/src/chat/__tests__/fixtures/saving-throw.json
@@ -1,0 +1,32 @@
+{
+  "id": "saveMsg001",
+  "uuid": "ChatMessage.saveMsg001",
+  "isRoll": true,
+  "type": 5,
+  "timestamp": 1698765445000,
+  "flavor": "Reflex Save",
+  "content": "<div class=\"dice-roll\"><div class=\"dice-result\"><div class=\"dice-formula\">1d20 + 6</div><h4 class=\"dice-total\">8</h4></div></div>",
+  "speaker": { "alias": "Valeros", "actor": "actor001" },
+  "whisper": [],
+  "author": { "id": "user001", "name": "Player1" },
+  "rolls": [
+    {
+      "formula": "1d20 + 6",
+      "total": 8,
+      "isCritical": false,
+      "isFumble": false,
+      "dice": [{ "faces": 20, "results": [{ "result": 2, "active": true }] }]
+    }
+  ],
+  "flags": {
+    "pf2e": {
+      "context": {
+        "type": "saving-throw",
+        "actor": "actor001",
+        "dc": { "value": 22 }
+      },
+      "origin": { "actor": "actor001", "type": "character" },
+      "outcomePrecise": "failure"
+    }
+  }
+}

--- a/apps/foundry-api-bridge/src/chat/__tests__/fixtures/skill-check.json
+++ b/apps/foundry-api-bridge/src/chat/__tests__/fixtures/skill-check.json
@@ -4,8 +4,8 @@
   "isRoll": true,
   "type": 5,
   "timestamp": 1698765440000,
-  "flavor": "Perception Check",
-  "content": "<div class=\"dice-roll\"><div class=\"dice-result\"><div class=\"dice-formula\">1d20 + 9</div><h4 class=\"dice-total\">21</h4></div></div>",
+  "flavor": "<h4 class=\"action\"><strong>Perception Check</strong></h4>",
+  "content": "21",
   "speaker": { "alias": "Valeros", "actor": "actor001" },
   "whisper": [],
   "author": { "id": "user001", "name": "Player1" },
@@ -13,8 +13,6 @@
     {
       "formula": "1d20 + 9",
       "total": 21,
-      "isCritical": false,
-      "isFumble": false,
       "dice": [{ "faces": 20, "results": [{ "result": 12, "active": true }] }]
     }
   ],
@@ -22,11 +20,12 @@
     "pf2e": {
       "context": {
         "type": "skill-check",
-        "actor": "actor001",
-        "dc": { "value": 18, "slug": "perception" }
+        "actor": "Actor.actor001",
+        "dc": { "value": 18, "visible": true },
+        "target": null,
+        "outcome": "success"
       },
-      "origin": { "actor": "actor001", "type": "character" },
-      "outcomePrecise": "success"
+      "origin": { "actor": "Actor.actor001", "type": "character" }
     }
   }
 }

--- a/apps/foundry-api-bridge/src/chat/__tests__/fixtures/skill-check.json
+++ b/apps/foundry-api-bridge/src/chat/__tests__/fixtures/skill-check.json
@@ -1,0 +1,32 @@
+{
+  "id": "skillMsg001",
+  "uuid": "ChatMessage.skillMsg001",
+  "isRoll": true,
+  "type": 5,
+  "timestamp": 1698765440000,
+  "flavor": "Perception Check",
+  "content": "<div class=\"dice-roll\"><div class=\"dice-result\"><div class=\"dice-formula\">1d20 + 9</div><h4 class=\"dice-total\">21</h4></div></div>",
+  "speaker": { "alias": "Valeros", "actor": "actor001" },
+  "whisper": [],
+  "author": { "id": "user001", "name": "Player1" },
+  "rolls": [
+    {
+      "formula": "1d20 + 9",
+      "total": 21,
+      "isCritical": false,
+      "isFumble": false,
+      "dice": [{ "faces": 20, "results": [{ "result": 12, "active": true }] }]
+    }
+  ],
+  "flags": {
+    "pf2e": {
+      "context": {
+        "type": "skill-check",
+        "actor": "actor001",
+        "dc": { "value": 18, "slug": "perception" }
+      },
+      "origin": { "actor": "actor001", "type": "character" },
+      "outcomePrecise": "success"
+    }
+  }
+}

--- a/apps/foundry-api-bridge/src/chat/__tests__/fixtures/spell-cast.json
+++ b/apps/foundry-api-bridge/src/chat/__tests__/fixtures/spell-cast.json
@@ -1,0 +1,20 @@
+{
+  "id": "spellMsg001",
+  "uuid": "ChatMessage.spellMsg001",
+  "isRoll": false,
+  "type": 5,
+  "timestamp": 1698765450000,
+  "flavor": "Magic Missile",
+  "content": "<p>You send a dart of force streaking toward a creature that you can see. It automatically hits and deals 1d4+1 force damage.</p>",
+  "speaker": { "alias": "Ezren", "actor": "actor002" },
+  "whisper": [],
+  "author": { "id": "user001", "name": "Player1" },
+  "rolls": [],
+  "flags": {
+    "pf2e": {
+      "context": { "type": "spell-cast", "actor": "actor002" },
+      "origin": { "actor": "actor002", "type": "spell" },
+      "casting": { "id": "spellSlot001", "tradition": "arcane", "level": 1 }
+    }
+  }
+}

--- a/apps/foundry-api-bridge/src/chat/__tests__/fixtures/spell-cast.json
+++ b/apps/foundry-api-bridge/src/chat/__tests__/fixtures/spell-cast.json
@@ -4,17 +4,22 @@
   "isRoll": false,
   "type": 5,
   "timestamp": 1698765450000,
-  "flavor": "Magic Missile",
-  "content": "<p>You send a dart of force streaking toward a creature that you can see. It automatically hits and deals 1d4+1 force damage.</p>",
+  "flavor": "",
+  "content": "<div class=\"pf2e chat-card item-card\"><header class=\"card-header flexrow\"><img src=\"icons/magic/fire/flame.webp\" alt=\"Magic Missile\"><h3>Magic Missile <span class=\"action-glyph\">1</span></h3></header><p>You send a dart of force streaking toward a creature that you can see. It automatically hits and deals 1d4+1 force damage.</p></div>",
   "speaker": { "alias": "Ezren", "actor": "actor002" },
   "whisper": [],
   "author": { "id": "user001", "name": "Player1" },
   "rolls": [],
   "flags": {
     "pf2e": {
-      "context": { "type": "spell-cast", "actor": "actor002" },
-      "origin": { "actor": "actor002", "type": "spell" },
-      "casting": { "id": "spellSlot001", "tradition": "arcane", "level": 1 }
+      "context": {
+        "type": "spell-cast",
+        "actor": "Actor.actor002",
+        "target": null,
+        "outcome": null
+      },
+      "origin": { "actor": "Actor.actor002", "type": "spell" },
+      "casting": { "id": "spellSlot001", "tradition": "arcane" }
     }
   }
 }

--- a/apps/foundry-api-bridge/src/chat/__tests__/fixtures/strike-attack.json
+++ b/apps/foundry-api-bridge/src/chat/__tests__/fixtures/strike-attack.json
@@ -4,8 +4,8 @@
   "isRoll": true,
   "type": 5,
   "timestamp": 1698765432000,
-  "flavor": "<strong>Strike</strong>: Longsword",
-  "content": "<div class=\"dice-roll\"><div class=\"dice-result\"><div class=\"dice-formula\">1d20 + 8</div><div class=\"dice-tooltip\"></div><h4 class=\"dice-total\">24</h4></div></div>",
+  "flavor": "<h4 class=\"action\"><strong>Strike</strong>: Longsword</h4>",
+  "content": "19",
   "speaker": { "alias": "Valeros", "actor": "actor001" },
   "whisper": [],
   "author": { "id": "user001", "name": "Player1" },
@@ -13,8 +13,6 @@
     {
       "formula": "1d20 + 8",
       "total": 24,
-      "isCritical": true,
-      "isFumble": false,
       "dice": [{ "faces": 20, "results": [{ "result": 16, "active": true }] }]
     }
   ],
@@ -22,12 +20,13 @@
     "pf2e": {
       "context": {
         "type": "attack-roll",
-        "actor": "actor001",
-        "item": "weapon001",
-        "target": { "actor": "targetActor001", "token": "targetToken001" }
+        "actor": "Actor.actor001",
+        "item": "Item.weapon001",
+        "target": { "actor": "Actor.targetActor001", "token": "Scene.scene001.Token.targetToken001" },
+        "outcome": "criticalSuccess",
+        "dc": null
       },
-      "origin": { "actor": "actor001", "type": "character" },
-      "outcomePrecise": "criticalSuccess"
+      "origin": { "actor": "Actor.actor001", "type": "character" }
     }
   }
 }

--- a/apps/foundry-api-bridge/src/chat/__tests__/fixtures/strike-attack.json
+++ b/apps/foundry-api-bridge/src/chat/__tests__/fixtures/strike-attack.json
@@ -1,0 +1,33 @@
+{
+  "id": "strikeMsg001",
+  "uuid": "ChatMessage.strikeMsg001",
+  "isRoll": true,
+  "type": 5,
+  "timestamp": 1698765432000,
+  "flavor": "<strong>Strike</strong>: Longsword",
+  "content": "<div class=\"dice-roll\"><div class=\"dice-result\"><div class=\"dice-formula\">1d20 + 8</div><div class=\"dice-tooltip\"></div><h4 class=\"dice-total\">24</h4></div></div>",
+  "speaker": { "alias": "Valeros", "actor": "actor001" },
+  "whisper": [],
+  "author": { "id": "user001", "name": "Player1" },
+  "rolls": [
+    {
+      "formula": "1d20 + 8",
+      "total": 24,
+      "isCritical": true,
+      "isFumble": false,
+      "dice": [{ "faces": 20, "results": [{ "result": 16, "active": true }] }]
+    }
+  ],
+  "flags": {
+    "pf2e": {
+      "context": {
+        "type": "attack-roll",
+        "actor": "actor001",
+        "item": "weapon001",
+        "target": { "actor": "targetActor001", "token": "targetToken001" }
+      },
+      "origin": { "actor": "actor001", "type": "character" },
+      "outcomePrecise": "criticalSuccess"
+    }
+  }
+}

--- a/apps/foundry-api-bridge/src/chat/__tests__/fixtures/unknown.json
+++ b/apps/foundry-api-bridge/src/chat/__tests__/fixtures/unknown.json
@@ -1,0 +1,16 @@
+{
+  "id": "unknownMsg001",
+  "uuid": "ChatMessage.unknownMsg001",
+  "isRoll": false,
+  "type": 0,
+  "timestamp": 1698765460000,
+  "flavor": "",
+  "content": "<p>A custom macro fired some effect.</p>",
+  "speaker": { "alias": "GM" },
+  "whisper": [],
+  "author": { "id": "gm001", "name": "GM" },
+  "rolls": [],
+  "flags": {
+    "world": { "customMacroId": "macro001" }
+  }
+}

--- a/apps/foundry-api-bridge/src/chat/__tests__/parse-message.test.ts
+++ b/apps/foundry-api-bridge/src/chat/__tests__/parse-message.test.ts
@@ -22,7 +22,6 @@ describe('parseChatMessage', () => {
 
     it('strips HTML from flavor', () => {
       const result = parseChatMessage(asInput(strikeAttackFixture));
-      expect(result.kind).toBe('strike-attack');
       if (result.kind !== 'strike-attack') return;
       expect(result.flavor).toBe('Strike: Longsword');
     });
@@ -38,23 +37,24 @@ describe('parseChatMessage', () => {
       const result = parseChatMessage(asInput(strikeAttackFixture));
       if (result.kind !== 'strike-attack') return;
       expect(result.targets).toHaveLength(1);
-      expect(result.targets[0]?.actorId).toBe('targetActor001');
-      expect(result.targets[0]?.tokenId).toBe('targetToken001');
+      // Foundry UUIDs include the document-type prefix
+      expect(result.targets[0]?.actorId).toBe('Actor.targetActor001');
+      expect(result.targets[0]?.tokenId).toBe('Scene.scene001.Token.targetToken001');
     });
 
-    it('extracts outcome from outcomePrecise', () => {
+    it('extracts outcome from context.outcome', () => {
       const result = parseChatMessage(asInput(strikeAttackFixture));
       if (result.kind !== 'strike-attack') return;
       expect(result.targets[0]?.outcome).toBe('criticalSuccess');
     });
 
-    it('produces empty targets when no target in flags', () => {
+    it('produces empty targets when context.target is null', () => {
       const msg = asInput({
         ...strikeAttackFixture,
         flags: {
           pf2e: {
-            context: { type: 'attack-roll', actor: 'actor001' },
-            origin: { actor: 'actor001', type: 'character' },
+            context: { type: 'attack-roll', actor: 'Actor.actor001', target: null, outcome: null },
+            origin: { actor: 'Actor.actor001', type: 'character' },
           },
         },
       });
@@ -70,17 +70,17 @@ describe('parseChatMessage', () => {
       expect(result.kind).toBe('damage');
     });
 
-    it('extracts damage type from formula bracket notation', () => {
+    it('extracts damage type from trailing word in formula', () => {
       const result = parseChatMessage(asInput(damageFixture));
       if (result.kind !== 'damage') return;
       expect(result.parts).toHaveLength(1);
       expect(result.parts[0]?.damageType).toBe('slashing');
     });
 
-    it('sums roll totals correctly', () => {
+    it('stores the roll total correctly', () => {
       const result = parseChatMessage(asInput(damageFixture));
       if (result.kind !== 'damage') return;
-      expect(result.total).toBe(14);
+      expect(result.total).toBe(9);
     });
 
     it('includes an apply-damage chip', () => {
@@ -90,12 +90,31 @@ describe('parseChatMessage', () => {
       expect(result.chips[0]?.type).toBe('apply-damage');
     });
 
+    it('extracts outcome from context.outcome', () => {
+      const result = parseChatMessage(asInput(damageFixture));
+      if (result.kind !== 'damage') return;
+      expect(result.outcome).toBe('success');
+    });
+
+    it('handles crit-doubled formula "2 * (1d6 + 6) bludgeoning"', () => {
+      const msg = asInput({
+        ...damageFixture,
+        rolls: [{ formula: '2 * (1d6 + 6) bludgeoning', total: 16, dice: [] }],
+        flags: { pf2e: { context: { type: 'damage-roll', outcome: 'criticalSuccess', target: null } } },
+      });
+      const result = parseChatMessage(msg);
+      if (result.kind !== 'damage') return;
+      expect(result.parts[0]?.damageType).toBe('bludgeoning');
+      expect(result.total).toBe(16);
+      expect(result.outcome).toBe('criticalSuccess');
+    });
+
     it('handles multiple rolls (multi-type damage)', () => {
       const msg = asInput({
         ...damageFixture,
         rolls: [
-          { formula: '2d6[slashing]', total: 8, isCritical: false, isFumble: false, dice: [] },
-          { formula: '1d6[fire]', total: 4, isCritical: false, isFumble: false, dice: [] },
+          { formula: '2d6 slashing', total: 8, dice: [] },
+          { formula: '1d6 fire', total: 4, dice: [] },
         ],
       });
       const result = parseChatMessage(msg);
@@ -119,13 +138,13 @@ describe('parseChatMessage', () => {
       expect(result.flavor).toBe('Perception Check');
     });
 
-    it('extracts DC from flags.pf2e.context.dc.value', () => {
+    it('extracts DC from context.dc.value', () => {
       const result = parseChatMessage(asInput(skillCheckFixture));
       if (result.kind !== 'skill-check') return;
       expect(result.dc).toBe(18);
     });
 
-    it('extracts outcome from outcomePrecise', () => {
+    it('extracts outcome from context.outcome', () => {
       const result = parseChatMessage(asInput(skillCheckFixture));
       if (result.kind !== 'skill-check') return;
       expect(result.outcome).toBe('success');
@@ -137,19 +156,17 @@ describe('parseChatMessage', () => {
       expect(result.chips).toHaveLength(0);
     });
 
-    it('omits dc when not present in flags', () => {
+    it('omits dc and outcome when context fields are null', () => {
       const msg = asInput({
         ...skillCheckFixture,
         flags: {
-          pf2e: {
-            context: { type: 'skill-check', actor: 'actor001' },
-            origin: { actor: 'actor001', type: 'character' },
-          },
+          pf2e: { context: { type: 'skill-check', actor: 'Actor.actor001', dc: null, outcome: null } },
         },
       });
       const result = parseChatMessage(msg);
       if (result.kind !== 'skill-check') return;
       expect('dc' in result).toBe(false);
+      expect('outcome' in result).toBe(false);
     });
   });
 
@@ -169,7 +186,7 @@ describe('parseChatMessage', () => {
     it('also matches flat-check context type', () => {
       const msg = asInput({
         ...savingThrowFixture,
-        flags: { pf2e: { context: { type: 'flat-check' }, origin: { type: 'character' } } },
+        flags: { pf2e: { context: { type: 'flat-check', outcome: null, dc: null, target: null } } },
       });
       const result = parseChatMessage(msg);
       expect(result.kind).toBe('saving-throw');
@@ -177,15 +194,29 @@ describe('parseChatMessage', () => {
   });
 
   describe('spell cast', () => {
-    it('returns kind spell-cast when origin.type is spell', () => {
+    it('returns kind spell-cast when context.type is spell-cast', () => {
       const result = parseChatMessage(asInput(spellCastFixture));
       expect(result.kind).toBe('spell-cast');
     });
 
-    it('extracts spell name as flavor (plain text)', () => {
+    it('extracts spell name from <h3> in content (flavor is empty in real messages)', () => {
       const result = parseChatMessage(asInput(spellCastFixture));
       if (result.kind !== 'spell-cast') return;
       expect(result.flavor).toBe('Magic Missile');
+    });
+
+    it('also matches when origin.type is spell (fallback detection)', () => {
+      const msg = asInput({
+        ...spellCastFixture,
+        flags: {
+          pf2e: { context: { type: 'something-else', outcome: null }, origin: { type: 'spell' } },
+        },
+      });
+      // 'something-else' context type doesn't match any handler, but origin.type === 'spell' does
+      // NOTE: the primary check wins (attack-roll, etc. take precedence) — origin.type is fallback
+      // This message has no recognised context type so origin.type catches it.
+      const result = parseChatMessage(msg);
+      expect(result.kind).toBe('spell-cast');
     });
 
     it('includes full content HTML as description', () => {
@@ -236,8 +267,8 @@ describe('parseChatMessage', () => {
       const result = parseChatMessage({
         id: 'x',
         isRoll: true,
-        flavor: '<strong>Strike</strong>: <em>Longsword</em>',
-        flags: { pf2e: { context: { type: 'attack-roll' }, origin: { type: 'character' } } },
+        flavor: '<h4 class="action"><strong>Strike</strong>: <em>Longsword</em></h4>',
+        flags: { pf2e: { context: { type: 'attack-roll', target: null, outcome: null, dc: null } } },
       });
       if (result.kind !== 'strike-attack') return;
       expect(result.flavor).toBe('Strike: Longsword');

--- a/apps/foundry-api-bridge/src/chat/__tests__/parse-message.test.ts
+++ b/apps/foundry-api-bridge/src/chat/__tests__/parse-message.test.ts
@@ -1,0 +1,246 @@
+import { parseChatMessage, type ParseInput } from '@/chat/parse-message';
+
+import strikeAttackFixture from './fixtures/strike-attack.json';
+import damageFixture from './fixtures/damage.json';
+import skillCheckFixture from './fixtures/skill-check.json';
+import savingThrowFixture from './fixtures/saving-throw.json';
+import spellCastFixture from './fixtures/spell-cast.json';
+import unknownFixture from './fixtures/unknown.json';
+
+// Cast imported JSON to ParseInput — json fixtures include superset fields
+// (speaker, author, etc.) that parseChatMessage doesn't read; the cast is safe.
+function asInput(fixture: unknown): ParseInput {
+  return fixture as ParseInput;
+}
+
+describe('parseChatMessage', () => {
+  describe('strike attack roll', () => {
+    it('returns kind strike-attack', () => {
+      const result = parseChatMessage(asInput(strikeAttackFixture));
+      expect(result.kind).toBe('strike-attack');
+    });
+
+    it('strips HTML from flavor', () => {
+      const result = parseChatMessage(asInput(strikeAttackFixture));
+      expect(result.kind).toBe('strike-attack');
+      if (result.kind !== 'strike-attack') return;
+      expect(result.flavor).toBe('Strike: Longsword');
+    });
+
+    it('includes a roll-damage chip', () => {
+      const result = parseChatMessage(asInput(strikeAttackFixture));
+      if (result.kind !== 'strike-attack') return;
+      expect(result.chips).toHaveLength(1);
+      expect(result.chips[0]?.type).toBe('roll-damage');
+    });
+
+    it('extracts target actor and token IDs', () => {
+      const result = parseChatMessage(asInput(strikeAttackFixture));
+      if (result.kind !== 'strike-attack') return;
+      expect(result.targets).toHaveLength(1);
+      expect(result.targets[0]?.actorId).toBe('targetActor001');
+      expect(result.targets[0]?.tokenId).toBe('targetToken001');
+    });
+
+    it('extracts outcome from outcomePrecise', () => {
+      const result = parseChatMessage(asInput(strikeAttackFixture));
+      if (result.kind !== 'strike-attack') return;
+      expect(result.targets[0]?.outcome).toBe('criticalSuccess');
+    });
+
+    it('produces empty targets when no target in flags', () => {
+      const msg = asInput({
+        ...strikeAttackFixture,
+        flags: {
+          pf2e: {
+            context: { type: 'attack-roll', actor: 'actor001' },
+            origin: { actor: 'actor001', type: 'character' },
+          },
+        },
+      });
+      const result = parseChatMessage(msg);
+      if (result.kind !== 'strike-attack') return;
+      expect(result.targets).toHaveLength(0);
+    });
+  });
+
+  describe('damage roll', () => {
+    it('returns kind damage', () => {
+      const result = parseChatMessage(asInput(damageFixture));
+      expect(result.kind).toBe('damage');
+    });
+
+    it('extracts damage type from formula bracket notation', () => {
+      const result = parseChatMessage(asInput(damageFixture));
+      if (result.kind !== 'damage') return;
+      expect(result.parts).toHaveLength(1);
+      expect(result.parts[0]?.damageType).toBe('slashing');
+    });
+
+    it('sums roll totals correctly', () => {
+      const result = parseChatMessage(asInput(damageFixture));
+      if (result.kind !== 'damage') return;
+      expect(result.total).toBe(14);
+    });
+
+    it('includes an apply-damage chip', () => {
+      const result = parseChatMessage(asInput(damageFixture));
+      if (result.kind !== 'damage') return;
+      expect(result.chips).toHaveLength(1);
+      expect(result.chips[0]?.type).toBe('apply-damage');
+    });
+
+    it('handles multiple rolls (multi-type damage)', () => {
+      const msg = asInput({
+        ...damageFixture,
+        rolls: [
+          { formula: '2d6[slashing]', total: 8, isCritical: false, isFumble: false, dice: [] },
+          { formula: '1d6[fire]', total: 4, isCritical: false, isFumble: false, dice: [] },
+        ],
+      });
+      const result = parseChatMessage(msg);
+      if (result.kind !== 'damage') return;
+      expect(result.parts).toHaveLength(2);
+      expect(result.parts[0]?.damageType).toBe('slashing');
+      expect(result.parts[1]?.damageType).toBe('fire');
+      expect(result.total).toBe(12);
+    });
+  });
+
+  describe('skill check', () => {
+    it('returns kind skill-check', () => {
+      const result = parseChatMessage(asInput(skillCheckFixture));
+      expect(result.kind).toBe('skill-check');
+    });
+
+    it('extracts flavor as plain text', () => {
+      const result = parseChatMessage(asInput(skillCheckFixture));
+      if (result.kind !== 'skill-check') return;
+      expect(result.flavor).toBe('Perception Check');
+    });
+
+    it('extracts DC from flags.pf2e.context.dc.value', () => {
+      const result = parseChatMessage(asInput(skillCheckFixture));
+      if (result.kind !== 'skill-check') return;
+      expect(result.dc).toBe(18);
+    });
+
+    it('extracts outcome from outcomePrecise', () => {
+      const result = parseChatMessage(asInput(skillCheckFixture));
+      if (result.kind !== 'skill-check') return;
+      expect(result.outcome).toBe('success');
+    });
+
+    it('emits no chips', () => {
+      const result = parseChatMessage(asInput(skillCheckFixture));
+      if (result.kind !== 'skill-check') return;
+      expect(result.chips).toHaveLength(0);
+    });
+
+    it('omits dc when not present in flags', () => {
+      const msg = asInput({
+        ...skillCheckFixture,
+        flags: {
+          pf2e: {
+            context: { type: 'skill-check', actor: 'actor001' },
+            origin: { actor: 'actor001', type: 'character' },
+          },
+        },
+      });
+      const result = parseChatMessage(msg);
+      if (result.kind !== 'skill-check') return;
+      expect('dc' in result).toBe(false);
+    });
+  });
+
+  describe('saving throw', () => {
+    it('returns kind saving-throw', () => {
+      const result = parseChatMessage(asInput(savingThrowFixture));
+      expect(result.kind).toBe('saving-throw');
+    });
+
+    it('extracts DC and failure outcome', () => {
+      const result = parseChatMessage(asInput(savingThrowFixture));
+      if (result.kind !== 'saving-throw') return;
+      expect(result.dc).toBe(22);
+      expect(result.outcome).toBe('failure');
+    });
+
+    it('also matches flat-check context type', () => {
+      const msg = asInput({
+        ...savingThrowFixture,
+        flags: { pf2e: { context: { type: 'flat-check' }, origin: { type: 'character' } } },
+      });
+      const result = parseChatMessage(msg);
+      expect(result.kind).toBe('saving-throw');
+    });
+  });
+
+  describe('spell cast', () => {
+    it('returns kind spell-cast when origin.type is spell', () => {
+      const result = parseChatMessage(asInput(spellCastFixture));
+      expect(result.kind).toBe('spell-cast');
+    });
+
+    it('extracts spell name as flavor (plain text)', () => {
+      const result = parseChatMessage(asInput(spellCastFixture));
+      if (result.kind !== 'spell-cast') return;
+      expect(result.flavor).toBe('Magic Missile');
+    });
+
+    it('includes full content HTML as description', () => {
+      const result = parseChatMessage(asInput(spellCastFixture));
+      if (result.kind !== 'spell-cast') return;
+      expect(result.description).toContain('force damage');
+    });
+
+    it('emits no chips', () => {
+      const result = parseChatMessage(asInput(spellCastFixture));
+      if (result.kind !== 'spell-cast') return;
+      expect(result.chips).toHaveLength(0);
+    });
+  });
+
+  describe('unknown / fallthrough', () => {
+    it('returns kind raw for messages without pf2e context', () => {
+      const result = parseChatMessage(asInput(unknownFixture));
+      expect(result.kind).toBe('raw');
+    });
+
+    it('includes raw content HTML', () => {
+      const result = parseChatMessage(asInput(unknownFixture));
+      if (result.kind !== 'raw') return;
+      expect(result.html).toContain('custom macro');
+    });
+
+    it('returns raw for a message with no flags at all', () => {
+      const result = parseChatMessage({ id: 'x', isRoll: false, content: '<p>hi</p>' });
+      expect(result.kind).toBe('raw');
+      if (result.kind !== 'raw') return;
+      expect(result.html).toBe('<p>hi</p>');
+    });
+
+    it('returns raw when pf2e.context.type is an unrecognised string', () => {
+      const result = parseChatMessage({
+        id: 'x',
+        isRoll: false,
+        content: '<p>some future message type</p>',
+        flags: { pf2e: { context: { type: 'new-unknown-type' }, origin: { type: 'character' } } },
+      });
+      expect(result.kind).toBe('raw');
+    });
+  });
+
+  describe('HTML stripping', () => {
+    it('strips HTML tags from flavor', () => {
+      const result = parseChatMessage({
+        id: 'x',
+        isRoll: true,
+        flavor: '<strong>Strike</strong>: <em>Longsword</em>',
+        flags: { pf2e: { context: { type: 'attack-roll' }, origin: { type: 'character' } } },
+      });
+      if (result.kind !== 'strike-attack') return;
+      expect(result.flavor).toBe('Strike: Longsword');
+    });
+  });
+});

--- a/apps/foundry-api-bridge/src/chat/parse-message.ts
+++ b/apps/foundry-api-bridge/src/chat/parse-message.ts
@@ -37,10 +37,12 @@ export interface ParseInput {
 
 // ── PF2e flag shapes ──────────────────────────────────────────────────────
 // Read defensively with optional chaining throughout.
+// Fields can be absent (optional) OR explicitly null — both variants appear
+// in real Foundry messages depending on message type and world state.
 
 interface Pf2eDcFlags {
   value?: number;
-  slug?: string;
+  visible?: boolean;
 }
 
 interface Pf2eContextTarget {
@@ -52,8 +54,13 @@ interface Pf2eContextFlags {
   type?: string;
   actor?: string;
   item?: string;
-  dc?: Pf2eDcFlags;
-  target?: Pf2eContextTarget;
+  // null when no DC is set or not applicable (e.g. uncontested attack rolls)
+  dc?: Pf2eDcFlags | null;
+  // null when no target is set; actor/token are Foundry Document UUIDs
+  // ("Actor.xxx" / "Scene.xxx.Token.yyy")
+  target?: Pf2eContextTarget | null;
+  // Degree of success: set when Foundry can determine it (DC + roll known)
+  outcome?: string | null;
 }
 
 interface Pf2eOriginFlags {
@@ -64,7 +71,6 @@ interface Pf2eOriginFlags {
 interface Pf2eFlags {
   context?: Pf2eContextFlags;
   origin?: Pf2eOriginFlags;
-  outcomePrecise?: string;
 }
 
 // ── Output types (mirror chatStructuredDataSchema in packages/shared) ─────
@@ -118,7 +124,9 @@ export function parseChatMessage(m: ParseInput): ChatStructuredData {
   if (contextType === 'saving-throw' || contextType === 'flat-check') {
     return parseRollCheck('saving-throw', m, pf2e);
   }
-  if (originType === 'spell') return parseSpellCast(m);
+  // 'spell-cast' appears in context.type; origin.type === 'spell' is a fallback
+  // for spell messages that lack an explicit context type.
+  if (contextType === 'spell-cast' || originType === 'spell') return parseSpellCast(m);
 
   return { kind: 'raw', html: m.content ?? '' };
 }
@@ -127,10 +135,12 @@ export function parseChatMessage(m: ParseInput): ChatStructuredData {
 
 function parseStrikeAttack(m: ParseInput, pf2e: Pf2eFlags | null): ChatStructuredData {
   const ctxTarget = pf2e?.context?.target;
+  // outcome is in context.outcome (null when no target/AC to compare against)
   const outcome = extractOutcome(pf2e);
 
   const targets: ChatTargetResult[] = [];
-  if (ctxTarget?.actor !== undefined) {
+  // ctxTarget is null (explicit) or absent when no target was selected
+  if (ctxTarget != null && ctxTarget.actor !== undefined) {
     const t: ChatTargetResult = { name: '' };
     t.actorId = ctxTarget.actor;
     if (ctxTarget.token !== undefined) t.tokenId = ctxTarget.token;
@@ -146,18 +156,28 @@ function parseStrikeAttack(m: ParseInput, pf2e: Pf2eFlags | null): ChatStructure
   };
 }
 
-function parseDamage(m: ParseInput, _pf2e: Pf2eFlags | null): ChatStructuredData {
+function parseDamage(m: ParseInput, pf2e: Pf2eFlags | null): ChatStructuredData {
   const rolls = m.rolls ?? [];
   const parts = extractDamageParts(rolls);
   const total = rolls.reduce((sum, r) => sum + r.total, 0);
+  const outcome = extractOutcome(pf2e);
 
-  return {
+  const result: {
+    kind: 'damage';
+    flavor: string;
+    parts: ChatDamagePart[];
+    total: number;
+    chips: ChatChip[];
+    outcome?: ChatOutcome;
+  } = {
     kind: 'damage',
     flavor: stripHtml(m.flavor ?? ''),
     parts,
     total,
     chips: [{ type: 'apply-damage', label: 'Apply Damage', params: {} }],
   };
+  if (outcome !== undefined) result.outcome = outcome;
+  return result;
 }
 
 function parseRollCheck(
@@ -184,10 +204,24 @@ function parseRollCheck(
 }
 
 function parseSpellCast(m: ParseInput): ChatStructuredData {
+  // PF2e spell-cast messages have an empty flavor field; the spell name is
+  // in the content HTML inside the first <h3> element. The <h3> also contains
+  // a <span class="action-glyph"> with the action-cost icon — strip those
+  // before extracting plain text so the name doesn't include the glyph number.
+  const content = m.content ?? '';
+  const h3Match = /<h3[^>]*>([\s\S]*?)<\/h3>/i.exec(content);
+  let spellName: string;
+  if (h3Match?.[1] !== undefined) {
+    const h3Text = h3Match[1].replace(/<span[^>]*class="action-glyph"[^>]*>[\s\S]*?<\/span>/gi, '');
+    spellName = stripHtml(h3Text);
+  } else {
+    spellName = stripHtml(m.flavor ?? '');
+  }
+
   return {
     kind: 'spell-cast',
-    flavor: stripHtml(m.flavor ?? ''),
-    description: m.content ?? '',
+    flavor: spellName,
+    description: content,
     chips: [],
   };
 }
@@ -201,7 +235,9 @@ function extractPf2eFlags(flags: Record<string, unknown> | undefined): Pf2eFlags
 }
 
 function extractOutcome(pf2e: Pf2eFlags | null): ChatOutcome | undefined {
-  const o = pf2e?.outcomePrecise;
+  // Outcome lives at flags.pf2e.context.outcome (not outcomePrecise).
+  // null means Foundry could not determine it yet (e.g. no target AC known).
+  const o = pf2e?.context?.outcome;
   if (
     o === 'criticalSuccess' ||
     o === 'success' ||
@@ -214,22 +250,28 @@ function extractOutcome(pf2e: Pf2eFlags | null): ChatOutcome | undefined {
 }
 
 function extractDc(pf2e: Pf2eFlags | null): number | undefined {
-  const val = pf2e?.context?.dc?.value;
+  // dc can be null (no DC set) — treat null the same as absent.
+  const dc = pf2e?.context?.dc;
+  if (dc == null) return undefined;
+  const val = dc.value;
   return typeof val === 'number' ? val : undefined;
 }
 
 function extractDamageParts(rolls: ParseInputRoll[]): ChatDamagePart[] {
   return rolls.map((r) => {
-    const typeMatch = /\[([^\]]+)\]/.exec(r.formula);
+    // PF2e formats damage as "2d6 slashing" or "2 * (1d6 + 6) bludgeoning" —
+    // the damage type is the last word in the formula (never a bare number).
+    const lastWord = /(\w+)\s*$/.exec(r.formula.trim())?.[1];
     const part: ChatDamagePart = { formula: r.formula, total: r.total };
-    const damageType = typeMatch?.[1];
-    if (damageType !== undefined) part.damageType = damageType;
+    if (lastWord !== undefined && !/^\d+$/.test(lastWord)) {
+      part.damageType = lastWord;
+    }
     return part;
   });
 }
 
 // Strip HTML tags so flavor text stored in structured data is plain text.
-// PF2e flavor fields are often `<strong>Strike</strong>: Longsword` etc.
+// PF2e flavor fields are often `<h4><strong>Strike</strong></h4>...` etc.
 function stripHtml(html: string): string {
   return html.replace(/<[^>]*>/g, '').trim();
 }

--- a/apps/foundry-api-bridge/src/chat/parse-message.ts
+++ b/apps/foundry-api-bridge/src/chat/parse-message.ts
@@ -1,0 +1,235 @@
+// Extracts structured semantic data from a PF2e Foundry ChatMessage.
+// Returns a discriminated union keyed on `kind` — the portal renders each
+// kind with purpose-built components instead of raw PF2e HTML.
+//
+// Unknown message types fall through to { kind: 'raw', html } so no data is
+// lost. Each branch reads defensively with optional chaining: PF2e flag shapes
+// vary between system versions, so absent fields must never throw.
+//
+// This is a pure function: no Foundry globals, no side effects. The
+// api-bridge's EventChannelController calls it from within a Foundry hook
+// callback, but the function itself can be tested in isolation.
+//
+// Keep the ChatStructuredData type here in sync with the Zod schema in
+// packages/shared/src/rpc/live.ts — the shared schema validates the wire
+// payload on the receiving end (foundry-mcp → player-portal).
+
+// ── Local input interface ──────────────────────────────────────────────────
+// Mirrors the subset of FoundryChatMessage that we need; the caller
+// (EventChannelController) passes the full message object.
+
+interface ParseInputRoll {
+  formula: string;
+  total: number;
+  isCritical?: boolean;
+  isFumble?: boolean;
+  dice?: Array<{ faces: number; results: Array<{ result: number; active: boolean }> }>;
+}
+
+export interface ParseInput {
+  id: string;
+  content?: string;
+  flavor?: string;
+  isRoll: boolean;
+  rolls?: ParseInputRoll[];
+  flags?: Record<string, unknown>;
+}
+
+// ── PF2e flag shapes ──────────────────────────────────────────────────────
+// Read defensively with optional chaining throughout.
+
+interface Pf2eDcFlags {
+  value?: number;
+  slug?: string;
+}
+
+interface Pf2eContextTarget {
+  actor?: string;
+  token?: string;
+}
+
+interface Pf2eContextFlags {
+  type?: string;
+  actor?: string;
+  item?: string;
+  dc?: Pf2eDcFlags;
+  target?: Pf2eContextTarget;
+}
+
+interface Pf2eOriginFlags {
+  actor?: string;
+  type?: string;
+}
+
+interface Pf2eFlags {
+  context?: Pf2eContextFlags;
+  origin?: Pf2eOriginFlags;
+  outcomePrecise?: string;
+}
+
+// ── Output types (mirror chatStructuredDataSchema in packages/shared) ─────
+
+type ChatOutcome = 'criticalSuccess' | 'success' | 'failure' | 'criticalFailure';
+
+interface ChatChip {
+  type: 'roll-damage' | 'place-template' | 'apply-damage' | 'save' | 'shove' | 'grapple' | 'unknown';
+  label: string;
+  params: Record<string, unknown>;
+}
+
+interface ChatTargetResult {
+  actorId?: string;
+  tokenId?: string;
+  name: string;
+  outcome?: ChatOutcome;
+}
+
+interface ChatDamagePart {
+  formula: string;
+  total: number;
+  damageType?: string;
+}
+
+export type ChatStructuredData =
+  | { kind: 'strike-attack'; flavor: string; targets: ChatTargetResult[]; chips: ChatChip[] }
+  | { kind: 'damage'; flavor: string; parts: ChatDamagePart[]; total: number; chips: ChatChip[] }
+  | { kind: 'skill-check'; flavor: string; dc?: number; outcome?: ChatOutcome; chips: ChatChip[] }
+  | { kind: 'saving-throw'; flavor: string; dc?: number; outcome?: ChatOutcome; chips: ChatChip[] }
+  | { kind: 'spell-cast'; flavor: string; description: string; chips: ChatChip[] }
+  | { kind: 'raw'; html: string };
+
+// ── Public API ─────────────────────────────────────────────────────────────
+
+/**
+ * Parse a Foundry ChatMessage into structured semantic data.
+ *
+ * Reads `flags.pf2e.context.type` to determine the message kind, then
+ * extracts the relevant fields. Falls through to `{ kind: 'raw', html }`
+ * for unrecognised message types so the portal can still render them.
+ */
+export function parseChatMessage(m: ParseInput): ChatStructuredData {
+  const pf2e = extractPf2eFlags(m.flags);
+  const contextType = pf2e?.context?.type;
+  const originType = pf2e?.origin?.type;
+
+  if (contextType === 'attack-roll') return parseStrikeAttack(m, pf2e);
+  if (contextType === 'damage-roll') return parseDamage(m, pf2e);
+  if (contextType === 'skill-check') return parseRollCheck('skill-check', m, pf2e);
+  if (contextType === 'saving-throw' || contextType === 'flat-check') {
+    return parseRollCheck('saving-throw', m, pf2e);
+  }
+  if (originType === 'spell') return parseSpellCast(m);
+
+  return { kind: 'raw', html: m.content ?? '' };
+}
+
+// ── Per-kind parsers ──────────────────────────────────────────────────────
+
+function parseStrikeAttack(m: ParseInput, pf2e: Pf2eFlags | null): ChatStructuredData {
+  const ctxTarget = pf2e?.context?.target;
+  const outcome = extractOutcome(pf2e);
+
+  const targets: ChatTargetResult[] = [];
+  if (ctxTarget?.actor !== undefined) {
+    const t: ChatTargetResult = { name: '' };
+    t.actorId = ctxTarget.actor;
+    if (ctxTarget.token !== undefined) t.tokenId = ctxTarget.token;
+    if (outcome !== undefined) t.outcome = outcome;
+    targets.push(t);
+  }
+
+  return {
+    kind: 'strike-attack',
+    flavor: stripHtml(m.flavor ?? ''),
+    targets,
+    chips: [{ type: 'roll-damage', label: 'Roll Damage', params: {} }],
+  };
+}
+
+function parseDamage(m: ParseInput, _pf2e: Pf2eFlags | null): ChatStructuredData {
+  const rolls = m.rolls ?? [];
+  const parts = extractDamageParts(rolls);
+  const total = rolls.reduce((sum, r) => sum + r.total, 0);
+
+  return {
+    kind: 'damage',
+    flavor: stripHtml(m.flavor ?? ''),
+    parts,
+    total,
+    chips: [{ type: 'apply-damage', label: 'Apply Damage', params: {} }],
+  };
+}
+
+function parseRollCheck(
+  kind: 'skill-check' | 'saving-throw',
+  m: ParseInput,
+  pf2e: Pf2eFlags | null,
+): ChatStructuredData {
+  const data: {
+    kind: 'skill-check' | 'saving-throw';
+    flavor: string;
+    chips: ChatChip[];
+    dc?: number;
+    outcome?: ChatOutcome;
+  } = {
+    kind,
+    flavor: stripHtml(m.flavor ?? ''),
+    chips: [],
+  };
+  const dc = extractDc(pf2e);
+  if (dc !== undefined) data.dc = dc;
+  const outcome = extractOutcome(pf2e);
+  if (outcome !== undefined) data.outcome = outcome;
+  return data;
+}
+
+function parseSpellCast(m: ParseInput): ChatStructuredData {
+  return {
+    kind: 'spell-cast',
+    flavor: stripHtml(m.flavor ?? ''),
+    description: m.content ?? '',
+    chips: [],
+  };
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function extractPf2eFlags(flags: Record<string, unknown> | undefined): Pf2eFlags | null {
+  const pf2e = flags?.['pf2e'];
+  if (typeof pf2e !== 'object' || pf2e === null) return null;
+  return pf2e;
+}
+
+function extractOutcome(pf2e: Pf2eFlags | null): ChatOutcome | undefined {
+  const o = pf2e?.outcomePrecise;
+  if (
+    o === 'criticalSuccess' ||
+    o === 'success' ||
+    o === 'failure' ||
+    o === 'criticalFailure'
+  ) {
+    return o;
+  }
+  return undefined;
+}
+
+function extractDc(pf2e: Pf2eFlags | null): number | undefined {
+  const val = pf2e?.context?.dc?.value;
+  return typeof val === 'number' ? val : undefined;
+}
+
+function extractDamageParts(rolls: ParseInputRoll[]): ChatDamagePart[] {
+  return rolls.map((r) => {
+    const typeMatch = /\[([^\]]+)\]/.exec(r.formula);
+    const part: ChatDamagePart = { formula: r.formula, total: r.total };
+    const damageType = typeMatch?.[1];
+    if (damageType !== undefined) part.damageType = damageType;
+    return part;
+  });
+}
+
+// Strip HTML tags so flavor text stored in structured data is plain text.
+// PF2e flavor fields are often `<strong>Strike</strong>: Longsword` etc.
+function stripHtml(html: string): string {
+  return html.replace(/<[^>]*>/g, '').trim();
+}

--- a/apps/foundry-api-bridge/src/chat/parse-message.ts
+++ b/apps/foundry-api-bridge/src/chat/parse-message.ts
@@ -98,7 +98,7 @@ interface ChatDamagePart {
 
 export type ChatStructuredData =
   | { kind: 'strike-attack'; flavor: string; targets: ChatTargetResult[]; chips: ChatChip[] }
-  | { kind: 'damage'; flavor: string; parts: ChatDamagePart[]; total: number; chips: ChatChip[] }
+  | { kind: 'damage'; flavor: string; parts: ChatDamagePart[]; total: number; chips: ChatChip[]; outcome?: ChatOutcome }
   | { kind: 'skill-check'; flavor: string; dc?: number; outcome?: ChatOutcome; chips: ChatChip[] }
   | { kind: 'saving-throw'; flavor: string; dc?: number; outcome?: ChatOutcome; chips: ChatChip[] }
   | { kind: 'spell-cast'; flavor: string; description: string; chips: ChatChip[] }

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/GetPartyForMemberHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/GetPartyForMemberHandler.ts
@@ -101,7 +101,7 @@ function buildMember(member: CharacterActor, actorId: string): PartyForMemberMem
   // Conditions via PF2e's itemTypes.condition — each slug is on the item
   // directly; degree value (frightened 2, sickened 1, etc.) is at system.value.value.
   const conditions = (member.itemTypes?.condition ?? []).map((c) => {
-    const raw = (c.system['value'] as Record<string, unknown> | undefined)?.value;
+    const raw = (c.system['value'] as Record<string, unknown> | undefined)?.['value'];
     return {
       slug: c.slug,
       value: typeof raw === 'number' ? raw : null,

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/__tests__/GetPartyForMemberHandler.test.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/__tests__/GetPartyForMemberHandler.test.ts
@@ -264,7 +264,7 @@ describe('getPartyForMemberHandler', () => {
     });
 
     it('returns empty conditions when itemTypes.condition is absent', async () => {
-      const member = makeMember({ id: 'chr-1', itemTypes: undefined });
+      const member = makeMember({ id: 'chr-1' });
       const party = makePartyActor({ members: [member] });
       setGame([], { 'chr-1': { ...member, parties: [party] } });
 

--- a/apps/foundry-api-bridge/src/events/EventChannelController.ts
+++ b/apps/foundry-api-bridge/src/events/EventChannelController.ts
@@ -1,4 +1,5 @@
 import type { EventPublisher } from '@/transport/Broadcaster';
+import { parseChatMessage } from '@/chat/parse-message';
 
 // Minimal local Foundry type snippets for the documents we read in hook
 // callbacks. Kept here rather than pulled from shared types because
@@ -352,6 +353,14 @@ function serializeChatMessage(m: FoundryChatMessage): Record<string, unknown> {
       })) ?? [],
     flags: m.flags ?? {},
     speakerOwnerIds: computeSpeakerOwnerIds(m.speaker),
+    structured: parseChatMessage({
+      id: m.id,
+      isRoll: m.isRoll,
+      ...(m.content !== undefined && { content: m.content }),
+      ...(m.flavor !== undefined && { flavor: m.flavor }),
+      ...(m.rolls !== undefined && { rolls: m.rolls }),
+      ...(m.flags !== undefined && { flags: m.flags }),
+    }),
   };
 }
 

--- a/apps/player-portal/src/features/characters/sheet/chat/ChipRow.tsx
+++ b/apps/player-portal/src/features/characters/sheet/chat/ChipRow.tsx
@@ -1,0 +1,37 @@
+import type { ChatChip } from '@foundry-toolkit/shared/rpc';
+
+interface Props {
+  chips: ChatChip[];
+}
+
+const CHIP_LABELS: Partial<Record<ChatChip['type'], string>> = {
+  'roll-damage': 'Roll Damage',
+  'place-template': 'Place Template',
+  'apply-damage': 'Apply Damage',
+  save: 'Save',
+  shove: 'Shove',
+  grapple: 'Grapple',
+};
+
+export function ChipRow({ chips }: Props): React.ReactElement | null {
+  if (chips.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      {chips.map((chip, i) => {
+        const label = CHIP_LABELS[chip.type] ?? chip.label;
+        return (
+          <button
+            key={i}
+            type="button"
+            disabled
+            title="Not yet interactive"
+            className="cursor-not-allowed select-none rounded border border-pf-border/50 bg-pf-bg px-2 py-0.5 text-[10px] font-medium text-pf-alt-dark opacity-60 pointer-events-none"
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/player-portal/src/features/characters/sheet/chat/DamageBreakdown.tsx
+++ b/apps/player-portal/src/features/characters/sheet/chat/DamageBreakdown.tsx
@@ -1,0 +1,30 @@
+import type { ChatDamagePart } from '@foundry-toolkit/shared/rpc';
+
+interface Props {
+  parts: ChatDamagePart[];
+  total: number;
+}
+
+export function DamageBreakdown({ parts, total }: Props): React.ReactElement {
+  const showTotal = parts.length > 1;
+
+  return (
+    <div className="space-y-0.5">
+      {parts.map((part, i) => (
+        <div key={i} className="flex items-center gap-2 text-[11px]">
+          <span className="font-mono text-pf-alt-dark">{part.formula}</span>
+          {part.damageType !== undefined && (
+            <span className="capitalize text-[10px] text-pf-alt-dark/70">{part.damageType}</span>
+          )}
+          <span className="ml-auto font-bold tabular-nums text-pf-primary">{part.total}</span>
+        </div>
+      ))}
+      {showTotal && (
+        <div className="flex items-center justify-between border-t border-pf-border/30 pt-0.5 text-[11px] font-semibold">
+          <span className="text-pf-alt-dark">Total</span>
+          <span className="tabular-nums text-pf-primary">{total}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/player-portal/src/features/characters/sheet/chat/MessageBubble.tsx
+++ b/apps/player-portal/src/features/characters/sheet/chat/MessageBubble.tsx
@@ -1,4 +1,7 @@
-import type { ChatMessageSnapshot, ChatRoll } from '@foundry-toolkit/shared/rpc';
+import type { ChatMessageSnapshot, ChatRoll, ChatStructuredData } from '@foundry-toolkit/shared/rpc';
+import { ChipRow } from './ChipRow';
+import { DamageBreakdown } from './DamageBreakdown';
+import { TargetTable } from './TargetTable';
 
 // Foundry ChatMessage type constants.
 const MSG_OOC = 1;
@@ -37,11 +40,122 @@ function RollResult({ roll }: { roll: ChatRoll }): React.ReactElement {
   );
 }
 
+// Maps structured kind to the badge label shown in the card header.
+function kindBadgeLabel(kind: ChatStructuredData['kind']): string | null {
+  switch (kind) {
+    case 'strike-attack':
+      return 'Attack';
+    case 'damage':
+      return 'Damage';
+    case 'skill-check':
+      return 'Check';
+    case 'saving-throw':
+      return 'Save';
+    case 'spell-cast':
+    case 'raw':
+      return null;
+  }
+}
+
+interface StructuredBodyProps {
+  message: ChatMessageSnapshot;
+  structured: Exclude<ChatStructuredData, { kind: 'raw' }>;
+}
+
+function StructuredBody({ message, structured }: StructuredBodyProps): React.ReactElement {
+  const firstRoll = message.rolls[0];
+
+  switch (structured.kind) {
+    case 'strike-attack':
+      return (
+        <>
+          {structured.flavor.length > 0 && (
+            <p className="text-[11px] italic text-pf-alt-dark">{structured.flavor}</p>
+          )}
+          {firstRoll !== undefined && <RollResult roll={firstRoll} />}
+          <TargetTable targets={structured.targets} />
+          <ChipRow chips={structured.chips} />
+        </>
+      );
+
+    case 'damage':
+      return (
+        <>
+          {structured.flavor.length > 0 && (
+            <p className="text-[11px] italic text-pf-alt-dark">{structured.flavor}</p>
+          )}
+          <DamageBreakdown parts={structured.parts} total={structured.total} />
+          <ChipRow chips={structured.chips} />
+        </>
+      );
+
+    case 'skill-check':
+    case 'saving-throw':
+      return (
+        <>
+          {structured.flavor.length > 0 && (
+            <p className="text-[11px] italic text-pf-alt-dark">{structured.flavor}</p>
+          )}
+          {firstRoll !== undefined && <RollResult roll={firstRoll} />}
+          {structured.dc !== undefined && (
+            <p className="text-[10px] text-pf-alt-dark/70">DC {structured.dc}</p>
+          )}
+          {structured.outcome !== undefined && (
+            <OutcomeBadge outcome={structured.outcome} />
+          )}
+        </>
+      );
+
+    case 'spell-cast':
+      return (
+        <>
+          {structured.flavor.length > 0 && (
+            <p className="text-[11px] italic text-pf-alt-dark">{structured.flavor}</p>
+          )}
+          {structured.description.length > 0 && (
+            <div
+              className="prose-sm max-w-none text-pf-text [&_a]:text-pf-primary [&_a]:underline"
+              dangerouslySetInnerHTML={{ __html: structured.description }}
+            />
+          )}
+          <ChipRow chips={structured.chips} />
+        </>
+      );
+  }
+}
+
+type OutcomeValue = 'criticalSuccess' | 'success' | 'failure' | 'criticalFailure';
+
+const OUTCOME_LABEL: Record<OutcomeValue, string> = {
+  criticalSuccess: 'Crit Success',
+  success: 'Success',
+  failure: 'Failure',
+  criticalFailure: 'Crit Fail',
+};
+
+const OUTCOME_CLASS: Record<OutcomeValue, string> = {
+  criticalSuccess: 'bg-green-100 text-green-700',
+  success: 'bg-blue-100 text-blue-700',
+  failure: 'bg-red-100 text-red-600',
+  criticalFailure: 'bg-red-200 text-red-800',
+};
+
+function OutcomeBadge({ outcome }: { outcome: OutcomeValue }): React.ReactElement {
+  return (
+    <span
+      className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${OUTCOME_CLASS[outcome]}`}
+    >
+      {OUTCOME_LABEL[outcome]}
+    </span>
+  );
+}
+
 interface Props {
   message: ChatMessageSnapshot;
 }
 
 export function MessageBubble({ message }: Props): React.ReactElement {
+  const { structured } = message;
   const isWhisper = message.whisper.length > 0;
   const isOoc = message.type === MSG_OOC;
   const isEmote = message.type === MSG_EMOTE;
@@ -64,6 +178,9 @@ export function MessageBubble({ message }: Props): React.ReactElement {
             : 'border-pf-border bg-pf-bg-dark',
   ].join(' ');
 
+  const structuredBadge =
+    structured !== undefined && structured.kind !== 'raw' ? kindBadgeLabel(structured.kind) : null;
+
   return (
     <div className={cardClass}>
       {/* Header: speaker · badges · timestamp */}
@@ -80,10 +197,17 @@ export function MessageBubble({ message }: Props): React.ReactElement {
             Whisper
           </span>
         )}
-        {isRoll && (
+        {/* Prefer structured kind badge; fall back to generic Roll badge */}
+        {structuredBadge !== null ? (
           <span className="rounded border border-pf-border/60 bg-pf-bg px-1 py-0.5 text-[10px] text-pf-alt-dark">
-            Roll
+            {structuredBadge}
           </span>
+        ) : (
+          isRoll && (
+            <span className="rounded border border-pf-border/60 bg-pf-bg px-1 py-0.5 text-[10px] text-pf-alt-dark">
+              Roll
+            </span>
+          )
         )}
         {time !== null && (
           <span className="ml-auto text-[10px] tabular-nums text-pf-alt-dark/70">{time}</span>
@@ -92,30 +216,36 @@ export function MessageBubble({ message }: Props): React.ReactElement {
 
       {/* Card body */}
       <div className="space-y-1 px-2 py-1.5">
-        {/* Roll flavor (e.g. "Perception Check") */}
-        {isRoll && message.flavor.length > 0 && (
-          <div
-            className="text-[11px] italic text-pf-alt-dark [&_img]:!max-h-3.5 [&_img]:!w-auto [&_img]:inline-block [&_img]:align-middle"
-            dangerouslySetInnerHTML={{ __html: message.flavor }}
-          />
-        )}
-
-        {/* Roll result summary */}
-        {isRoll && message.rolls[0] !== undefined && <RollResult roll={message.rolls[0]} />}
-
-        {/* Message content (PF2e-rendered HTML — trusted source).
-            PF2e action chips (<button> elements) have no live handlers in the portal;
-            pointer-events-none prevents accidental interaction. */}
-        {message.content.length > 0 && (
-          <div
-            className={[
-              'prose-sm max-w-none text-pf-text',
-              '[&_a]:text-pf-primary [&_a]:underline',
-              '[&_img]:!max-h-5 [&_img]:!w-auto [&_img]:inline-block [&_img]:align-middle',
-              '[&_button]:cursor-not-allowed [&_button]:opacity-50 [&_button]:select-none [&_button]:pointer-events-none',
-            ].join(' ')}
-            dangerouslySetInnerHTML={{ __html: message.content }}
-          />
+        {structured !== undefined && structured.kind !== 'raw' ? (
+          <StructuredBody message={message} structured={structured} />
+        ) : (
+          <>
+            {/* Roll flavor for unstructured roll messages */}
+            {isRoll && message.flavor.length > 0 && (
+              <div
+                className="text-[11px] italic text-pf-alt-dark [&_img]:!max-h-3.5 [&_img]:!w-auto [&_img]:inline-block [&_img]:align-middle"
+                dangerouslySetInnerHTML={{ __html: message.flavor }}
+              />
+            )}
+            {/* Roll result for unstructured roll messages */}
+            {isRoll && message.rolls[0] !== undefined && (
+              <RollResult roll={message.rolls[0]} />
+            )}
+            {/* Full PF2e-rendered HTML — trusted source.
+                PF2e action chips (<button>) have no live handlers in the portal;
+                pointer-events-none prevents accidental interaction. */}
+            {message.content.length > 0 && (
+              <div
+                className={[
+                  'prose-sm max-w-none text-pf-text',
+                  '[&_a]:text-pf-primary [&_a]:underline',
+                  '[&_img]:!max-h-5 [&_img]:!w-auto [&_img]:inline-block [&_img]:align-middle',
+                  '[&_button]:cursor-not-allowed [&_button]:opacity-50 [&_button]:select-none [&_button]:pointer-events-none',
+                ].join(' ')}
+                dangerouslySetInnerHTML={{ __html: message.content }}
+              />
+            )}
+          </>
         )}
       </div>
     </div>

--- a/apps/player-portal/src/features/characters/sheet/chat/TargetTable.tsx
+++ b/apps/player-portal/src/features/characters/sheet/chat/TargetTable.tsx
@@ -1,0 +1,49 @@
+import type { ChatTargetResult } from '@foundry-toolkit/shared/rpc';
+
+interface Props {
+  targets: ChatTargetResult[];
+}
+
+type Outcome = NonNullable<ChatTargetResult['outcome']>;
+
+const OUTCOME_LABEL: Record<Outcome, string> = {
+  criticalSuccess: 'Crit Success',
+  success: 'Success',
+  failure: 'Failure',
+  criticalFailure: 'Crit Fail',
+};
+
+const OUTCOME_CLASS: Record<Outcome, string> = {
+  criticalSuccess: 'bg-green-100 text-green-700',
+  success: 'bg-blue-100 text-blue-700',
+  failure: 'bg-red-100 text-red-600',
+  criticalFailure: 'bg-red-200 text-red-800',
+};
+
+function OutcomeBadge({ outcome }: { outcome: Outcome }): React.ReactElement {
+  return (
+    <span
+      className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${OUTCOME_CLASS[outcome]}`}
+    >
+      {OUTCOME_LABEL[outcome]}
+    </span>
+  );
+}
+
+export function TargetTable({ targets }: Props): React.ReactElement | null {
+  if (targets.length === 0) return null;
+
+  return (
+    <div className="space-y-0.5">
+      {targets.map((t, i) => (
+        <div key={i} className="flex items-center gap-1.5 text-[11px]">
+          {t.name.length > 0 && <span className="text-pf-text">{t.name}</span>}
+          {t.actorId !== undefined && t.name.length === 0 && (
+            <span className="font-mono text-[10px] text-pf-alt-dark/60">{t.actorId}</span>
+          )}
+          {t.outcome !== undefined && <OutcomeBadge outcome={t.outcome} />}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/shared/src/rpc/live.ts
+++ b/packages/shared/src/rpc/live.ts
@@ -85,6 +85,84 @@ export const chatRollSchema = z.object({
   dice: z.array(chatRollDiceTermSchema),
 });
 
+// ── Structured chat-message data ─────────────────────────────────────────────
+// Parsed semantic structure extracted from flags.pf2e.* by the api-bridge.
+// The portal renders these directly instead of raw PF2e HTML when present.
+// Unknown message types fall through to { kind: 'raw', html } so nothing is
+// lost. Not all four message types may be present in a given session — the
+// portal falls back to the HTML render for any message that lacks `structured`.
+
+export const chatChipTypeSchema = z.enum([
+  'roll-damage',
+  'place-template',
+  'apply-damage',
+  'save',
+  'shove',
+  'grapple',
+  'unknown',
+]);
+
+export const chatChipSchema = z.object({
+  type: chatChipTypeSchema,
+  label: z.string(),
+  params: z.record(z.string(), z.unknown()),
+});
+
+export const chatTargetResultSchema = z.object({
+  actorId: z.string().optional(),
+  tokenId: z.string().optional(),
+  name: z.string(),
+  outcome: z.enum(['criticalSuccess', 'success', 'failure', 'criticalFailure']).optional(),
+  total: z.number().optional(),
+  ac: z.number().optional(),
+});
+
+export const chatDamagePartSchema = z.object({
+  formula: z.string(),
+  total: z.number(),
+  damageType: z.string().optional(),
+});
+
+export const chatStructuredDataSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('strike-attack'),
+    flavor: z.string(),
+    targets: z.array(chatTargetResultSchema),
+    chips: z.array(chatChipSchema),
+  }),
+  z.object({
+    kind: z.literal('damage'),
+    flavor: z.string(),
+    parts: z.array(chatDamagePartSchema),
+    total: z.number(),
+    chips: z.array(chatChipSchema),
+  }),
+  z.object({
+    kind: z.literal('skill-check'),
+    flavor: z.string(),
+    dc: z.number().optional(),
+    outcome: z.enum(['criticalSuccess', 'success', 'failure', 'criticalFailure']).optional(),
+    chips: z.array(chatChipSchema),
+  }),
+  z.object({
+    kind: z.literal('saving-throw'),
+    flavor: z.string(),
+    dc: z.number().optional(),
+    outcome: z.enum(['criticalSuccess', 'success', 'failure', 'criticalFailure']).optional(),
+    chips: z.array(chatChipSchema),
+  }),
+  z.object({
+    kind: z.literal('spell-cast'),
+    flavor: z.string(),
+    description: z.string(),
+    chips: z.array(chatChipSchema),
+  }),
+  z.object({
+    kind: z.literal('raw'),
+    html: z.string(),
+  }),
+]);
+
 // All nullable fields match the ?? null / ?? [] fallbacks in serializeChatMessage.
 export const chatMessageSnapshotSchema = z.object({
   id: z.string(),
@@ -100,6 +178,10 @@ export const chatMessageSnapshotSchema = z.object({
   isRoll: z.boolean(),
   rolls: z.array(chatRollSchema),
   flags: z.record(z.string(), z.unknown()),
+  // Structured semantic data extracted from flags.pf2e.* by the api-bridge.
+  // Optional: absent for messages before this feature, or when the api-bridge
+  // emits a kind the portal doesn't yet recognise. Falls back to raw HTML.
+  structured: chatStructuredDataSchema.optional(),
 });
 
 export const chatLogBackfillSchema = z.object({
@@ -109,5 +191,10 @@ export const chatLogBackfillSchema = z.object({
 
 export type ChatSpeaker = z.infer<typeof chatSpeakerSchema>;
 export type ChatRoll = z.infer<typeof chatRollSchema>;
+export type ChatChipType = z.infer<typeof chatChipTypeSchema>;
+export type ChatChip = z.infer<typeof chatChipSchema>;
+export type ChatTargetResult = z.infer<typeof chatTargetResultSchema>;
+export type ChatDamagePart = z.infer<typeof chatDamagePartSchema>;
+export type ChatStructuredData = z.infer<typeof chatStructuredDataSchema>;
 export type ChatMessageSnapshot = z.infer<typeof chatMessageSnapshotSchema>;
 export type ChatLogBackfill = z.infer<typeof chatLogBackfillSchema>;

--- a/packages/shared/src/rpc/live.ts
+++ b/packages/shared/src/rpc/live.ts
@@ -136,6 +136,7 @@ export const chatStructuredDataSchema = z.discriminatedUnion('kind', [
     parts: z.array(chatDamagePartSchema),
     total: z.number(),
     chips: z.array(chatChipSchema),
+    outcome: z.enum(['criticalSuccess', 'success', 'failure', 'criticalFailure']).optional(),
   }),
   z.object({
     kind: z.literal('skill-check'),


### PR DESCRIPTION
## Summary

Replaces the single `dangerouslySetInnerHTML` blob in the chat feed with structured per-message data. The api-bridge now parses `flags.pf2e.*` on every chat message and emits a `ChatStructuredData` discriminated union alongside the existing HTML. The portal renders strike rolls, damage rolls, skill checks/saves, and spell casts with purpose-built React components. Unknown message types fall through to the existing HTML render so nothing is lost.

Chips (Roll Damage, Apply Damage, etc.) are rendered as inert disabled buttons — interactivity is tracked in #160.

The parser was validated against real PF2e messages via `/api/eval`, which corrected three assumptions from the initial implementation: outcome location (`context.outcome` not `outcomePrecise`), damage type format (trailing word `"1d4 bludgeoning"` not `[bracket]` notation), and spell-cast flavor (always empty — name extracted from content `<h3>` with action-glyph spans stripped).

## Apps touched

- `apps/foundry-api-bridge` — `npm run dev` (Foundry module — requires the Docker workflow)
- `apps/player-portal` — `npm run dev:player-portal` or `npm run dev:player-portal:mock`
- `packages/shared` — types only, no runtime change needed

## Changes

**`packages/shared/src/rpc/live.ts`**
- New Zod schemas: `chatChipSchema`, `chatTargetResultSchema`, `chatDamagePartSchema`, `chatStructuredDataSchema` (discriminated union on `kind`)
- Added optional `structured` field to `chatMessageSnapshotSchema` — absent for messages before this PR or for unknown kinds; portal falls back to HTML render
- New exported types: `ChatChipType`, `ChatChip`, `ChatTargetResult`, `ChatDamagePart`, `ChatStructuredData`

**`apps/foundry-api-bridge/src/chat/parse-message.ts`** (new)
- Pure function `parseChatMessage(m: ParseInput): ChatStructuredData`
- Dispatches on `flags.pf2e.context.type`: `attack-roll` → `strike-attack`, `damage-roll` → `damage`, `skill-check` → `skill-check`, `saving-throw`/`flat-check` → `saving-throw`, `spell-cast` / `origin.type === 'spell'` → `spell-cast`
- Outcome from `context.outcome` (null-safe); DC from `context.dc.value` (null-safe)
- Damage type extracted as trailing word from formula (e.g. `"2 * (1d6 + 6) bludgeoning"` → `"bludgeoning"`)
- Spell name from first `<h3>` in content with `action-glyph` spans stripped
- Falls through to `{ kind: 'raw', html }` for everything else

**`apps/foundry-api-bridge/src/events/EventChannelController.ts`**
- `serializeChatMessage` now calls `parseChatMessage` and includes `structured` in the JSON payload

**`apps/player-portal/src/components/chat/`** (new files)
- `ChipRow.tsx` — renders chip array as inert disabled buttons
- `DamageBreakdown.tsx` — renders damage parts list with optional total row
- `TargetTable.tsx` — renders target rows with outcome badges (Crit Success / Success / Failure / Crit Fail)

**`apps/player-portal/src/components/chat/MessageBubble.tsx`**
- When `message.structured` is present and `kind !== 'raw'`, renders `<StructuredBody>` using the new sub-components
- Falls back to existing HTML render for `raw` kind or absent `structured`
- Kind-specific header badges: "Attack", "Damage", "Check", "Save" replace the generic "Roll" badge

## Structured message types now covered

| Kind | Detected via | What renders |
|---|---|---|
| `strike-attack` | `context.type === 'attack-roll'` | Flavor, d20 roll result, target row + outcome, Roll Damage chip |
| `damage` | `context.type === 'damage-roll'` | Flavor, damage parts (formula / type / value), outcome, Apply Damage chip |
| `skill-check` | `context.type === 'skill-check'` | Flavor, d20 roll result, DC if known, outcome badge |
| `saving-throw` | `context.type === 'saving-throw'` or `flat-check` | Same as skill-check |
| `spell-cast` | `context.type === 'spell-cast'` or `origin.type === 'spell'` | Spell name (from `<h3>`), description HTML, chips |
| `raw` | fallthrough | Existing `dangerouslySetInnerHTML` path |

## Test plan

- [ ] **Strike roll**: send a melee/spell attack in Foundry → portal shows sender + "Attack" badge, attack name, d20 formula → total, target row with outcome badge (if AC is known), inert "Roll Damage" chip
- [ ] **Damage roll**: follow up strike → portal shows "Damage" badge, formula + damage type + value, outcome (Success/Crit), inert "Apply Damage" chip
- [ ] **Skill check**: roll a skill → portal shows "Check" badge, skill name, d20 result, DC + Success/Failure outcome when GM sets DC
- [ ] **Spell cast**: cast a spell → portal shows spell name (from content `<h3>`), description text
- [ ] **Unknown type**: run a custom macro → portal renders raw HTML fallback, no errors in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)