### PR TITLE
refactor(api-bridge): extract Foundry global type shims to shared module

### DIFF
--- a/apps/foundry-api-bridge/src/commands/handlers/actor/actions/types.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/actions/types.ts
@@ -1,5 +1,5 @@
 import type { InvokeActorActionResult } from '@/commands/types';
-import type { FoundryD20Roll } from '../actorTypes';
+import type { FoundryD20Roll } from '../../../../types/foundry-event-shapes.js';
 
 // Minimal Foundry type snippets. Kept local to the actions layer because
 // the pf2e runtime surface isn't covered by the bundled foundry-vtt
@@ -50,24 +50,24 @@ export interface Pf2eStrike {
   critical?: (args: Record<string, unknown>) => Promise<unknown>;
 }
 
-export interface FoundryItem {
+interface FoundryItem {
   id: string;
   name: string;
   type: string;
   toMessage(args?: Record<string, unknown>): Promise<unknown>;
 }
 
-export interface FoundryItemCollection {
+interface FoundryItemCollection {
   get(id: string): FoundryItem | undefined;
 }
 
-export interface ActorsCollection {
+interface ActorsCollection {
   get(id: string): FoundryActor | undefined;
 }
 
 export type PF2eActionFn = (options: Record<string, unknown>) => Promise<unknown>;
 
-export interface FoundryGame {
+interface FoundryGame {
   actors: ActorsCollection;
   messages?: { contents: Array<{ id: string; isRoll?: boolean }> };
   pf2e?: {
@@ -75,7 +75,7 @@ export interface FoundryGame {
   };
 }
 
-export interface FoundryGlobals {
+interface FoundryGlobals {
   game: FoundryGame;
 }
 

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/actorTypes.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/actorTypes.ts
@@ -1,32 +1,5 @@
 import type { DiceResult } from '@/commands/types';
-
-export interface FoundryDiceTerm {
-  faces?: number;
-  number?: number;
-  results?: Array<{ result: number }>;
-}
-
-export interface FoundryD20Roll {
-  total: number;
-  formula: string;
-  terms: FoundryDiceTerm[];
-  isCritical: boolean;
-  isFumble: boolean;
-}
-
-export interface FoundryDamageRoll {
-  total: number;
-  formula: string;
-  terms: FoundryDiceTerm[];
-}
-
-export interface RollDialogConfig {
-  configure: boolean;
-}
-
-export interface RollMessageConfig {
-  create: boolean;
-}
+import type { FoundryDiceTerm } from '../../../types/foundry-event-shapes.js';
 
 export function extractDiceResults(terms: FoundryDiceTerm[]): DiceResult[] {
   const diceResults: DiceResult[] = [];
@@ -43,58 +16,3 @@ export function extractDiceResults(terms: FoundryDiceTerm[]): DiceResult[] {
 
   return diceResults;
 }
-
-export interface FoundryItemsCollection {
-  get(id: string): FoundryItem | undefined;
-}
-
-export interface FoundryItem {
-  id: string;
-  name: string;
-  type: string;
-  img: string;
-  system: Record<string, unknown>;
-}
-
-export interface FoundryActor {
-  id: string;
-  uuid: string;
-  name: string;
-  type: string;
-  img: string;
-  folder: { id: string; name: string } | null;
-  items: FoundryItemsCollection;
-  system: Record<string, unknown>;
-  update(data: Record<string, unknown>): Promise<FoundryActor>;
-  delete(): Promise<FoundryActor>;
-  toObject(source?: boolean): Record<string, unknown>;
-}
-
-export interface ActorsCollection {
-  get(id: string): FoundryActor | undefined;
-}
-
-export interface FoundryPack {
-  collection: string;
-  metadata: {
-    type: string;
-  };
-  getDocument(id: string): Promise<FoundryActor | null>;
-}
-
-export interface PacksCollection {
-  get(id: string): FoundryPack | undefined;
-}
-
-export interface FoundryGame {
-  actors: ActorsCollection & {
-    documentClass: {
-      create(data: Record<string, unknown>): Promise<FoundryActor>;
-      createDocuments(data: Record<string, unknown>[]): Promise<FoundryActor[]>;
-    };
-  };
-  packs: PacksCollection;
-}
-
-declare const game: FoundryGame;
-export { game };

--- a/apps/foundry-api-bridge/src/commands/handlers/effect/effectTypes.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/effect/effectTypes.ts
@@ -37,7 +37,7 @@ export interface FoundryEffectsCollection {
   get(id: string): FoundryActiveEffect | undefined;
 }
 
-export interface EffectFoundryActor {
+interface EffectFoundryActor {
   id: string;
   name: string;
   effects: FoundryEffectsCollection;
@@ -59,11 +59,11 @@ export interface ActiveEffectCreateData {
   duration?: EffectDurationData;
 }
 
-export interface EffectActorsCollection {
+interface EffectActorsCollection {
   get(id: string): EffectFoundryActor | undefined;
 }
 
-export interface EffectFoundryGame {
+interface EffectFoundryGame {
   actors: EffectActorsCollection;
 }
 

--- a/apps/foundry-api-bridge/src/commands/handlers/item/itemTypes.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/item/itemTypes.ts
@@ -1,10 +1,5 @@
 import type { RollResult } from '@/commands/types';
-
-export interface FoundryDiceTerm {
-  faces?: number;
-  number?: number;
-  results?: Array<{ result: number }>;
-}
+import type { FoundryDiceTerm } from '../../../types/foundry-event-shapes.js';
 
 export interface FoundryRoll {
   total: number;
@@ -93,13 +88,13 @@ export interface FoundryItemsCollection {
   get(id: string): FoundryItem | undefined;
 }
 
-export interface FoundryActor {
+interface FoundryActor {
   id: string;
   name: string;
   items: FoundryItemsCollection;
 }
 
-export interface ActorsCollection {
+interface ActorsCollection {
   get(id: string): FoundryActor | undefined;
 }
 
@@ -152,7 +147,7 @@ export interface FoundryHooks {
   off(hook: string, id: number): void;
 }
 
-export interface ItemFoundryGame {
+interface ItemFoundryGame {
   actors: ActorsCollection;
   user: FoundryUser;
   modules: FoundryModulesCollection;

--- a/apps/foundry-api-bridge/src/commands/handlers/scene/sceneTypes.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/scene/sceneTypes.ts
@@ -9,6 +9,7 @@ import type {
   SceneRegionResult,
   SceneTokenSummary,
 } from '@/commands/types';
+import type { FoundryToken } from '../../../types/foundry-event-shapes.js';
 
 export interface FoundryNote {
   x: number;
@@ -82,29 +83,7 @@ export interface FoundryRegion {
   shapes: FoundryRegionShape[] | undefined;
 }
 
-export interface FoundryToken {
-  id: string;
-  name: string | undefined;
-  x: number;
-  y: number;
-  width: number | undefined;
-  height: number | undefined;
-  elevation: number | undefined;
-  hidden: boolean | undefined;
-  disposition: number | undefined;
-  actor: {
-    id: string;
-    system?: {
-      attributes?: {
-        hp?: { value: number; max: number };
-        ac?: { value: number };
-      };
-    };
-    statuses?: Set<string>;
-  } | null;
-}
-
-export interface FoundryScene {
+interface FoundryScene {
   id: string;
   name: string;
   active: boolean;
@@ -124,7 +103,7 @@ export interface FoundryScene {
   activate(): Promise<FoundryScene>;
 }
 
-export interface FoundryScenesCollection {
+interface FoundryScenesCollection {
   get(id: string): FoundryScene | undefined;
   active: FoundryScene | null;
   forEach(fn: (scene: FoundryScene) => void): void;

--- a/apps/foundry-api-bridge/src/commands/handlers/shared.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/shared.ts
@@ -1,32 +1,7 @@
 import type { DiceResult } from '@/commands/types';
+import type { FoundryDiceTerm } from '../../types/foundry-event-shapes.js';
 
-export interface FoundryDiceTerm {
-  faces?: number;
-  number?: number;
-  results?: Array<{ result: number }>;
-}
-
-export interface FoundryD20Roll {
-  total: number;
-  formula: string;
-  terms: FoundryDiceTerm[];
-  isCritical: boolean;
-  isFumble: boolean;
-}
-
-export interface FoundryDamageRoll {
-  total: number;
-  formula: string;
-  terms: FoundryDiceTerm[];
-}
-
-export interface RollDialogConfig {
-  configure: boolean;
-}
-
-export interface RollMessageConfig {
-  create: boolean;
-}
+export type { FoundryDiceTerm };
 
 export function extractDiceResults(terms: FoundryDiceTerm[]): DiceResult[] {
   const diceResults: DiceResult[] = [];

--- a/apps/foundry-api-bridge/src/commands/handlers/table/tableTypes.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/table/tableTypes.ts
@@ -1,4 +1,5 @@
 import type { TableResultData, RollTableResult, RollTableSummary } from '@/commands/types';
+import type { FoundryRoll } from '../../../types/foundry-event-shapes.js';
 
 export interface FoundryTableResult {
   _id: string;
@@ -15,11 +16,6 @@ export interface FoundryTableResult {
 
 export interface FoundryTableResultsCollection {
   contents: FoundryTableResult[];
-}
-
-export interface FoundryRoll {
-  total: number;
-  formula: string;
 }
 
 export interface FoundryRollTableDraw {
@@ -53,7 +49,7 @@ export interface FoundryTablesCollection {
   documentClass: FoundryRollTableConstructor;
 }
 
-export interface FoundryGame {
+interface FoundryGame {
   tables: FoundryTablesCollection;
 }
 

--- a/apps/foundry-api-bridge/src/commands/handlers/token/tokenTypes.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/token/tokenTypes.ts
@@ -1,4 +1,5 @@
 import type { TokenResult } from '@/commands/types';
+import type { FoundryToken as SharedFoundryToken } from '../../../types/foundry-event-shapes.js';
 
 export interface TokenUpdateData {
   x?: number;
@@ -13,17 +14,14 @@ export interface TokenUpdateData {
   lockRotation?: boolean;
 }
 
-export interface FoundryToken {
-  id: string;
+// Strict token shape for CRUD operations. Extends the shared superset and
+// narrows the fields that token handlers require to be non-optional.
+export interface FoundryToken extends SharedFoundryToken {
   name: string;
-  x: number;
-  y: number;
   elevation: number;
   rotation: number;
   hidden: boolean;
-  texture: {
-    src: string;
-  };
+  texture: { src: string };
   disposition: number;
   actor: {
     id: string;
@@ -43,7 +41,7 @@ export interface TokenUpdateOptions {
   animate?: boolean;
 }
 
-export interface FoundryTokensCollection {
+interface FoundryTokensCollection {
   get(id: string): FoundryToken | undefined;
   contents: FoundryToken[];
 }
@@ -58,7 +56,7 @@ export interface TokenCreateData {
   scale?: number;
 }
 
-export interface FoundryScene {
+interface FoundryScene {
   id: string;
   name: string;
   tokens: FoundryTokensCollection;
@@ -66,7 +64,7 @@ export interface FoundryScene {
   deleteEmbeddedDocuments(type: 'Token', ids: string[]): Promise<unknown[]>;
 }
 
-export interface FoundryScenesCollection {
+interface FoundryScenesCollection {
   get(id: string): FoundryScene | undefined;
   active: FoundryScene | null;
 }

--- a/apps/foundry-api-bridge/src/types/foundry-event-shapes.ts
+++ b/apps/foundry-api-bridge/src/types/foundry-event-shapes.ts
@@ -1,0 +1,201 @@
+// Shared Foundry VTT global type shims.
+// Handler *Types.ts files previously each declared their own copy of these interfaces.
+
+export interface FoundryDiceTerm {
+  faces?: number;
+  number?: number;
+  results?: Array<{ result: number }>;
+}
+
+export interface FoundryD20Roll {
+  total: number;
+  formula: string;
+  terms: FoundryDiceTerm[];
+  isCritical: boolean;
+  isFumble: boolean;
+}
+
+export interface FoundryDamageRoll {
+  total: number;
+  formula: string;
+  terms: FoundryDiceTerm[];
+}
+
+export interface RollDialogConfig {
+  configure: boolean;
+}
+
+export interface RollMessageConfig {
+  create: boolean;
+}
+
+// Superset of the FoundryRoll shapes in itemTypes.ts (required terms) and
+// tableTypes.ts (no terms). tableTypes only needs {total, formula}.
+export interface FoundryRoll {
+  total: number;
+  formula: string;
+  terms?: FoundryDiceTerm[];
+  isCritical?: boolean;
+  isFumble?: boolean;
+}
+
+// ── Item / Actor shapes ────────────────────────────────────────────────────
+
+export interface ActorItem {
+  id: string;
+  name: string;
+  type: string;
+  img?: string;
+  system?: Record<string, unknown>;
+  toMessage?(args?: Record<string, unknown>): Promise<unknown>;
+}
+
+export type FoundryItem = ActorItem;
+
+export interface ActorItemsCollection {
+  contents?: ActorItem[];
+  get(id: string): ActorItem | undefined;
+}
+
+export type FoundryItemsCollection = ActorItemsCollection;
+
+// Superset of FoundryActor across actorTypes.ts, itemTypes.ts, and
+// actor/actions/types.ts. PF2e-specific methods are optional.
+export interface FoundryActor {
+  id: string;
+  uuid?: string;
+  name: string;
+  type?: string;
+  img?: string;
+  folder?: { id: string; name: string } | null;
+  items?: ActorItemsCollection;
+  system?: Record<string, unknown>;
+  update?(data: Record<string, unknown>): Promise<FoundryActor>;
+  delete?(): Promise<FoundryActor>;
+  toObject?(source?: boolean): Record<string, unknown>;
+  transferItemToActor?(targetActor: FoundryActor, item: ActorItem, quantity: number): Promise<unknown>;
+  increaseCondition?(slug: string): Promise<unknown>;
+  decreaseCondition?(slug: string): Promise<unknown>;
+  getStatistic?(slug: string): unknown;
+}
+
+export interface ActorsCollection {
+  get(id: string): FoundryActor | undefined;
+  forEach?(fn: (actor: FoundryActor) => void): void;
+}
+
+// ── Pack shapes ────────────────────────────────────────────────────────────
+
+// Superset of FoundryPack from actorTypes.ts (simple, with getDocument) and
+// worldTypes.ts (with index, richer metadata).
+export interface FoundryPack {
+  collection: string;
+  metadata: {
+    type?: string;
+    label?: string;
+    system?: string;
+    packageName?: string;
+  };
+  index?: { size: number };
+  getDocument?(id: string): Promise<FoundryActor | null>;
+}
+
+export interface PacksCollection {
+  get(id: string): FoundryPack | undefined;
+  forEach?(fn: (pack: FoundryPack) => void): void;
+  size?: number;
+}
+
+// ── Scene / Token shapes ───────────────────────────────────────────────────
+
+// Superset of FoundryToken from sceneTypes.ts (display-only, optional fields)
+// and tokenTypes.ts (CRUD, required fields). Handler files that need strict
+// required fields extend this interface locally.
+export interface FoundryToken {
+  id: string;
+  name?: string;
+  x: number;
+  y: number;
+  width?: number;
+  height?: number;
+  elevation?: number;
+  rotation?: number;
+  hidden?: boolean;
+  texture?: { src: string };
+  disposition?: number;
+  actor?: {
+    id: string;
+    system?: {
+      attributes?: {
+        hp?: { value: number; max: number };
+        ac?: { value: number };
+      };
+    };
+    statuses?: Set<string>;
+  } | null;
+  update?(data: Record<string, unknown>, options?: Record<string, unknown>): Promise<FoundryToken>;
+  delete?(): Promise<FoundryToken>;
+}
+
+export interface FoundryTokensCollection {
+  get(id: string): FoundryToken | undefined;
+  contents?: FoundryToken[];
+}
+
+// Superset of FoundryScene from sceneTypes.ts (full detail with notes, walls,
+// etc.) and tokenTypes.ts (slim CRUD surface with embedded document methods).
+export interface FoundryScene {
+  id: string;
+  name: string;
+  active?: boolean;
+  img?: string;
+  background?: { src?: string };
+  width?: number;
+  height?: number;
+  grid?: {
+    size?: number;
+    type?: number;
+    units?: string;
+    distance?: number;
+  };
+  darkness?: number;
+  notes?: { contents: unknown[] };
+  walls?: { contents: unknown[] };
+  lights?: { contents: unknown[] };
+  tiles?: { contents: unknown[] };
+  drawings?: { contents: unknown[] };
+  regions?: { contents: unknown[] };
+  tokens?: { contents: FoundryToken[] };
+  createEmbeddedDocuments?(type: string, data: Record<string, unknown>[]): Promise<unknown[]>;
+  deleteEmbeddedDocuments?(type: string, ids: string[]): Promise<unknown[]>;
+  activate?(): Promise<FoundryScene>;
+}
+
+// Superset of FoundryScenesCollection from sceneTypes.ts (get, active, forEach)
+// and tokenTypes.ts (get, active — no forEach).
+export interface FoundryScenesCollection {
+  get(id: string): FoundryScene | undefined;
+  active: FoundryScene | null;
+  forEach?(fn: (scene: FoundryScene) => void): void;
+}
+
+// ── Game global shim ──────────────────────────────────────────────────────
+
+// Base Foundry game global shape covering the actors + packs slice.
+// Handler files that need combat, tables, journal, etc. declare domain-specific
+// extensions locally. The `declare const game: FoundryGame` idiom in each
+// handler file narrows this to whatever properties the handler actually reads.
+export interface FoundryGame {
+  actors?: ActorsCollection & {
+    documentClass?: {
+      create(data: Record<string, unknown>): Promise<FoundryActor>;
+      createDocuments(data: Record<string, unknown>[]): Promise<FoundryActor[]>;
+    };
+  };
+  packs?: PacksCollection;
+  scenes?: FoundryScenesCollection;
+  messages?: { contents: Array<{ id: string; isRoll?: boolean }> };
+  pf2e?: {
+    actions?: Record<string, ((options: Record<string, unknown>) => Promise<unknown>) | undefined>;
+  };
+}


### PR DESCRIPTION
## Summary

Resolves audit finding **F13** from REFACTOR-AUDIT-2026-04-30.md. The repeated inline Foundry type shims (`FoundryGame`, `FoundryActor`, `ActorItem`, `ActorItemsCollection`, `FoundryDiceTerm`, `FoundryRoll`, etc.) that were copy-declared in each handler's `*Types.ts` file now live once in `src/types/foundry-event-shapes.ts`. Handler files import from there instead of re-declaring. Purely mechanical — no runtime behavior changes.

**Apps touched**
- `apps/foundry-api-bridge` only — no dev server needed to validate (type-only refactor)

## Changes

- **New**: `src/types/foundry-event-shapes.ts` — canonical shim module exporting `FoundryDiceTerm`, `FoundryD20Roll`, `FoundryDamageRoll`, `RollDialogConfig`, `RollMessageConfig`, `FoundryRoll` (superset), `ActorItem`/`FoundryItem`, `ActorItemsCollection`/`FoundryItemsCollection`, `FoundryActor`, `ActorsCollection`, `FoundryToken` (superset), `FoundryTokensCollection`, `FoundryScene` (superset), `FoundryScenesCollection` (superset), `FoundryPack` (superset), `PacksCollection`, `FoundryGame` (base)
- **`actorTypes.ts`**: stripped down to just `extractDiceResults`; all inline interface declarations removed; `export { game }` removed (the 1 F13 export finding)
- **`handlers/shared.ts`**: removed duplicate dice/roll type declarations; re-exports `FoundryDiceTerm` for `RollDiceHandler.ts` backward compat
- **`actor/actions/types.ts`**: `FoundryD20Roll` import redirected to shared module; `FoundryGame`, `FoundryGlobals`, `FoundryItem`, `ActorsCollection`, `FoundryItemCollection` removed from exports (local-only)
- **`itemTypes.ts`**: `FoundryDiceTerm` imported from shared; `FoundryActor`, `ActorsCollection`, `ItemFoundryGame` exports removed
- **`effectTypes.ts`**: `EffectFoundryActor`, `EffectActorsCollection`, `EffectFoundryGame` exports removed (local-only)
- **`tableTypes.ts`**: `FoundryRoll` replaced by shared import; `FoundryGame` export removed (local-only)
- **`tokenTypes.ts`**: `FoundryToken` extends shared superset (narrows required fields); `FoundryScene`, `FoundryScenesCollection`, `FoundryTokensCollection` exports removed
- **`sceneTypes.ts`**: `FoundryToken` replaced by shared import; `FoundryScene`, `FoundryScenesCollection` exports removed

## Knip / F13 dissolution

Before: 34 F13-bucket type findings spread across handler `*Types.ts` files (per KNIP-CLEANUP-AUDIT-2026-05-04.md).

After (`npx knip --workspace apps/foundry-api-bridge --include exports,types`): all handler-file F13 items removed from their original locations. Domain-specific `FoundryGame` variants in combat/scene/token/journal handlers stay exported (they're genuinely consumed by sibling handlers and are not duplicates). The shared module itself shows some "unused exported type" findings for types not yet imported by all consumers — these are canonical, non-duplicated definitions that the follow-up api-bridge cleanup PR will address.

Net diff: **9 files changed, 230 insertions(+), 168 deletions(−)**; the insertion count includes the new shared module; deletion count is from stripped handler files.

## Test plan

- [x] `npm run type-check -w @foundry-toolkit/api-bridge` — same 2 pre-existing errors (unrelated to this PR), zero new errors
- [x] `npm run lint -w @foundry-toolkit/api-bridge` — clean
- [x] `npm run format:check` — clean
- [x] `npm run test -w @foundry-toolkit/api-bridge` — 794 tests, 51 suites, all pass
- [x] `git diff main --stat` — 8 `*Types.ts` files shrunk + 1 new `foundry-event-shapes.ts`; net deletions > additions in handler files