### PR TITLE
ci: publish PR images to GHCR on every pull request

### DIFF
--- a/.github/workflows/pr-image.yml
+++ b/.github/workflows/pr-image.yml
@@ -1,0 +1,127 @@
+name: PR images
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to rebuild'
+        required: true
+        type: string
+
+# Cancel in-flight builds for the same PR when a new push arrives.
+# On PR close this also cancels any still-running build for the same PR.
+concurrency:
+  group: pr-image-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+  pull-requests: read
+
+jobs:
+  build-and-push:
+    if: github.event_name == 'workflow_dispatch' || github.event.action != 'closed'
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+          - service: foundry
+            image: ghcr.io/alexdickerson/foundry-toolkit-foundry
+            dockerfile: deploy/Dockerfile.foundry
+          - service: foundry-mcp
+            image: ghcr.io/alexdickerson/foundry-toolkit-mcp
+            dockerfile: deploy/Dockerfile.foundry-mcp
+          - service: player-portal
+            image: ghcr.io/alexdickerson/foundry-toolkit-portal
+            dockerfile: deploy/Dockerfile.player-portal
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute short SHA
+        id: sha
+        run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ matrix.image }}
+          # pr-<number>        rolling tag — always points to the latest commit on the PR
+          # pr-<number>-<sha>  immutable tag — pin to a specific commit when debugging
+          # No 'latest' tag; that belongs to releases only.
+          tags: |
+            type=raw,value=pr-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+            type=raw,value=pr-${{ github.event.pull_request.number || github.event.inputs.pr_number }}-${{ steps.sha.outputs.short }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+          # Shares the GHA cache with release builds — same Dockerfiles, so hits are likely.
+          cache-from: type=gha,scope=${{ matrix.service }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.service }}
+
+  # Runs when a PR is closed (merged or abandoned) and deletes both the rolling
+  # pr-<number> tag and any pr-<number>-<sha> tags from all three GHCR packages.
+  #
+  # Auth note: GITHUB_TOKEN can delete package versions only for packages that are
+  # linked to this repository. Packages published here via GITHUB_TOKEN are
+  # auto-linked on first push, so this should work after the first successful build.
+  # If you see 403 errors on PR close before any images have been published, visit
+  # each package's settings at https://github.com/users/alexdickerson/packages and
+  # link it to this repository, or store a PAT with delete:packages scope as
+  # GHCR_DELETE_TOKEN and replace secrets.GITHUB_TOKEN below.
+  cleanup:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Delete PR image tags from GHCR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          PACKAGES=(
+            "foundry-toolkit-foundry"
+            "foundry-toolkit-mcp"
+            "foundry-toolkit-portal"
+          )
+          for pkg in "${PACKAGES[@]}"; do
+            echo "Scanning ${pkg} for pr-${PR_NUMBER} tags..."
+            # 404 (package never published) yields [] via the fallback; treat as empty.
+            response=$(gh api "/user/packages/container/${pkg}/versions?per_page=100" 2>/dev/null || echo "[]")
+            version_ids=$(echo "$response" | jq -r \
+              --arg pr_tag    "pr-${PR_NUMBER}" \
+              --arg pr_prefix "pr-${PR_NUMBER}-" \
+              '.[] | select(.metadata.container.tags | map(. == $pr_tag or startswith($pr_prefix)) | any) | .id')
+            if [ -z "$version_ids" ]; then
+              echo "No pr-${PR_NUMBER} versions found in ${pkg}, skipping"
+              continue
+            fi
+            while IFS= read -r vid; do
+              echo "Deleting version ${vid} from ${pkg}..."
+              # Non-zero exit (including 404 = already gone) is logged but not fatal.
+              if gh api --method DELETE "/user/packages/container/${pkg}/versions/${vid}" 2>&1; then
+                echo "Deleted ${vid}"
+              else
+                echo "Warning: could not delete ${vid} from ${pkg} (skipping)"
+              fi
+            done <<< "$version_ids"
+          done


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/pr-image.yml` — a new workflow that builds and pushes Docker images for every PR to GHCR, separate from the existing tag-driven `release-image.yml`.
- Publishes two tags per service per commit: `pr-<number>` (rolling, always the latest commit) and `pr-<number>-<sha>` (immutable, for pinning a specific commit).
- Cleans up both tag types from GHCR when the PR is closed (merged or abandoned).

## Apps touched

**No apps touched.** Only `.github/workflows/pr-image.yml` was added. No app code, packages, or config was changed — no dev server needs to be spun up to validate this PR.

The PR itself will trigger the new workflow, so CI run success is the functional validation.

## Services / images

| Service | Image | Dockerfile |
|---|---|---|
| `foundry` | `ghcr.io/alexdickerson/foundry-toolkit-foundry` | `deploy/Dockerfile.foundry` |
| `foundry-mcp` | `ghcr.io/alexdickerson/foundry-toolkit-mcp` | `deploy/Dockerfile.foundry-mcp` |
| `player-portal` | `ghcr.io/alexdickerson/foundry-toolkit-portal` | `deploy/Dockerfile.player-portal` |

`apps/foundry-api-bridge` is intentionally excluded, mirroring the release workflow.

## Usage

```bash
# Pull the latest build for PR #42
docker pull ghcr.io/alexdickerson/foundry-toolkit-mcp:pr-42

# Pin to a specific commit
docker pull ghcr.io/alexdickerson/foundry-toolkit-mcp:pr-42-abc1234
```

## Cleanup credential note

`GITHUB_TOKEN` can delete GHCR package versions only for packages linked to this repository. Packages published here are auto-linked on first push, so cleanup should work after the first successful build runs. If cleanup returns 403s before any images have been published, visit each package's settings on GHCR and link it to this repository (or add a PAT with `delete:packages` scope as `GHCR_DELETE_TOKEN`).

## Test plan

- [ ] Confirm the `PR images` workflow appears in the Actions tab and runs on this PR
- [ ] Verify all three service builds succeed and tags appear in GHCR
- [ ] Confirm `docker pull ghcr.io/alexdickerson/foundry-toolkit-mcp:pr-<this-pr-number>` works
- [ ] Merge or close this PR and verify the cleanup job deletes the tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)