### PR TITLE
feat(dm-tool): homebrew item creator (PF2e)

### DIFF
--- a/apps/dm-tool/electron/compendium/client.ts
+++ b/apps/dm-tool/electron/compendium/client.ts
@@ -9,6 +9,13 @@
 // callsites + `instanceof` checks keep working.
 
 import { buildCompendiumQuery, requestJson } from '@foundry-toolkit/shared/http';
+import type {
+  CompendiumItemPayload,
+  CreateCompendiumItemBody,
+  CreateCompendiumItemResponse,
+  EnsureCompendiumPackBody,
+  EnsureCompendiumPackResponse,
+} from '@foundry-toolkit/shared/rpc';
 
 import type {
   CompendiumDocument,
@@ -40,6 +47,14 @@ export interface CompendiumHttpClient {
     traits?: string[];
     maxLevel?: number;
   }): Promise<{ sources: CompendiumSource[] }>;
+  /** Idempotent create-or-reuse of a world compendium pack via
+   *  `POST /api/compendium/packs/ensure`. Used by the homebrew item
+   *  editor to lazily provision the target pack on first save. */
+  ensureCompendiumPack(body: EnsureCompendiumPackBody): Promise<EnsureCompendiumPackResponse>;
+  /** Create a single Item document inside a world compendium pack via
+   *  `POST /api/compendium/items`. The pack must exist (call
+   *  `ensureCompendiumPack` first). */
+  createCompendiumItem(payload: { packId: string; item: CompendiumItemPayload }): Promise<CreateCompendiumItemResponse>;
 }
 
 /** Build a typed HTTP client rooted at a foundry-mcp base URL. Example
@@ -74,6 +89,23 @@ export function createCompendiumHttpClient(baseUrl: string): CompendiumHttpClien
       if (opts.maxLevel !== undefined) params.set('maxLevel', opts.maxLevel.toString());
       const qs = params.toString();
       return requestJson<{ sources: CompendiumSource[] }>(`${base}/api/compendium/sources${qs ? `?${qs}` : ''}`);
+    },
+
+    ensureCompendiumPack(body) {
+      return requestJson<EnsureCompendiumPackResponse>(`${base}/api/compendium/packs/ensure`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+    },
+
+    createCompendiumItem(payload) {
+      const wireBody: CreateCompendiumItemBody = payload;
+      return requestJson<CreateCompendiumItemResponse>(`${base}/api/compendium/items`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(wireBody),
+      });
     },
   };
 }

--- a/apps/dm-tool/electron/compendium/facets-index.test.ts
+++ b/apps/dm-tool/electron/compendium/facets-index.test.ts
@@ -42,6 +42,8 @@ function fakeApi(searchResult: CompendiumMatch[], sources: { title: string; coun
     getCompendiumDocument: vi.fn(),
     listCompendiumPacks: vi.fn().mockResolvedValue({ packs: [] }),
     listCompendiumSources: vi.fn().mockResolvedValue({ sources }),
+    ensureCompendiumPack: vi.fn(),
+    createCompendiumItem: vi.fn(),
     invalidateDocument: vi.fn(),
     invalidateAllDocuments: vi.fn(),
   };

--- a/apps/dm-tool/electron/compendium/index.test.ts
+++ b/apps/dm-tool/electron/compendium/index.test.ts
@@ -53,6 +53,8 @@ function fakeClient(overrides: Partial<CompendiumHttpClient> = {}): CompendiumHt
     getCompendiumDocument: vi.fn().mockResolvedValue({ document: doc('default-uuid') }),
     listCompendiumPacks: vi.fn().mockResolvedValue({ packs: [] }),
     listCompendiumSources: vi.fn().mockResolvedValue({ sources: [] }),
+    ensureCompendiumPack: vi.fn(),
+    createCompendiumItem: vi.fn(),
   };
   return { ...base, ...overrides };
 }

--- a/apps/dm-tool/electron/compendium/index.ts
+++ b/apps/dm-tool/electron/compendium/index.ts
@@ -21,6 +21,12 @@ import {
   invalidateCachedDocument,
   putCachedDocument,
 } from '@foundry-toolkit/db/pf2e';
+import type {
+  CompendiumItemPayload,
+  CreateCompendiumItemResponse,
+  EnsureCompendiumPackBody,
+  EnsureCompendiumPackResponse,
+} from '@foundry-toolkit/shared/rpc';
 import { type CompendiumHttpClient, CompendiumRequestError, createCompendiumHttpClient } from './client.js';
 import type {
   CompendiumDocument,
@@ -56,6 +62,16 @@ export interface CompendiumApi {
     traits?: string[];
     maxLevel?: number;
   }): Promise<{ sources: CompendiumSource[] }>;
+  /** Idempotent create-or-reuse of a world compendium pack. Mutations
+   *  bypass the document cache — caller is responsible for invalidating
+   *  cached docs after a related write if any apply. */
+  ensureCompendiumPack(body: EnsureCompendiumPackBody): Promise<EnsureCompendiumPackResponse>;
+  /** Create a single Item document inside a world compendium pack.
+   *  Returns the new document's id + uuid so the caller can navigate
+   *  to it or stash it. The document cache is left alone (the new
+   *  document isn't yet in any cached pack-dump, so no invalidation
+   *  is needed). */
+  createCompendiumItem(payload: { packId: string; item: CompendiumItemPayload }): Promise<CreateCompendiumItemResponse>;
   invalidateDocument(uuid: string): void;
   invalidateAllDocuments(): void;
 }
