### PR TITLE
chore(vscode): nest test files under their source in the explorer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,14 @@
   "[jsonc]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "explorer.fileNesting.enabled": true,
+  "explorer.fileNesting.expand": false,
+  "explorer.fileNesting.patterns": {
+    "*.ts": "${capture}.test.ts, ${capture}.spec.ts",
+    "*.tsx": "${capture}.test.tsx, ${capture}.spec.tsx, ${capture}.test.ts",
+    "*.js": "${capture}.test.js, ${capture}.spec.js",
+    "*.jsx": "${capture}.test.jsx, ${capture}.spec.jsx"
+  },
   "search.exclude": {
     "**/node_modules": true,
     "**/dist": true,


### PR DESCRIPTION
Add VS Code file-nesting settings to collapse test files under their source files in the explorer tree.

**Apps touched**
- None (pure editor config)