### PR TITLE
chore(vscode): nest boilerplate config files under sensible parents

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,7 +21,16 @@
     "*.ts": "${capture}.test.ts, ${capture}.spec.ts",
     "*.tsx": "${capture}.test.tsx, ${capture}.spec.tsx, ${capture}.test.ts",
     "*.js": "${capture}.test.js, ${capture}.spec.js",
-    "*.jsx": "${capture}.test.jsx, ${capture}.spec.jsx"
+    "*.jsx": "${capture}.test.jsx, ${capture}.spec.jsx",
+
+    "package.json": "package-lock.json, npm-shrinkwrap.json, yarn.lock, pnpm-lock.yaml, bun.lockb, .npmrc, .nvmrc, .node-version",
+    "tsconfig.json": "tsconfig.*.json",
+    "vite.config.ts": "vite.config.*.ts, vitest.config.ts, vitest.config.*.ts",
+    "vitest.config.ts": "vitest.config.*.ts",
+    "eslint.config.js": ".eslintrc*, .eslintignore, .prettierrc*, .prettierignore, prettier.config.*",
+    ".gitignore": ".gitattributes, .editorconfig, .gitmodules",
+    "Dockerfile": "Dockerfile.*, .dockerignore, docker-compose*.yml, docker-compose*.yaml",
+    "README.md": "README*, CHANGELOG*, CONTRIBUTING*, LICENSE*, NOTICE*, AUTHORS*, CODE_OF_CONDUCT*"
   },
   "search.exclude": {
     "**/node_modules": true,


### PR DESCRIPTION
## Summary
Restores VS Code's default lockfile and tsconfig nesting that PR #212's customization inadvertently dropped, and adds patterns for this repo's specific config files.

**Apps touched**
- None — pure editor configuration

## Details
When `explorer.fileNesting.patterns` is customized in VS Code, it replaces the built-in defaults rather than merging with them. This restores those defaults and adds patterns for:
- Vite/Vitest config files
- ESLint and Prettier configuration
- Docker files
- README and documentation files

🤖 Generated with [Claude Code](https://claude.com/claude-code)