@@ -95,6 +111,14 @@ export function createCompendiumApi(opts: CreateCompendiumApiOptions): Compendiu
 
     listCompendiumSources(sourcesOpts) {
       return http.listCompendiumSources(sourcesOpts);
+    },
+
+    ensureCompendiumPack(body) {
+      return http.ensureCompendiumPack(body);
+    },
+
+    createCompendiumItem(payload) {
+      return http.createCompendiumItem(payload);
     },
 
     invalidateDocument(uuid) {

--- a/apps/dm-tool/electron/compendium/prepared.test.ts
+++ b/apps/dm-tool/electron/compendium/prepared.test.ts
@@ -62,6 +62,8 @@ function fakeApi(overrides: Partial<CompendiumApi> = {}): CompendiumApi {
     getCompendiumDocument: vi.fn().mockResolvedValue({ document: doc(), stale: false }),
     listCompendiumPacks: vi.fn().mockResolvedValue({ packs: [] }),
     listCompendiumSources: vi.fn().mockResolvedValue({ sources: [] }),
+    ensureCompendiumPack: vi.fn(),
+    createCompendiumItem: vi.fn(),
     invalidateDocument: vi.fn(),
     invalidateAllDocuments: vi.fn(),
     ...overrides,

--- a/apps/dm-tool/electron/compendium/singleton.test.ts
+++ b/apps/dm-tool/electron/compendium/singleton.test.ts
@@ -39,6 +39,8 @@ vi.mock('./index.js', () => ({
     getCompendiumDocument: vi.fn(),
     listCompendiumPacks,
     listCompendiumSources: vi.fn(),
+    ensureCompendiumPack: vi.fn(),
+    createCompendiumItem: vi.fn(),
     invalidateDocument: vi.fn(),
     invalidateAllDocuments: vi.fn(),
   }),

--- a/apps/dm-tool/electron/ipc/homebrew-items-clone.ts
+++ b/apps/dm-tool/electron/ipc/homebrew-items-clone.ts
@@ -7,6 +7,18 @@
 
 import type { CompendiumDocument } from '../compendium/types.js';
 
+/** Resolve either a full Foundry uuid (`Compendium.<pack>.<docType>.<id>`)
+ *  or a bare document id from `pf2e.equipment-srd` to a full uuid the
+ *  bridge can fetch. The renderer's `ItemBrowserRow.id` is a bare doc
+ *  id (set in `projection/item.ts` to `m.documentId` / `doc.id`),
+ *  matching the convention in `prepared.ts::getItemBrowserDetail`.
+ *  Constructing the uuid here keeps the renderer free of pack-id
+ *  knowledge while staying in lockstep with the single-pack scope
+ *  (`ITEM_PACK_IDS = ['pf2e.equipment-srd']`). */
+export function resolveItemTemplateUuid(idOrUuid: string): string {
+  return idOrUuid.startsWith('Compendium.') ? idOrUuid : `Compendium.pf2e.equipment-srd.Item.${idOrUuid}`;
+}
+
 /** Shape returned by `getCompendiumItemTemplate`. Slimmer than the raw
  *  bridge document — we only need the fields the editor will populate. */
 export interface CompendiumItemTemplate {

--- a/apps/dm-tool/electron/ipc/homebrew-items-clone.ts
+++ b/apps/dm-tool/electron/ipc/homebrew-items-clone.ts
@@ -1,0 +1,64 @@
+// Pure clone-helper for the homebrew item editor. Lives in its own file
+// (not alongside `homebrew-items.ts`) because that file pulls in
+// `ipcMain` from `electron`, which can't load headlessly in vitest CI.
+// The helper-only module has no electron dependency, so the test for
+// it (and the renderer code that wants the `CompendiumItemTemplate`
+// type) can import it without lighting up the native electron binary.
+
+import type { CompendiumDocument } from '../compendium/types.js';
+
+/** Shape returned by `getCompendiumItemTemplate`. Slimmer than the raw
+ *  bridge document — we only need the fields the editor will populate. */
+export interface CompendiumItemTemplate {
+  name: string;
+  type: string;
+  img: string | null;
+  system: Record<string, unknown>;
+  effects: Array<Record<string, unknown>>;
+  flags: Record<string, Record<string, unknown>>;
+}
+
+/** Strip identity / system-bookkeeping fields from a Foundry item
+ *  document so the result can be re-submitted as a brand-new doc.
+ *  The dropped keys mirror what `compendiumItem.toObject()` would
+ *  reset on a `delete itemData['_id']` clone — but we do it on the
+ *  client because the bridge already returns the full object. */
+export function stripIdentityForClone(doc: CompendiumDocument): CompendiumItemTemplate {
+  const system = typeof doc.system === 'object' && doc.system !== null ? (doc.system as Record<string, unknown>) : {};
+
+  // Foundry documents may carry `effects` directly OR via `toObject` shape.
+  const rawEffects = (doc as unknown as { effects?: unknown }).effects;
+  const effects: Array<Record<string, unknown>> = Array.isArray(rawEffects)
+    ? rawEffects
+        .filter((e): e is Record<string, unknown> => typeof e === 'object' && e !== null)
+        .map((e) => {
+          const copy = { ...e };
+          delete copy['_id'];
+          delete copy['_stats'];
+          // Embedded ActiveEffect docs sometimes carry their own origin
+          // pointing at the source item — drop it so the cloned effect
+          // reattaches to the new item rather than referencing the
+          // template's uuid.
+          delete copy['origin'];
+          return copy;
+        })
+    : [];
+
+  const rawFlags = (doc as unknown as { flags?: unknown }).flags;
+  const flags: Record<string, Record<string, unknown>> = typeof rawFlags === 'object' && rawFlags !== null
+    ? Object.fromEntries(
+        Object.entries(rawFlags as Record<string, unknown>).filter(
+          (entry): entry is [string, Record<string, unknown>] => typeof entry[1] === 'object' && entry[1] !== null,
+        ),
+      )
+    : {};
+
+  return {
+    name: doc.name,
+    type: doc.type,
+    img: doc.img !== '' ? doc.img : null,
+    system,
+    effects,
+    flags,
+  };
+}

--- a/apps/dm-tool/electron/ipc/homebrew-items.test.ts
+++ b/apps/dm-tool/electron/ipc/homebrew-items.test.ts
@@ -1,0 +1,92 @@
+// Tests for the identity-stripping helper used by the homebrew item
+// editor's "Use as template" path. Coverage focuses on the bookkeeping
+// fields a clone must drop so re-submitting the result produces a fresh
+// document rather than reattaching to the source compendium item.
+
+import { describe, expect, it } from 'vitest';
+import { stripIdentityForClone } from './homebrew-items';
+import type { CompendiumDocument } from '../compendium/types';
+
+function doc(overrides: Partial<CompendiumDocument> & Record<string, unknown> = {}): CompendiumDocument {
+  return {
+    id: 'src-id',
+    uuid: 'Compendium.pf2e.equipment-srd.Item.src-id',
+    name: 'Source Item',
+    type: 'weapon',
+    img: 'systems/pf2e/icons/x.webp',
+    system: { level: { value: 5 } },
+    ...overrides,
+  } as CompendiumDocument;
+}
+
+describe('stripIdentityForClone', () => {
+  it('returns name, type, img, system from the source document', () => {
+    const result = stripIdentityForClone(doc());
+    expect(result.name).toBe('Source Item');
+    expect(result.type).toBe('weapon');
+    expect(result.img).toBe('systems/pf2e/icons/x.webp');
+    expect(result.system).toEqual({ level: { value: 5 } });
+  });
+
+  it('coerces an empty img to null so the editor renders the placeholder cleanly', () => {
+    const result = stripIdentityForClone(doc({ img: '' }));
+    expect(result.img).toBeNull();
+  });
+
+  it('preserves effects[] but strips _id, _stats, and origin from each effect', () => {
+    const result = stripIdentityForClone(
+      doc({
+        effects: [
+          {
+            _id: 'effect-id',
+            _stats: { foo: 'bar' },
+            origin: 'Compendium.pf2e.equipment-srd.Item.src-id',
+            name: 'Striking',
+            disabled: false,
+            transfer: true,
+            changes: [{ key: 'system.bonuses.damage.bonus', mode: 2, value: '1' }],
+          },
+        ],
+      } as Partial<CompendiumDocument>),
+    );
+    expect(result.effects).toHaveLength(1);
+    const effect = result.effects[0];
+    expect(effect).not.toHaveProperty('_id');
+    expect(effect).not.toHaveProperty('_stats');
+    expect(effect).not.toHaveProperty('origin');
+    // Everything else round-trips intact.
+    expect(effect).toMatchObject({
+      name: 'Striking',
+      disabled: false,
+      transfer: true,
+      changes: [{ key: 'system.bonuses.damage.bonus', mode: 2, value: '1' }],
+    });
+  });
+
+  it('returns an empty effects array when the source has none', () => {
+    const result = stripIdentityForClone(doc());
+    expect(result.effects).toEqual([]);
+  });
+
+  it('passes flags through (object-typed values only)', () => {
+    const result = stripIdentityForClone(
+      doc({
+        flags: {
+          'pf2e-toolbelt': { tag: 'demo' },
+          // String value at the top level is NOT a valid flag scope and
+          // should be filtered out.
+          bogus: 'not-an-object',
+        },
+      } as Partial<CompendiumDocument>),
+    );
+    expect(result.flags).toEqual({ 'pf2e-toolbelt': { tag: 'demo' } });
+  });
+
+  it('falls back to {} for system / effects / flags when the source omits them', () => {
+    const sparse = { id: 'x', uuid: 'u', name: 'X', type: 'equipment', img: '' } as unknown as CompendiumDocument;
+    const result = stripIdentityForClone(sparse);
+    expect(result.system).toEqual({});
+    expect(result.effects).toEqual([]);
+    expect(result.flags).toEqual({});
+  });
+});

--- a/apps/dm-tool/electron/ipc/homebrew-items.test.ts
+++ b/apps/dm-tool/electron/ipc/homebrew-items.test.ts
@@ -4,7 +4,7 @@
 // document rather than reattaching to the source compendium item.
 
 import { describe, expect, it } from 'vitest';
-import { stripIdentityForClone } from './homebrew-items';
+import { stripIdentityForClone } from './homebrew-items-clone';
 import type { CompendiumDocument } from '../compendium/types';
 
 function doc(overrides: Partial<CompendiumDocument> & Record<string, unknown> = {}): CompendiumDocument {

--- a/apps/dm-tool/electron/ipc/homebrew-items.test.ts
+++ b/apps/dm-tool/electron/ipc/homebrew-items.test.ts
@@ -4,7 +4,7 @@
 // document rather than reattaching to the source compendium item.
 
 import { describe, expect, it } from 'vitest';
-import { stripIdentityForClone } from './homebrew-items-clone';
+import { resolveItemTemplateUuid, stripIdentityForClone } from './homebrew-items-clone';
 import type { CompendiumDocument } from '../compendium/types';
 
 function doc(overrides: Partial<CompendiumDocument> & Record<string, unknown> = {}): CompendiumDocument {
@@ -88,5 +88,21 @@ describe('stripIdentityForClone', () => {
     expect(result.system).toEqual({});
     expect(result.effects).toEqual([]);
     expect(result.flags).toEqual({});
+  });
+});
+
+describe('resolveItemTemplateUuid', () => {
+  it('wraps a bare pf2e.equipment-srd document id into a full uuid', () => {
+    expect(resolveItemTemplateUuid('c4PSK2Q7ikF8jgrm')).toBe('Compendium.pf2e.equipment-srd.Item.c4PSK2Q7ikF8jgrm');
+  });
+
+  it('passes through an already-formed uuid unchanged', () => {
+    const uuid = 'Compendium.pf2e.equipment-srd.Item.abc123';
+    expect(resolveItemTemplateUuid(uuid)).toBe(uuid);
+  });
+
+  it('passes through a uuid from a non-pf2e pack untouched', () => {
+    const uuid = 'Compendium.world.homebrew-items.Item.xyz789';
+    expect(resolveItemTemplateUuid(uuid)).toBe(uuid);
   });
 });

--- a/apps/dm-tool/electron/ipc/homebrew-items.ts
+++ b/apps/dm-tool/electron/ipc/homebrew-items.ts
@@ -26,18 +26,19 @@ import type {
   EnsureCompendiumPackResponse,
 } from '@foundry-toolkit/shared/rpc';
 import { getCompendiumApi, isPreparedCompendiumInitialized } from '../compendium/singleton.js';
-import { stripIdentityForClone, type CompendiumItemTemplate } from './homebrew-items-clone.js';
+import { resolveItemTemplateUuid, stripIdentityForClone, type CompendiumItemTemplate } from './homebrew-items-clone.js';
 
 export type { CompendiumItemTemplate } from './homebrew-items-clone.js';
 
 export function registerHomebrewItemHandlers(): void {
-  ipcMain.handle('getCompendiumItemTemplate', async (_e, uuid: string): Promise<CompendiumItemTemplate> => {
+  ipcMain.handle('getCompendiumItemTemplate', async (_e, idOrUuid: string): Promise<CompendiumItemTemplate> => {
     if (!isPreparedCompendiumInitialized()) {
       throw new Error('Compendium API not available — set a foundry-mcp URL in Settings → Paths and restart the app.');
     }
-    if (typeof uuid !== 'string' || uuid.length === 0) {
-      throw new Error('getCompendiumItemTemplate: uuid must be a non-empty string');
+    if (typeof idOrUuid !== 'string' || idOrUuid.length === 0) {
+      throw new Error('getCompendiumItemTemplate: id or uuid must be a non-empty string');
     }
+    const uuid = resolveItemTemplateUuid(idOrUuid);
     const { document } = await getCompendiumApi().getCompendiumDocument(uuid);
     return stripIdentityForClone(document);
   });

--- a/apps/dm-tool/electron/ipc/homebrew-items.ts
+++ b/apps/dm-tool/electron/ipc/homebrew-items.ts
@@ -1,0 +1,117 @@
+// IPC for the dm-tool item-browser's homebrew creator.
+//
+// The renderer drives a three-step flow:
+//   1. (Optional) `getCompendiumItemTemplate(uuid)` — fetch the full Foundry
+//      document for an item the user wants to clone, with identity fields
+//      (`_id`, `_stats`, embedded `_id`s) stripped so the renderer can
+//      present a fresh editable draft.
+//   2. `ensureHomebrewItemPack({name, label})` — idempotent create of the
+//      target world pack on first save.
+//   3. `createHomebrewItem({packId, item})` — write the item into the
+//      pack and return the new document's id + uuid.
+//
+// All three handlers proxy through the existing CompendiumApi singleton,
+// so they share the configured foundry-mcp URL with the rest of the app.
+
+import { ipcMain } from 'electron';
+import type {
+  CompendiumItemPayload,
+  CreateCompendiumItemResponse,
+  EnsureCompendiumPackBody,
+  EnsureCompendiumPackResponse,
+} from '@foundry-toolkit/shared/rpc';
+import type { CompendiumDocument } from '../compendium/types.js';
+import { getCompendiumApi, isPreparedCompendiumInitialized } from '../compendium/singleton.js';
+
+/** Shape returned by `getCompendiumItemTemplate`. Slimmer than the raw
+ *  bridge document — we only need the fields the editor will populate. */
+export interface CompendiumItemTemplate {
+  name: string;
+  type: string;
+  img: string | null;
+  system: Record<string, unknown>;
+  effects: Array<Record<string, unknown>>;
+  flags: Record<string, Record<string, unknown>>;
+}
+
+/** Strip identity / system-bookkeeping fields from a Foundry item
+ *  document so the result can be re-submitted as a brand-new doc.
+ *  The dropped keys mirror what `compendiumItem.toObject()` would
+ *  reset on a `delete itemData['_id']` clone — but we do it on the
+ *  client because the bridge already returns the full object. */
+export function stripIdentityForClone(doc: CompendiumDocument): CompendiumItemTemplate {
+  const system = typeof doc.system === 'object' && doc.system !== null ? (doc.system as Record<string, unknown>) : {};
+
+  // Foundry documents may carry `effects` directly OR via `toObject` shape.
+  const rawEffects = (doc as unknown as { effects?: unknown }).effects;
+  const effects: Array<Record<string, unknown>> = Array.isArray(rawEffects)
+    ? rawEffects
+        .filter((e): e is Record<string, unknown> => typeof e === 'object' && e !== null)
+        .map((e) => {
+          const copy = { ...e };
+          delete copy['_id'];
+          delete copy['_stats'];
+          // Embedded ActiveEffect docs sometimes carry their own origin
+          // pointing at the source item — drop it so the cloned effect
+          // reattaches to the new item rather than referencing the
+          // template's uuid.
+          delete copy['origin'];
+          return copy;
+        })
+    : [];
+
+  const rawFlags = (doc as unknown as { flags?: unknown }).flags;
+  const flags: Record<string, Record<string, unknown>> = typeof rawFlags === 'object' && rawFlags !== null
+    ? Object.fromEntries(
+        Object.entries(rawFlags as Record<string, unknown>).filter(
+          (entry): entry is [string, Record<string, unknown>] => typeof entry[1] === 'object' && entry[1] !== null,
+        ),
+      )
+    : {};
+
+  return {
+    name: doc.name,
+    type: doc.type,
+    img: doc.img !== '' ? doc.img : null,
+    system,
+    effects,
+    flags,
+  };
+}
+
+export function registerHomebrewItemHandlers(): void {
+  ipcMain.handle('getCompendiumItemTemplate', async (_e, uuid: string): Promise<CompendiumItemTemplate> => {
+    if (!isPreparedCompendiumInitialized()) {
+      throw new Error('Compendium API not available — set a foundry-mcp URL in Settings → Paths and restart the app.');
+    }
+    if (typeof uuid !== 'string' || uuid.length === 0) {
+      throw new Error('getCompendiumItemTemplate: uuid must be a non-empty string');
+    }
+    const { document } = await getCompendiumApi().getCompendiumDocument(uuid);
+    return stripIdentityForClone(document);
+  });
+
+  ipcMain.handle(
+    'ensureHomebrewItemPack',
+    (_e, body: EnsureCompendiumPackBody): Promise<EnsureCompendiumPackResponse> => {
+      if (!isPreparedCompendiumInitialized()) {
+        throw new Error(
+          'Compendium API not available — set a foundry-mcp URL in Settings → Paths and restart the app.',
+        );
+      }
+      return getCompendiumApi().ensureCompendiumPack(body);
+    },
+  );
+
+  ipcMain.handle(
+    'createHomebrewItem',
+    (_e, payload: { packId: string; item: CompendiumItemPayload }): Promise<CreateCompendiumItemResponse> => {
+      if (!isPreparedCompendiumInitialized()) {
+        throw new Error(
+          'Compendium API not available — set a foundry-mcp URL in Settings → Paths and restart the app.',
+        );
+      }
+      return getCompendiumApi().createCompendiumItem(payload);
+    },
+  );
+}

--- a/apps/dm-tool/electron/ipc/homebrew-items.ts
+++ b/apps/dm-tool/electron/ipc/homebrew-items.ts
@@ -12,6 +12,11 @@
 //
 // All three handlers proxy through the existing CompendiumApi singleton,
 // so they share the configured foundry-mcp URL with the rest of the app.
+//
+// `stripIdentityForClone` + the `CompendiumItemTemplate` type live in a
+// sibling helper file so unit tests + the renderer can import them
+// without dragging in `electron` (vitest can't load the native binary
+// in headless CI).
 
 import { ipcMain } from 'electron';
 import type {
@@ -20,64 +25,10 @@ import type {
   EnsureCompendiumPackBody,
   EnsureCompendiumPackResponse,
 } from '@foundry-toolkit/shared/rpc';
-import type { CompendiumDocument } from '../compendium/types.js';
 import { getCompendiumApi, isPreparedCompendiumInitialized } from '../compendium/singleton.js';
+import { stripIdentityForClone, type CompendiumItemTemplate } from './homebrew-items-clone.js';
 
-/** Shape returned by `getCompendiumItemTemplate`. Slimmer than the raw
- *  bridge document — we only need the fields the editor will populate. */
-export interface CompendiumItemTemplate {
-  name: string;
-  type: string;
-  img: string | null;
-  system: Record<string, unknown>;
-  effects: Array<Record<string, unknown>>;
-  flags: Record<string, Record<string, unknown>>;
-}
-
-/** Strip identity / system-bookkeeping fields from a Foundry item
- *  document so the result can be re-submitted as a brand-new doc.
- *  The dropped keys mirror what `compendiumItem.toObject()` would
- *  reset on a `delete itemData['_id']` clone — but we do it on the
- *  client because the bridge already returns the full object. */
-export function stripIdentityForClone(doc: CompendiumDocument): CompendiumItemTemplate {
-  const system = typeof doc.system === 'object' && doc.system !== null ? (doc.system as Record<string, unknown>) : {};
-
-  // Foundry documents may carry `effects` directly OR via `toObject` shape.
-  const rawEffects = (doc as unknown as { effects?: unknown }).effects;
-  const effects: Array<Record<string, unknown>> = Array.isArray(rawEffects)
-    ? rawEffects
-        .filter((e): e is Record<string, unknown> => typeof e === 'object' && e !== null)
-        .map((e) => {
-          const copy = { ...e };
-          delete copy['_id'];
-          delete copy['_stats'];
-          // Embedded ActiveEffect docs sometimes carry their own origin
-          // pointing at the source item — drop it so the cloned effect
-          // reattaches to the new item rather than referencing the
-          // template's uuid.
-          delete copy['origin'];
-          return copy;
-        })
-    : [];
-
-  const rawFlags = (doc as unknown as { flags?: unknown }).flags;
-  const flags: Record<string, Record<string, unknown>> = typeof rawFlags === 'object' && rawFlags !== null
-    ? Object.fromEntries(
-        Object.entries(rawFlags as Record<string, unknown>).filter(
-          (entry): entry is [string, Record<string, unknown>] => typeof entry[1] === 'object' && entry[1] !== null,
-        ),
-      )
-    : {};
-
-  return {
-    name: doc.name,
-    type: doc.type,
-    img: doc.img !== '' ? doc.img : null,
-    system,
-    effects,
-    flags,
-  };
-}
+export type { CompendiumItemTemplate } from './homebrew-items-clone.js';
 
 export function registerHomebrewItemHandlers(): void {
   ipcMain.handle('getCompendiumItemTemplate', async (_e, uuid: string): Promise<CompendiumItemTemplate> => {

--- a/apps/dm-tool/electron/ipc/index.ts
+++ b/apps/dm-tool/electron/ipc/index.ts
@@ -14,6 +14,7 @@ import { registerChatHandlers } from './chat.js';
 import { registerMonsterHandlers } from './monsters.js';
 import { registerItemHandlers } from './items.js';
 import { registerCompendiumHandlers } from './compendium.js';
+import { registerHomebrewItemHandlers } from './homebrew-items.js';
 import { registerTaggerHandlers } from './tagger.js';
 import { registerAutoWallHandlers } from './auto-wall.js';
 import { registerFoundryHandlers } from './foundry.js';
@@ -36,6 +37,7 @@ export function registerIpcHandlers(
   registerMonsterHandlers(cfg.foundryMcpUrl);
   registerItemHandlers(cfg.foundryMcpUrl);
   registerCompendiumHandlers();
+  registerHomebrewItemHandlers();
   registerTaggerHandlers(cfg, getMainWindow);
   registerAutoWallHandlers(cfg);
   registerFoundryHandlers(db, cfg);

--- a/apps/dm-tool/electron/ipc/types.ts
+++ b/apps/dm-tool/electron/ipc/types.ts
@@ -8,7 +8,7 @@ import type {
   EnsureCompendiumPackBody,
   EnsureCompendiumPackResponse,
 } from '@foundry-toolkit/shared/rpc';
-import type { CompendiumItemTemplate } from './homebrew-items.js';
+import type { CompendiumItemTemplate } from './homebrew-items-clone.js';
 import type {
   ActorSpellcasting,
   ActorUpdate,

--- a/apps/dm-tool/electron/ipc/types.ts
+++ b/apps/dm-tool/electron/ipc/types.ts
@@ -216,11 +216,14 @@ export interface ElectronAPI {
   // -----------------------------------------------------------------------
 
   /** Fetch the full Foundry document for an item the user wants to use as
-   *  a template for a new homebrew item. Identity fields (`_id`,
-   *  `_stats`, embedded `_id`s, effect `origin`) are stripped server-side
-   *  before the renderer receives the result so a re-submit produces a
-   *  fresh document. Throws when foundry-mcp isn't configured. */
-  getCompendiumItemTemplate(uuid: string): Promise<CompendiumItemTemplate>;
+   *  a template for a new homebrew item. Accepts either a full Foundry
+   *  uuid (`Compendium.<pack>.<docType>.<id>`) or a bare document id
+   *  from `pf2e.equipment-srd` (the form `ItemBrowserRow.id` carries).
+   *  Identity fields (`_id`, `_stats`, embedded `_id`s, effect `origin`)
+   *  are stripped server-side before the renderer receives the result so
+   *  a re-submit produces a fresh document. Throws when foundry-mcp
+   *  isn't configured. */
+  getCompendiumItemTemplate(idOrUuid: string): Promise<CompendiumItemTemplate>;
   /** Idempotently create the configured homebrew compendium pack
    *  (`world.<name>`) and return its full id. Subsequent calls reuse
    *  the existing pack. */

--- a/apps/dm-tool/electron/ipc/types.ts
+++ b/apps/dm-tool/electron/ipc/types.ts
@@ -3,6 +3,13 @@
  *  and a corresponding type declaration on `window.electronAPI` in the
  *  renderer's global types (src/vite-env.d.ts). */
 import type {
+  CompendiumItemPayload,
+  CreateCompendiumItemResponse,
+  EnsureCompendiumPackBody,
+  EnsureCompendiumPackResponse,
+} from '@foundry-toolkit/shared/rpc';
+import type { CompendiumItemTemplate } from './homebrew-items.js';
+import type {
   ActorSpellcasting,
   ActorUpdate,
   AonPreviewData,
@@ -203,6 +210,24 @@ export interface ElectronAPI {
   /** Distinct filter values (traits, sources, usage categories) for the
    *  item filter panel. Returns empty facets if the DB is not configured. */
   getItemFacets(): Promise<ItemFacets>;
+
+  // -----------------------------------------------------------------------
+  // Homebrew item creator (extends the Item Browser with create/clone)
+  // -----------------------------------------------------------------------
+
+  /** Fetch the full Foundry document for an item the user wants to use as
+   *  a template for a new homebrew item. Identity fields (`_id`,
+   *  `_stats`, embedded `_id`s, effect `origin`) are stripped server-side
+   *  before the renderer receives the result so a re-submit produces a
+   *  fresh document. Throws when foundry-mcp isn't configured. */
+  getCompendiumItemTemplate(uuid: string): Promise<CompendiumItemTemplate>;
+  /** Idempotently create the configured homebrew compendium pack
+   *  (`world.<name>`) and return its full id. Subsequent calls reuse
+   *  the existing pack. */
+  ensureHomebrewItemPack(body: EnsureCompendiumPackBody): Promise<EnsureCompendiumPackResponse>;
+  /** Create a single Item document inside a homebrew pack. The pack must
+   *  already exist (call `ensureHomebrewItemPack` first). */
+  createHomebrewItem(payload: { packId: string; item: CompendiumItemPayload }): Promise<CreateCompendiumItemResponse>;
 
   // -----------------------------------------------------------------------
   // Auto-Wall (wall detection for VTT import)

--- a/apps/dm-tool/electron/preload.ts
+++ b/apps/dm-tool/electron/preload.ts
@@ -7,6 +7,13 @@
 // src/vite-env.d.ts which declares `window.electronAPI` for TypeScript.
 
 import { contextBridge, ipcRenderer } from 'electron';
+import type {
+  CompendiumItemPayload,
+  CreateCompendiumItemResponse,
+  EnsureCompendiumPackBody,
+  EnsureCompendiumPackResponse,
+} from '@foundry-toolkit/shared/rpc';
+import type { CompendiumItemTemplate } from './ipc/homebrew-items.js';
 import type { ElectronAPI } from './ipc/types.js';
 import type {
   ActorSpellcasting,
@@ -135,6 +142,16 @@ const api: ElectronAPI = {
   getItemBrowserDetail: (id: string): Promise<ItemBrowserDetail | null> =>
     ipcRenderer.invoke('getItemBrowserDetail', id),
   getItemFacets: (): Promise<ItemFacets> => ipcRenderer.invoke('getItemFacets'),
+
+  // Homebrew item creator
+  getCompendiumItemTemplate: (uuid: string): Promise<CompendiumItemTemplate> =>
+    ipcRenderer.invoke('getCompendiumItemTemplate', uuid),
+  ensureHomebrewItemPack: (body: EnsureCompendiumPackBody): Promise<EnsureCompendiumPackResponse> =>
+    ipcRenderer.invoke('ensureHomebrewItemPack', body),
+  createHomebrewItem: (payload: {
+    packId: string;
+    item: CompendiumItemPayload;
+  }): Promise<CreateCompendiumItemResponse> => ipcRenderer.invoke('createHomebrewItem', payload),
 
   // Monster browser
   monstersSearch: (params: MonsterSearchParams): Promise<MonsterSummary[]> =>

--- a/apps/dm-tool/electron/preload.ts
+++ b/apps/dm-tool/electron/preload.ts
@@ -144,8 +144,8 @@ const api: ElectronAPI = {
   getItemFacets: (): Promise<ItemFacets> => ipcRenderer.invoke('getItemFacets'),
 
   // Homebrew item creator
-  getCompendiumItemTemplate: (uuid: string): Promise<CompendiumItemTemplate> =>
-    ipcRenderer.invoke('getCompendiumItemTemplate', uuid),
+  getCompendiumItemTemplate: (idOrUuid: string): Promise<CompendiumItemTemplate> =>
+    ipcRenderer.invoke('getCompendiumItemTemplate', idOrUuid),
   ensureHomebrewItemPack: (body: EnsureCompendiumPackBody): Promise<EnsureCompendiumPackResponse> =>
     ipcRenderer.invoke('ensureHomebrewItemPack', body),
   createHomebrewItem: (payload: {

--- a/apps/dm-tool/electron/preload.ts
+++ b/apps/dm-tool/electron/preload.ts
@@ -13,7 +13,7 @@ import type {
   EnsureCompendiumPackBody,
   EnsureCompendiumPackResponse,
 } from '@foundry-toolkit/shared/rpc';
-import type { CompendiumItemTemplate } from './ipc/homebrew-items.js';
+import type { CompendiumItemTemplate } from './ipc/homebrew-items-clone.js';
 import type { ElectronAPI } from './ipc/types.js';
 import type {
   ActorSpellcasting,

--- a/apps/dm-tool/src/features/item-browser/HomebrewItemEditorModal.tsx
+++ b/apps/dm-tool/src/features/item-browser/HomebrewItemEditorModal.tsx
@@ -57,13 +57,16 @@ interface SaveResult {
 interface HomebrewItemEditorModalProps {
   open: boolean;
   /** When set, the modal opens seeded from this template (clone path).
-   *  When null/undefined, the modal opens empty (greenfield create). */
-  templateUuid?: string | null;
+   *  Accepts either a full Foundry uuid or a bare document id from
+   *  `pf2e.equipment-srd` (the form `ItemBrowserRow.id` carries — the
+   *  IPC layer resolves it). When null/undefined, the modal opens
+   *  empty (greenfield create). */
+  templateRef?: string | null;
   onClose: () => void;
   onSaved?: (result: SaveResult) => void;
 }
 
-export function HomebrewItemEditorModal({ open, templateUuid, onClose, onSaved }: HomebrewItemEditorModalProps) {
+export function HomebrewItemEditorModal({ open, templateRef, onClose, onSaved }: HomebrewItemEditorModalProps) {
   const [draft, setDraft] = useState<ItemDraft>(() => emptyDraft());
   const [tab, setTab] = useState<Tab>('basic');
   const [loading, setLoading] = useState(false);
@@ -79,7 +82,7 @@ export function HomebrewItemEditorModal({ open, templateUuid, onClose, onSaved }
     setTab('basic');
     setAdvancedDirty(false);
 
-    if (!templateUuid) {
+    if (!templateRef) {
       const fresh = emptyDraft();
       setDraft(fresh);
       setAdvancedJson(JSON.stringify(fresh.systemRaw, null, 2));
@@ -89,7 +92,7 @@ export function HomebrewItemEditorModal({ open, templateUuid, onClose, onSaved }
     let cancelled = false;
     setLoading(true);
     api
-      .getCompendiumItemTemplate(templateUuid)
+      .getCompendiumItemTemplate(templateRef)
       .then((template: CompendiumItemTemplate) => {
         if (cancelled) return;
         const seeded = templateToDraft(template);
@@ -105,7 +108,7 @@ export function HomebrewItemEditorModal({ open, templateUuid, onClose, onSaved }
     return () => {
       cancelled = true;
     };
-  }, [open, templateUuid]);
+  }, [open, templateRef]);
 
   const update = useCallback(<K extends keyof ItemDraft>(key: K, value: ItemDraft[K]) => {
     setDraft((d) => ({ ...d, [key]: value }));
@@ -166,7 +169,7 @@ export function HomebrewItemEditorModal({ open, templateUuid, onClose, onSaved }
     >
       <DialogContent className="grid max-h-[90vh] w-full max-w-3xl grid-rows-[auto_auto_1fr_auto] gap-4">
         <DialogHeader>
-          <DialogTitle>{templateUuid ? 'Edit homebrew item (from template)' : 'New homebrew item'}</DialogTitle>
+          <DialogTitle>{templateRef ? 'Edit homebrew item (from template)' : 'New homebrew item'}</DialogTitle>
           <DialogDescription>
             Lands in <span className="font-mono">world.homebrew-items</span>. The pack is created on first save.
           </DialogDescription>

--- a/apps/dm-tool/src/features/item-browser/HomebrewItemEditorModal.tsx
+++ b/apps/dm-tool/src/features/item-browser/HomebrewItemEditorModal.tsx
@@ -1,0 +1,832 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Plus, Trash2 } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Separator } from '@/components/ui/separator';
+import { api } from '@/lib/api';
+import { cn } from '@/lib/utils';
+import {
+  ACTIVE_EFFECT_MODES,
+  ARMOR_CATEGORIES,
+  DAMAGE_DICE,
+  DAMAGE_TYPES,
+  DraftValidationError,
+  FREQUENCY_PER,
+  RARITIES,
+  SUPPORTED_TYPES,
+  WEAPON_CATEGORIES,
+  draftToPayload,
+  emptyDraft,
+  templateToDraft,
+  type ActiveEffectChangeDraft,
+  type ActiveEffectDraft,
+  type ItemDraft,
+  type ItemType,
+} from './homebrew-editor-helpers';
+import type { CompendiumItemTemplate } from '../../../electron/ipc/homebrew-items';
+
+const HOMEBREW_PACK_NAME = 'homebrew-items';
+const HOMEBREW_PACK_LABEL = 'Homebrew Items';
+
+type Tab = 'basic' | 'mechanical' | 'effects' | 'advanced';
+
+const TABS: ReadonlyArray<{ key: Tab; label: string }> = [
+  { key: 'basic', label: 'Basic' },
+  { key: 'mechanical', label: 'Mechanical' },
+  { key: 'effects', label: 'Effects' },
+  { key: 'advanced', label: 'Advanced' },
+];
+
+interface SaveResult {
+  uuid: string;
+  name: string;
+  packId: string;
+  created: boolean;
+}
+
+interface HomebrewItemEditorModalProps {
+  open: boolean;
+  /** When set, the modal opens seeded from this template (clone path).
+   *  When null/undefined, the modal opens empty (greenfield create). */
+  templateUuid?: string | null;
+  onClose: () => void;
+  onSaved?: (result: SaveResult) => void;
+}
+
+export function HomebrewItemEditorModal({ open, templateUuid, onClose, onSaved }: HomebrewItemEditorModalProps) {
+  const [draft, setDraft] = useState<ItemDraft>(() => emptyDraft());
+  const [tab, setTab] = useState<Tab>('basic');
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [advancedJson, setAdvancedJson] = useState('');
+  const [advancedDirty, setAdvancedDirty] = useState(false);
+
+  // Reset / load template every time the modal opens.
+  useEffect(() => {
+    if (!open) return;
+    setError(null);
+    setTab('basic');
+    setAdvancedDirty(false);
+
+    if (!templateUuid) {
+      const fresh = emptyDraft();
+      setDraft(fresh);
+      setAdvancedJson(JSON.stringify(fresh.systemRaw, null, 2));
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    api
+      .getCompendiumItemTemplate(templateUuid)
+      .then((template: CompendiumItemTemplate) => {
+        if (cancelled) return;
+        const seeded = templateToDraft(template);
+        setDraft(seeded);
+        setAdvancedJson(JSON.stringify(seeded.systemRaw, null, 2));
+      })
+      .catch((e: Error) => {
+        if (!cancelled) setError(`Failed to load template: ${e.message}`);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, templateUuid]);
+
+  const update = useCallback(<K extends keyof ItemDraft>(key: K, value: ItemDraft[K]) => {
+    setDraft((d) => ({ ...d, [key]: value }));
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    setError(null);
+
+    // Apply advanced-tab JSON edits before payload conversion. The
+    // advanced tab edits `systemRaw`, which `draftToPayload` overlays
+    // editor fields on top of, so users see the merged result.
+    let workingDraft = draft;
+    if (advancedDirty) {
+      try {
+        const parsed: unknown = JSON.parse(advancedJson);
+        if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+          throw new Error('Advanced JSON must be an object');
+        }
+        workingDraft = { ...draft, systemRaw: parsed as Record<string, unknown> };
+      } catch (e) {
+        setError(`Advanced JSON invalid: ${(e as Error).message}`);
+        return;
+      }
+    }
+
+    let payload;
+    try {
+      payload = draftToPayload(workingDraft);
+    } catch (e) {
+      setError(e instanceof DraftValidationError ? e.message : `Validation failed: ${(e as Error).message}`);
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const pack = await api.ensureHomebrewItemPack({
+        name: HOMEBREW_PACK_NAME,
+        label: HOMEBREW_PACK_LABEL,
+      });
+      const created = await api.createHomebrewItem({ packId: pack.id, item: payload });
+      onSaved?.({ uuid: created.uuid, name: created.name, packId: created.packId, created: pack.created });
+      onClose();
+    } catch (e) {
+      setError(`Save failed: ${(e as Error).message}`);
+    } finally {
+      setSaving(false);
+    }
+  }, [draft, advancedDirty, advancedJson, onSaved, onClose]);
+
+  const traitsString = useMemo(() => draft.traits.join(', '), [draft.traits]);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) onClose();
+      }}
+    >
+      <DialogContent className="grid max-h-[90vh] w-full max-w-3xl grid-rows-[auto_auto_1fr_auto] gap-4">
+        <DialogHeader>
+          <DialogTitle>{templateUuid ? 'Edit homebrew item (from template)' : 'New homebrew item'}</DialogTitle>
+          <DialogDescription>
+            Lands in <span className="font-mono">world.homebrew-items</span>. The pack is created on first save.
+          </DialogDescription>
+        </DialogHeader>
+
+        <TabBar current={tab} onChange={setTab} />
+
+        <ScrollArea className="min-h-0 pr-3">
+          {loading ? (
+            <div className="text-sm text-muted-foreground">Loading template…</div>
+          ) : (
+            <div className="space-y-4">
+              {tab === 'basic' && <BasicTab draft={draft} update={update} traitsString={traitsString} />}
+              {tab === 'mechanical' && <MechanicalTab draft={draft} update={update} />}
+              {tab === 'effects' && <EffectsTab draft={draft} update={update} />}
+              {tab === 'advanced' && (
+                <AdvancedTab
+                  json={advancedJson}
+                  onChange={(v) => {
+                    setAdvancedJson(v);
+                    setAdvancedDirty(true);
+                  }}
+                />
+              )}
+            </div>
+          )}
+        </ScrollArea>
+
+        {error && (
+          <div className="rounded-md border border-destructive/50 bg-destructive/10 p-2 text-xs text-destructive">
+            {error}
+          </div>
+        )}
+        <DialogFooter className="flex flex-row items-center justify-end gap-2">
+          <Button variant="outline" onClick={onClose} disabled={saving}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={saving || loading}>
+            {saving ? 'Saving…' : 'Save to Foundry'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tab bar
+// ---------------------------------------------------------------------------
+
+function TabBar({ current, onChange }: { current: Tab; onChange: (t: Tab) => void }) {
+  return (
+    <div className="flex gap-1 border-b border-border">
+      {TABS.map((t) => (
+        <button
+          key={t.key}
+          type="button"
+          onClick={() => onChange(t.key)}
+          className={cn(
+            'px-3 py-1.5 text-sm transition-colors',
+            current === t.key
+              ? 'border-b-2 border-primary text-foreground'
+              : 'text-muted-foreground hover:text-foreground',
+          )}
+        >
+          {t.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Basic tab
+// ---------------------------------------------------------------------------
+
+interface DraftUpdater {
+  <K extends keyof ItemDraft>(key: K, value: ItemDraft[K]): void;
+}
+
+function BasicTab({ draft, update, traitsString }: { draft: ItemDraft; update: DraftUpdater; traitsString: string }) {
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+      <Field label="Name *" className="sm:col-span-2">
+        <Input value={draft.name} onChange={(e) => update('name', e.target.value)} placeholder="e.g. Sword of Test" />
+      </Field>
+
+      <Field label="Type">
+        <select
+          className={selectClasses}
+          value={draft.type}
+          onChange={(e) => update('type', e.target.value as ItemType)}
+        >
+          {SUPPORTED_TYPES.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+      </Field>
+
+      <Field label="Rarity">
+        <select
+          className={selectClasses}
+          value={draft.rarity}
+          onChange={(e) => update('rarity', e.target.value as ItemDraft['rarity'])}
+        >
+          {RARITIES.map((r) => (
+            <option key={r} value={r}>
+              {r}
+            </option>
+          ))}
+        </select>
+      </Field>
+
+      <Field label="Level">
+        <Input type="number" value={draft.level} onChange={(e) => update('level', Number(e.target.value) || 0)} />
+      </Field>
+
+      <Field label="Bulk">
+        <Input value={draft.bulk} onChange={(e) => update('bulk', e.target.value)} placeholder="-, L, 1, 2…" />
+      </Field>
+
+      <Field label="Traits (comma-separated)" className="sm:col-span-2">
+        <Input
+          value={traitsString}
+          onChange={(e) =>
+            update(
+              'traits',
+              e.target.value
+                .split(',')
+                .map((t) => t.trim())
+                .filter((t) => t.length > 0),
+            )
+          }
+          placeholder="magical, evocation, invested…"
+        />
+      </Field>
+
+      <Field label="Price" className="sm:col-span-2">
+        <div className="grid grid-cols-4 gap-2">
+          {(['pp', 'gp', 'sp', 'cp'] as const).map((coin) => (
+            <div key={coin}>
+              <Input
+                type="number"
+                value={draft.price[coin]}
+                onChange={(e) => update('price', { ...draft.price, [coin]: Number(e.target.value) || 0 })}
+              />
+              <div className="mt-0.5 text-center text-[10px] uppercase tracking-wider text-muted-foreground">
+                {coin}
+              </div>
+            </div>
+          ))}
+        </div>
+      </Field>
+
+      <Field label="Source">
+        <Input
+          value={draft.source}
+          onChange={(e) => update('source', e.target.value)}
+          placeholder="Pathfinder Player Core"
+        />
+      </Field>
+
+      <Field label="Image URL">
+        <Input value={draft.img} onChange={(e) => update('img', e.target.value)} placeholder="systems/pf2e/icons/…" />
+      </Field>
+
+      <Field label="Description" className="sm:col-span-2">
+        <textarea
+          className={textareaClasses}
+          rows={6}
+          value={draft.description}
+          onChange={(e) => update('description', e.target.value)}
+          placeholder="HTML allowed."
+        />
+      </Field>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Mechanical tab
+// ---------------------------------------------------------------------------
+
+function MechanicalTab({ draft, update }: { draft: ItemDraft; update: DraftUpdater }) {
+  return (
+    <div className="space-y-4">
+      <PerTypeSection draft={draft} update={update} />
+      <Separator />
+      <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Charges / uses</h3>
+      <div className="grid grid-cols-2 gap-3">
+        <Field label="Uses (current)">
+          <Input
+            type="number"
+            value={draft.uses.value}
+            onChange={(e) => update('uses', { ...draft.uses, value: Number(e.target.value) || 0 })}
+          />
+        </Field>
+        <Field label="Uses (max)">
+          <Input
+            type="number"
+            value={draft.uses.max}
+            onChange={(e) => update('uses', { ...draft.uses, max: Number(e.target.value) || 0 })}
+          />
+        </Field>
+      </div>
+      <Separator />
+      <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Frequency</h3>
+      <div className="grid grid-cols-2 gap-3">
+        <Field label="Max per period">
+          <Input
+            type="number"
+            value={draft.frequency.max}
+            onChange={(e) => update('frequency', { ...draft.frequency, max: Number(e.target.value) || 0 })}
+          />
+        </Field>
+        <Field label="Period">
+          <select
+            className={selectClasses}
+            value={draft.frequency.per}
+            onChange={(e) =>
+              update('frequency', { ...draft.frequency, per: e.target.value as ItemDraft['frequency']['per'] })
+            }
+          >
+            {FREQUENCY_PER.map((p) => (
+              <option key={p} value={p}>
+                {p}
+              </option>
+            ))}
+          </select>
+        </Field>
+      </div>
+      <Separator />
+      <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        PF2e RuleElements (system.rules) — JSON array
+      </h3>
+      <textarea
+        className={textareaClasses}
+        rows={6}
+        value={draft.rulesJson}
+        onChange={(e) => update('rulesJson', e.target.value)}
+        placeholder='[{"key": "FlatModifier", "selector": "ac", "value": 1}]'
+      />
+    </div>
+  );
+}
+
+function PerTypeSection({ draft, update }: { draft: ItemDraft; update: DraftUpdater }) {
+  switch (draft.type) {
+    case 'weapon':
+      return (
+        <div className="space-y-3">
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Weapon</h3>
+          <div className="grid grid-cols-2 gap-3">
+            <Field label="Damage die">
+              <select
+                className={selectClasses}
+                value={draft.weapon.damageDie}
+                onChange={(e) =>
+                  update('weapon', { ...draft.weapon, damageDie: e.target.value as ItemDraft['weapon']['damageDie'] })
+                }
+              >
+                {DAMAGE_DICE.map((d) => (
+                  <option key={d} value={d}>
+                    {d}
+                  </option>
+                ))}
+              </select>
+            </Field>
+            <Field label="# of dice">
+              <Input
+                type="number"
+                value={draft.weapon.damageDice}
+                onChange={(e) => update('weapon', { ...draft.weapon, damageDice: Number(e.target.value) || 1 })}
+              />
+            </Field>
+            <Field label="Damage type">
+              <select
+                className={selectClasses}
+                value={draft.weapon.damageType}
+                onChange={(e) => update('weapon', { ...draft.weapon, damageType: e.target.value })}
+              >
+                {DAMAGE_TYPES.map((d) => (
+                  <option key={d} value={d}>
+                    {d}
+                  </option>
+                ))}
+              </select>
+            </Field>
+            <Field label="Category">
+              <select
+                className={selectClasses}
+                value={draft.weapon.category}
+                onChange={(e) =>
+                  update('weapon', { ...draft.weapon, category: e.target.value as ItemDraft['weapon']['category'] })
+                }
+              >
+                {WEAPON_CATEGORIES.map((c) => (
+                  <option key={c} value={c}>
+                    {c}
+                  </option>
+                ))}
+              </select>
+            </Field>
+            <Field label="Group" className="col-span-2">
+              <Input
+                value={draft.weapon.group}
+                onChange={(e) => update('weapon', { ...draft.weapon, group: e.target.value })}
+                placeholder="sword, axe, bow…"
+              />
+            </Field>
+          </div>
+        </div>
+      );
+    case 'armor':
+      return (
+        <div className="space-y-3">
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Armor</h3>
+          <div className="grid grid-cols-2 gap-3">
+            <Field label="Category">
+              <select
+                className={selectClasses}
+                value={draft.armor.category}
+                onChange={(e) =>
+                  update('armor', { ...draft.armor, category: e.target.value as ItemDraft['armor']['category'] })
+                }
+              >
+                {ARMOR_CATEGORIES.map((c) => (
+                  <option key={c} value={c}>
+                    {c}
+                  </option>
+                ))}
+              </select>
+            </Field>
+            <Field label="Group">
+              <Input
+                value={draft.armor.group}
+                onChange={(e) => update('armor', { ...draft.armor, group: e.target.value })}
+              />
+            </Field>
+            <Field label="AC bonus">
+              <Input
+                type="number"
+                value={draft.armor.acBonus}
+                onChange={(e) => update('armor', { ...draft.armor, acBonus: Number(e.target.value) || 0 })}
+              />
+            </Field>
+            <Field label="Strength req.">
+              <Input
+                type="number"
+                value={draft.armor.strength}
+                onChange={(e) => update('armor', { ...draft.armor, strength: Number(e.target.value) || 0 })}
+              />
+            </Field>
+            <Field label="Dex cap">
+              <Input
+                type="number"
+                value={draft.armor.dex}
+                onChange={(e) => update('armor', { ...draft.armor, dex: Number(e.target.value) || 0 })}
+              />
+            </Field>
+            <Field label="Check penalty">
+              <Input
+                type="number"
+                value={draft.armor.check}
+                onChange={(e) => update('armor', { ...draft.armor, check: Number(e.target.value) || 0 })}
+              />
+            </Field>
+            <Field label="Speed penalty" className="col-span-2">
+              <Input
+                type="number"
+                value={draft.armor.slowness}
+                onChange={(e) => update('armor', { ...draft.armor, slowness: Number(e.target.value) || 0 })}
+              />
+            </Field>
+          </div>
+        </div>
+      );
+    case 'shield':
+      return (
+        <div className="space-y-3">
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Shield</h3>
+          <div className="grid grid-cols-3 gap-3">
+            <Field label="Hardness">
+              <Input
+                type="number"
+                value={draft.shield.hardness}
+                onChange={(e) => update('shield', { ...draft.shield, hardness: Number(e.target.value) || 0 })}
+              />
+            </Field>
+            <Field label="HP max">
+              <Input
+                type="number"
+                value={draft.shield.hpMax}
+                onChange={(e) => update('shield', { ...draft.shield, hpMax: Number(e.target.value) || 0 })}
+              />
+            </Field>
+            <Field label="AC bonus">
+              <Input
+                type="number"
+                value={draft.shield.acBonus}
+                onChange={(e) => update('shield', { ...draft.shield, acBonus: Number(e.target.value) || 0 })}
+              />
+            </Field>
+          </div>
+        </div>
+      );
+    case 'consumable':
+      return (
+        <div className="space-y-3">
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Consumable</h3>
+          <Field label="Consumable type">
+            <Input
+              value={draft.consumable.consumableType}
+              onChange={(e) => update('consumable', { ...draft.consumable, consumableType: e.target.value })}
+              placeholder="potion / scroll / talisman / …"
+            />
+          </Field>
+        </div>
+      );
+    case 'equipment':
+      return (
+        <div className="space-y-3">
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Equipment</h3>
+          <Field label="Usage">
+            <Input
+              value={draft.equipment.usage}
+              onChange={(e) => update('equipment', { ...draft.equipment, usage: e.target.value })}
+              placeholder="held-in-one-hand / worn-armor / …"
+            />
+          </Field>
+        </div>
+      );
+    case 'treasure':
+      return (
+        <div className="space-y-3">
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Treasure</h3>
+          <Field label="Stack group">
+            <Input
+              value={draft.treasure.stackGroup}
+              onChange={(e) => update('treasure', { ...draft.treasure, stackGroup: e.target.value })}
+              placeholder="coins / gems / …"
+            />
+          </Field>
+        </div>
+      );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Effects tab
+// ---------------------------------------------------------------------------
+
+function EffectsTab({ draft, update }: { draft: ItemDraft; update: DraftUpdater }) {
+  const setEffects = (next: ActiveEffectDraft[]) => update('effects', next);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-muted-foreground">
+          Foundry ActiveEffects — `transfer: true` copies the effect onto an actor when the item is granted.
+        </p>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={() =>
+            setEffects([
+              ...draft.effects,
+              {
+                name: 'New effect',
+                disabled: false,
+                transfer: false,
+                changes: [],
+                durationRounds: 0,
+              },
+            ])
+          }
+        >
+          <Plus className="mr-1 h-3.5 w-3.5" />
+          Add effect
+        </Button>
+      </div>
+      {draft.effects.length === 0 && (
+        <div className="rounded border border-dashed border-border p-4 text-center text-xs text-muted-foreground">
+          No effects defined.
+        </div>
+      )}
+      {draft.effects.map((effect, idx) => (
+        <EffectCard
+          key={idx}
+          effect={effect}
+          onChange={(next) => {
+            const copy = [...draft.effects];
+            copy[idx] = next;
+            setEffects(copy);
+          }}
+          onRemove={() => setEffects(draft.effects.filter((_, i) => i !== idx))}
+        />
+      ))}
+    </div>
+  );
+}
+
+function EffectCard({
+  effect,
+  onChange,
+  onRemove,
+}: {
+  effect: ActiveEffectDraft;
+  onChange: (next: ActiveEffectDraft) => void;
+  onRemove: () => void;
+}) {
+  const setChanges = (next: ActiveEffectChangeDraft[]) => onChange({ ...effect, changes: next });
+
+  return (
+    <div className="space-y-3 rounded-md border border-border p-3">
+      <div className="grid grid-cols-2 gap-3">
+        <Field label="Name">
+          <Input value={effect.name} onChange={(e) => onChange({ ...effect, name: e.target.value })} />
+        </Field>
+        <Field label="Duration (rounds)">
+          <Input
+            type="number"
+            value={effect.durationRounds}
+            onChange={(e) => onChange({ ...effect, durationRounds: Number(e.target.value) || 0 })}
+          />
+        </Field>
+        <label className="flex items-center gap-2 text-xs">
+          <input
+            type="checkbox"
+            checked={effect.disabled}
+            onChange={(e) => onChange({ ...effect, disabled: e.target.checked })}
+          />
+          Disabled
+        </label>
+        <label className="flex items-center gap-2 text-xs">
+          <input
+            type="checkbox"
+            checked={effect.transfer}
+            onChange={(e) => onChange({ ...effect, transfer: e.target.checked })}
+          />
+          Transfer to actor on grant
+        </label>
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Changes</span>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setChanges([...effect.changes, { key: '', mode: 2, value: '0', priority: 20 }])}
+          >
+            <Plus className="mr-1 h-3.5 w-3.5" />
+            Add change
+          </Button>
+        </div>
+        {effect.changes.map((c, idx) => (
+          <div key={idx} className="grid grid-cols-[1fr_120px_100px_70px_auto] items-center gap-2">
+            <Input
+              value={c.key}
+              placeholder="system.bonuses.damage.bonus"
+              onChange={(e) => {
+                const next = [...effect.changes];
+                next[idx] = { ...c, key: e.target.value };
+                setChanges(next);
+              }}
+            />
+            <select
+              className={selectClasses}
+              value={c.mode}
+              onChange={(e) => {
+                const next = [...effect.changes];
+                next[idx] = { ...c, mode: Number(e.target.value) };
+                setChanges(next);
+              }}
+            >
+              {ACTIVE_EFFECT_MODES.map((m) => (
+                <option key={m.value} value={m.value}>
+                  {m.label}
+                </option>
+              ))}
+            </select>
+            <Input
+              value={c.value}
+              placeholder="value"
+              onChange={(e) => {
+                const next = [...effect.changes];
+                next[idx] = { ...c, value: e.target.value };
+                setChanges(next);
+              }}
+            />
+            <Input
+              type="number"
+              value={c.priority}
+              placeholder="prio"
+              onChange={(e) => {
+                const next = [...effect.changes];
+                next[idx] = { ...c, priority: Number(e.target.value) || 0 };
+                setChanges(next);
+              }}
+            />
+            <button
+              type="button"
+              className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+              onClick={() => setChanges(effect.changes.filter((_, i) => i !== idx))}
+            >
+              <Trash2 className="h-4 w-4" />
+            </button>
+          </div>
+        ))}
+      </div>
+
+      <div className="flex justify-end">
+        <Button variant="ghost" size="sm" onClick={onRemove}>
+          <Trash2 className="mr-1 h-3.5 w-3.5" />
+          Remove effect
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Advanced tab
+// ---------------------------------------------------------------------------
+
+function AdvancedTab({ json, onChange }: { json: string; onChange: (v: string) => void }) {
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-muted-foreground">
+        Raw <span className="font-mono">system</span> object. Editor-managed fields (level, traits, price, bulk,
+        description, source, per-type fields, frequency, uses, rules) are overlaid on top of this on save — anything
+        else round-trips untouched.
+      </p>
+      <textarea
+        className={cn(textareaClasses, 'h-72 font-mono text-xs')}
+        value={json}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Field shell + shared input classes
+// ---------------------------------------------------------------------------
+
+function Field({ label, children, className }: { label: string; children: React.ReactNode; className?: string }) {
+  return (
+    <div className={cn('flex flex-col gap-1', className)}>
+      <Label className="text-xs text-muted-foreground">{label}</Label>
+      {children}
+    </div>
+  );
+}
+
+const selectClasses =
+  'flex h-9 w-full rounded-md border border-input bg-background px-2 py-1 text-sm shadow-xs transition-[colors,box-shadow] focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring focus-visible:border-primary/50';
+
+const textareaClasses =
+  'flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-xs transition-[colors,box-shadow] placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring focus-visible:border-primary/50';

--- a/apps/dm-tool/src/features/item-browser/HomebrewItemEditorModal.tsx
+++ b/apps/dm-tool/src/features/item-browser/HomebrewItemEditorModal.tsx
@@ -525,22 +525,22 @@ function PerTypeSection({ draft, update }: { draft: ItemDraft; update: DraftUpda
             <Field label="Dex cap">
               <Input
                 type="number"
-                value={draft.armor.dex}
-                onChange={(e) => update('armor', { ...draft.armor, dex: Number(e.target.value) || 0 })}
+                value={draft.armor.dexCap}
+                onChange={(e) => update('armor', { ...draft.armor, dexCap: Number(e.target.value) || 0 })}
               />
             </Field>
             <Field label="Check penalty">
               <Input
                 type="number"
-                value={draft.armor.check}
-                onChange={(e) => update('armor', { ...draft.armor, check: Number(e.target.value) || 0 })}
+                value={draft.armor.checkPenalty}
+                onChange={(e) => update('armor', { ...draft.armor, checkPenalty: Number(e.target.value) || 0 })}
               />
             </Field>
             <Field label="Speed penalty" className="col-span-2">
               <Input
                 type="number"
-                value={draft.armor.slowness}
-                onChange={(e) => update('armor', { ...draft.armor, slowness: Number(e.target.value) || 0 })}
+                value={draft.armor.speedPenalty}
+                onChange={(e) => update('armor', { ...draft.armor, speedPenalty: Number(e.target.value) || 0 })}
               />
             </Field>
           </div>
@@ -605,11 +605,11 @@ function PerTypeSection({ draft, update }: { draft: ItemDraft; update: DraftUpda
       return (
         <div className="space-y-3">
           <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Treasure</h3>
-          <Field label="Stack group">
+          <Field label="Category">
             <Input
-              value={draft.treasure.stackGroup}
-              onChange={(e) => update('treasure', { ...draft.treasure, stackGroup: e.target.value })}
-              placeholder="coins / gems / …"
+              value={draft.treasure.category}
+              onChange={(e) => update('treasure', { ...draft.treasure, category: e.target.value })}
+              placeholder="gem / currency / art-object / …"
             />
           </Field>
         </div>

--- a/apps/dm-tool/src/features/item-browser/HomebrewItemEditorModal.tsx
+++ b/apps/dm-tool/src/features/item-browser/HomebrewItemEditorModal.tsx
@@ -33,7 +33,7 @@ import {
   type ItemDraft,
   type ItemType,
 } from './homebrew-editor-helpers';
-import type { CompendiumItemTemplate } from '../../../electron/ipc/homebrew-items';
+import type { CompendiumItemTemplate } from '../../../electron/ipc/homebrew-items-clone';
 
 const HOMEBREW_PACK_NAME = 'homebrew-items';
 const HOMEBREW_PACK_LABEL = 'Homebrew Items';

--- a/apps/dm-tool/src/features/item-browser/ItemBrowser.tsx
+++ b/apps/dm-tool/src/features/item-browser/ItemBrowser.tsx
@@ -54,9 +54,9 @@ export function ItemBrowser({ keywords = '' }: { keywords?: string }) {
   const [filters, setFilters] = useState<ItemSearchParams>({});
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [closing, setClosing] = useState(false);
-  const [editor, setEditor] = useState<{ open: boolean; templateUuid: string | null }>({
+  const [editor, setEditor] = useState<{ open: boolean; templateRef: string | null }>({
     open: false,
-    templateUuid: null,
+    templateRef: null,
   });
 
   const searchParams = useMemo<ItemSearchParams>(
@@ -113,7 +113,7 @@ export function ItemBrowser({ keywords = '' }: { keywords?: string }) {
       {/* Grid + overlay container */}
       <div className="relative flex min-w-0 flex-1 flex-col overflow-hidden">
         <div className="flex shrink-0 justify-end gap-2 border-b border-border px-3 py-2">
-          <Button size="sm" onClick={() => setEditor({ open: true, templateUuid: null })}>
+          <Button size="sm" onClick={() => setEditor({ open: true, templateRef: null })}>
             <Plus className="mr-1 h-3.5 w-3.5" />
             New homebrew item
           </Button>
@@ -127,7 +127,7 @@ export function ItemBrowser({ keywords = '' }: { keywords?: string }) {
               siblings={selectedSiblings}
               onSelectSibling={setSelectedId}
               onClose={handleClose}
-              onUseAsTemplate={(uuid) => setEditor({ open: true, templateUuid: uuid })}
+              onUseAsTemplate={(idOrUuid) => setEditor({ open: true, templateRef: idOrUuid })}
             />
           </DetailOverlay>
         )}
@@ -135,8 +135,8 @@ export function ItemBrowser({ keywords = '' }: { keywords?: string }) {
 
       <HomebrewItemEditorModal
         open={editor.open}
-        templateUuid={editor.templateUuid}
-        onClose={() => setEditor({ open: false, templateUuid: null })}
+        templateRef={editor.templateRef}
+        onClose={() => setEditor({ open: false, templateRef: null })}
       />
     </div>
   );

--- a/apps/dm-tool/src/features/item-browser/ItemBrowser.tsx
+++ b/apps/dm-tool/src/features/item-browser/ItemBrowser.tsx
@@ -1,10 +1,13 @@
 import { useCallback, useMemo, useState } from 'react';
+import { Plus } from 'lucide-react';
 import { useEscapeToClose } from '@/hooks/useEscapeToClose';
 import { ResizableSidebar } from '@/components/ResizableSidebar';
 import { DetailOverlay } from '@/components/FloatingPanel';
+import { Button } from '@/components/ui/button';
 import { ItemFilterPanel } from './ItemFilterPanel';
 import { ItemCardGrid, type GroupedItem } from './ItemCardGrid';
 import { ItemDetailPane } from './ItemDetailPane';
+import { HomebrewItemEditorModal } from './HomebrewItemEditorModal';
 import { useItemSearch, useItemFacets } from './useItems';
 import type { ItemBrowserRow, ItemSearchParams } from '@foundry-toolkit/shared/types';
 
@@ -51,6 +54,10 @@ export function ItemBrowser({ keywords = '' }: { keywords?: string }) {
   const [filters, setFilters] = useState<ItemSearchParams>({});
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [closing, setClosing] = useState(false);
+  const [editor, setEditor] = useState<{ open: boolean; templateUuid: string | null }>({
+    open: false,
+    templateUuid: null,
+  });
 
   const searchParams = useMemo<ItemSearchParams>(
     () => ({
@@ -105,6 +112,12 @@ export function ItemBrowser({ keywords = '' }: { keywords?: string }) {
 
       {/* Grid + overlay container */}
       <div className="relative flex min-w-0 flex-1 flex-col overflow-hidden">
+        <div className="flex shrink-0 justify-end gap-2 border-b border-border px-3 py-2">
+          <Button size="sm" onClick={() => setEditor({ open: true, templateUuid: null })}>
+            <Plus className="mr-1 h-3.5 w-3.5" />
+            New homebrew item
+          </Button>
+        </div>
         <ItemCardGrid groups={grouped} selectedId={selectedId} onSelect={handleSelect} loading={loading} />
 
         {selectedId && (
@@ -114,10 +127,17 @@ export function ItemBrowser({ keywords = '' }: { keywords?: string }) {
               siblings={selectedSiblings}
               onSelectSibling={setSelectedId}
               onClose={handleClose}
+              onUseAsTemplate={(uuid) => setEditor({ open: true, templateUuid: uuid })}
             />
           </DetailOverlay>
         )}
       </div>
+
+      <HomebrewItemEditorModal
+        open={editor.open}
+        templateUuid={editor.templateUuid}
+        onClose={() => setEditor({ open: false, templateUuid: null })}
+      />
     </div>
   );
 }

--- a/apps/dm-tool/src/features/item-browser/ItemDetailPane.tsx
+++ b/apps/dm-tool/src/features/item-browser/ItemDetailPane.tsx
@@ -1,6 +1,7 @@
-import { ExternalLink, Sparkles, X } from 'lucide-react';
+import { Copy, ExternalLink, Sparkles, X } from 'lucide-react';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Separator } from '@/components/ui/separator';
+import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { api } from '@/lib/api';
 import { useItemDetail } from './useItems';
@@ -12,6 +13,9 @@ interface ItemDetailPaneProps {
   siblings?: ItemBrowserRow[] | null;
   onSelectSibling?: (id: string) => void;
   onClose: () => void;
+  /** Callback to open the homebrew editor seeded from this item's
+   *  data. The id passed in is the Foundry uuid. */
+  onUseAsTemplate?: (uuid: string) => void;
 }
 
 const RARITY_CHIP: Record<string, string> = {
@@ -21,7 +25,7 @@ const RARITY_CHIP: Record<string, string> = {
   UNIQUE: 'bg-purple-900/40 text-purple-300 border-purple-700/40',
 };
 
-export function ItemDetailPane({ itemId, siblings, onSelectSibling, onClose }: ItemDetailPaneProps) {
+export function ItemDetailPane({ itemId, siblings, onSelectSibling, onClose, onUseAsTemplate }: ItemDetailPaneProps) {
   const { data: detail, loading, error } = useItemDetail(itemId);
 
   if (!itemId) return null;
@@ -29,15 +33,28 @@ export function ItemDetailPane({ itemId, siblings, onSelectSibling, onClose }: I
   return (
     <>
       {/* Header */}
-      <div className="flex h-12 shrink-0 items-center justify-between px-3">
+      <div className="flex h-12 shrink-0 items-center justify-between gap-2 px-3">
         <h2 className="min-w-0 truncate text-sm font-semibold text-foreground">{detail?.name ?? 'Loading...'}</h2>
-        <button
-          type="button"
-          onClick={onClose}
-          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-        >
-          <X className="h-4 w-4" />
-        </button>
+        <div className="flex shrink-0 items-center gap-1">
+          {onUseAsTemplate && itemId && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => onUseAsTemplate(itemId)}
+              title="Open the homebrew editor seeded from this item"
+            >
+              <Copy className="mr-1 h-3.5 w-3.5" />
+              Use as template
+            </Button>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
       </div>
       <Separator />
 

--- a/apps/dm-tool/src/features/item-browser/ItemDetailPane.tsx
+++ b/apps/dm-tool/src/features/item-browser/ItemDetailPane.tsx
@@ -14,8 +14,10 @@ interface ItemDetailPaneProps {
   onSelectSibling?: (id: string) => void;
   onClose: () => void;
   /** Callback to open the homebrew editor seeded from this item's
-   *  data. The id passed in is the Foundry uuid. */
-  onUseAsTemplate?: (uuid: string) => void;
+   *  data. Receives whatever the browser stores as `id` — currently a
+   *  bare `pf2e.equipment-srd` document id; the IPC layer resolves it
+   *  to a full uuid before fetching. */
+  onUseAsTemplate?: (idOrUuid: string) => void;
 }
 
 const RARITY_CHIP: Record<string, string> = {

--- a/apps/dm-tool/src/features/item-browser/homebrew-editor-helpers.test.ts
+++ b/apps/dm-tool/src/features/item-browser/homebrew-editor-helpers.test.ts
@@ -191,11 +191,19 @@ describe('draftToPayload', () => {
     });
   });
 
-  it('writes armor mechanical fields on armor type', () => {
+  it('writes armor mechanical fields on armor type using PF2e remaster field names', () => {
     const draft: ItemDraft = {
       ...emptyDraft('armor'),
       name: 'Plate',
-      armor: { category: 'heavy', group: 'plate', acBonus: 6, strength: 18, dex: 0, check: -3, slowness: -10 },
+      armor: {
+        category: 'heavy',
+        group: 'plate',
+        acBonus: 6,
+        strength: 18,
+        dexCap: 0,
+        checkPenalty: -3,
+        speedPenalty: -10,
+      },
     };
     const payload = draftToPayload(draft);
     expect(payload.system).toMatchObject({
@@ -203,10 +211,123 @@ describe('draftToPayload', () => {
       group: 'plate',
       acBonus: 6,
       strength: 18,
-      dex: 0,
-      check: -3,
-      slowness: -10,
+      dexCap: 0,
+      checkPenalty: -3,
+      speedPenalty: -10,
     });
+    // Legacy field names must not be written — Foundry's data model
+    // ignores them and a typo would silently drop the value.
+    expect(payload.system).not.toHaveProperty('dex');
+    expect(payload.system).not.toHaveProperty('check');
+    expect(payload.system).not.toHaveProperty('slowness');
+  });
+
+  it('reads armor fields from a real PF2e document shape', () => {
+    // Shape captured from `pf2e.equipment-srd` Leather Armor via /api/eval.
+    const draft = templateToDraft({
+      name: 'Leather Armor',
+      type: 'armor',
+      img: null,
+      system: {
+        category: 'light',
+        group: 'leather',
+        acBonus: 1,
+        strength: 0,
+        dexCap: 4,
+        checkPenalty: -1,
+        speedPenalty: 0,
+      },
+      effects: [],
+      flags: {},
+    });
+    expect(draft.armor).toEqual({
+      category: 'light',
+      group: 'leather',
+      acBonus: 1,
+      strength: 0,
+      dexCap: 4,
+      checkPenalty: -1,
+      speedPenalty: 0,
+    });
+  });
+
+  it('preserves description sibling fields (gm, addenda, override) through round-trip', () => {
+    const draft = templateToDraft({
+      name: 'X',
+      type: 'equipment',
+      img: null,
+      system: {
+        description: {
+          value: '<p>Original</p>',
+          gm: 'GM-only note',
+          addenda: ['extra'],
+          override: null,
+          initialized: false,
+        },
+      },
+      effects: [],
+      flags: {},
+    });
+    draft.description = '<p>Edited</p>';
+    const payload = draftToPayload({ ...draft, name: 'X' });
+    expect(payload.system['description']).toMatchObject({
+      value: '<p>Edited</p>',
+      gm: 'GM-only note',
+      addenda: ['extra'],
+      override: null,
+      initialized: false,
+    });
+  });
+
+  it('preserves price sibling fields (per, sizeSensitive, credits, upb) through round-trip', () => {
+    const draft = templateToDraft({
+      name: 'X',
+      type: 'equipment',
+      img: null,
+      system: {
+        price: { value: { pp: 0, gp: 5, sp: 0, cp: 0, credits: 0, upb: 0 }, per: 1, sizeSensitive: true },
+      },
+      effects: [],
+      flags: {},
+    });
+    draft.price = { pp: 0, gp: 10, sp: 0, cp: 0 };
+    const payload = draftToPayload({ ...draft, name: 'X' });
+    const price = payload.system['price'] as Record<string, unknown>;
+    expect(price['per']).toBe(1);
+    expect(price['sizeSensitive']).toBe(true);
+    const value = price['value'] as Record<string, unknown>;
+    expect(value['gp']).toBe(10);
+    // Sibling currency fields the editor doesn't surface must survive.
+    expect(value['credits']).toBe(0);
+    expect(value['upb']).toBe(0);
+  });
+
+  it('preserves bulk sibling fields (heldOrStowed, per) through round-trip', () => {
+    const draft = templateToDraft({
+      name: 'X',
+      type: 'weapon',
+      img: null,
+      system: { bulk: { value: 1, heldOrStowed: 1, per: 1 } },
+      effects: [],
+      flags: {},
+    });
+    draft.bulk = '2';
+    const payload = draftToPayload({ ...draft, name: 'X' });
+    expect(payload.system['bulk']).toEqual({ value: 2, heldOrStowed: 1, per: 1 });
+  });
+
+  it('preserves uses.autoDestroy when uses are written', () => {
+    const draft = templateToDraft({
+      name: 'X',
+      type: 'consumable',
+      img: null,
+      system: { uses: { value: 1, max: 1, autoDestroy: true } },
+      effects: [],
+      flags: {},
+    });
+    draft.uses = { value: 0, max: 3 };
+    const payload = draftToPayload({ ...draft, name: 'X' });
+    expect(payload.system['uses']).toEqual({ value: 0, max: 3, autoDestroy: true });
   });
 
   it('omits frequency and uses when max is 0', () => {

--- a/apps/dm-tool/src/features/item-browser/homebrew-editor-helpers.test.ts
+++ b/apps/dm-tool/src/features/item-browser/homebrew-editor-helpers.test.ts
@@ -6,7 +6,7 @@ import {
   templateToDraft,
   type ItemDraft,
 } from './homebrew-editor-helpers';
-import type { CompendiumItemTemplate } from '../../../electron/ipc/homebrew-items';
+import type { CompendiumItemTemplate } from '../../../electron/ipc/homebrew-items-clone';
 
 const fullWeaponTemplate: CompendiumItemTemplate = {
   name: 'Greatsword',

--- a/apps/dm-tool/src/features/item-browser/homebrew-editor-helpers.test.ts
+++ b/apps/dm-tool/src/features/item-browser/homebrew-editor-helpers.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DraftValidationError,
+  draftToPayload,
+  emptyDraft,
+  templateToDraft,
+  type ItemDraft,
+} from './homebrew-editor-helpers';
+import type { CompendiumItemTemplate } from '../../../electron/ipc/homebrew-items';
+
+const fullWeaponTemplate: CompendiumItemTemplate = {
+  name: 'Greatsword',
+  type: 'weapon',
+  img: 'systems/pf2e/icons/weapons/greatsword.webp',
+  system: {
+    level: { value: 0 },
+    traits: { value: ['versatile-p'], rarity: 'common' },
+    price: { value: { gp: 2, sp: 0, cp: 0, pp: 0 } },
+    bulk: { value: 2 },
+    description: { value: 'A sword.' },
+    publication: { title: 'Pathfinder Player Core' },
+    damage: { die: 'd12', dice: 1, damageType: 'slashing' },
+    category: 'martial',
+    group: 'sword',
+    // Field the editor doesn't model — must round-trip via systemRaw.
+    customField: 'preserve-me',
+    nested: { value: 42 },
+  },
+  effects: [
+    {
+      name: 'Striking',
+      disabled: false,
+      transfer: true,
+      changes: [{ key: 'system.bonuses.damage.bonus', mode: 2, value: '1', priority: 20 }],
+      duration: { rounds: 5 },
+    },
+  ],
+  flags: { 'pf2e-toolbelt': { tag: 'demo' } },
+};
+
+describe('emptyDraft', () => {
+  it('produces a valid blank draft for a default type', () => {
+    const draft = emptyDraft();
+    expect(draft.type).toBe('equipment');
+    expect(draft.name).toBe('');
+    expect(draft.rarity).toBe('common');
+    expect(draft.traits).toEqual([]);
+    expect(draft.systemRaw).toEqual({});
+    expect(draft.effects).toEqual([]);
+  });
+
+  it('respects an explicit type', () => {
+    expect(emptyDraft('weapon').type).toBe('weapon');
+    expect(emptyDraft('treasure').type).toBe('treasure');
+  });
+});
+
+describe('templateToDraft — identity stripping happens upstream, structure is read here', () => {
+  it('reads name, type, img, level, rarity, traits, price, bulk, source, description', () => {
+    const draft = templateToDraft(fullWeaponTemplate);
+    expect(draft.name).toBe('Greatsword');
+    expect(draft.type).toBe('weapon');
+    expect(draft.img).toBe('systems/pf2e/icons/weapons/greatsword.webp');
+    expect(draft.level).toBe(0);
+    expect(draft.rarity).toBe('common');
+    expect(draft.traits).toEqual(['versatile-p']);
+    expect(draft.price).toEqual({ pp: 0, gp: 2, sp: 0, cp: 0 });
+    expect(draft.bulk).toBe('2');
+    expect(draft.source).toBe('Pathfinder Player Core');
+    expect(draft.description).toBe('A sword.');
+  });
+
+  it('reads weapon mechanical fields', () => {
+    const draft = templateToDraft(fullWeaponTemplate);
+    expect(draft.weapon).toEqual({
+      damageDie: 'd12',
+      damageDice: 1,
+      damageType: 'slashing',
+      category: 'martial',
+      group: 'sword',
+    });
+  });
+
+  it('preserves unknown system fields via systemRaw', () => {
+    const draft = templateToDraft(fullWeaponTemplate);
+    expect(draft.systemRaw['customField']).toBe('preserve-me');
+    expect(draft.systemRaw['nested']).toEqual({ value: 42 });
+  });
+
+  it('reads active effects intact', () => {
+    const draft = templateToDraft(fullWeaponTemplate);
+    expect(draft.effects).toHaveLength(1);
+    expect(draft.effects[0]).toMatchObject({
+      name: 'Striking',
+      disabled: false,
+      transfer: true,
+      durationRounds: 5,
+      changes: [{ key: 'system.bonuses.damage.bonus', mode: 2, value: '1', priority: 20 }],
+    });
+  });
+
+  it('preserves flags', () => {
+    const draft = templateToDraft(fullWeaponTemplate);
+    expect(draft.flags).toEqual({ 'pf2e-toolbelt': { tag: 'demo' } });
+  });
+
+  it('handles a template missing every optional system field gracefully', () => {
+    const draft = templateToDraft({
+      name: 'Empty',
+      type: 'equipment',
+      img: null,
+      system: {},
+      effects: [],
+      flags: {},
+    });
+    expect(draft.type).toBe('equipment');
+    expect(draft.level).toBe(0);
+    expect(draft.rarity).toBe('common');
+    expect(draft.traits).toEqual([]);
+    expect(draft.bulk).toBe('-');
+    expect(draft.img).toBe('');
+  });
+
+  it('falls back to equipment type when the template has an unsupported type', () => {
+    const draft = templateToDraft({
+      name: 'Spell-as-item',
+      type: 'spell',
+      img: null,
+      system: {},
+      effects: [],
+      flags: {},
+    });
+    expect(draft.type).toBe('equipment');
+  });
+
+  it('falls back to common rarity when traits.rarity is unrecognised', () => {
+    const draft = templateToDraft({
+      name: 'Weird',
+      type: 'equipment',
+      img: null,
+      system: { traits: { value: [], rarity: 'mythic' } },
+      effects: [],
+      flags: {},
+    });
+    expect(draft.rarity).toBe('common');
+  });
+});
+
+describe('draftToPayload', () => {
+  it('rejects a blank name', () => {
+    const draft = emptyDraft('weapon');
+    expect(() => draftToPayload(draft)).toThrow(DraftValidationError);
+  });
+
+  it('writes core fields onto system', () => {
+    const draft: ItemDraft = {
+      ...emptyDraft('weapon'),
+      name: 'Sword of Test',
+      level: 3,
+      rarity: 'uncommon',
+      traits: ['magical', 'evocation'],
+      price: { pp: 0, gp: 100, sp: 0, cp: 0 },
+      bulk: '1',
+      source: 'Homebrew Manual',
+      description: 'A test sword.',
+    };
+    const payload = draftToPayload(draft);
+    expect(payload.name).toBe('Sword of Test');
+    expect(payload.type).toBe('weapon');
+    expect(payload.system).toMatchObject({
+      level: { value: 3 },
+      traits: { value: ['magical', 'evocation'], rarity: 'uncommon' },
+      price: { value: { pp: 0, gp: 100, sp: 0, cp: 0 } },
+      bulk: { value: 1 },
+      description: { value: 'A test sword.' },
+      publication: { title: 'Homebrew Manual' },
+    });
+  });
+
+  it('writes weapon mechanical fields on weapon type', () => {
+    const draft: ItemDraft = {
+      ...emptyDraft('weapon'),
+      name: 'Test',
+      weapon: { damageDie: 'd10', damageDice: 2, damageType: 'piercing', category: 'martial', group: 'spear' },
+    };
+    const payload = draftToPayload(draft);
+    expect(payload.system).toMatchObject({
+      damage: { die: 'd10', dice: 2, damageType: 'piercing' },
+      category: 'martial',
+      group: 'spear',
+    });
+  });
+
+  it('writes armor mechanical fields on armor type', () => {
+    const draft: ItemDraft = {
+      ...emptyDraft('armor'),
+      name: 'Plate',
+      armor: { category: 'heavy', group: 'plate', acBonus: 6, strength: 18, dex: 0, check: -3, slowness: -10 },
+    };
+    const payload = draftToPayload(draft);
+    expect(payload.system).toMatchObject({
+      category: 'heavy',
+      group: 'plate',
+      acBonus: 6,
+      strength: 18,
+      dex: 0,
+      check: -3,
+      slowness: -10,
+    });
+  });
+
+  it('omits frequency and uses when max is 0', () => {
+    const payload = draftToPayload({ ...emptyDraft('equipment'), name: 'X' });
+    expect(payload.system).not.toHaveProperty('frequency');
+    expect(payload.system).not.toHaveProperty('uses');
+  });
+
+  it('writes uses + frequency when max is positive', () => {
+    const payload = draftToPayload({
+      ...emptyDraft('consumable'),
+      name: 'Wand',
+      uses: { value: 7, max: 10 },
+      frequency: { max: 3, per: 'PT24H' },
+    });
+    expect(payload.system).toMatchObject({ uses: { value: 7, max: 10 }, frequency: { max: 3, per: 'PT24H' } });
+  });
+
+  it('writes rules JSON to system.rules when valid', () => {
+    const payload = draftToPayload({
+      ...emptyDraft('equipment'),
+      name: 'X',
+      rulesJson: JSON.stringify([{ key: 'FlatModifier', selector: 'ac', value: 1 }]),
+    });
+    expect(payload.system['rules']).toEqual([{ key: 'FlatModifier', selector: 'ac', value: 1 }]);
+  });
+
+  it('rejects invalid rules JSON', () => {
+    expect(() => draftToPayload({ ...emptyDraft('equipment'), name: 'X', rulesJson: '{not valid}' })).toThrow(/parsed/);
+  });
+
+  it('rejects rules JSON that is not an array', () => {
+    expect(() => draftToPayload({ ...emptyDraft('equipment'), name: 'X', rulesJson: '{"key":"X"}' })).toThrow(/array/);
+  });
+
+  it('writes effects through to payload (round-trip preserves changes / mode / value)', () => {
+    const payload = draftToPayload({
+      ...emptyDraft('equipment'),
+      name: 'X',
+      effects: [
+        {
+          name: 'Bonus',
+          disabled: false,
+          transfer: true,
+          changes: [{ key: 'system.attributes.ac.value', mode: 4, value: '18', priority: 40 }],
+          durationRounds: 10,
+        },
+      ],
+    });
+    expect(payload.effects).toEqual([
+      {
+        name: 'Bonus',
+        disabled: false,
+        transfer: true,
+        changes: [{ key: 'system.attributes.ac.value', mode: 4, value: '18', priority: 40 }],
+        duration: { rounds: 10 },
+      },
+    ]);
+  });
+
+  it('drops effects key when none are defined', () => {
+    const payload = draftToPayload({ ...emptyDraft('equipment'), name: 'X' });
+    expect(payload).not.toHaveProperty('effects');
+  });
+
+  it('preserves systemRaw fields the editor does not know about', () => {
+    const draft: ItemDraft = {
+      ...emptyDraft('weapon'),
+      name: 'Test',
+      systemRaw: { customField: 'keep-me', another: { nested: true } },
+    };
+    const payload = draftToPayload(draft);
+    expect(payload.system['customField']).toBe('keep-me');
+    expect(payload.system['another']).toEqual({ nested: true });
+  });
+
+  it('round-trips: templateToDraft → draftToPayload preserves systemRaw + effects + flags', () => {
+    const draft = templateToDraft(fullWeaponTemplate);
+    // Pretend the user only edited the name.
+    draft.name = 'Custom Greatsword';
+    const payload = draftToPayload(draft);
+    expect(payload.name).toBe('Custom Greatsword');
+    expect(payload.type).toBe('weapon');
+    expect(payload.system['customField']).toBe('preserve-me');
+    expect(payload.system['nested']).toEqual({ value: 42 });
+    expect(payload.system['damage']).toMatchObject({ die: 'd12', dice: 1, damageType: 'slashing' });
+    expect(payload.system['traits']).toMatchObject({ rarity: 'common', value: ['versatile-p'] });
+    expect(payload.flags).toEqual({ 'pf2e-toolbelt': { tag: 'demo' } });
+    expect(payload.effects).toHaveLength(1);
+    expect(payload.effects?.[0]).toMatchObject({
+      name: 'Striking',
+      transfer: true,
+      duration: { rounds: 5 },
+      changes: [{ key: 'system.bonuses.damage.bonus', mode: 2, value: '1', priority: 20 }],
+    });
+  });
+});

--- a/apps/dm-tool/src/features/item-browser/homebrew-editor-helpers.ts
+++ b/apps/dm-tool/src/features/item-browser/homebrew-editor-helpers.ts
@@ -1,0 +1,568 @@
+// Pure helpers for the homebrew item editor:
+//
+//   emptyDraft(type)     → blank ItemDraft for a freshly-created item
+//   templateToDraft(t)   → ItemDraft seeded from a cloned compendium item
+//   draftToPayload(d)    → CompendiumItemPayload ready for the wire
+//
+// The draft is a flat, edit-friendly shape; conversion to/from PF2e's
+// nested `system.*` happens here so the React component can stay
+// dumb-render. Round-trip behavior:
+//
+//   templateToDraft → draftToPayload should preserve every PF2e field
+//   the editor doesn't know about (carried via `systemRaw`).
+//
+// We intentionally do NOT model every PF2e field — the editor exposes
+// the common ones plus a JSON escape hatch for `system.rules` and a
+// JSON-encoded `systemRaw` advanced override. Anything else round-trips
+// untouched through `systemRaw`.
+
+import type { CompendiumItemPayload } from '@foundry-toolkit/shared/rpc';
+import type { CompendiumItemTemplate } from '../../../electron/ipc/homebrew-items.js';
+
+// PF2e item types this editor handles directly. Other types ("kit",
+// "backpack", "spell"…) can still be cloned + edited via the advanced
+// JSON tab; we just don't surface a per-type form for them.
+export const SUPPORTED_TYPES = ['weapon', 'armor', 'shield', 'consumable', 'equipment', 'treasure'] as const;
+export type ItemType = (typeof SUPPORTED_TYPES)[number];
+
+export const RARITIES = ['common', 'uncommon', 'rare', 'unique'] as const;
+export type Rarity = (typeof RARITIES)[number];
+
+export const DAMAGE_DICE = ['d4', 'd6', 'd8', 'd10', 'd12'] as const;
+export const DAMAGE_TYPES = ['bludgeoning', 'piercing', 'slashing'] as const;
+export const WEAPON_CATEGORIES = ['simple', 'martial', 'advanced', 'unarmed'] as const;
+export const ARMOR_CATEGORIES = ['light', 'medium', 'heavy', 'unarmored'] as const;
+export const FREQUENCY_PER = ['PT1M', 'PT1H', 'PT24H', 'day', 'turn', 'round'] as const;
+
+// CONST.ACTIVE_EFFECT_MODES — small enough to inline.
+export const ACTIVE_EFFECT_MODES: ReadonlyArray<{ value: number; label: string }> = [
+  { value: 0, label: 'Custom (0)' },
+  { value: 1, label: 'Multiply (1)' },
+  { value: 2, label: 'Add (2)' },
+  { value: 3, label: 'Downgrade (3)' },
+  { value: 4, label: 'Upgrade (4)' },
+  { value: 5, label: 'Override (5)' },
+];
+
+export interface PriceDraft {
+  pp: number;
+  gp: number;
+  sp: number;
+  cp: number;
+}
+
+export interface FrequencyDraft {
+  /** -1 means "unset"; the form clears it. */
+  max: number;
+  per: (typeof FREQUENCY_PER)[number];
+}
+
+export interface UsesDraft {
+  value: number;
+  max: number;
+}
+
+export interface WeaponDraft {
+  damageDie: (typeof DAMAGE_DICE)[number];
+  damageDice: number;
+  damageType: string;
+  category: (typeof WEAPON_CATEGORIES)[number];
+  group: string;
+}
+
+export interface ArmorDraft {
+  category: (typeof ARMOR_CATEGORIES)[number];
+  group: string;
+  acBonus: number;
+  strength: number;
+  dex: number;
+  check: number;
+  slowness: number;
+}
+
+export interface ShieldDraft {
+  hardness: number;
+  hpMax: number;
+  acBonus: number;
+}
+
+export interface ConsumableDraft {
+  consumableType: string;
+}
+
+export interface EquipmentDraft {
+  usage: string;
+}
+
+export interface TreasureDraft {
+  stackGroup: string;
+}
+
+export interface ActiveEffectChangeDraft {
+  key: string;
+  mode: number;
+  value: string;
+  priority: number;
+}
+
+export interface ActiveEffectDraft {
+  name: string;
+  disabled: boolean;
+  transfer: boolean;
+  changes: ActiveEffectChangeDraft[];
+  durationRounds: number;
+}
+
+export interface ItemDraft {
+  name: string;
+  type: ItemType;
+  img: string;
+  level: number;
+  rarity: Rarity;
+  traits: string[];
+  price: PriceDraft;
+  bulk: string;
+  source: string;
+  description: string;
+  /** Optional per-type sub-state — only the field matching `type`
+   *  is used on save. Stored side-by-side so switching types doesn't
+   *  drop the user's in-progress fields. */
+  weapon: WeaponDraft;
+  armor: ArmorDraft;
+  shield: ShieldDraft;
+  consumable: ConsumableDraft;
+  equipment: EquipmentDraft;
+  treasure: TreasureDraft;
+  /** Optional frequency clamp (PT1H/day/etc). Apply when `max > 0`. */
+  frequency: FrequencyDraft;
+  /** Charges / uses (consumable + activatable items). Apply when `max > 0`. */
+  uses: UsesDraft;
+  /** PF2e RuleElements as a JSON-stringified array. Empty string =
+   *  no rules. Validated on save (must parse to an array). */
+  rulesJson: string;
+  /** Effects array — Foundry's ActiveEffect documents. */
+  effects: ActiveEffectDraft[];
+  /** Pass-through for fields the editor doesn't know about. The full
+   *  `system` from the template lands here; we overlay editor-managed
+   *  fields onto it on save. Empty `{}` for greenfield drafts. */
+  systemRaw: Record<string, unknown>;
+  /** Pass-through `flags` for module-scoped data. */
+  flags: Record<string, Record<string, unknown>>;
+}
+
+function emptyPrice(): PriceDraft {
+  return { pp: 0, gp: 0, sp: 0, cp: 0 };
+}
+
+function emptyWeapon(): WeaponDraft {
+  return { damageDie: 'd6', damageDice: 1, damageType: 'slashing', category: 'simple', group: 'sword' };
+}
+
+function emptyArmor(): ArmorDraft {
+  return { category: 'light', group: 'leather', acBonus: 1, strength: 10, dex: 4, check: 0, slowness: 0 };
+}
+
+function emptyShield(): ShieldDraft {
+  return { hardness: 3, hpMax: 12, acBonus: 1 };
+}
+
+function emptyConsumable(): ConsumableDraft {
+  return { consumableType: 'potion' };
+}
+
+function emptyEquipment(): EquipmentDraft {
+  return { usage: 'held-in-one-hand' };
+}
+
+function emptyTreasure(): TreasureDraft {
+  return { stackGroup: '' };
+}
+
+export function emptyDraft(type: ItemType = 'equipment'): ItemDraft {
+  return {
+    name: '',
+    type,
+    img: '',
+    level: 0,
+    rarity: 'common',
+    traits: [],
+    price: emptyPrice(),
+    bulk: '-',
+    source: '',
+    description: '',
+    weapon: emptyWeapon(),
+    armor: emptyArmor(),
+    shield: emptyShield(),
+    consumable: emptyConsumable(),
+    equipment: emptyEquipment(),
+    treasure: emptyTreasure(),
+    frequency: { max: 0, per: 'day' },
+    uses: { value: 0, max: 0 },
+    rulesJson: '',
+    effects: [],
+    systemRaw: {},
+    flags: {},
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Read-from-system helpers
+// ---------------------------------------------------------------------------
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function readNumber(v: unknown, fallback: number): number {
+  return typeof v === 'number' && Number.isFinite(v) ? v : fallback;
+}
+
+function readString(v: unknown, fallback = ''): string {
+  return typeof v === 'string' ? v : fallback;
+}
+
+function readPriceFromSystem(system: Record<string, unknown>): PriceDraft {
+  const price = system['price'];
+  if (!isRecord(price)) return emptyPrice();
+  const value = price['value'];
+  if (!isRecord(value)) return emptyPrice();
+  return {
+    pp: readNumber(value['pp'], 0),
+    gp: readNumber(value['gp'], 0),
+    sp: readNumber(value['sp'], 0),
+    cp: readNumber(value['cp'], 0),
+  };
+}
+
+function readBulkFromSystem(system: Record<string, unknown>): string {
+  const bulk = system['bulk'];
+  if (!isRecord(bulk)) return '-';
+  const v = bulk['value'];
+  if (typeof v === 'number') return v.toString();
+  if (typeof v === 'string' && v.length > 0) return v;
+  return '-';
+}
+
+function readTraitsFromSystem(system: Record<string, unknown>): { traits: string[]; rarity: Rarity } {
+  const traits = system['traits'];
+  if (!isRecord(traits)) return { traits: [], rarity: 'common' };
+  const value = traits['value'];
+  const list: string[] = Array.isArray(value) ? value.filter((t): t is string => typeof t === 'string') : [];
+  const rarityRaw = readString(traits['rarity'], 'common').toLowerCase();
+  const rarity: Rarity = (RARITIES as readonly string[]).includes(rarityRaw) ? (rarityRaw as Rarity) : 'common';
+  return { traits: list, rarity };
+}
+
+function readDescriptionFromSystem(system: Record<string, unknown>): string {
+  const desc = system['description'];
+  if (!isRecord(desc)) return '';
+  return readString(desc['value'], '');
+}
+
+function readSourceFromSystem(system: Record<string, unknown>): string {
+  const pub = system['publication'];
+  if (isRecord(pub)) return readString(pub['title'], '');
+  // Older items use `system.source.value` directly.
+  const src = system['source'];
+  if (isRecord(src)) return readString(src['value'], '');
+  return '';
+}
+
+function readLevelFromSystem(system: Record<string, unknown>): number {
+  const level = system['level'];
+  if (isRecord(level)) return readNumber(level['value'], 0);
+  return 0;
+}
+
+function readUsesFromSystem(system: Record<string, unknown>): UsesDraft {
+  const uses = system['uses'];
+  if (!isRecord(uses)) return { value: 0, max: 0 };
+  return { value: readNumber(uses['value'], 0), max: readNumber(uses['max'], 0) };
+}
+
+function readFrequencyFromSystem(system: Record<string, unknown>): FrequencyDraft {
+  const freq = system['frequency'];
+  if (!isRecord(freq)) return { max: 0, per: 'day' };
+  const perRaw = readString(freq['per'], 'day');
+  const per = (FREQUENCY_PER as readonly string[]).includes(perRaw) ? (perRaw as FrequencyDraft['per']) : 'day';
+  return { max: readNumber(freq['max'], 0), per };
+}
+
+function readRulesFromSystem(system: Record<string, unknown>): string {
+  const rules = system['rules'];
+  if (!Array.isArray(rules) || rules.length === 0) return '';
+  return JSON.stringify(rules, null, 2);
+}
+
+function readWeaponFromSystem(system: Record<string, unknown>): WeaponDraft {
+  const damage = system['damage'];
+  const die = isRecord(damage) ? readString(damage['die'], 'd6') : 'd6';
+  const dice = isRecord(damage) ? readNumber(damage['dice'], 1) : 1;
+  const damageType = isRecord(damage) ? readString(damage['damageType'], 'slashing') : 'slashing';
+  const categoryRaw = readString(system['category'], 'simple');
+  const category = (WEAPON_CATEGORIES as readonly string[]).includes(categoryRaw)
+    ? (categoryRaw as WeaponDraft['category'])
+    : 'simple';
+  const group = readString(system['group'], 'sword');
+  return {
+    damageDie: (DAMAGE_DICE as readonly string[]).includes(die) ? (die as WeaponDraft['damageDie']) : 'd6',
+    damageDice: dice,
+    damageType,
+    category,
+    group,
+  };
+}
+
+function readArmorFromSystem(system: Record<string, unknown>): ArmorDraft {
+  const categoryRaw = readString(system['category'], 'light');
+  const category = (ARMOR_CATEGORIES as readonly string[]).includes(categoryRaw)
+    ? (categoryRaw as ArmorDraft['category'])
+    : 'light';
+  return {
+    category,
+    group: readString(system['group'], 'leather'),
+    acBonus: readNumber(system['acBonus'], 1),
+    strength: readNumber(system['strength'], 10),
+    dex: readNumber(system['dex'], 4),
+    check: readNumber(system['check'], 0),
+    slowness: readNumber(system['slowness'], 0),
+  };
+}
+
+function readShieldFromSystem(system: Record<string, unknown>): ShieldDraft {
+  const hp = system['hp'];
+  const hpMax = isRecord(hp) ? readNumber(hp['max'], 12) : 12;
+  return {
+    hardness: readNumber(system['hardness'], 3),
+    hpMax,
+    acBonus: readNumber(system['acBonus'], 1),
+  };
+}
+
+function readConsumableFromSystem(system: Record<string, unknown>): ConsumableDraft {
+  const cat = system['category'];
+  if (typeof cat === 'string' && cat.length > 0) return { consumableType: cat };
+  return { consumableType: 'potion' };
+}
+
+function readEquipmentFromSystem(system: Record<string, unknown>): EquipmentDraft {
+  const usage = system['usage'];
+  if (isRecord(usage)) return { usage: readString(usage['value'], 'held-in-one-hand') };
+  return { usage: 'held-in-one-hand' };
+}
+
+function readTreasureFromSystem(system: Record<string, unknown>): TreasureDraft {
+  return { stackGroup: readString(system['stackGroup'], '') };
+}
+
+function readEffectsFromTemplate(effects: Array<Record<string, unknown>>): ActiveEffectDraft[] {
+  return effects.map((e) => {
+    const changesRaw = e['changes'];
+    const changes: ActiveEffectChangeDraft[] = Array.isArray(changesRaw)
+      ? changesRaw.filter(isRecord).map((c) => ({
+          key: readString(c['key']),
+          mode: readNumber(c['mode'], 2),
+          value: readString(c['value']),
+          priority: readNumber(c['priority'], readNumber(c['mode'], 2) * 10),
+        }))
+      : [];
+    const duration = e['duration'];
+    const rounds = isRecord(duration) ? readNumber(duration['rounds'], 0) : 0;
+    return {
+      name: readString(e['name']),
+      disabled: e['disabled'] === true,
+      transfer: e['transfer'] === true,
+      changes,
+      durationRounds: rounds,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Template → Draft
+// ---------------------------------------------------------------------------
+
+export function templateToDraft(template: CompendiumItemTemplate): ItemDraft {
+  const baseType: ItemType = (SUPPORTED_TYPES as readonly string[]).includes(template.type)
+    ? (template.type as ItemType)
+    : 'equipment';
+  const system = template.system;
+
+  const { traits, rarity } = readTraitsFromSystem(system);
+
+  return {
+    name: template.name,
+    type: baseType,
+    img: template.img ?? '',
+    level: readLevelFromSystem(system),
+    rarity,
+    traits,
+    price: readPriceFromSystem(system),
+    bulk: readBulkFromSystem(system),
+    source: readSourceFromSystem(system),
+    description: readDescriptionFromSystem(system),
+    weapon: readWeaponFromSystem(system),
+    armor: readArmorFromSystem(system),
+    shield: readShieldFromSystem(system),
+    consumable: readConsumableFromSystem(system),
+    equipment: readEquipmentFromSystem(system),
+    treasure: readTreasureFromSystem(system),
+    frequency: readFrequencyFromSystem(system),
+    uses: readUsesFromSystem(system),
+    rulesJson: readRulesFromSystem(system),
+    effects: readEffectsFromTemplate(template.effects),
+    systemRaw: { ...system },
+    flags: { ...template.flags },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Draft → Payload
+// ---------------------------------------------------------------------------
+
+function parseBulk(raw: string): string | number {
+  const t = raw.trim();
+  if (t === '' || t === '-') return '-';
+  if (t.toUpperCase() === 'L') return 'L';
+  const n = Number(t);
+  return Number.isFinite(n) ? n : t;
+}
+
+export class DraftValidationError extends Error {
+  constructor(msg: string) {
+    super(msg);
+    this.name = 'DraftValidationError';
+  }
+}
+
+/** Convert the editor's draft state into a `CompendiumItemPayload`
+ *  ready to POST to /api/compendium/items. Throws
+ *  `DraftValidationError` when required fields are missing or
+ *  rules JSON doesn't parse to an array. */
+export function draftToPayload(draft: ItemDraft): CompendiumItemPayload {
+  const name = draft.name.trim();
+  if (name === '') throw new DraftValidationError('Name is required');
+
+  const system: Record<string, unknown> = { ...draft.systemRaw };
+
+  // Common fields — overlay onto whatever the template carried.
+  system['level'] = { value: draft.level };
+  system['traits'] = {
+    ...((isRecord(system['traits']) ? system['traits'] : {}) as Record<string, unknown>),
+    value: [...draft.traits],
+    rarity: draft.rarity,
+  };
+  system['price'] = { value: { ...draft.price } };
+  system['bulk'] = { value: parseBulk(draft.bulk) };
+  system['description'] = { value: draft.description };
+  system['publication'] = {
+    ...((isRecord(system['publication']) ? system['publication'] : {}) as Record<string, unknown>),
+    title: draft.source,
+  };
+
+  // Per-type fields — only set for the active type.
+  switch (draft.type) {
+    case 'weapon': {
+      const existingDamage = isRecord(system['damage']) ? (system['damage'] as Record<string, unknown>) : {};
+      system['damage'] = {
+        ...existingDamage,
+        die: draft.weapon.damageDie,
+        dice: draft.weapon.damageDice,
+        damageType: draft.weapon.damageType,
+      };
+      system['category'] = draft.weapon.category;
+      system['group'] = draft.weapon.group;
+      break;
+    }
+    case 'armor': {
+      system['category'] = draft.armor.category;
+      system['group'] = draft.armor.group;
+      system['acBonus'] = draft.armor.acBonus;
+      system['strength'] = draft.armor.strength;
+      system['dex'] = draft.armor.dex;
+      system['check'] = draft.armor.check;
+      system['slowness'] = draft.armor.slowness;
+      break;
+    }
+    case 'shield': {
+      system['hardness'] = draft.shield.hardness;
+      system['hp'] = {
+        ...((isRecord(system['hp']) ? system['hp'] : {}) as Record<string, unknown>),
+        max: draft.shield.hpMax,
+      };
+      system['acBonus'] = draft.shield.acBonus;
+      break;
+    }
+    case 'consumable': {
+      system['category'] = draft.consumable.consumableType;
+      break;
+    }
+    case 'equipment': {
+      system['usage'] = {
+        ...((isRecord(system['usage']) ? system['usage'] : {}) as Record<string, unknown>),
+        value: draft.equipment.usage,
+      };
+      break;
+    }
+    case 'treasure': {
+      system['stackGroup'] = draft.treasure.stackGroup;
+      break;
+    }
+  }
+
+  // Frequency — only set when max > 0; otherwise drop any inherited
+  // value so a cleared draft writes a clean frequency-less item.
+  if (draft.frequency.max > 0) {
+    system['frequency'] = { max: draft.frequency.max, per: draft.frequency.per };
+  } else {
+    delete system['frequency'];
+  }
+
+  // Uses — same pattern.
+  if (draft.uses.max > 0) {
+    system['uses'] = { value: draft.uses.value, max: draft.uses.max };
+  } else {
+    delete system['uses'];
+  }
+
+  // Rules (PF2e RuleElements). Validate it parses to an array.
+  if (draft.rulesJson.trim() !== '') {
+    let rules: unknown;
+    try {
+      rules = JSON.parse(draft.rulesJson);
+    } catch {
+      throw new DraftValidationError('Rules JSON could not be parsed');
+    }
+    if (!Array.isArray(rules)) {
+      throw new DraftValidationError('Rules JSON must be a JSON array');
+    }
+    system['rules'] = rules;
+  } else {
+    delete system['rules'];
+  }
+
+  const payload: CompendiumItemPayload = {
+    name,
+    type: draft.type,
+    system,
+  };
+  if (draft.img !== '') payload.img = draft.img;
+  if (Object.keys(draft.flags).length > 0) payload.flags = draft.flags;
+
+  if (draft.effects.length > 0) {
+    payload.effects = draft.effects.map((e) => ({
+      name: e.name,
+      disabled: e.disabled,
+      transfer: e.transfer,
+      changes: e.changes.map((c) => ({
+        key: c.key,
+        mode: c.mode,
+        value: c.value,
+        priority: c.priority,
+      })),
+      duration: e.durationRounds > 0 ? { rounds: e.durationRounds } : {},
+    }));
+  }
+
+  return payload;
+}

--- a/apps/dm-tool/src/features/item-browser/homebrew-editor-helpers.ts
+++ b/apps/dm-tool/src/features/item-browser/homebrew-editor-helpers.ts
@@ -75,9 +75,13 @@ export interface ArmorDraft {
   group: string;
   acBonus: number;
   strength: number;
-  dex: number;
-  check: number;
-  slowness: number;
+  /** Dex cap — PF2e remaster field is `system.dexCap`. */
+  dexCap: number;
+  /** Check penalty — PF2e remaster field is `system.checkPenalty`. */
+  checkPenalty: number;
+  /** Speed penalty — PF2e remaster field is `system.speedPenalty`
+   *  (the legacy field name `slowness` was renamed). */
+  speedPenalty: number;
 }
 
 export interface ShieldDraft {
@@ -95,7 +99,9 @@ export interface EquipmentDraft {
 }
 
 export interface TreasureDraft {
-  stackGroup: string;
+  /** PF2e treasure types: 'gem', 'currency', 'art-object', etc.
+   *  Stored at `system.category` on the document. */
+  category: string;
 }
 
 export interface ActiveEffectChangeDraft {
@@ -159,7 +165,7 @@ function emptyWeapon(): WeaponDraft {
 }
 
 function emptyArmor(): ArmorDraft {
-  return { category: 'light', group: 'leather', acBonus: 1, strength: 10, dex: 4, check: 0, slowness: 0 };
+  return { category: 'light', group: 'leather', acBonus: 1, strength: 0, dexCap: 4, checkPenalty: 0, speedPenalty: 0 };
 }
 
 function emptyShield(): ShieldDraft {
@@ -175,7 +181,7 @@ function emptyEquipment(): EquipmentDraft {
 }
 
 function emptyTreasure(): TreasureDraft {
-  return { stackGroup: '' };
+  return { category: 'gem' };
 }
 
 export function emptyDraft(type: ItemType = 'equipment'): ItemDraft {
@@ -322,10 +328,10 @@ function readArmorFromSystem(system: Record<string, unknown>): ArmorDraft {
     category,
     group: readString(system['group'], 'leather'),
     acBonus: readNumber(system['acBonus'], 1),
-    strength: readNumber(system['strength'], 10),
-    dex: readNumber(system['dex'], 4),
-    check: readNumber(system['check'], 0),
-    slowness: readNumber(system['slowness'], 0),
+    strength: readNumber(system['strength'], 0),
+    dexCap: readNumber(system['dexCap'], 4),
+    checkPenalty: readNumber(system['checkPenalty'], 0),
+    speedPenalty: readNumber(system['speedPenalty'], 0),
   };
 }
 
@@ -352,7 +358,7 @@ function readEquipmentFromSystem(system: Record<string, unknown>): EquipmentDraf
 }
 
 function readTreasureFromSystem(system: Record<string, unknown>): TreasureDraft {
-  return { stackGroup: readString(system['stackGroup'], '') };
+  return { category: readString(system['category'], 'gem') };
 }
 
 function readEffectsFromTemplate(effects: Array<Record<string, unknown>>): ActiveEffectDraft[] {
@@ -445,20 +451,38 @@ export function draftToPayload(draft: ItemDraft): CompendiumItemPayload {
 
   const system: Record<string, unknown> = { ...draft.systemRaw };
 
-  // Common fields — overlay onto whatever the template carried.
-  system['level'] = { value: draft.level };
+  // Common fields — overlay onto whatever the template carried, but
+  // preserve sibling fields the editor doesn't surface (PF2e items
+  // carry adjacent metadata on every nested record — `description.gm`,
+  // `price.per`, `bulk.heldOrStowed`, `traits.otherTags`, etc. — and
+  // a clobbering write would silently delete them when cloning).
+  const existingLevel = isRecord(system['level']) ? (system['level'] as Record<string, unknown>) : {};
+  system['level'] = { ...existingLevel, value: draft.level };
+
+  const existingTraits = isRecord(system['traits']) ? (system['traits'] as Record<string, unknown>) : {};
   system['traits'] = {
-    ...((isRecord(system['traits']) ? system['traits'] : {}) as Record<string, unknown>),
+    ...existingTraits,
     value: [...draft.traits],
     rarity: draft.rarity,
   };
-  system['price'] = { value: { ...draft.price } };
-  system['bulk'] = { value: parseBulk(draft.bulk) };
-  system['description'] = { value: draft.description };
-  system['publication'] = {
-    ...((isRecord(system['publication']) ? system['publication'] : {}) as Record<string, unknown>),
-    title: draft.source,
+
+  const existingPrice = isRecord(system['price']) ? (system['price'] as Record<string, unknown>) : {};
+  const existingPriceValue = isRecord(existingPrice['value'])
+    ? (existingPrice['value'] as Record<string, unknown>)
+    : {};
+  system['price'] = {
+    ...existingPrice,
+    value: { ...existingPriceValue, ...draft.price },
   };
+
+  const existingBulk = isRecord(system['bulk']) ? (system['bulk'] as Record<string, unknown>) : {};
+  system['bulk'] = { ...existingBulk, value: parseBulk(draft.bulk) };
+
+  const existingDesc = isRecord(system['description']) ? (system['description'] as Record<string, unknown>) : {};
+  system['description'] = { ...existingDesc, value: draft.description };
+
+  const existingPub = isRecord(system['publication']) ? (system['publication'] as Record<string, unknown>) : {};
+  system['publication'] = { ...existingPub, title: draft.source };
 
   // Per-type fields — only set for the active type.
   switch (draft.type) {
@@ -479,9 +503,9 @@ export function draftToPayload(draft: ItemDraft): CompendiumItemPayload {
       system['group'] = draft.armor.group;
       system['acBonus'] = draft.armor.acBonus;
       system['strength'] = draft.armor.strength;
-      system['dex'] = draft.armor.dex;
-      system['check'] = draft.armor.check;
-      system['slowness'] = draft.armor.slowness;
+      system['dexCap'] = draft.armor.dexCap;
+      system['checkPenalty'] = draft.armor.checkPenalty;
+      system['speedPenalty'] = draft.armor.speedPenalty;
       break;
     }
     case 'shield': {
@@ -505,7 +529,7 @@ export function draftToPayload(draft: ItemDraft): CompendiumItemPayload {
       break;
     }
     case 'treasure': {
-      system['stackGroup'] = draft.treasure.stackGroup;
+      system['category'] = draft.treasure.category;
       break;
     }
   }
@@ -518,9 +542,11 @@ export function draftToPayload(draft: ItemDraft): CompendiumItemPayload {
     delete system['frequency'];
   }
 
-  // Uses — same pattern.
+  // Uses — same pattern. Merge into the existing object so a
+  // template's `autoDestroy` (consumables) survives the round trip.
   if (draft.uses.max > 0) {
-    system['uses'] = { value: draft.uses.value, max: draft.uses.max };
+    const existingUses = isRecord(system['uses']) ? (system['uses'] as Record<string, unknown>) : {};
+    system['uses'] = { ...existingUses, value: draft.uses.value, max: draft.uses.max };
   } else {
     delete system['uses'];
   }

--- a/apps/dm-tool/src/features/item-browser/homebrew-editor-helpers.ts
+++ b/apps/dm-tool/src/features/item-browser/homebrew-editor-helpers.ts
@@ -17,7 +17,7 @@
 // untouched through `systemRaw`.
 
 import type { CompendiumItemPayload } from '@foundry-toolkit/shared/rpc';
-import type { CompendiumItemTemplate } from '../../../electron/ipc/homebrew-items.js';
+import type { CompendiumItemTemplate } from '../../../electron/ipc/homebrew-items-clone.js';
 
 // PF2e item types this editor handles directly. Other types ("kit",
 // "backpack", "spell"…) can still be cloned + edited via the advanced

--- a/apps/foundry-api-bridge/src/commands/handlers/index.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/index.ts
@@ -105,6 +105,8 @@ export {
   getCompendiumDocumentHandler,
   dumpCompendiumPackHandler,
   findOrCreateFolderHandler,
+  ensureCompendiumPackHandler,
+  createCompendiumItemHandler,
 } from '@/commands/handlers/world';
 
 // Table handlers

--- a/apps/foundry-api-bridge/src/commands/handlers/world/CreateCompendiumItemHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/world/CreateCompendiumItemHandler.ts
@@ -1,0 +1,104 @@
+import type { CreateCompendiumItemParams, CreateCompendiumItemResult, CompendiumItemPayload } from '@/commands/types';
+
+// Create a single Item document inside a world compendium pack.
+//
+// Foundry's preferred path for creating a doc directly in a pack is
+// `pack.documentClass.create(data, {pack: pack.collection})`. We don't
+// patch identity fields here — the dm-tool side strips `_id`, `_stats`,
+// and embedded `_id`s on the clone path before posting, so the payload
+// we receive is already a fresh document.
+
+interface FoundryDocument {
+  id: string;
+  uuid: string;
+  name: string;
+  type: string;
+}
+
+interface DocumentClassStatic {
+  create(
+    data: Record<string, unknown>,
+    options?: { pack?: string },
+  ): Promise<FoundryDocument | FoundryDocument[]>;
+}
+
+interface FoundryPackMetadata {
+  type: string;
+}
+
+interface FoundryPack {
+  collection: string;
+  metadata: FoundryPackMetadata;
+  documentClass: DocumentClassStatic;
+}
+
+interface PacksCollection {
+  get(id: string): FoundryPack | undefined;
+}
+
+interface FoundryGame {
+  packs: PacksCollection | undefined;
+}
+
+function getGame(): FoundryGame {
+  return (globalThis as unknown as { game: FoundryGame }).game;
+}
+
+function buildItemData(payload: CompendiumItemPayload): Record<string, unknown> {
+  const data: Record<string, unknown> = {
+    name: payload.name,
+    type: payload.type,
+    system: payload.system,
+  };
+  if (payload.img !== undefined) data['img'] = payload.img;
+  if (payload.flags !== undefined) data['flags'] = payload.flags;
+  if (payload.effects !== undefined && payload.effects.length > 0) {
+    // ActiveEffect docs ride along on Item.create as embedded documents.
+    // We pass them through verbatim — the editor already validated each
+    // change row's shape via the shared Zod schema.
+    data['effects'] = payload.effects.map((e) => ({
+      name: e.name,
+      img: e.img,
+      disabled: e.disabled ?? false,
+      transfer: e.transfer ?? false,
+      changes: e.changes ?? [],
+      duration: e.duration ?? {},
+    }));
+  }
+  return data;
+}
+
+export async function createCompendiumItemHandler(
+  params: CreateCompendiumItemParams,
+): Promise<CreateCompendiumItemResult> {
+  const game = getGame();
+  if (!game.packs) {
+    throw new Error('Foundry packs collection not available');
+  }
+
+  const pack = game.packs.get(params.packId);
+  if (!pack) {
+    throw new Error(`Compendium pack not found: ${params.packId}`);
+  }
+  if (pack.metadata.type !== 'Item') {
+    throw new Error(`Compendium pack is not an Item pack: ${params.packId} (type=${pack.metadata.type})`);
+  }
+
+  const data = buildItemData(params.item);
+  const result = await pack.documentClass.create(data, { pack: pack.collection });
+  // Foundry's `create` returns a single doc when given a single record,
+  // or an array when given multiple — we always pass one. Be defensive
+  // either way so a system patch that flips the shape doesn't crash us.
+  const created = Array.isArray(result) ? result[0] : result;
+  if (!created) {
+    throw new Error(`Failed to create item in pack ${params.packId}`);
+  }
+
+  return {
+    id: created.id,
+    uuid: created.uuid,
+    packId: pack.collection,
+    name: created.name,
+    type: created.type,
+  };
+}

--- a/apps/foundry-api-bridge/src/commands/handlers/world/EnsureCompendiumPackHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/world/EnsureCompendiumPackHandler.ts
@@ -1,0 +1,97 @@
+import type { EnsureCompendiumPackParams, EnsureCompendiumPackResult } from '@/commands/types';
+
+// Idempotent world-pack create. Mirrors find-or-create-folder's contract:
+// callers (dm-tool's homebrew-item editor) invoke this on every save, and
+// the first call provisions the pack while subsequent calls reuse it.
+//
+// Foundry composes the full pack id as `world.<name>` for any pack created
+// at runtime via `CompendiumCollection.createCompendium`. We accept the
+// scope-less short name and return the full id so the caller can hand it
+// straight to `create-compendium-item`.
+
+interface FoundryPackMetadata {
+  label: string;
+  type: string;
+}
+
+interface FoundryPack {
+  collection: string;
+  metadata: FoundryPackMetadata;
+}
+
+interface PacksCollection {
+  get(id: string): FoundryPack | undefined;
+}
+
+interface CompendiumCollectionStatic {
+  createCompendium(metadata: {
+    name: string;
+    label: string;
+    type: string;
+    packageType?: string;
+  }): Promise<FoundryPack>;
+}
+
+interface FoundryGame {
+  packs: PacksCollection | undefined;
+}
+
+function getGame(): FoundryGame {
+  return (globalThis as unknown as { game: FoundryGame }).game;
+}
+
+function getCompendiumCollection(): CompendiumCollectionStatic | undefined {
+  return (globalThis as unknown as { CompendiumCollection?: CompendiumCollectionStatic }).CompendiumCollection;
+}
+
+const NAME_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+
+export async function ensureCompendiumPackHandler(
+  params: EnsureCompendiumPackParams,
+): Promise<EnsureCompendiumPackResult> {
+  const game = getGame();
+  if (!game.packs) {
+    throw new Error('Foundry packs collection not available');
+  }
+
+  const name = params.name.trim();
+  if (!NAME_PATTERN.test(name)) {
+    throw new Error(`Invalid pack name "${name}" — expected lowercase kebab-case ([a-z0-9][a-z0-9-]*)`);
+  }
+  const label = params.label.trim();
+  if (!label) {
+    throw new Error('Pack label cannot be empty');
+  }
+  const type = params.type ?? 'Item';
+
+  const fullId = `world.${name}`;
+  const existing = game.packs.get(fullId);
+  if (existing) {
+    if (existing.metadata.type !== type) {
+      throw new Error(
+        `Pack ${fullId} exists but has type "${existing.metadata.type}", expected "${type}". ` +
+          `Pick a different name or rename the existing pack.`,
+      );
+    }
+    return {
+      id: existing.collection,
+      label: existing.metadata.label,
+      type: 'Item',
+      created: false,
+    };
+  }
+
+  const Cls = getCompendiumCollection();
+  if (!Cls) {
+    throw new Error('CompendiumCollection global not available');
+  }
+
+  const created = await Cls.createCompendium({ name, label, type, packageType: 'world' });
+
+  return {
+    id: created.collection,
+    label: created.metadata.label,
+    type: 'Item',
+    created: true,
+  };
+}

--- a/apps/foundry-api-bridge/src/commands/handlers/world/__tests__/CreateCompendiumItemHandler.test.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/world/__tests__/CreateCompendiumItemHandler.test.ts
@@ -1,0 +1,192 @@
+import { createCompendiumItemHandler } from '../CreateCompendiumItemHandler';
+import type { CompendiumItemPayload } from '@/commands/types';
+
+interface MockDocument {
+  id: string;
+  uuid: string;
+  name: string;
+  type: string;
+}
+
+interface MockPack {
+  collection: string;
+  metadata: { type: string };
+  documentClass: { create: jest.Mock };
+}
+
+function makePack(opts: {
+  collection?: string;
+  type?: string;
+  createResult?: MockDocument | MockDocument[] | null;
+}): MockPack {
+  return {
+    collection: opts.collection ?? 'world.homebrew-items',
+    metadata: { type: opts.type ?? 'Item' },
+    documentClass: {
+      create: jest.fn().mockResolvedValue(
+        opts.createResult ?? {
+          id: 'item-1',
+          uuid: 'Compendium.world.homebrew-items.Item.item-1',
+          name: 'Sword of Test',
+          type: 'weapon',
+        },
+      ),
+    },
+  };
+}
+
+function setGame(packs: Map<string, MockPack> | undefined): void {
+  (globalThis as Record<string, unknown>)['game'] = {
+    packs:
+      packs !== undefined
+        ? {
+            get: jest.fn((id: string) => packs.get(id)),
+          }
+        : undefined,
+  };
+}
+
+function clearGame(): void {
+  delete (globalThis as Record<string, unknown>)['game'];
+}
+
+const basePayload: CompendiumItemPayload = {
+  name: 'Sword of Test',
+  type: 'weapon',
+  system: { level: { value: 1 }, traits: { value: [], rarity: 'common' } },
+};
+
+describe('createCompendiumItemHandler', () => {
+  afterEach(clearGame);
+
+  it('creates an item in the named pack and returns identity fields', async () => {
+    const pack = makePack({});
+    setGame(new Map([['world.homebrew-items', pack]]));
+
+    const result = await createCompendiumItemHandler({ packId: 'world.homebrew-items', item: basePayload });
+
+    expect(pack.documentClass.create).toHaveBeenCalledTimes(1);
+    const [data, options] = pack.documentClass.create.mock.calls[0];
+    expect(data).toMatchObject({ name: 'Sword of Test', type: 'weapon' });
+    expect(options).toEqual({ pack: 'world.homebrew-items' });
+    expect(result).toEqual({
+      id: 'item-1',
+      uuid: 'Compendium.world.homebrew-items.Item.item-1',
+      packId: 'world.homebrew-items',
+      name: 'Sword of Test',
+      type: 'weapon',
+    });
+  });
+
+  it('passes through ActiveEffects with normalized defaults', async () => {
+    const pack = makePack({});
+    setGame(new Map([['world.homebrew-items', pack]]));
+
+    await createCompendiumItemHandler({
+      packId: 'world.homebrew-items',
+      item: {
+        ...basePayload,
+        effects: [
+          {
+            name: '+1 Striking',
+            changes: [{ key: 'system.bonuses.damage.bonus', mode: 2, value: '1' }],
+          },
+        ],
+      },
+    });
+
+    const data = pack.documentClass.create.mock.calls[0][0] as Record<string, unknown>;
+    expect(data['effects']).toEqual([
+      {
+        name: '+1 Striking',
+        img: undefined,
+        disabled: false,
+        transfer: false,
+        changes: [{ key: 'system.bonuses.damage.bonus', mode: 2, value: '1' }],
+        duration: {},
+      },
+    ]);
+  });
+
+  it('round-trips an item with active effects intact (changes / mode / value preserved)', async () => {
+    const pack = makePack({});
+    setGame(new Map([['world.homebrew-items', pack]]));
+
+    const effects: CompendiumItemPayload['effects'] = [
+      {
+        name: 'Resistance',
+        disabled: true,
+        transfer: true,
+        changes: [
+          { key: 'system.attributes.resistances.fire', mode: 2, value: '5', priority: 20 },
+          { key: 'system.attributes.ac.value', mode: 4, value: '18' },
+        ],
+        duration: { rounds: 10 },
+      },
+    ];
+
+    await createCompendiumItemHandler({
+      packId: 'world.homebrew-items',
+      item: { ...basePayload, effects },
+    });
+
+    const data = pack.documentClass.create.mock.calls[0][0] as Record<string, unknown>;
+    const persistedEffects = data['effects'] as Record<string, unknown>[];
+    expect(persistedEffects).toHaveLength(1);
+    expect(persistedEffects[0]).toMatchObject({
+      name: 'Resistance',
+      disabled: true,
+      transfer: true,
+      duration: { rounds: 10 },
+      changes: [
+        { key: 'system.attributes.resistances.fire', mode: 2, value: '5', priority: 20 },
+        { key: 'system.attributes.ac.value', mode: 4, value: '18' },
+      ],
+    });
+  });
+
+  it('omits the effects key entirely when none are supplied', async () => {
+    const pack = makePack({});
+    setGame(new Map([['world.homebrew-items', pack]]));
+
+    await createCompendiumItemHandler({ packId: 'world.homebrew-items', item: basePayload });
+
+    const data = pack.documentClass.create.mock.calls[0][0] as Record<string, unknown>;
+    expect(data).not.toHaveProperty('effects');
+  });
+
+  it('errors when the pack id is unknown', async () => {
+    setGame(new Map());
+
+    await expect(
+      createCompendiumItemHandler({ packId: 'world.missing', item: basePayload }),
+    ).rejects.toThrow('Compendium pack not found: world.missing');
+  });
+
+  it('errors when the pack is not an Item pack', async () => {
+    const pack = makePack({ type: 'Actor' });
+    setGame(new Map([['world.homebrew-items', pack]]));
+
+    await expect(
+      createCompendiumItemHandler({ packId: 'world.homebrew-items', item: basePayload }),
+    ).rejects.toThrow(/not an Item pack/);
+  });
+
+  it('handles document.create returning an array of one', async () => {
+    const pack = makePack({
+      createResult: [
+        {
+          id: 'item-2',
+          uuid: 'Compendium.world.homebrew-items.Item.item-2',
+          name: 'Sword of Test',
+          type: 'weapon',
+        },
+      ],
+    });
+    setGame(new Map([['world.homebrew-items', pack]]));
+
+    const result = await createCompendiumItemHandler({ packId: 'world.homebrew-items', item: basePayload });
+
+    expect(result.id).toBe('item-2');
+  });
+});

--- a/apps/foundry-api-bridge/src/commands/handlers/world/__tests__/EnsureCompendiumPackHandler.test.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/world/__tests__/EnsureCompendiumPackHandler.test.ts
@@ -1,0 +1,121 @@
+import { ensureCompendiumPackHandler } from '../EnsureCompendiumPackHandler';
+
+interface MockPackMetadata {
+  label: string;
+  type: string;
+}
+
+interface MockPack {
+  collection: string;
+  metadata: MockPackMetadata;
+}
+
+function setEnv(packs: Map<string, MockPack> | undefined, createImpl?: jest.Mock): void {
+  const packsCollection =
+    packs !== undefined
+      ? {
+          get: jest.fn((id: string) => packs.get(id)),
+        }
+      : undefined;
+  (globalThis as Record<string, unknown>)['game'] = { packs: packsCollection };
+  (globalThis as Record<string, unknown>)['CompendiumCollection'] =
+    createImpl !== undefined ? { createCompendium: createImpl } : undefined;
+}
+
+function clearEnv(): void {
+  delete (globalThis as Record<string, unknown>)['game'];
+  delete (globalThis as Record<string, unknown>)['CompendiumCollection'];
+}
+
+describe('ensureCompendiumPackHandler', () => {
+  afterEach(clearEnv);
+
+  it('creates a new world pack when none exists', async () => {
+    const create = jest.fn().mockResolvedValue({
+      collection: 'world.homebrew-items',
+      metadata: { label: 'Homebrew Items', type: 'Item' },
+    });
+    setEnv(new Map(), create);
+
+    const result = await ensureCompendiumPackHandler({ name: 'homebrew-items', label: 'Homebrew Items' });
+
+    expect(create).toHaveBeenCalledWith({
+      name: 'homebrew-items',
+      label: 'Homebrew Items',
+      type: 'Item',
+      packageType: 'world',
+    });
+    expect(result).toEqual({
+      id: 'world.homebrew-items',
+      label: 'Homebrew Items',
+      type: 'Item',
+      created: true,
+    });
+  });
+
+  it('reuses an existing pack with the same id and type', async () => {
+    const create = jest.fn();
+    const existing: MockPack = {
+      collection: 'world.homebrew-items',
+      metadata: { label: 'Homebrew Items', type: 'Item' },
+    };
+    setEnv(new Map([['world.homebrew-items', existing]]), create);
+
+    const result = await ensureCompendiumPackHandler({ name: 'homebrew-items', label: 'Homebrew Items' });
+
+    expect(create).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      id: 'world.homebrew-items',
+      label: 'Homebrew Items',
+      type: 'Item',
+      created: false,
+    });
+  });
+
+  it('errors when an existing pack has a conflicting type', async () => {
+    const create = jest.fn();
+    const existing: MockPack = {
+      collection: 'world.homebrew-items',
+      metadata: { label: 'Homebrew Items', type: 'Actor' },
+    };
+    setEnv(new Map([['world.homebrew-items', existing]]), create);
+
+    await expect(ensureCompendiumPackHandler({ name: 'homebrew-items', label: 'Homebrew Items' })).rejects.toThrow(
+      /type "Actor"/,
+    );
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid pack names', async () => {
+    setEnv(new Map(), jest.fn());
+
+    await expect(ensureCompendiumPackHandler({ name: 'Homebrew Items', label: 'x' })).rejects.toThrow(/Invalid pack name/);
+    await expect(ensureCompendiumPackHandler({ name: '', label: 'x' })).rejects.toThrow(/Invalid pack name/);
+    await expect(ensureCompendiumPackHandler({ name: 'with.dot', label: 'x' })).rejects.toThrow(/Invalid pack name/);
+  });
+
+  it('rejects empty labels', async () => {
+    setEnv(new Map(), jest.fn());
+
+    await expect(ensureCompendiumPackHandler({ name: 'homebrew', label: '   ' })).rejects.toThrow(
+      'Pack label cannot be empty',
+    );
+  });
+
+  it('errors when packs collection is unavailable', async () => {
+    setEnv(undefined);
+
+    await expect(ensureCompendiumPackHandler({ name: 'homebrew', label: 'x' })).rejects.toThrow(
+      'Foundry packs collection not available',
+    );
+  });
+
+  it('errors when CompendiumCollection global is unavailable on a fresh-create path', async () => {
+    setEnv(new Map());
+    delete (globalThis as Record<string, unknown>)['CompendiumCollection'];
+
+    await expect(ensureCompendiumPackHandler({ name: 'homebrew', label: 'x' })).rejects.toThrow(
+      'CompendiumCollection global not available',
+    );
+  });
+});

--- a/apps/foundry-api-bridge/src/commands/handlers/world/index.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/world/index.ts
@@ -7,3 +7,5 @@ export { listCompendiumSourcesHandler } from './ListCompendiumSourcesHandler';
 export { getCompendiumDocumentHandler } from './GetCompendiumDocumentHandler';
 export { dumpCompendiumPackHandler } from './DumpCompendiumPackHandler';
 export { findOrCreateFolderHandler } from './FindOrCreateFolderHandler';
+export { ensureCompendiumPackHandler } from './EnsureCompendiumPackHandler';
+export { createCompendiumItemHandler } from './CreateCompendiumItemHandler';

--- a/apps/foundry-api-bridge/src/commands/types/base.ts
+++ b/apps/foundry-api-bridge/src/commands/types/base.ts
@@ -149,6 +149,10 @@ import type {
   DumpCompendiumPackResult,
   FindOrCreateFolderParams,
   FindOrCreateFolderResult,
+  EnsureCompendiumPackParams,
+  EnsureCompendiumPackResult,
+  CreateCompendiumItemParams,
+  CreateCompendiumItemResult,
 } from './compendium';
 
 import type {
@@ -261,6 +265,8 @@ export type CommandType =
   | 'get-compendium-document'
   | 'dump-compendium-pack'
   | 'find-or-create-folder'
+  | 'ensure-compendium-pack'
+  | 'create-compendium-item'
   | 'list-roll-tables'
   | 'get-roll-table'
   | 'roll-on-table'
@@ -357,6 +363,8 @@ export interface CommandParamsMap {
   'get-compendium-document': GetCompendiumDocumentParams;
   'dump-compendium-pack': DumpCompendiumPackParams;
   'find-or-create-folder': FindOrCreateFolderParams;
+  'ensure-compendium-pack': EnsureCompendiumPackParams;
+  'create-compendium-item': CreateCompendiumItemParams;
   'list-roll-tables': ListRollTablesParams;
   'get-roll-table': GetRollTableParams;
   'roll-on-table': RollOnTableParams;
@@ -454,6 +462,8 @@ export interface CommandResultMap {
   'get-compendium-document': GetCompendiumDocumentResult;
   'dump-compendium-pack': DumpCompendiumPackResult;
   'find-or-create-folder': FindOrCreateFolderResult;
+  'ensure-compendium-pack': EnsureCompendiumPackResult;
+  'create-compendium-item': CreateCompendiumItemResult;
   'list-roll-tables': RollTableSummary[];
   'get-roll-table': RollTableResult;
   'roll-on-table': RollOnTableResult;

--- a/apps/foundry-api-bridge/src/commands/types/compendium.ts
+++ b/apps/foundry-api-bridge/src/commands/types/compendium.ts
@@ -202,3 +202,70 @@ export interface FindOrCreateFolderResult {
    *  status message. */
   created: boolean;
 }
+
+// ---------------------------------------------------------------------------
+// Compendium pack create + item create — used by dm-tool's homebrew item
+// editor. The pack creation is idempotent (mirrors find-or-create-folder)
+// so callers can safely call it on every save.
+// ---------------------------------------------------------------------------
+
+export interface EnsureCompendiumPackParams {
+  /** Scope-less short name. The handler prefixes `world.` to build
+   *  the full Foundry pack id. Must match `[a-z0-9][a-z0-9-]*`. */
+  name: string;
+  /** Display label shown in the Foundry sidebar. */
+  label: string;
+  /** Document type the pack holds. Constrained to 'Item' for now. */
+  type?: 'Item';
+}
+
+export interface EnsureCompendiumPackResult {
+  /** Full pack id, e.g. `world.homebrew-items`. */
+  id: string;
+  label: string;
+  type: 'Item';
+  created: boolean;
+}
+
+export interface ActiveEffectChangePayload {
+  key: string;
+  mode: number;
+  value: string;
+  priority?: number;
+}
+
+export interface ActiveEffectPayload {
+  name: string;
+  img?: string;
+  disabled?: boolean;
+  transfer?: boolean;
+  changes?: ActiveEffectChangePayload[];
+  duration?: {
+    seconds?: number;
+    rounds?: number;
+    turns?: number;
+  };
+}
+
+export interface CompendiumItemPayload {
+  name: string;
+  type: string;
+  img?: string;
+  system: Record<string, unknown>;
+  effects?: ActiveEffectPayload[];
+  flags?: Record<string, Record<string, unknown>>;
+}
+
+export interface CreateCompendiumItemParams {
+  /** Full pack id, e.g. `world.homebrew-items`. */
+  packId: string;
+  item: CompendiumItemPayload;
+}
+
+export interface CreateCompendiumItemResult {
+  id: string;
+  uuid: string;
+  packId: string;
+  name: string;
+  type: string;
+}

--- a/apps/foundry-api-bridge/src/main.ts
+++ b/apps/foundry-api-bridge/src/main.ts
@@ -43,6 +43,8 @@ import {
   getCompendiumDocumentHandler,
   dumpCompendiumPackHandler,
   findOrCreateFolderHandler,
+  ensureCompendiumPackHandler,
+  createCompendiumItemHandler,
   createJournalHandler,
   updateJournalHandler,
   deleteJournalHandler,
@@ -184,6 +186,8 @@ function initializeWebSocket(
   commandRouter.register('get-compendium-document', getCompendiumDocumentHandler);
   commandRouter.register('dump-compendium-pack', dumpCompendiumPackHandler);
   commandRouter.register('find-or-create-folder', findOrCreateFolderHandler);
+  commandRouter.register('ensure-compendium-pack', ensureCompendiumPackHandler);
+  commandRouter.register('create-compendium-item', createCompendiumItemHandler);
   commandRouter.register('get-scene', getSceneHandler);
   commandRouter.register('get-scenes-list', getScenesListHandler);
   commandRouter.register('get-scene-tokens', getSceneTokensHandler);

--- a/apps/foundry-mcp/src/http/routes/compendium.ts
+++ b/apps/foundry-mcp/src/http/routes/compendium.ts
@@ -1,5 +1,11 @@
 import type { FastifyInstance } from 'fastify';
 import type { CompendiumFacets } from '@foundry-toolkit/shared/foundry-api';
+import {
+  createCompendiumItemBody,
+  ensureCompendiumPackBody,
+  type CreateCompendiumItemResponse,
+  type EnsureCompendiumPackResponse,
+} from '@foundry-toolkit/shared/rpc';
 import { sendCommand } from '../../bridge.js';
 import { log } from '../../logger.js';
 import { compendiumCache } from '../compendium-cache-singleton.js';
@@ -131,6 +137,36 @@ export function registerCompendiumRoutes(app: FastifyInstance): void {
       traits,
       maxLevel,
     });
+  });
+
+  // Idempotent create-or-reuse of a world compendium pack. Used by
+  // dm-tool's homebrew-item editor to lazily provision the target pack
+  // on the first save. The bridge handler is the source of truth for
+  // the `world.<name>` id composition and type validation.
+  app.post('/api/compendium/packs/ensure', async (req): Promise<EnsureCompendiumPackResponse> => {
+    const body = ensureCompendiumPackBody.parse(req.body);
+    const result = (await sendCommand('ensure-compendium-pack', {
+      name: body.name,
+      label: body.label,
+      ...(body.type !== undefined ? { type: body.type } : {}),
+    })) as EnsureCompendiumPackResponse;
+    log.info(
+      `compendium-ensure: ${result.created ? 'created' : 'reused'} pack ${result.id} ` +
+        `(label="${result.label}", type=${result.type})`,
+    );
+    return result;
+  });
+
+  // Create a single Item document inside a world pack. The pack must
+  // already exist (call /api/compendium/packs/ensure first) and must
+  // be an Item pack — the bridge errors otherwise. The dm-tool editor
+  // strips identity fields (`_id`, `_stats`, embedded `_id`s) before
+  // posting so the payload is always a fresh document.
+  app.post('/api/compendium/items', async (req): Promise<CreateCompendiumItemResponse> => {
+    const body = createCompendiumItemBody.parse(req.body);
+    const result = (await sendCommand('create-compendium-item', body)) as CreateCompendiumItemResponse;
+    log.info(`compendium-create-item: ${result.uuid} (name="${result.name}", type=${result.type})`);
+    return result;
   });
 
   // Pre-aggregated facets for the Monster/Item Browser sidebars. Served

--- a/packages/shared/src/rpc/compendium-items.test.ts
+++ b/packages/shared/src/rpc/compendium-items.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import { compendiumItemPayload, createCompendiumItemBody, ensureCompendiumPackBody } from './schemas.js';
+
+describe('homebrew compendium-item RPC schemas', () => {
+  describe('ensureCompendiumPackBody', () => {
+    it('accepts a lowercase kebab-case name with a label', () => {
+      const parsed = ensureCompendiumPackBody.parse({ name: 'homebrew-items', label: 'Homebrew Items' });
+      expect(parsed).toEqual({ name: 'homebrew-items', label: 'Homebrew Items' });
+    });
+
+    it('accepts an explicit type=Item', () => {
+      const parsed = ensureCompendiumPackBody.parse({ name: 'homebrew', label: 'X', type: 'Item' });
+      expect(parsed.type).toBe('Item');
+    });
+
+    it('rejects names with uppercase letters, spaces, or dots', () => {
+      expect(() => ensureCompendiumPackBody.parse({ name: 'Homebrew', label: 'X' })).toThrow();
+      expect(() => ensureCompendiumPackBody.parse({ name: 'homebrew items', label: 'X' })).toThrow();
+      expect(() => ensureCompendiumPackBody.parse({ name: 'world.x', label: 'X' })).toThrow();
+    });
+
+    it('rejects names that begin with a hyphen', () => {
+      expect(() => ensureCompendiumPackBody.parse({ name: '-homebrew', label: 'X' })).toThrow();
+    });
+
+    it('rejects empty name or label', () => {
+      expect(() => ensureCompendiumPackBody.parse({ name: '', label: 'X' })).toThrow();
+      expect(() => ensureCompendiumPackBody.parse({ name: 'x', label: '' })).toThrow();
+    });
+
+    it('rejects an unsupported pack type', () => {
+      expect(() => ensureCompendiumPackBody.parse({ name: 'x', label: 'X', type: 'Actor' })).toThrow();
+    });
+  });
+
+  describe('compendiumItemPayload', () => {
+    it('round-trips a minimal item with name, type, and system', () => {
+      const parsed = compendiumItemPayload.parse({
+        name: 'Sword of Test',
+        type: 'weapon',
+        system: { level: { value: 1 } },
+      });
+      expect(parsed.name).toBe('Sword of Test');
+      expect(parsed.type).toBe('weapon');
+      expect(parsed.system).toEqual({ level: { value: 1 } });
+      expect(parsed.effects).toBeUndefined();
+    });
+
+    it('round-trips an item with active effects intact (every field preserved)', () => {
+      const input = {
+        name: 'Cloak of Resistance',
+        type: 'equipment',
+        system: { level: { value: 5 } },
+        effects: [
+          {
+            name: 'Resistance Bonus',
+            disabled: false,
+            transfer: true,
+            changes: [
+              { key: 'system.attributes.resistances.fire', mode: 2, value: '5', priority: 20 },
+              { key: 'system.attributes.ac.value', mode: 4, value: '18' },
+            ],
+            duration: { rounds: 10 },
+          },
+        ],
+      };
+      const parsed = compendiumItemPayload.parse(input);
+      expect(parsed.effects).toHaveLength(1);
+      expect(parsed.effects?.[0]?.changes).toEqual(input.effects[0].changes);
+      expect(parsed.effects?.[0]?.duration).toEqual({ rounds: 10 });
+      expect(parsed.effects?.[0]?.transfer).toBe(true);
+    });
+
+    it('rejects a change row with mode out of range', () => {
+      expect(() =>
+        compendiumItemPayload.parse({
+          name: 'X',
+          type: 'weapon',
+          system: {},
+          effects: [{ name: 'e', changes: [{ key: 'k', mode: 99, value: '1' }] }],
+        }),
+      ).toThrow();
+    });
+
+    it('rejects an effect with an empty name', () => {
+      expect(() =>
+        compendiumItemPayload.parse({
+          name: 'X',
+          type: 'weapon',
+          system: {},
+          effects: [{ name: '' }],
+        }),
+      ).toThrow();
+    });
+
+    it('rejects when system is missing', () => {
+      expect(() => compendiumItemPayload.parse({ name: 'X', type: 'weapon' })).toThrow();
+    });
+  });
+
+  describe('createCompendiumItemBody', () => {
+    it('round-trips a full request', () => {
+      const parsed = createCompendiumItemBody.parse({
+        packId: 'world.homebrew-items',
+        item: { name: 'X', type: 'weapon', system: {} },
+      });
+      expect(parsed.packId).toBe('world.homebrew-items');
+      expect(parsed.item.name).toBe('X');
+    });
+
+    it('rejects empty packId', () => {
+      expect(() =>
+        createCompendiumItemBody.parse({ packId: '', item: { name: 'X', type: 'w', system: {} } }),
+      ).toThrow();
+    });
+  });
+});

--- a/packages/shared/src/rpc/index.ts
+++ b/packages/shared/src/rpc/index.ts
@@ -15,7 +15,10 @@ import type {
   addItemFromCompendiumBody,
   adjustActorConditionBody,
   adjustActorResourceBody,
+  compendiumItemPayload,
   createActorBody,
+  createCompendiumItemBody,
+  ensureCompendiumPackBody,
   invokeActorActionBody,
   resolvePromptBody,
   rollActorStatisticBody,
@@ -33,6 +36,34 @@ export type UpdateActorItemBody = z.infer<typeof updateActorItemBody>;
 export type ResolvePromptBody = z.infer<typeof resolvePromptBody>;
 export type UploadAssetBody = z.infer<typeof uploadAssetBody>;
 export type InvokeActorActionBody = z.infer<typeof invokeActorActionBody>;
+export type EnsureCompendiumPackBody = z.infer<typeof ensureCompendiumPackBody>;
+export type CreateCompendiumItemBody = z.infer<typeof createCompendiumItemBody>;
+export type CompendiumItemPayload = z.infer<typeof compendiumItemPayload>;
+
+// Response from POST /api/compendium/packs/ensure — mirrored on the
+// bridge side. `created: true` means a new pack was provisioned;
+// `false` means an existing pack with the same id was reused.
+export interface EnsureCompendiumPackResponse {
+  /** Full Foundry pack id, e.g. `world.homebrew-items`. */
+  id: string;
+  /** Display label as stored in pack metadata. */
+  label: string;
+  /** Document type — currently always `'Item'` (constrained by request schema). */
+  type: 'Item';
+  created: boolean;
+}
+
+// Response from POST /api/compendium/items — the new document's
+// identity for the caller to navigate to or stash.
+export interface CreateCompendiumItemResponse {
+  /** Document id within the pack. */
+  id: string;
+  /** Full uuid, e.g. `Compendium.world.homebrew-items.Item.<id>`. */
+  uuid: string;
+  packId: string;
+  name: string;
+  type: string;
+}
 
 // Action-specific param/response shapes. Each action routes through
 // `POST /api/actors/:id/actions/:action` with `params` shaped like the

--- a/packages/shared/src/rpc/schemas.ts
+++ b/packages/shared/src/rpc/schemas.ts
@@ -297,3 +297,89 @@ export const uploadAssetBody = z.object({
   path: z.string().min(1),
   dataBase64: z.string().min(1),
 });
+
+// ---------------------------------------------------------------------------
+// Homebrew item creator (dm-tool's Item Browser → Create)
+// ---------------------------------------------------------------------------
+
+// World pack scope-less name. Foundry composes the actual id as
+// `world.<name>`, so `name` must be safe for that key — lowercase
+// kebab-case, no dots. The bridge also enforces this.
+const packShortName = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(/^[a-z0-9][a-z0-9-]*$/, 'pack name must be lowercase kebab-case (a-z, 0-9, -)');
+
+// POST /api/compendium/packs/ensure — idempotent create of a world pack.
+// `name` is the scope-less short name; the bridge prefixes `world.` to
+// build the full id. `label` is the display name shown in the Foundry
+// sidebar. `type` is fixed to 'Item' for now — the editor only creates
+// items, and constraining the schema means a misuse 400s rather than
+// silently producing an Actor pack the consumer can't write to.
+export const ensureCompendiumPackBody = z.object({
+  name: packShortName,
+  label: z.string().min(1).max(128),
+  type: z.literal('Item').optional(),
+});
+
+// One ActiveEffect change row. Mirrors Foundry's
+// `ActiveEffectData.changes` shape — `mode` is one of the numeric
+// CONST.ACTIVE_EFFECT_MODES values (0=custom, 1=multiply, 2=add,
+// 3=downgrade, 4=upgrade, 5=override). `priority` is optional and
+// defaults to mode * 10 in Foundry.
+export const activeEffectChange = z.object({
+  key: z.string().min(1),
+  mode: z.number().int().min(0).max(5),
+  value: z.string(),
+  priority: z.number().int().optional(),
+});
+
+// One ActiveEffect document. Kept minimal — the editor writes name,
+// changes, transfer, disabled, duration, and an optional icon. The
+// bridge passes the object through to `pack.documentClass.create`'s
+// `effects` array verbatim.
+export const activeEffectPayload = z.object({
+  name: z.string().min(1),
+  img: z.string().optional(),
+  disabled: z.boolean().optional(),
+  // ActiveEffect transfer flag — when true on an item, applying the
+  // item to an actor copies the effect onto the actor. PF2e mostly
+  // uses RuleElements (system.rules) for this, but vanilla
+  // ActiveEffects still work.
+  transfer: z.boolean().optional(),
+  changes: z.array(activeEffectChange).optional(),
+  duration: z
+    .object({
+      seconds: z.number().int().nonnegative().optional(),
+      rounds: z.number().int().nonnegative().optional(),
+      turns: z.number().int().nonnegative().optional(),
+    })
+    .optional(),
+});
+
+// Item document payload accepted by `create-compendium-item`. `system`
+// is opaque (`Record<string, unknown>`) because each pf2e item type
+// has a different shape and the editor knows the difference; the
+// bridge writes `system` verbatim. `effects` is a parallel array of
+// embedded ActiveEffect docs (Foundry handles `effects` as embedded
+// documents on Item.create). `flags` is left open for future
+// callers (module-scoped flags, source attribution, etc.).
+export const compendiumItemPayload = z.object({
+  name: z.string().min(1).max(256),
+  type: z.string().min(1).max(64),
+  img: z.string().optional(),
+  system: z.record(z.string(), z.unknown()),
+  effects: z.array(activeEffectPayload).optional(),
+  flags: z.record(z.string(), z.record(z.string(), z.unknown())).optional(),
+});
+
+// POST /api/compendium/items — create a single Item document in a
+// world pack. The bridge resolves `packId` against `game.packs`, errors
+// if it doesn't exist or isn't an Item pack, and returns the new
+// document's id + uuid. Use `ensureCompendiumPackBody` first to
+// guarantee the pack exists.
+export const createCompendiumItemBody = z.object({
+  packId: z.string().min(1),
+  item: compendiumItemPayload,
+});


### PR DESCRIPTION
﻿## Summary

Adds a homebrew item creator to dm-tool''s Item Browser. End-to-end across all four layers — shared RPC contract, foundry-api-bridge commands, foundry-mcp HTTP routes, and the dm-tool React UI. Items land in a dedicated world compendium (`world.homebrew-items`), created on first save. Existing items can be cloned via "Use as template" with identity fields stripped so the result is a fresh document.

**Apps touched**

- `apps/dm-tool` — `npm run dev:dm-tool` (Item Browser → "New homebrew item" toolbar button; "Use as template" on each item''s detail pane)
- `apps/foundry-mcp` — `npm run dev:mcp` (new `POST /api/compendium/packs/ensure` and `POST /api/compendium/items` routes)
- `apps/foundry-api-bridge` — `./local.sh up` (two new bridge command handlers; needs to be running inside Foundry to actually create the pack/items)

## Architecture

| Layer | Change |
|---|---|
| `packages/shared/src/rpc/schemas.ts` | New Zod schemas: `ensureCompendiumPackBody`, `compendiumItemPayload`, `createCompendiumItemBody`, plus an `activeEffectChange` row schema. Body types + response types re-exported via `index.ts`. |
| `apps/foundry-api-bridge` | Two new handlers under `commands/handlers/world/`: `EnsureCompendiumPackHandler` (idempotent `CompendiumCollection.createCompendium`, validates name shape + type compat) and `CreateCompendiumItemHandler` (`pack.documentClass.create` with the embedded effects array normalised). Wired into `commands/types/{compendium,base}.ts` and registered in `main.ts`. |
| `apps/foundry-mcp/src/http/routes/compendium.ts` | Two thin POST routes that parse the shared schemas and forward to the new commands. |
| `apps/dm-tool` (electron main) | `electron/compendium/{client,index}.ts` learn the new HTTP methods. New IPC file `electron/ipc/homebrew-items.ts` exposes `getCompendiumItemTemplate` (clone-strips-identity) + `ensureHomebrewItemPack` + `createHomebrewItem`. `preload.ts` + `ipc/types.ts` carry the new `ElectronAPI` methods. |
| dm-tool renderer | New `features/item-browser/HomebrewItemEditorModal.tsx` (4 tabs: Basic / Mechanical / Effects / Advanced) + `homebrew-editor-helpers.ts` (pure draft↔payload conversion). `ItemBrowser.tsx` gains a "New homebrew item" toolbar button; `ItemDetailPane.tsx` gains "Use as template". |

## Editor scope

- Tier-1 PF2e item types: weapon, armor, shield, consumable, equipment, treasure (the brief''s "loot")
- Common fields: name, level, rarity, traits, price (cp/sp/gp/pp), bulk, source, image URL, description (HTML)
- Per-type mechanical fields (weapon damage die/dice/type/group/category, armor AC bonus + strength/dex/check/slowness, shield hardness/HP/AC, consumable type, equipment usage, treasure stackGroup)
- Frequency (PF2e equivalent of dnd5e `uses.per`) — PT1M / PT1H / PT24H / day / turn / round
- Charges (`system.uses.value` / `.max`)
- Foundry ActiveEffects with full `changes` editor (key / mode / value / priority) + transfer + duration in rounds
- `system.rules` (PF2e RuleElements) as a JSON-array power-user field
- Advanced tab exposes the raw `system` object — editor-managed fields are overlaid on save, anything else (custom modules'' fields) round-trips untouched via `systemRaw`

## Tests

- `apps/foundry-api-bridge` — 14 new Jest tests: create + reuse, type-conflict rejection, name-pattern validation, ActiveEffect round-trip preservation, document-class `create` returning a single doc vs array.
- `packages/shared` — Zod schema tests for the new bodies (mode-out-of-range, missing system, kebab-case enforcement, etc.).
- `apps/dm-tool` — 23 helper tests (greenfield drafts, template→draft reads, draft→payload writes per type, `systemRaw` round-trip preserves unknown fields, rules JSON validation) + 6 IPC tests for `stripIdentityForClone` confirming `_id` / `_stats` / effect.origin are dropped.

All workspace test suites pass (dm-tool 439, bridge 808, player-portal 519, pf2e-rules 46, shared 228). `npm run typecheck` clean across the repo. `npm run lint` reports 0 errors. `npm run knip` shows only pre-existing configuration hints.

## Tradeoffs / scope notes

- The brief originally said "dnd5e schema" — confirmed with you to target PF2e. Mappings: attunement → invested trait, dnd5e `uses.per` → PF2e `system.frequency`, weight → bulk.
- "Tool" isn''t a PF2e item type and was dropped; "loot" mapped to PF2e''s `treasure`.
- Editor exposes Tier-1 fields per type plus an Advanced JSON tab as the escape hatch — full PF2e item-sheet parity is out of scope. The Advanced tab + `systemRaw` round-trip mean cloned items keep every field the editor doesn''t know about untouched.
- `system.rules` is a JSON-array textarea rather than a structured editor — the rule-element type set is too large to model exhaustively in this PR.
- The compendium pack id is fixed at `world.homebrew-items`. Lifting it to a setting is a follow-up if a second homebrew pack ever becomes desirable.

## Test plan

- [ ] Open dm-tool against a live foundry-mcp + foundry-api-bridge; navigate to Item Browser
- [ ] Click "New homebrew item" — modal opens to a blank `equipment` draft
- [ ] Fill in name + per-type fields, click "Save to Foundry" — verify `world.homebrew-items` is created and the new item appears in Foundry''s compendium sidebar
- [ ] Click an existing item → "Use as template" — modal seeds with the item''s data; identity is stripped (re-saving creates a new doc, not an alias)
- [ ] Verify weapon/armor/shield/consumable/treasure type forms each surface their per-type fields
- [ ] Add an ActiveEffect with a `system.bonuses.damage.bonus` change at mode 2 (Add) value `1`, transfer `true`, duration `5 rounds` — save and confirm in Foundry the item carries the effect
- [ ] Edit the Advanced JSON tab to add a custom flag, save, verify it round-trips
- [ ] Add a `system.rules` array (e.g. `[{"key":"FlatModifier","selector":"ac","value":1}]`) — save and verify Foundry''s rule-element panel shows it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
