### PR TITLE
chore(ai): un-export AnthropicCallInput

### DIFF
--- a/packages/ai/src/shared/anthropic.ts
+++ b/packages/ai/src/shared/anthropic.ts
@@ -10,7 +10,7 @@ import { ANTHROPIC_API_URL, ANTHROPIC_API_VERSION } from './constants.js';
 
 export type VisionMediaType = 'image/jpeg' | 'image/png' | 'image/webp' | 'image/gif';
 
-export interface AnthropicCallInput {
+interface AnthropicCallInput {
   apiKey: string;
   model: string;
   maxTokens: number;


### PR DESCRIPTION
## Summary

Un-exported `AnthropicCallInput` interface from `packages/ai/src/shared/anthropic.ts`. All three callers of `callAnthropic()` use inline object literals with no explicit type annotation, so the export is unused. The interface remains in the function signature for type safety.

## Changes

- Remove `export` keyword from `AnthropicCallInput` interface in `packages/ai/src/shared/anthropic.ts:13`

## Test plan

- [x] `npm run typecheck` — all clean
- [x] `npm run lint` — no new warnings
- [x] `npm run test` — 123+ tests pass
- [x] `npm run knip` — packages/ai unused exports/types count drops to zero

**Audit reference:** `docs/KNIP-CLEANUP-AUDIT-2026-05-04.md` (Q4 — AnthropicCallInput)

**Apps touched:** None directly. The `packages/ai` package is consumed by `apps/dm-tool` via `callAnthropic()` function calls, not type imports.