### PR TITLE
fix(deploy): mount foundry-data rw in foundry-mcp to allow scene uploads

### DIFF
--- a/apps/dm-tool/electron/foundry-mcp-client.test.ts
+++ b/apps/dm-tool/electron/foundry-mcp-client.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { callTool, type McpSession } from './foundry-mcp-client.js';
+
+const SESSION: McpSession = { url: 'http://mcp:8765', sessionId: 'sid', nextId: 2 };
+
+function sseResponse(payload: unknown): Response {
+  return new Response(`data: ${JSON.stringify(payload)}\n`, { status: 200 });
+}
+
+describe('callTool', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns parsed JSON on success', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      sseResponse({ result: { content: [{ type: 'text', text: JSON.stringify({ path: 'maps/a.jpg', bytes: 42 }) }] } }),
+    );
+    const result = await callTool(SESSION, 'upload_asset', { path: 'maps/a.jpg', data: '' });
+    expect(result).toEqual({ path: 'maps/a.jpg', bytes: 42 });
+  });
+
+  it('strips the "Error: " prefix when the tool response signals an error', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      sseResponse({
+        result: {
+          content: [
+            { type: 'text', text: "Error: EROFS: read-only file system, open '/foundry-data/Data/maps/x.jpg'" },
+          ],
+          isError: true,
+        },
+      }),
+    );
+    await expect(callTool(SESSION, 'upload_asset', { path: 'maps/x.jpg', data: '' })).rejects.toThrow(/^EROFS:/);
+  });
+
+  it('throws the original JSON-RPC error when there is no text content', async () => {
+    vi.mocked(fetch).mockResolvedValue(sseResponse({ error: { message: 'Method not found' } }));
+    await expect(callTool(SESSION, 'upload_asset', {})).rejects.toThrow('Method not found');
+  });
+});

--- a/apps/dm-tool/electron/foundry-mcp-client.ts
+++ b/apps/dm-tool/electron/foundry-mcp-client.ts
@@ -118,7 +118,7 @@ export async function callTool(
   }
 
   if (textContent.text.startsWith('Error:')) {
-    throw new Error(textContent.text);
+    throw new Error(textContent.text.replace(/^Error:\s*/, ''));
   }
 
   return JSON.parse(textContent.text) as Record<string, unknown>;

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -42,10 +42,11 @@ services:
       ALLOW_EVAL: ${ALLOW_EVAL:-0}
       HOST: 0.0.0.0
       PORT: '8765'
-      # Give foundry-mcp read access to Foundry's data dir for compendium packs.
+      # foundry-mcp needs read access (compendium packs) and write access
+      # (upload_asset writes map images into Data/maps/ when pushing scenes).
       FOUNDRY_DATA: /foundry-data
     volumes:
-      - foundry-data:/foundry-data:ro
+      - foundry-data:/foundry-data
     depends_on:
       - foundry
     networks:


### PR DESCRIPTION
## Summary

Pushing a scene from dm-tool failed with `EROFS: read-only file system, open '/foundry-data/Data/maps/...'`. The `foundry-mcp` container's `upload_asset` tool writes the map image into Foundry's data directory before creating the scene, but the `foundry-data` volume was mounted read-only (`:ro`) — correct for compendium reads, wrong for asset writes. Removing `:ro` gives foundry-mcp the write access it needs.

Also fixed a secondary cosmetic bug: `callTool` in dm-tool re-threw tool error messages that already started with `"Error: "` as `new Error("Error: EROFS: ...")`, producing the double-prefix `"Error: Error: EROFS: ..."` the user saw. The prefix is now stripped before re-throwing.

## Changes

- `deploy/compose.yaml`: remove `:ro` from `foundry-data:/foundry-data` mount in `foundry-mcp`; update comment to reflect that write access is also needed
- `apps/dm-tool/electron/foundry-mcp-client.ts`: strip `"Error: "` prefix in `callTool` before re-throwing tool error responses
- `apps/dm-tool/electron/foundry-mcp-client.test.ts`: regression test — asserts `callTool` error messages do not start with `"Error:"`

**Root causes ruled out:**

- dm-tool misconfiguration (wrong `libraryPath`) — the error path `/foundry-data/Data/maps/...` confirms foundry-mcp received and processed the request; the failure is on the write side, not the read side
- Docker volume mounted `:ro` on the Foundry container — only the `foundry-mcp` service had the `:ro` flag; the `foundry` service mounts `foundry-data:/data` without restriction
- Path traversal in `upload_asset` — the handler already normalizes and validates paths before writing

## Apps touched

- `deploy/compose.yaml` — restart the foundry-mcp container after deploying (`docker compose up -d foundry-mcp`)
- `apps/dm-tool` — `npm run dev:dm-tool`

## Test plan

- [ ] `npm run test -w @foundry-toolkit/dm-tool` passes (408 tests)
- [ ] `npm run typecheck -w @foundry-toolkit/dm-tool` clean
- [ ] Deploy updated compose; attempt "Push to Foundry" from dm-tool map browser — scene should create successfully