### PR TITLE
chore(dm-tool): delete dead exports and annotate public API surface (knip cleanup)

### DIFF
--- a/apps/dm-tool/electron/book-scanner.ts
+++ b/apps/dm-tool/electron/book-scanner.ts
@@ -76,7 +76,7 @@ function walk(rootPath: string, dir: string, out: ScannedFile[]): void {
 
 /** Derive category/subcategory/ruleset from the relative path segments.
  *  Exported for unit-testability if we ever add tests. */
-export function classifyPath(parts: string[]): {
+function classifyPath(parts: string[]): {
   category: string;
   subcategory: string | null;
   ruleset: 'legacy' | 'remastered' | null;
@@ -107,7 +107,7 @@ export function classifyPath(parts: string[]): {
  *  for apostrophes (`Player_s Guide`) and ampersands (`Guns _ Gears`).
  *
  *  Exported so we can reuse the same logic in the reader title bar. */
-export function normalizeTitle(fileName: string): string {
+function normalizeTitle(fileName: string): string {
   let s = fileName;
   // Strip .pdf (case-insensitive).
   if (s.toLowerCase().endsWith('.pdf')) s = s.slice(0, -4);

--- a/apps/dm-tool/electron/compendium/index.ts
+++ b/apps/dm-tool/electron/compendium/index.ts
@@ -107,14 +107,5 @@ export function createCompendiumApi(opts: CreateCompendiumApiOptions): Compendiu
   };
 }
 
-export type { CompendiumApi as default };
 export { CompendiumRequestError } from './client.js';
-export type {
-  ApiError,
-  CompendiumDocument,
-  CompendiumMatch,
-  CompendiumPack,
-  CompendiumSearchOptions,
-  CompendiumSource,
-  ItemPrice,
-} from './types.js';
+export type { CompendiumPack } from './types.js';

--- a/apps/dm-tool/electron/compendium/prepared.ts
+++ b/apps/dm-tool/electron/compendium/prepared.ts
@@ -36,7 +36,6 @@ import { getItemFacetsIndex, getMonsterFacetsIndex } from './facets-index.js';
 import type { CompendiumApi } from './index.js';
 import {
   itemDocToBrowserDetail,
-  itemDocToLootShortlistItem,
   itemMatchToBrowserRow,
   monsterDocToDetail,
   monsterDocToResult,
@@ -97,7 +96,7 @@ export interface PreparedCompendium {
   buildLootShortlist(partyLevel: number): Promise<LootShortlistItem[]>;
 }
 
-export interface PreparedCompendiumOptions {
+interface PreparedCompendiumOptions {
   /** Resolver called at each monster-facing query to decide which
    *  compendium packs to search. Invoked once per outer call so changes
    *  (e.g. via Settings → Monsters) take effect immediately — no
@@ -536,7 +535,3 @@ function matchToLootShortlistItem(m: CompendiumMatch): LootShortlistItem {
     source: null,
   };
 }
-
-// Exported for tests that want to exercise the projection without
-// reinstantiating the factory.
-export { itemDocToLootShortlistItem };

--- a/apps/dm-tool/electron/compendium/projection/index.ts
+++ b/apps/dm-tool/electron/compendium/projection/index.ts
@@ -2,28 +2,12 @@
 // monolithic projection.ts so all existing import sites continue to work
 // by pointing at `./projection/index.js`.
 
-export { cleanDescription } from './shared.js';
 export {
-  formatMelee,
-  formatRanged,
-  formatActions,
-  formatImmunities,
-  formatWeaknesses,
-  formatSpeed,
-  monsterSpells,
   monsterDocToResult,
   monsterDocToRow,
   monsterDocToDetail,
-  monsterDocToSummary,
   monsterMatchToSummary,
   type MonsterRow,
   type MonsterResult,
 } from './monster.js';
-export {
-  formatPriceStructured,
-  priceToCopper,
-  itemDocToBrowserRow,
-  itemDocToBrowserDetail,
-  itemMatchToBrowserRow,
-  itemDocToLootShortlistItem,
-} from './item.js';
+export { priceToCopper, itemDocToBrowserDetail, itemMatchToBrowserRow, itemDocToLootShortlistItem } from './item.js';

--- a/apps/dm-tool/electron/compendium/projection/item.ts
+++ b/apps/dm-tool/electron/compendium/projection/item.ts
@@ -38,7 +38,7 @@ function nonRarityTraits(traits: string[]): string[] {
 // ---------------------------------------------------------------------------
 
 /** Format an ItemPrice object as a human-readable string ("1,600 gp"). */
-export function formatPriceStructured(price: ItemPrice | undefined): string | null {
+function formatPriceStructured(price: ItemPrice | undefined): string | null {
   if (!price || !isRecord(price.value)) return null;
   const parts: string[] = [];
   const { pp, gp, sp, cp } = price.value;

--- a/apps/dm-tool/electron/compendium/projection/monster.ts
+++ b/apps/dm-tool/electron/compendium/projection/monster.ts
@@ -137,7 +137,7 @@ function formatAttackList(raw: unknown): string {
 }
 
 export const formatMelee = formatAttackList;
-export const formatRanged = formatAttackList;
+const formatRanged = formatAttackList;
 
 // ---------------------------------------------------------------------------
 // PF2e processed-actor strike format

--- a/apps/dm-tool/electron/compendium/singleton.ts
+++ b/apps/dm-tool/electron/compendium/singleton.ts
@@ -37,7 +37,7 @@ let prepared: PreparedCompendium | null = null;
 let availableActorPacks: Set<string> | null = null;
 let availableActorPacksFetch: Promise<void> | null = null;
 
-export interface InitPreparedCompendiumOptions {
+interface InitPreparedCompendiumOptions {
   /** foundry-mcp base URL, e.g. `http://server.ad:8765`. Trailing slash
    *  is tolerated; an empty string throws. */
   foundryMcpUrl: string;

--- a/apps/dm-tool/electron/config.ts
+++ b/apps/dm-tool/electron/config.ts
@@ -197,14 +197,6 @@ export function loadBootstrapConfig(): BootstrapConfig {
   return { dbPath: join(app.getPath('userData'), 'dm-tool.db') };
 }
 
-/** Path the setup IPC should write the bootstrap config.json to. Prefers
- *  the dev location (apps/dm-tool/config.json) when not packaged, falls
- *  back to userData otherwise. */
-export function bootstrapConfigWritePath(): string {
-  if (app.isPackaged) return join(app.getPath('userData'), 'config.json');
-  return join(process.cwd(), 'config.json');
-}
-
 // ---------------------------------------------------------------------------
 // Settings load (reads the DB)
 // ---------------------------------------------------------------------------

--- a/apps/dm-tool/electron/constants.ts
+++ b/apps/dm-tool/electron/constants.ts
@@ -10,7 +10,6 @@ export { DEFAULT_CHAT_MODEL as DEFAULT_MODEL } from '@foundry-toolkit/shared/typ
 // --- Archives of Nethys ------------------------------------------------------
 
 export const AON_ELASTICSEARCH_URL = 'https://elasticsearch.aonprd.com/aon/_search';
-export const AON_BASE_URL = 'https://2e.aonprd.com';
 
 // --- Foundry VTT MCP --------------------------------------------------------
 

--- a/apps/dm-tool/electron/foundry-mcp-client.ts
+++ b/apps/dm-tool/electron/foundry-mcp-client.ts
@@ -12,7 +12,7 @@ import { MCP_PROTOCOL_VERSION } from './constants.js';
 // Re-export for backwards compatibility with existing dm-tool imports that
 // expect these types from this module. New code should import directly from
 // `@foundry-toolkit/shared/foundry-api`.
-export type { ActorRef as ActorResult, CompendiumMatch };
+export type { CompendiumMatch };
 
 // ---------------------------------------------------------------------------
 // Transport
@@ -154,7 +154,7 @@ export async function createActorFromCompendium(
   return result as unknown as ActorRef;
 }
 
-export type FolderDocumentType =
+type FolderDocumentType =
   | 'Actor'
   | 'Item'
   | 'Scene'
@@ -165,7 +165,7 @@ export type FolderDocumentType =
   | 'Adventure'
   | 'Card';
 
-export interface FolderResult {
+interface FolderResult {
   id: string;
   name: string;
   type: string;

--- a/apps/dm-tool/electron/util.ts
+++ b/apps/dm-tool/electron/util.ts
@@ -26,12 +26,6 @@ export function stripHtml(html: string): string {
     .trim();
 }
 
-/** Truncate text to `max` characters, appending an ellipsis if trimmed. */
-export function truncate(text: string, max: number): string {
-  if (text.length <= max) return text;
-  return text.slice(0, max) + '…';
-}
-
 /** Attempt to parse JSON, returning `fallback` on failure or null input. */
 export function tryParseJson<T>(raw: string | null, fallback: T): T {
   if (!raw) return fallback;

--- a/apps/dm-tool/src/components/ui/button.tsx
+++ b/apps/dm-tool/src/components/ui/button.tsx
@@ -42,4 +42,4 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 );
 Button.displayName = 'Button';
 
-export { Button, buttonVariants };
+export { Button };

--- a/apps/dm-tool/src/components/ui/dialog.tsx
+++ b/apps/dm-tool/src/components/ui/dialog.tsx
@@ -10,7 +10,6 @@ import { cn } from '@/lib/utils';
 const Dialog = DialogPrimitive.Root;
 const DialogTrigger = DialogPrimitive.Trigger;
 const DialogPortal = DialogPrimitive.Portal;
-const DialogClose = DialogPrimitive.Close;
 
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
@@ -82,15 +81,4 @@ const DialogDescription = React.forwardRef<
 ));
 DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
-export {
-  Dialog,
-  DialogPortal,
-  DialogOverlay,
-  DialogTrigger,
-  DialogClose,
-  DialogContent,
-  DialogHeader,
-  DialogFooter,
-  DialogTitle,
-  DialogDescription,
-};
+export { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogFooter, DialogTitle, DialogDescription };

--- a/apps/dm-tool/src/components/ui/scroll-area.tsx
+++ b/apps/dm-tool/src/components/ui/scroll-area.tsx
@@ -34,4 +34,4 @@ const ScrollBar = React.forwardRef<
 ));
 ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName;
 
-export { ScrollArea, ScrollBar };
+export { ScrollArea };

--- a/apps/dm-tool/src/features/book-browser/BookBrowser/sidebar.tsx
+++ b/apps/dm-tool/src/features/book-browser/BookBrowser/sidebar.tsx
@@ -39,7 +39,7 @@ export function NavItem({
 }
 
 /** Expandable nav group — chevron + label + count, with children. */
-export function NavGroup({
+function NavGroup({
   name,
   count,
   active,

--- a/apps/dm-tool/src/features/book-browser/ap-merge.ts
+++ b/apps/dm-tool/src/features/book-browser/ap-merge.ts
@@ -4,7 +4,7 @@
 
 import type { Book } from '@foundry-toolkit/shared/types';
 
-export interface ApPartInfo {
+interface ApPartInfo {
   book: Book;
   partNumber: number;
   totalParts: number;

--- a/apps/dm-tool/src/features/combat/spell-slot-display.ts
+++ b/apps/dm-tool/src/features/combat/spell-slot-display.ts
@@ -5,7 +5,7 @@
 import type { CombatSpellEntry, SpellPreparationMode } from '@foundry-toolkit/shared/types';
 
 /** Which visual treatment to apply for this entry's slot state. */
-export type SlotDisplayKind =
+type SlotDisplayKind =
   | 'spontaneous' // n/max per rank
   | 'focus' // dot indicators for focus points
   | 'prepared' // per-spell expended checkboxes (handled by SpellRow)

--- a/apps/dm-tool/src/features/settings/SettingsDialog.tsx
+++ b/apps/dm-tool/src/features/settings/SettingsDialog.tsx
@@ -31,7 +31,7 @@ import {
 
 type SettingsTab = 'paths' | 'maps' | 'books' | 'combat' | 'monsters' | 'items' | 'tools';
 
-export interface SettingsDialogProps {
+interface SettingsDialogProps {
   uiScale: number;
   onUiScaleChange: (n: number) => void;
   fontFamily: FontFamily;

--- a/apps/dm-tool/src/hooks/usePreferences.ts
+++ b/apps/dm-tool/src/hooks/usePreferences.ts
@@ -20,7 +20,7 @@ import {
 } from '@/lib/constants';
 import { readJson, readNumber, readString, writeJson, writeString } from '@/lib/storage-utils';
 
-export interface Preferences {
+interface Preferences {
   uiScale: number;
   setUiScale: React.Dispatch<React.SetStateAction<number>>;
   thumbScale: number;

--- a/knip.json
+++ b/knip.json
@@ -11,7 +11,7 @@
       ]
     },
     "apps/dm-tool": {
-      "entry": ["electron.vite.config.ts", "electron/main.ts", "electron/preload.ts"],
+      "entry": ["electron.vite.config.ts", "electron/main.ts", "electron/preload.ts", "electron/**/*.test.ts"],
       "project": ["electron/**/*.ts", "src/**/*.{ts,tsx}"],
       "ignoreDependencies": ["tailwindcss", "tailwindcss-animate"]
     },


### PR DESCRIPTION
## Summary

Clears all dm-tool findings from `npm run knip`. Removes 25 dead function/value exports, 8 dead type exports, and 7 dead type re-exports from the `electron/compendium/index.ts` barrel. Adds `electron/**/*.test.ts` to the dm-tool knip entry graph so test-file-only exports stop showing as unused.

Source of truth: `docs/KNIP-CLEANUP-AUDIT-2026-05-04.md`.

**Apps touched**
- `apps/dm-tool` — `npm run dev:dm-tool`

## Changes

**DELETE bucket (25 exports + 8 types)**
- Removed `export` from functions/types used only within their defining file across: `book-scanner.ts`, `config.ts`, `foundry-mcp-client.ts`, `prepared.ts`, `singleton.ts`, `projection/item.ts`, `projection/monster.ts`, `ap-merge.ts`, `spell-slot-display.ts`, `SettingsDialog.tsx`, `usePreferences.ts`
- Deleted three fully-dead symbols entirely: `bootstrapConfigWritePath` (`config.ts`), `AON_BASE_URL` (`constants.ts`), `truncate` (`util.ts`)
- Stripped 11 dead re-export lines from `electron/compendium/projection/index.ts`
- Removed `export` from `DialogPortal`, `DialogOverlay`, `DialogClose` in `dialog.tsx`; removed `export` from `buttonVariants` (`button.tsx`), `ScrollBar` (`scroll-area.tsx`), `NavGroup` (`sidebar.tsx`)

**Q1 JUDGMENT->DELETE (partial — see note)**
- Removed 6 unused type re-exports from `electron/compendium/index.ts`: `ApiError`, `CompendiumDocument`, `CompendiumMatch`, `CompendiumSearchOptions`, `CompendiumSource`, `ItemPrice`, and the `default` alias. The barrel itself is kept (active consumers import `CompendiumApi`, `CompendiumPack`, `CompendiumRequestError` from it). Note: the audit's Q1 grep missed relative imports; the barrel was not deleted wholesale.
- Removed `ActorResult` re-export from `foundry-mcp-client.ts`

**SCRIPT-USED bucket (config only)**
- Added `"electron/**/*.test.ts"` to dm-tool `entry` in `knip.json` — clears 5 singleton test-helper exports from findings without touching source

**PUBLIC bucket**
- The 10 PUBLIC types (`BootstrapConfig`, `MonsterArtAssets`, `InputProps`, `ButtonProps`, `ProgressProps`, `TaggerOptions/Progress/Result`, `PushSceneOptions/Result`) are reachable via the entry graph and report zero findings after the other deletions.

## Test plan

- [ ] `npm run typecheck -w @foundry-toolkit/dm-tool` clean (both node + web targets)
- [ ] `npm run lint -w @foundry-toolkit/dm-tool` clean
- [ ] `npm run test -w @foundry-toolkit/dm-tool` 410 tests pass across 29 test files
- [ ] `npm run knip` zero dm-tool findings
- [ ] `npm run dev:dm-tool` boots; click through combat, monsters, settings