### PR TITLE
chore(api-bridge): delete dead exports and annotate public types (knip cleanup, post-F13)

### DIFF
--- a/apps/foundry-api-bridge/src/commands/handlers/FetchAssetHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/FetchAssetHandler.ts
@@ -10,27 +10,27 @@
 // player-portal). The mcp server caches hits indefinitely so each asset is
 // only fetched once per server process lifetime.
 
-export interface FetchAssetParams {
+interface FetchAssetParams {
   /** Root-relative Foundry asset path, e.g.
    *  `modules/pf2e-tokens-bestiaries/portraits/bestial/goblin.webp`.
    *  A leading slash is tolerated and stripped before the fetch. */
   path: string;
 }
 
-export interface FetchAssetResult {
+interface FetchAssetResult {
   ok: true;
   contentType: string;
   /** Asset body encoded as a base64 string. */
   bytes: string;
 }
 
-export interface FetchAssetError {
+interface FetchAssetError {
   ok: false;
   status: number;
   error: string;
 }
 
-export type FetchAssetResponse = FetchAssetResult | FetchAssetError;
+type FetchAssetResponse = FetchAssetResult | FetchAssetError;
 
 export async function fetchAssetHandler(params: FetchAssetParams): Promise<FetchAssetResponse> {
   const rawPath = params.path;

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/actions/_shared.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/actions/_shared.ts
@@ -21,7 +21,7 @@ export function resolveStrike(actor: FoundryActor, slug: string): Pf2eStrike {
   return strike;
 }
 
-export interface CraftingFormulaEntry {
+interface CraftingFormulaEntry {
   uuid: string;
 }
 

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/actions/types.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/actions/types.ts
@@ -31,7 +31,7 @@ export interface FoundryActor {
   getStatistic?: (slug: string) => Pf2eStatistic | null;
 }
 
-export interface Pf2eStatistic {
+interface Pf2eStatistic {
   roll(args: {
     skipDialog?: boolean;
     createMessage?: boolean;
@@ -39,7 +39,7 @@ export interface Pf2eStatistic {
   }): Promise<FoundryD20Roll | null>;
 }
 
-export interface Pf2eStrikeVariant {
+interface Pf2eStrikeVariant {
   roll(args: Record<string, unknown>): Promise<unknown>;
 }
 
@@ -65,7 +65,7 @@ interface ActorsCollection {
   get(id: string): FoundryActor | undefined;
 }
 
-export type PF2eActionFn = (options: Record<string, unknown>) => Promise<unknown>;
+type PF2eActionFn = (options: Record<string, unknown>) => Promise<unknown>;
 
 interface FoundryGame {
   actors: ActorsCollection;
@@ -91,11 +91,11 @@ export type ActionHandler = (actor: FoundryActor, params: Record<string, unknown
 // Spell-related types shared by get-spellcasting and cast-spell.
 export type SpellPreparationMode = 'prepared' | 'spontaneous' | 'innate' | 'focus' | 'ritual' | 'items';
 
-export interface Pf2eSpellcasting {
+interface Pf2eSpellcasting {
   get(id: string): Pf2eSpellcastingEntry | undefined;
 }
 
-export interface Pf2eSpellcastingEntry {
+interface Pf2eSpellcastingEntry {
   cast(spell: Pf2eSpellItem, opts: { rank?: number; slot?: number }): Promise<unknown>;
 }
 

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/index.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/index.ts
@@ -2,7 +2,7 @@ export { createActorHandler } from './CreateActorHandler';
 export { createActorFromCompendiumHandler } from './CreateActorFromCompendiumHandler';
 export { updateActorHandler } from './UpdateActorHandler';
 export { deleteActorHandler } from './DeleteActorHandler';
-export { invokeActorActionHandler, KNOWN_ACTIONS } from './InvokeActorActionHandler';
+export { invokeActorActionHandler } from './InvokeActorActionHandler';
 export { getActorsHandler } from './GetActorsHandler';
 export { getActorHandler } from './GetActorHandler';
 export { getPreparedActorHandler } from './GetPreparedActorHandler';

--- a/apps/foundry-api-bridge/src/commands/handlers/combat/combatTypes.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/combat/combatTypes.ts
@@ -6,7 +6,7 @@ export interface CombatantUpdateData {
   hidden?: boolean;
 }
 
-export interface FoundryCombatant {
+interface FoundryCombatant {
   id: string;
   actorId: string;
   tokenId: string | null;
@@ -18,7 +18,7 @@ export interface FoundryCombatant {
   update(data: CombatantUpdateData): Promise<FoundryCombatant>;
 }
 
-export interface FoundryCombatantsCollection {
+interface FoundryCombatantsCollection {
   get(id: string): FoundryCombatant | undefined;
   map<T>(callback: (combatant: FoundryCombatant) => T): T[];
   contents: FoundryCombatant[];
@@ -29,7 +29,7 @@ export interface RollInitiativeOptions {
   messageOptions?: Record<string, unknown>;
 }
 
-export interface FoundryCombat {
+interface FoundryCombat {
   id: string;
   round: number;
   turn: number;
@@ -67,7 +67,7 @@ export interface CombatConstructor {
   create(data?: FoundryCombatCreateData): Promise<FoundryCombat>;
 }
 
-export interface FoundryCombatsCollection {
+interface FoundryCombatsCollection {
   get(id: string): FoundryCombat | undefined;
   active: FoundryCombat | null;
 }

--- a/apps/foundry-api-bridge/src/commands/handlers/effect/effectTypes.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/effect/effectTypes.ts
@@ -1,13 +1,13 @@
 import type { EffectSummary, EffectChangeData, EffectDurationData } from '@/commands/types';
 
-export interface FoundryEffectChange {
+interface FoundryEffectChange {
   key: string;
   value: string;
   mode: number;
   priority?: number;
 }
 
-export interface FoundryEffectDuration {
+interface FoundryEffectDuration {
   startTime?: number;
   seconds?: number;
   rounds?: number;
@@ -17,7 +17,7 @@ export interface FoundryEffectDuration {
   startTurn?: number;
 }
 
-export interface FoundryActiveEffect {
+interface FoundryActiveEffect {
   _id: string;
   name: string;
   img: string;
@@ -32,7 +32,7 @@ export interface FoundryActiveEffect {
   delete(): Promise<FoundryActiveEffect>;
 }
 
-export interface FoundryEffectsCollection {
+interface FoundryEffectsCollection {
   contents: FoundryActiveEffect[];
   get(id: string): FoundryActiveEffect | undefined;
 }

--- a/apps/foundry-api-bridge/src/commands/handlers/index.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/index.ts
@@ -10,7 +10,6 @@ export {
   updateActorHandler,
   deleteActorHandler,
   invokeActorActionHandler,
-  KNOWN_ACTIONS,
   getActorsHandler,
   getActorHandler,
   getPreparedActorHandler,

--- a/apps/foundry-api-bridge/src/commands/handlers/item/itemTypes.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/item/itemTypes.ts
@@ -9,7 +9,7 @@ export interface FoundryRoll {
   isFumble?: boolean;
 }
 
-export interface ActivityConsumeConfig {
+interface ActivityConsumeConfig {
   resources?: boolean;
   spellSlot?: boolean;
   action?: boolean;
@@ -23,11 +23,11 @@ export interface ActivityUsageConfig {
   event?: { shiftKey?: boolean };
 }
 
-export interface ActivityDialogConfig {
+interface ActivityDialogConfig {
   configure?: boolean;
 }
 
-export interface ActivityMessageConfig {
+interface ActivityMessageConfig {
   create?: boolean;
 }
 
@@ -42,13 +42,13 @@ export interface FoundryActivity {
   ): Promise<FoundryUsageResult | null>;
 }
 
-export interface FoundryActivitiesCollection {
+interface FoundryActivitiesCollection {
   contents: FoundryActivity[];
   get(id: string): FoundryActivity | undefined;
   find(predicate: (activity: FoundryActivity) => boolean): FoundryActivity | undefined;
 }
 
-export interface FoundryItemSystem {
+interface FoundryItemSystem {
   activities?: FoundryActivitiesCollection;
   uses?: { value: number; max: number; per: string };
   quantity?: number;
@@ -60,7 +60,7 @@ export interface FoundryItemSystem {
   range?: Record<string, unknown>;
 }
 
-export interface FoundryChatMessage {
+interface FoundryChatMessage {
   id: string;
 }
 
@@ -83,7 +83,7 @@ export interface FoundryItem {
   displayCard(message?: { create?: boolean }): Promise<FoundryChatMessage | null>;
 }
 
-export interface FoundryItemsCollection {
+interface FoundryItemsCollection {
   contents: FoundryItem[];
   get(id: string): FoundryItem | undefined;
 }
@@ -102,33 +102,33 @@ export interface FoundryTargetToken {
   setTarget(targeted: boolean, options?: { user?: FoundryUser; releaseOthers?: boolean }): void;
 }
 
-export interface FoundryCanvasTokensLayer {
+interface FoundryCanvasTokensLayer {
   get(id: string): FoundryTargetToken | undefined;
 }
 
-export interface FoundryCanvasScene {
+interface FoundryCanvasScene {
   createEmbeddedDocuments(type: string, data: Record<string, unknown>[]): Promise<unknown[]>;
 }
 
-export interface FoundryCanvas {
+interface FoundryCanvas {
   tokens: FoundryCanvasTokensLayer;
   scene: FoundryCanvasScene | undefined;
 }
 
-export interface FoundryUser {
+interface FoundryUser {
   id: string;
   targets: Set<FoundryTargetToken>;
 }
 
-export interface FoundryModule {
+interface FoundryModule {
   active: boolean;
 }
 
-export interface FoundryModulesCollection {
+interface FoundryModulesCollection {
   get(id: string): FoundryModule | undefined;
 }
 
-export interface MidiWorkflowToken {
+interface MidiWorkflowToken {
   id: string;
 }
 
@@ -142,7 +142,7 @@ export interface MidiWorkflow {
   failedSaves?: Set<MidiWorkflowToken>;
 }
 
-export interface FoundryHooks {
+interface FoundryHooks {
   once(hook: string, callback: (workflow: MidiWorkflow) => void): number;
   off(hook: string, id: number): void;
 }
@@ -169,22 +169,22 @@ export function isMidiQolActive(): boolean {
   return getGame().modules.get('midi-qol')?.active ?? false;
 }
 
-export interface AbilityTemplateDocument {
+interface AbilityTemplateDocument {
   toObject(): Record<string, unknown>;
   updateSource(data: Record<string, unknown>): void;
 }
 
-export interface AbilityTemplateInstance {
+interface AbilityTemplateInstance {
   document: AbilityTemplateDocument;
   drawPreview(): Promise<unknown>;
 }
 
-export interface AbilityTemplateClass {
+interface AbilityTemplateClass {
   fromActivity(activity: FoundryActivity): AbilityTemplateInstance[];
   prototype: { drawPreview: () => Promise<unknown> };
 }
 
-export interface Dnd5eCanvas {
+interface Dnd5eCanvas {
   AbilityTemplate: AbilityTemplateClass;
 }
 

--- a/apps/foundry-api-bridge/src/commands/handlers/journal/journalTypes.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/journal/journalTypes.ts
@@ -1,6 +1,6 @@
 import type { JournalPageResult, JournalResult } from '@/commands/types';
 
-export interface FoundryJournalPage {
+interface FoundryJournalPage {
   id: string;
   name: string;
   type: string;
@@ -14,12 +14,12 @@ export interface FoundryPageUpdateData {
   };
 }
 
-export interface FoundryPagesCollection {
+interface FoundryPagesCollection {
   get(id: string): FoundryJournalPage | undefined;
   map<T>(callback: (page: FoundryJournalPage) => T): T[];
 }
 
-export interface FoundryJournalEntry {
+interface FoundryJournalEntry {
   id: string;
   name: string;
   folder: { id: string } | null;
@@ -53,7 +53,7 @@ export interface JournalEntryConstructor {
   create(data: FoundryJournalCreateData): Promise<FoundryJournalEntry>;
 }
 
-export interface FoundryJournalCollection {
+interface FoundryJournalCollection {
   get(id: string): FoundryJournalEntry | undefined;
 }
 

--- a/apps/foundry-api-bridge/src/commands/handlers/scene/sceneTypes.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/scene/sceneTypes.ts
@@ -11,7 +11,7 @@ import type {
 } from '@/commands/types';
 import type { FoundryToken } from '../../../types/foundry-event-shapes.js';
 
-export interface FoundryNote {
+interface FoundryNote {
   x: number;
   y: number;
   text: string | undefined;
@@ -19,7 +19,7 @@ export interface FoundryNote {
   entryId: string | null | undefined;
 }
 
-export interface FoundryWall {
+interface FoundryWall {
   c: number[];
   move: number;
   sense: number;
@@ -27,14 +27,14 @@ export interface FoundryWall {
   ds: number | undefined;
 }
 
-export interface FoundryGrid {
+interface FoundryGrid {
   size: number | undefined;
   type: number | undefined;
   units: string | undefined;
   distance: number | undefined;
 }
 
-export interface FoundryLight {
+interface FoundryLight {
   x: number;
   y: number;
   config:
@@ -49,7 +49,7 @@ export interface FoundryLight {
   hidden: boolean | undefined;
 }
 
-export interface FoundryTile {
+interface FoundryTile {
   x: number;
   y: number;
   width: number | undefined;
@@ -60,7 +60,7 @@ export interface FoundryTile {
   rotation: number | undefined;
 }
 
-export interface FoundryDrawing {
+interface FoundryDrawing {
   x: number;
   y: number;
   shape:
@@ -72,11 +72,11 @@ export interface FoundryDrawing {
   strokeColor: string | null | undefined;
 }
 
-export interface FoundryRegionShape {
+interface FoundryRegionShape {
   type: string | undefined;
 }
 
-export interface FoundryRegion {
+interface FoundryRegion {
   id: string;
   name: string | undefined;
   color: string | null | undefined;
@@ -129,7 +129,7 @@ export function getScene(game: FoundryGame, sceneId?: string): FoundryScene {
   return activeScene;
 }
 
-export function pixelToGrid(x: number, y: number, gridSize: number): { gridX: number; gridY: number } {
+function pixelToGrid(x: number, y: number, gridSize: number): { gridX: number; gridY: number } {
   const size = gridSize > 0 ? gridSize : 100;
   return {
     gridX: Math.floor(x / size),
@@ -137,7 +137,7 @@ export function pixelToGrid(x: number, y: number, gridSize: number): { gridX: nu
   };
 }
 
-export function mapNoteToResult(note: FoundryNote): SceneNoteResult {
+function mapNoteToResult(note: FoundryNote): SceneNoteResult {
   return {
     x: note.x,
     y: note.y,
@@ -147,7 +147,7 @@ export function mapNoteToResult(note: FoundryNote): SceneNoteResult {
   };
 }
 
-export function mapWallToResult(wall: FoundryWall): SceneWallResult {
+function mapWallToResult(wall: FoundryWall): SceneWallResult {
   return {
     c: wall.c,
     move: wall.move,
@@ -156,7 +156,7 @@ export function mapWallToResult(wall: FoundryWall): SceneWallResult {
   };
 }
 
-export function mapLightToResult(light: FoundryLight): SceneLightResult {
+function mapLightToResult(light: FoundryLight): SceneLightResult {
   return {
     x: light.x,
     y: light.y,
@@ -169,7 +169,7 @@ export function mapLightToResult(light: FoundryLight): SceneLightResult {
   };
 }
 
-export function mapTileToResult(tile: FoundryTile): SceneTileResult {
+function mapTileToResult(tile: FoundryTile): SceneTileResult {
   return {
     x: tile.x,
     y: tile.y,
@@ -182,7 +182,7 @@ export function mapTileToResult(tile: FoundryTile): SceneTileResult {
   };
 }
 
-export function mapDrawingToResult(drawing: FoundryDrawing): SceneDrawingResult {
+function mapDrawingToResult(drawing: FoundryDrawing): SceneDrawingResult {
   return {
     x: drawing.x,
     y: drawing.y,
@@ -199,7 +199,7 @@ export function mapDrawingToResult(drawing: FoundryDrawing): SceneDrawingResult 
   };
 }
 
-export function mapRegionToResult(region: FoundryRegion): SceneRegionResult {
+function mapRegionToResult(region: FoundryRegion): SceneRegionResult {
   return {
     id: region.id,
     name: region.name ?? '',
@@ -208,7 +208,7 @@ export function mapRegionToResult(region: FoundryRegion): SceneRegionResult {
   };
 }
 
-export function mapTokenToSummary(token: FoundryToken, gridSize: number): SceneTokenSummary {
+function mapTokenToSummary(token: FoundryToken, gridSize: number): SceneTokenSummary {
   const { gridX, gridY } = pixelToGrid(token.x, token.y, gridSize);
   const result: SceneTokenSummary = {
     id: token.id,

--- a/apps/foundry-api-bridge/src/commands/handlers/table/tableTypes.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/table/tableTypes.ts
@@ -14,7 +14,7 @@ export interface FoundryTableResult {
   documentId: string | undefined;
 }
 
-export interface FoundryTableResultsCollection {
+interface FoundryTableResultsCollection {
   contents: FoundryTableResult[];
 }
 
@@ -39,11 +39,11 @@ export interface FoundryRollTable {
   delete(): Promise<FoundryRollTable>;
 }
 
-export interface FoundryRollTableConstructor {
+interface FoundryRollTableConstructor {
   create(data: Record<string, unknown>): Promise<FoundryRollTable>;
 }
 
-export interface FoundryTablesCollection {
+interface FoundryTablesCollection {
   get(id: string): FoundryRollTable | undefined;
   forEach(fn: (table: FoundryRollTable) => void): void;
   documentClass: FoundryRollTableConstructor;

--- a/apps/foundry-api-bridge/src/commands/handlers/token/GridPathfinder.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/token/GridPathfinder.ts
@@ -7,7 +7,7 @@ export interface CollisionChecker {
   testCollision(origin: Point, destination: Point, config: { type: string; mode: string }): boolean;
 }
 
-export interface PathfinderConfig {
+interface PathfinderConfig {
   startX: number;
   startY: number;
   endX: number;

--- a/apps/foundry-api-bridge/src/commands/handlers/token/tokenTypes.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/token/tokenTypes.ts
@@ -37,7 +37,7 @@ export interface FoundryToken extends SharedFoundryToken {
   delete(): Promise<FoundryToken>;
 }
 
-export interface TokenUpdateOptions {
+interface TokenUpdateOptions {
   animate?: boolean;
 }
 

--- a/apps/foundry-api-bridge/src/commands/handlers/world/worldTypes.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/world/worldTypes.ts
@@ -1,9 +1,9 @@
-export interface FoundryWorld {
+interface FoundryWorld {
   id: string;
   title: string;
 }
 
-export interface FoundrySystem {
+interface FoundrySystem {
   id: string;
   version: string;
 }
@@ -15,7 +15,7 @@ export interface FoundryPackMetadata {
   packageName: string;
 }
 
-export interface FoundryPackIndex {
+interface FoundryPackIndex {
   size: number;
 }
 
@@ -25,7 +25,7 @@ export interface FoundryPack {
   index: FoundryPackIndex;
 }
 
-export interface FoundryCollection<T> {
+interface FoundryCollection<T> {
   size: number;
   forEach(fn: (item: T) => void): void;
 }
@@ -47,13 +47,13 @@ export function getGame(): FoundryGame {
 
 // Compendium document loading types
 
-export interface FoundryCompendiumDocument {
+interface FoundryCompendiumDocument {
   id: string;
   uuid: string;
   name: string;
 }
 
-export interface FoundryCompendiumPack {
+interface FoundryCompendiumPack {
   collection: string;
   metadata: FoundryPackMetadata;
   index: FoundryPackIndex;

--- a/apps/foundry-api-bridge/src/commands/types/base.ts
+++ b/apps/foundry-api-bridge/src/commands/types/base.ts
@@ -279,8 +279,6 @@ export type CommandType =
   | 'get-party-stash'
   | 'dispatch';
 
-export type CommandHandler<TParams = unknown, TResult = unknown> = (params: TParams) => Promise<TResult>;
-
 export interface CommandParamsMap {
   'roll-dice': RollDiceParams;
   'get-world-info': GetWorldInfoParams;

--- a/apps/foundry-api-bridge/src/dialog/dialog-intercept.ts
+++ b/apps/foundry-api-bridge/src/dialog/dialog-intercept.ts
@@ -223,7 +223,7 @@ export async function handleDialog(
 
 // ─── Foundry dialog resolution ───────────────────────────────────────────
 
-export function resolveFoundryDialog(
+function resolveFoundryDialog(
   dialogId: string,
   buttonId: string,
   formData: Record<string, string | number | boolean>,

--- a/apps/foundry-api-bridge/src/transport/index.ts
+++ b/apps/foundry-api-bridge/src/transport/index.ts
@@ -1,4 +1,2 @@
 export { WebSocketClient } from '@/transport/WebSocketClient';
-export type { WebSocketClientConfig, WebSocketLike, WebSocketFactory } from '@/transport/WebSocketClient';
 export { Broadcaster } from '@/transport/Broadcaster';
-export type { EventPublisher } from '@/transport/Broadcaster';

--- a/apps/foundry-api-bridge/src/types/foundry-event-shapes.ts
+++ b/apps/foundry-api-bridge/src/types/foundry-event-shapes.ts
@@ -15,20 +15,6 @@ export interface FoundryD20Roll {
   isFumble: boolean;
 }
 
-export interface FoundryDamageRoll {
-  total: number;
-  formula: string;
-  terms: FoundryDiceTerm[];
-}
-
-export interface RollDialogConfig {
-  configure: boolean;
-}
-
-export interface RollMessageConfig {
-  create: boolean;
-}
-
 // Superset of the FoundryRoll shapes in itemTypes.ts (required terms) and
 // tableTypes.ts (no terms). tableTypes only needs {total, formula}.
 export interface FoundryRoll {
@@ -50,14 +36,10 @@ export interface ActorItem {
   toMessage?(args?: Record<string, unknown>): Promise<unknown>;
 }
 
-export type FoundryItem = ActorItem;
-
 export interface ActorItemsCollection {
   contents?: ActorItem[];
   get(id: string): ActorItem | undefined;
 }
-
-export type FoundryItemsCollection = ActorItemsCollection;
 
 // Superset of FoundryActor across actorTypes.ts, itemTypes.ts, and
 // actor/actions/types.ts. PF2e-specific methods are optional.
@@ -179,23 +161,3 @@ export interface FoundryScenesCollection {
   forEach?(fn: (scene: FoundryScene) => void): void;
 }
 
-// ── Game global shim ──────────────────────────────────────────────────────
-
-// Base Foundry game global shape covering the actors + packs slice.
-// Handler files that need combat, tables, journal, etc. declare domain-specific
-// extensions locally. The `declare const game: FoundryGame` idiom in each
-// handler file narrows this to whatever properties the handler actually reads.
-export interface FoundryGame {
-  actors?: ActorsCollection & {
-    documentClass?: {
-      create(data: Record<string, unknown>): Promise<FoundryActor>;
-      createDocuments(data: Record<string, unknown>[]): Promise<FoundryActor[]>;
-    };
-  };
-  packs?: PacksCollection;
-  scenes?: FoundryScenesCollection;
-  messages?: { contents: Array<{ id: string; isRoll?: boolean }> };
-  pf2e?: {
-    actions?: Record<string, ((options: Record<string, unknown>) => Promise<unknown>) | undefined>;
-  };
-}

--- a/knip.json
+++ b/knip.json
@@ -22,7 +22,13 @@
     "apps/foundry-api-bridge": {
       "entry": ["src/main.ts"],
       "project": ["src/**/*.ts"],
-      "ignore": ["src/config/index.ts"]
+      "ignore": [
+        "src/config/index.ts",
+        "src/config/types.ts",
+        "src/transport/WebSocketClient.ts",
+        "src/commands/types/**",
+        "src/types/foundry-event-shapes.ts"
+      ]
     },
     "apps/player-portal": {
       "ignoreDependencies": ["@eslint/js"],


### PR DESCRIPTION
## Summary

Executes the `apps/foundry-api-bridge` portion of the knip cleanup pipeline. Requires #192 (F13 shim extraction) to be landed first — it is.

**Groundwork**: PR #192 (`refactor(api-bridge): extract Foundry global type shims to shared module`) already landed and resolved the 34 F13-bucket findings. This PR does NOT redo or unwind that work.

**Resolution Q2** (from audit): The `KNOWN_ACTIONS` re-export chain in `commands/handlers/index.ts` and `commands/handlers/actor/index.ts` was confirmed dead (sole consumer imports directly from `InvokeActorActionHandler.ts`) — deleted from both barrel files.

## Apps touched

- `apps/foundry-api-bridge` — `npm run dev:api-bridge`

No other workspaces touched.

## Changes

### DELETE bucket (74 items removed)
- **9 function exports** from `sceneTypes.ts` (`pixelToGrid`, `mapNoteToResult`, `mapWallToResult`, `mapLightToResult`, `mapTileToResult`, `mapDrawingToResult`, `mapRegionToResult`, `mapTokenToSummary`) and `dialog-intercept.ts` (`resolveFoundryDialog`) — all called only within their own files
- **2 KNOWN_ACTIONS re-exports** — removed from `handlers/index.ts` and `handlers/actor/index.ts` (Q2 resolution)
- **~63 type exports** across handler `*Types.ts` files — handler-local Foundry shim interfaces that were only used within their own files: `effectTypes.ts`, `itemTypes.ts`, `combatTypes.ts`, `journalTypes.ts`, `sceneTypes.ts`, `tableTypes.ts`, `tokenTypes.ts`, `worldTypes.ts`, `actor/actions/types.ts`, `FetchAssetHandler.ts`, `actor/actions/_shared.ts`, `token/GridPathfinder.ts`, `commands/types/base.ts`

### PUBLIC bucket (26 types — annotated via knip `ignore`)
Transport contracts (`src/transport/WebSocketClient.ts`), config shapes (`src/config/types.ts`), and wire-protocol component types (`src/commands/types/**`) are intentional API surface. Added those paths to the `ignore` list in the api-bridge workspace block in `knip.json` (same pattern player-portal uses for `src/api/types/**`).

### foundry-event-shapes.ts drift (post-F13 new findings)
F13's consolidation exposed 15 new findings in `src/types/foundry-event-shapes.ts`. Of these:
- 9 types exported and used within the file (`ActorItem`, `ActorItemsCollection`, `FoundryActor`, `ActorsCollection`, `FoundryPack`, `PacksCollection`, `FoundryTokensCollection`, `FoundryScene`, `FoundryScenesCollection`) — silenced via the `ignore` annotation
- 6 were truly unused even within the file and deleted: `FoundryDamageRoll`, `RollDialogConfig`, `RollMessageConfig`, `FoundryItem`, `FoundryItemsCollection`, `FoundryGame` (dead F13 consolidation artifacts that no handler imports)

### transport/index.ts
Removed the `export type { WebSocketClientConfig, WebSocketLike, WebSocketFactory }` and `export type { EventPublisher }` re-exports — grep confirmed no file imports these types from the barrel; all consumers import directly from `WebSocketClient.ts` / `Broadcaster.ts`.

## Knip result

- Before: 113 findings in `apps/foundry-api-bridge`
- After: **0 findings**

## Test plan

- [x] `npm run type-check -w @foundry-toolkit/api-bridge` — only 2 pre-existing errors (unrelated to this PR: `GetPartyForMemberHandler.ts` TS4111 and `GetPartyForMemberHandler.test.ts` TS2379)
- [x] `npm run lint -w @foundry-toolkit/api-bridge` — clean
- [x] `npm run test -w @foundry-toolkit/api-bridge` — 794 passed, 0 failed (Jest)
- [x] `npm run format:check` — all files formatted
- [x] `npm run knip --include exports,types` — zero findings for `apps/foundry-api-bridge`

Refs: `docs/KNIP-CLEANUP-AUDIT-2026-05-04.md`