### PR TITLE
chore(knip): clear residual findings and expand CI coverage to exports + types

### DIFF
--- a/apps/dm-tool/electron/compendium/index.ts
+++ b/apps/dm-tool/electron/compendium/index.ts
@@ -35,7 +35,7 @@ import type {
 // server side has shifted.
 const DEFAULT_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 
-export interface CreateCompendiumApiOptions {
+interface CreateCompendiumApiOptions {
   /** Base URL of the foundry-mcp server, e.g. `http://localhost:8765`.
    *  Trailing slash is tolerated. */
   baseUrl: string;

--- a/apps/dm-tool/electron/compendium/projection/index.ts
+++ b/apps/dm-tool/electron/compendium/projection/index.ts
@@ -10,4 +10,4 @@ export {
   type MonsterRow,
   type MonsterResult,
 } from './monster.js';
-export { priceToCopper, itemDocToBrowserDetail, itemMatchToBrowserRow, itemDocToLootShortlistItem } from './item.js';
+export { priceToCopper, itemDocToBrowserDetail, itemMatchToBrowserRow } from './item.js';

--- a/apps/dm-tool/electron/compendium/types.ts
+++ b/apps/dm-tool/electron/compendium/types.ts
@@ -4,7 +4,6 @@
 // monorepo, the shared module is the single source of truth.
 
 export type {
-  ApiError,
   CompendiumDocument,
   CompendiumEmbeddedItem,
   CompendiumMatch,

--- a/knip.json
+++ b/knip.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
+  "ignoreExportsUsedInFile": true,
   "workspaces": {
     ".": {
       "ignoreDependencies": [
@@ -7,12 +8,14 @@
         "@secretlint/secretlint-rule-aws",
         "@secretlint/secretlint-rule-github",
         "@secretlint/secretlint-rule-openai",
-        "@secretlint/secretlint-rule-pattern"
+        "@secretlint/secretlint-rule-pattern",
+        "lint-staged"
       ]
     },
     "apps/dm-tool": {
       "entry": ["electron.vite.config.ts", "electron/main.ts", "electron/preload.ts", "electron/**/*.test.ts"],
       "project": ["electron/**/*.ts", "src/**/*.{ts,tsx}"],
+      "ignore": ["electron/compendium/singleton.ts"],
       "ignoreDependencies": ["tailwindcss", "tailwindcss-animate"]
     },
     "apps/foundry-mcp": {
@@ -32,7 +35,7 @@
     },
     "apps/player-portal": {
       "ignoreDependencies": ["@eslint/js"],
-      "ignore": ["src/api/types/**", "src/components/tabs/Proficiencies.tsx"]
+      "ignore": ["src/api/types/**", "src/components/tabs/Proficiencies.tsx", "src/components/picker/**"]
     },
     "packages/ai": {
       "entry": [

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "npm run test --workspaces --if-present",
     "lint": "eslint . && npm run lint --workspaces --if-present",
     "lint:fix": "eslint . --fix",
-    "knip": "knip --include files,dependencies,unresolved",
+    "knip": "knip --include files,dependencies,unresolved,exports,types,nsExports,nsTypes",
     "build": "npm run build --workspaces --if-present",
     "dev:dm-tool": "npm --workspace apps/dm-tool run dev",
     "dev:mcp": "npm --workspace apps/foundry-mcp run dev",


### PR DESCRIPTION
## Summary

Final stage of the multi-PR knip cleanup pipeline documented in `docs/KNIP-CLEANUP-AUDIT-2026-05-04.md`. Clears the 24 residual findings that remained after the workspace-level cleanup PRs (#189–#193), then flips the CI flag to gate against unused exports and types going forward.

**Apps touched**
- `apps/dm-tool` — three DELETE-bucket removals + knip config annotation
- `apps/player-portal` — knip config annotation only
- `package.json` + `knip.json` — root config changes

No dev server spin-up needed; all changes are configuration and dead-export removal.

## Changes

**DELETE bucket (3 findings removed from source)**
- `CreateCompendiumApiOptions` in `electron/compendium/index.ts` — de-exported (no consumers per audit Q1 grep)
- `ApiError` in `electron/compendium/types.ts` — removed from re-export block (no consumers)
- `itemDocToLootShortlistItem` in `electron/compendium/projection/index.ts` — removed from barrel (drift from recent feature work)

**PUBLIC bucket — annotated via knip config (21 findings)**
- Root `ignoreExportsUsedInFile: true` silences 13 dm-tool items used within their own files: shadcn/ui prop types (`ButtonProps`, `InputProps`, `ProgressProps`), IPC contract types (`TaggerOptions`, `TaggerProgress`, `TaggerResult`, `PushSceneOptions`, `PushSceneResult`, `BootstrapConfig`), and `MonsterArtAssets`
- `electron/compendium/singleton.ts` added to dm-tool `ignore`: `getAvailableActorPacks` and `resetPreparedCompendium` are test-only exports consumed via `await import()` in `singleton.test.ts` — dynamic imports are not statically traceable by knip
- `src/components/picker/**` added to player-portal `ignore`: 6 PUBLIC picker building-block exports (`CompendiumDetailPanel`, `PickerDialog`, `CompendiumPickerSplitPane`, `PickerResultListProps`)
- `lint-staged` added to root `ignoreDependencies`: invoked by `.husky/pre-commit` via `npx lint-staged`, which knip cannot trace through shell scripts

**CI flag flip**
```
"knip": "knip --include files,dependencies,unresolved,exports,types,nsExports,nsTypes"
```
`npm run knip` exits 0 with no `Unused exports` or `Unused exported types` sections. The 27 configuration hints (redundant entry patterns + "Remove from ignore" advisories) are advisory and do not fail CI.

## Test plan

- [x] `npm run knip` — exits 0, no blocking findings
- [x] `npm run typecheck` — clean across all workspaces
- [x] `npm run lint` — 0 errors (pre-existing warnings only, all in untouched files)
- [x] `npm run format:check` — clean

Refs: audit pipeline started in #189 (foundry-mcp), continued through #190 (player-portal), #191 (dm-tool), #192 (api-bridge shim extraction), #193 (api-bridge dead exports).