### PR TITLE
feat(deploy): headless-bridge service for 24/7 api-bridge availability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
           npm run test --workspace apps/player-portal
           npm run test --workspace apps/foundry-api-bridge
           npm run test --workspace apps/foundry-mcp
+          npm run test --workspace apps/headless-bridge
           npm run test --workspace packages/shared
           npm run test --workspace packages/pf2e-rules
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ apps/dm-tool/dist/
 apps/player-portal/dist/
 apps/player-portal/server-dist/
 apps/foundry-mcp/dist/
+apps/headless-bridge/dist/
 packages/*/dist/
 
 # foundry-api-bridge: keep checked-in static assets in dist/ but ignore vite output

--- a/apps/headless-bridge/package.json
+++ b/apps/headless-bridge/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/main.js"
   },
   "dependencies": {
-    "playwright": "1.49.0"
+    "playwright": "1.59.1"
   },
   "devDependencies": {
     "@types/node": "^25.0.0",

--- a/apps/headless-bridge/package.json
+++ b/apps/headless-bridge/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@foundry-toolkit/headless-bridge",
+  "version": "0.1.0",
+  "description": "Headless Chromium process that keeps the foundry-api-bridge module connected 24/7",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "start": "node dist/main.js"
+  },
+  "dependencies": {
+    "playwright": "1.49.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.0.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.4"
+  }
+}

--- a/apps/headless-bridge/src/env.test.ts
+++ b/apps/headless-bridge/src/env.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { parseEnv, EnvError } from './env.js';
+
+const BASE_ENV = {
+  FOUNDRY_URL: 'http://foundry:30000',
+  BRIDGE_GM_USER: 'Bridge GM',
+  BRIDGE_WORLD_ID: 'my-campaign',
+};
+
+describe('parseEnv', () => {
+  it('parses required and optional fields', () => {
+    const env = parseEnv({
+      ...BASE_ENV,
+      FOUNDRY_ADMIN_KEY: 'secret',
+      FOUNDRY_MCP_URL: 'http://mcp:8765',
+      BRIDGE_GM_PASS: 'pw',
+    });
+    expect(env.foundryUrl).toBe('http://foundry:30000');
+    expect(env.foundryAdminKey).toBe('secret');
+    expect(env.foundryMcpUrl).toBe('http://mcp:8765');
+    expect(env.bridgeGmUser).toBe('Bridge GM');
+    expect(env.bridgeGmPass).toBe('pw');
+    expect(env.bridgeWorldId).toBe('my-campaign');
+  });
+
+  it('strips trailing slash from FOUNDRY_URL', () => {
+    const env = parseEnv({ ...BASE_ENV, FOUNDRY_URL: 'http://foundry:30000/' });
+    expect(env.foundryUrl).toBe('http://foundry:30000');
+  });
+
+  it('strips trailing slash from FOUNDRY_MCP_URL', () => {
+    const env = parseEnv({ ...BASE_ENV, FOUNDRY_MCP_URL: 'http://foundry-mcp:8765/' });
+    expect(env.foundryMcpUrl).toBe('http://foundry-mcp:8765');
+  });
+
+  it('defaults FOUNDRY_MCP_URL to http://foundry-mcp:8765', () => {
+    const env = parseEnv(BASE_ENV);
+    expect(env.foundryMcpUrl).toBe('http://foundry-mcp:8765');
+  });
+
+  it('defaults optional fields to empty string', () => {
+    const env = parseEnv(BASE_ENV);
+    expect(env.foundryAdminKey).toBe('');
+    expect(env.bridgeGmPass).toBe('');
+  });
+
+  it('throws EnvError when FOUNDRY_URL is missing', () => {
+    const { FOUNDRY_URL: _, ...rest } = BASE_ENV;
+    expect(() => parseEnv(rest)).toThrow(EnvError);
+    expect(() => parseEnv(rest)).toThrow('FOUNDRY_URL');
+  });
+
+  it('throws EnvError when BRIDGE_GM_USER is missing', () => {
+    const { BRIDGE_GM_USER: _, ...rest } = BASE_ENV;
+    expect(() => parseEnv(rest)).toThrow(EnvError);
+    expect(() => parseEnv(rest)).toThrow('BRIDGE_GM_USER');
+  });
+
+  it('throws EnvError when BRIDGE_WORLD_ID is missing', () => {
+    const { BRIDGE_WORLD_ID: _, ...rest } = BASE_ENV;
+    expect(() => parseEnv(rest)).toThrow(EnvError);
+    expect(() => parseEnv(rest)).toThrow('BRIDGE_WORLD_ID');
+  });
+});

--- a/apps/headless-bridge/src/env.ts
+++ b/apps/headless-bridge/src/env.ts
@@ -1,0 +1,35 @@
+export interface BridgeEnv {
+  foundryUrl: string;
+  foundryAdminKey: string;
+  foundryMcpUrl: string;
+  bridgeGmUser: string;
+  bridgeGmPass: string;
+  bridgeWorldId: string;
+}
+
+export class EnvError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'EnvError';
+  }
+}
+
+export function parseEnv(env: Record<string, string | undefined> = process.env): BridgeEnv {
+  function required(key: string): string {
+    const value = env[key];
+    if (!value) throw new EnvError(`Missing required env var: ${key}`);
+    return value;
+  }
+  function optional(key: string, defaultValue = ''): string {
+    return env[key] ?? defaultValue;
+  }
+
+  return {
+    foundryUrl: required('FOUNDRY_URL').replace(/\/$/, ''),
+    foundryAdminKey: optional('FOUNDRY_ADMIN_KEY'),
+    foundryMcpUrl: optional('FOUNDRY_MCP_URL', 'http://foundry-mcp:8765').replace(/\/$/, ''),
+    bridgeGmUser: required('BRIDGE_GM_USER'),
+    bridgeGmPass: optional('BRIDGE_GM_PASS'),
+    bridgeWorldId: required('BRIDGE_WORLD_ID'),
+  };
+}

--- a/apps/headless-bridge/src/foundry.ts
+++ b/apps/headless-bridge/src/foundry.ts
@@ -1,0 +1,112 @@
+import type { Page } from 'playwright';
+import type { BridgeEnv } from './env.js';
+
+const LOG = '[headless-bridge]';
+
+// Foundry VTT v14 page routes:
+//   /setup  — world management (requires admin auth if FOUNDRY_ADMIN_KEY is set)
+//   /join   — user login for the currently-active world
+//   /game   — in-world view; the api-bridge module activates here
+
+export async function loginToWorld(page: Page, env: BridgeEnv): Promise<void> {
+  const { foundryUrl, foundryAdminKey, bridgeGmUser, bridgeGmPass, bridgeWorldId } = env;
+
+  console.info(`${LOG} Navigating to ${foundryUrl}`);
+  await page.goto(foundryUrl, { waitUntil: 'networkidle', timeout: 30_000 });
+  console.info(`${LOG} Landed on: ${page.url()}`);
+
+  if (page.url().includes('/game')) {
+    console.info(`${LOG} Already in-world — nothing to do`);
+    return;
+  }
+
+  if (!page.url().includes('/join')) {
+    // On the setup page — authenticate as admin and launch the world
+    await handleSetup(page, foundryUrl, foundryAdminKey, bridgeWorldId);
+  }
+
+  await handleJoin(page, foundryUrl, bridgeGmUser, bridgeGmPass);
+}
+
+async function handleSetup(page: Page, foundryUrl: string, adminKey: string, worldId: string): Promise<void> {
+  // Foundry shows an admin password form when the admin key is set and the
+  // client has no valid session cookie. The input name is "adminKey" in v13
+  // and "key" in some v14 builds — try both.
+  const adminInput = page.locator('input[name="adminKey"], input[name="key"]').first();
+  const needsAuth = await adminInput.isVisible({ timeout: 3_000 }).catch(() => false);
+
+  if (needsAuth) {
+    if (!adminKey) {
+      throw new Error(
+        'Foundry setup requires admin authentication but FOUNDRY_ADMIN_KEY is not set. ' +
+          'Set FOUNDRY_ADMIN_KEY to the Foundry admin password, or pre-launch the world manually ' +
+          'so the headless browser can go straight to /join.',
+      );
+    }
+    console.info(`${LOG} Submitting admin key`);
+    await adminInput.fill(adminKey);
+    await page.locator('button[type="submit"]').first().click();
+    await page.waitForLoadState('networkidle', { timeout: 30_000 });
+    console.info(`${LOG} Admin auth done — now on: ${page.url()}`);
+  }
+
+  // Admin auth may have redirected straight to /join if a world was already active.
+  if (page.url().includes('/join')) return;
+
+  // Find the world card by its ID (= directory slug under Data/worlds/).
+  // Foundry v14 renders each world as a list item with a data-id attribute.
+  console.info(`${LOG} Locating world "${worldId}" in setup`);
+  const worldCard = page.locator(`[data-id="${worldId}"]`).first();
+  const cardVisible = await worldCard.isVisible({ timeout: 15_000 }).catch(() => false);
+  if (!cardVisible) {
+    throw new Error(
+      `World "${worldId}" not found on the Foundry setup page. ` +
+        "Check that BRIDGE_WORLD_ID matches the world's directory slug " +
+        '(the name shown under each world card in the setup UI, not the display title). ' +
+        `Worlds live in Data/worlds/<slug>/.`,
+    );
+  }
+
+  // The launch button lives inside the world card. Foundry uses a variety of
+  // button labels ("Launch", "Launch World") across versions — match loosely.
+  const launchBtn = worldCard
+    .locator('button')
+    .filter({ hasText: /launch/i })
+    .first();
+  if (!(await launchBtn.isVisible({ timeout: 2_000 }).catch(() => false))) {
+    throw new Error(
+      `Could not find a Launch button for world "${worldId}". ` +
+        'The world card was found but the launch control is missing — the world may already be launching.',
+    );
+  }
+
+  console.info(`${LOG} Launching world "${worldId}"`);
+  await launchBtn.click();
+
+  // Foundry initializes the world then redirects to /join.
+  await page.waitForURL((url) => url.href.startsWith(`${foundryUrl}/join`), { timeout: 90_000 });
+  console.info(`${LOG} World active`);
+}
+
+async function handleJoin(page: Page, foundryUrl: string, username: string, password: string): Promise<void> {
+  await page.waitForLoadState('networkidle', { timeout: 30_000 });
+  console.info(`${LOG} Selecting user "${username}"`);
+
+  // Foundry renders world users in a <select> whose option text is the
+  // display name and value is the user's UUID.
+  const userSelect = page.locator('select[name="userid"], select#select-character, select').first();
+  await userSelect.waitFor({ state: 'visible', timeout: 15_000 });
+  await userSelect.selectOption({ label: username });
+
+  const passwordInput = page.locator('input[name="password"], input[type="password"]').first();
+  if (password && (await passwordInput.isVisible({ timeout: 2_000 }).catch(() => false))) {
+    await passwordInput.fill(password);
+  }
+
+  await page.locator('button[type="submit"]').first().click();
+  console.info(`${LOG} Joining — waiting for world to load (up to 2 min)`);
+
+  // World load populates all actors, scenes, and modules. Allow generous time.
+  await page.waitForURL((url) => url.href.startsWith(`${foundryUrl}/game`), { timeout: 120_000 });
+  console.info(`${LOG} In-world as "${username}" — api-bridge module is initialising`);
+}

--- a/apps/headless-bridge/src/health.ts
+++ b/apps/headless-bridge/src/health.ts
@@ -1,0 +1,14 @@
+export interface HealthResponse {
+  ok: boolean;
+  foundryConnected: boolean;
+}
+
+export async function checkMcpHealth(mcpUrl: string): Promise<HealthResponse> {
+  const response = await fetch(`${mcpUrl}/health`, {
+    signal: AbortSignal.timeout(5_000),
+  });
+  if (!response.ok) {
+    throw new Error(`Health endpoint returned ${response.status}`);
+  }
+  return (await response.json()) as HealthResponse;
+}

--- a/apps/headless-bridge/src/health.ts
+++ b/apps/headless-bridge/src/health.ts
@@ -3,9 +3,11 @@ export interface HealthResponse {
   foundryConnected: boolean;
 }
 
+const HEALTH_TIMEOUT_MS = 5_000;
+
 export async function checkMcpHealth(mcpUrl: string): Promise<HealthResponse> {
   const response = await fetch(`${mcpUrl}/health`, {
-    signal: AbortSignal.timeout(5_000),
+    signal: AbortSignal.timeout(HEALTH_TIMEOUT_MS),
   });
   if (!response.ok) {
     throw new Error(`Health endpoint returned ${response.status}`);

--- a/apps/headless-bridge/src/main.ts
+++ b/apps/headless-bridge/src/main.ts
@@ -1,0 +1,99 @@
+import { chromium } from 'playwright';
+import { parseEnv } from './env.js';
+import { loginToWorld } from './foundry.js';
+import { checkMcpHealth } from './health.js';
+
+const LOG = '[headless-bridge]';
+
+// After a successful login, give the world time to load and the api-bridge
+// module time to open its WebSocket to foundry-mcp before health checks begin.
+const WARMUP_DELAY_MS = 60_000;
+const HEALTH_POLL_INTERVAL_MS = 30_000;
+// Allow this many consecutive failures before crashing so a brief foundry-mcp
+// restart or transient network hiccup doesn't cause an unnecessary restart.
+const FAILURE_THRESHOLD = 3;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function main(): Promise<void> {
+  const env = parseEnv();
+
+  console.info(`${LOG} Starting`);
+  console.info(`${LOG}   Foundry: ${env.foundryUrl}`);
+  console.info(`${LOG}   World:   ${env.bridgeWorldId}`);
+  console.info(`${LOG}   User:    ${env.bridgeGmUser}`);
+  console.info(`${LOG}   MCP:     ${env.foundryMcpUrl}`);
+
+  const browser = await chromium.launch({ headless: true });
+  console.info(`${LOG} Chromium launched`);
+
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  page.on('crash', () => {
+    console.error(`${LOG} Page crashed — exiting for Docker restart`);
+    process.exit(1);
+  });
+
+  page.on('close', () => {
+    console.error(`${LOG} Page closed unexpectedly — exiting for Docker restart`);
+    process.exit(1);
+  });
+
+  // Surface Foundry JS errors at warn level so they appear in logs without
+  // killing the container — PF2e and other systems emit non-fatal errors.
+  page.on('pageerror', (err) => {
+    console.warn(`${LOG} Foundry page error: ${err.message}`);
+  });
+
+  await loginToWorld(page, env);
+  console.info(`${LOG} Login complete — waiting ${String(WARMUP_DELAY_MS / 1000)}s for bridge module to connect`);
+
+  await sleep(WARMUP_DELAY_MS);
+
+  let consecutiveFailures = 0;
+
+  // Health is probed by hitting foundry-mcp's /health endpoint, which returns
+  // { ok: true, foundryConnected: bool }. The bridge module opens a WebSocket
+  // to foundry-mcp on startup; foundryConnected flips true once it's OPEN.
+  const healthLoop = setInterval(() => {
+    void (async () => {
+      try {
+        const health = await checkMcpHealth(env.foundryMcpUrl);
+        if (health.foundryConnected) {
+          if (consecutiveFailures > 0) {
+            console.info(`${LOG} Bridge reconnected`);
+          }
+          consecutiveFailures = 0;
+        } else {
+          consecutiveFailures++;
+          console.warn(`${LOG} Bridge not connected (${String(consecutiveFailures)}/${String(FAILURE_THRESHOLD)})`);
+          if (consecutiveFailures >= FAILURE_THRESHOLD) {
+            clearInterval(healthLoop);
+            console.error(
+              `${LOG} Bridge disconnected for ${String(FAILURE_THRESHOLD)} consecutive checks — exiting for Docker restart`,
+            );
+            process.exit(1);
+          }
+        }
+      } catch (err) {
+        consecutiveFailures++;
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(`${LOG} Health check error: ${msg} (${String(consecutiveFailures)}/${String(FAILURE_THRESHOLD)})`);
+        if (consecutiveFailures >= FAILURE_THRESHOLD) {
+          clearInterval(healthLoop);
+          console.error(`${LOG} Health checks failed repeatedly — exiting for Docker restart`);
+          process.exit(1);
+        }
+      }
+    })();
+  }, HEALTH_POLL_INTERVAL_MS);
+}
+
+main().catch((err: unknown) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  console.error(`${LOG} Fatal: ${msg}`);
+  process.exit(1);
+});

--- a/apps/headless-bridge/tsconfig.json
+++ b/apps/headless-bridge/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "declaration": false,
+    "sourceMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/apps/headless-bridge/vitest.config.ts
+++ b/apps/headless-bridge/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -52,6 +52,29 @@ SECURE_SESSION_SECRET=change-me-to-something-random
 # without Caddy — also remove the Caddy service from compose.yaml).
 FOUNDRY_ROUTE_PREFIX=foundry
 
+# ── Headless bridge (headless-bridge container) ─────────────────────────────
+# Dedicated Foundry GM account used exclusively by the headless browser to
+# keep the api-bridge module connected 24/7.
+#
+# Setup steps (one-time, in Foundry's web UI):
+#   1. Open http://localhost:30000 and log in as admin.
+#   2. Go to Game Settings → Server Settings → User Management.
+#   3. Create a new user named "bridge-gm" (or any name) with Role = Gamemaster.
+#   4. Set a password for that user and record it as BRIDGE_GM_PASS below.
+#
+# IMPORTANT — one active session per account:
+#   Foundry boots the older session when the same account logs in from a
+#   second browser.  Use a different account than your primary GM so your
+#   real GM session is never interrupted by the headless process.
+#
+# BRIDGE_WORLD_ID is the world's directory slug, NOT its display title.
+#   Find it in Foundry's setup page: it appears in small text under each
+#   world's title, or look inside your Foundry data volume at:
+#     foundry-data/worlds/<slug>/world.json
+BRIDGE_GM_USER=bridge-gm
+BRIDGE_GM_PASS=change-me
+BRIDGE_WORLD_ID=your-world-id
+
 # ── Image tag ────────────────────────────────────────────────────────────────
 # Which GHCR image tag to pull for all three services.
 # Use a pinned version (e.g. v0.2.0) for production; 'latest' for always-current.

--- a/deploy/Dockerfile.headless-bridge
+++ b/deploy/Dockerfile.headless-bridge
@@ -33,13 +33,13 @@ RUN npm run build --workspace apps/headless-bridge
 ###############################################################################
 # Stage 2 — Runtime with pre-installed Chromium
 #
-# mcr.microsoft.com/playwright:v1.49.0-jammy bundles Chromium and all
+# mcr.microsoft.com/playwright:v1.59.1-jammy bundles Chromium and all
 # required system libraries (Ubuntu Jammy).  We skip npm browser download
 # because the base image already provides binaries at /ms-playwright.
 #
 # Playwright npm package version must match this image tag's minor version.
 ###############################################################################
-FROM mcr.microsoft.com/playwright:v1.49.0-jammy
+FROM mcr.microsoft.com/playwright:v1.59.1-jammy
 
 WORKDIR /app
 

--- a/deploy/Dockerfile.headless-bridge
+++ b/deploy/Dockerfile.headless-bridge
@@ -1,0 +1,60 @@
+###############################################################################
+# foundry-toolkit — headless-bridge container
+#
+# Runs a headless Chromium browser (via Playwright) that logs into Foundry as
+# a dedicated GM account and holds the session open 24/7, keeping the
+# foundry-api-bridge module connected to foundry-mcp without requiring a
+# browser tab to stay open.
+#
+# Build context: monorepo root
+#   docker build -f deploy/Dockerfile.headless-bridge \
+#     -t foundry-toolkit-headless-bridge:dev .
+###############################################################################
+
+###############################################################################
+# Stage 1 — Compile TypeScript
+###############################################################################
+FROM node:22-alpine AS build
+WORKDIR /app
+
+# Workspace manifests — cached independently of source changes.
+COPY package.json package-lock.json ./
+COPY apps/headless-bridge/package.json apps/headless-bridge/
+
+# Skip browser download in the build stage; this stage only compiles TS.
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+RUN npm install --ignore-scripts
+
+COPY apps/headless-bridge/src apps/headless-bridge/src
+COPY apps/headless-bridge/tsconfig.json apps/headless-bridge/
+
+RUN npm run build --workspace apps/headless-bridge
+
+###############################################################################
+# Stage 2 — Runtime with pre-installed Chromium
+#
+# mcr.microsoft.com/playwright:v1.49.0-jammy bundles Chromium and all
+# required system libraries (Ubuntu Jammy).  We skip npm browser download
+# because the base image already provides binaries at /ms-playwright.
+#
+# Playwright npm package version must match this image tag's minor version.
+###############################################################################
+FROM mcr.microsoft.com/playwright:v1.49.0-jammy
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+COPY apps/headless-bridge/package.json apps/headless-bridge/
+
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+RUN npm install --ignore-scripts
+
+# Compiled JS from stage 1.
+COPY --from=build /app/apps/headless-bridge/dist apps/headless-bridge/dist
+
+# Drop to a non-root user.
+RUN groupadd -r bridge && useradd -r -g bridge -u 1001 bridge \
+    && chown -R bridge:bridge /app
+USER bridge
+
+CMD ["node", "apps/headless-bridge/dist/main.js"]

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -3,13 +3,13 @@
 Five containers. One env file. Everything the GM needs to run a Foundry VTT
 session with the full foundry-toolkit feature set available to players.
 
-| Service          | Image                                    | Port            | Audience                 |
-| ---------------- | ---------------------------------------- | --------------- | ------------------------ |
-| caddy            | `caddy:2.8`                              | 80, 443         | public internet (TLS)    |
-| foundry          | `foundry-toolkit-foundry:<tag>`          | 30000\*         | GM (via Caddy or direct) |
-| foundry-mcp      | `foundry-toolkit-mcp:<tag>`             | 8765            | internal only            |
-| player-portal    | `foundry-toolkit-portal:<tag>`           | 3000            | players (via Caddy)      |
-| headless-bridge  | `foundry-toolkit-headless-bridge:<tag>`  | none (internal) | automation               |
+| Service         | Image                                   | Port            | Audience                 |
+| --------------- | --------------------------------------- | --------------- | ------------------------ |
+| caddy           | `caddy:2.8`                             | 80, 443         | public internet (TLS)    |
+| foundry         | `foundry-toolkit-foundry:<tag>`         | 30000\*         | GM (via Caddy or direct) |
+| foundry-mcp     | `foundry-toolkit-mcp:<tag>`             | 8765            | internal only            |
+| player-portal   | `foundry-toolkit-portal:<tag>`          | 3000            | players (via Caddy)      |
+| headless-bridge | `foundry-toolkit-headless-bridge:<tag>` | none (internal) | automation               |
 
 \* Port 30000 is bound to `127.0.0.1` only — the GM can reach Foundry directly
 at `http://localhost:30000` without going through Caddy. Port 3000 is not
@@ -145,20 +145,20 @@ simplest.
 
 ## Environment variables
 
-| Variable                | Service(s)                        | Required | Purpose                                                                             |
-| ----------------------- | --------------------------------- | -------- | ----------------------------------------------------------------------------------- |
-| `FOUNDRY_USERNAME`      | foundry                           | yes      | Paizo account username for Foundry download                                         |
-| `FOUNDRY_PASSWORD`      | foundry                           | yes      | Paizo account password                                                              |
-| `FOUNDRY_ADMIN_KEY`     | foundry, headless-bridge          | rec.     | Foundry admin console password                                                      |
-| `FOUNDRY_ROUTE_PREFIX`  | foundry                           | no       | URL path prefix for Foundry (`foundry` → served at `/foundry/`); empty = no prefix  |
-| `OPENAI_API_KEY`        | foundry-mcp                       | no       | GPT-image-1 map editing (`edit_image` tool)                                         |
-| `ALLOW_EVAL`            | foundry-mcp                       | no       | `1` enables `/api/eval` debug endpoint                                              |
-| `SHARED_SECRET`         | foundry-mcp, player-portal        | yes      | Bearer token for `/api/live/*` POST writes                                          |
-| `SECURE_SESSION_SECRET` | player-portal                     | no\*     | Cookie signing for portal user auth                                                 |
-| `BRIDGE_GM_USER`        | headless-bridge                   | yes†     | Foundry username for the headless GM                                                |
-| `BRIDGE_GM_PASS`        | headless-bridge                   | no       | Password for `BRIDGE_GM_USER`                                                       |
-| `BRIDGE_WORLD_ID`       | headless-bridge                   | yes†     | World directory slug to join                                                        |
-| `IMAGE_TAG`             | —                                 | no       | Image tag to pull (default: `latest`)                                               |
+| Variable                | Service(s)                 | Required | Purpose                                                                            |
+| ----------------------- | -------------------------- | -------- | ---------------------------------------------------------------------------------- |
+| `FOUNDRY_USERNAME`      | foundry                    | yes      | Paizo account username for Foundry download                                        |
+| `FOUNDRY_PASSWORD`      | foundry                    | yes      | Paizo account password                                                             |
+| `FOUNDRY_ADMIN_KEY`     | foundry, headless-bridge   | rec.     | Foundry admin console password                                                     |
+| `FOUNDRY_ROUTE_PREFIX`  | foundry                    | no       | URL path prefix for Foundry (`foundry` → served at `/foundry/`); empty = no prefix |
+| `OPENAI_API_KEY`        | foundry-mcp                | no       | GPT-image-1 map editing (`edit_image` tool)                                        |
+| `ALLOW_EVAL`            | foundry-mcp                | no       | `1` enables `/api/eval` debug endpoint                                             |
+| `SHARED_SECRET`         | foundry-mcp, player-portal | yes      | Bearer token for `/api/live/*` POST writes                                         |
+| `SECURE_SESSION_SECRET` | player-portal              | no\*     | Cookie signing for portal user auth                                                |
+| `BRIDGE_GM_USER`        | headless-bridge            | yes†     | Foundry username for the headless GM                                               |
+| `BRIDGE_GM_PASS`        | headless-bridge            | no       | Password for `BRIDGE_GM_USER`                                                      |
+| `BRIDGE_WORLD_ID`       | headless-bridge            | yes†     | World directory slug to join                                                       |
+| `IMAGE_TAG`             | —                          | no       | Image tag to pull (default: `latest`)                                              |
 
 \*Required once the portal user auth feature ships.
 †Required only when running the `headless-bridge` service.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,14 +1,15 @@
 # foundry-toolkit compose stack
 
-Four containers. One env file. Everything the GM needs to run a Foundry VTT
+Five containers. One env file. Everything the GM needs to run a Foundry VTT
 session with the full foundry-toolkit feature set available to players.
 
-| Service       | Image                           | Port    | Audience                 |
-| ------------- | ------------------------------- | ------- | ------------------------ |
-| caddy         | `caddy:2.8`                     | 80, 443 | public internet (TLS)    |
-| foundry       | `foundry-toolkit-foundry:<tag>` | 30000\* | GM (via Caddy or direct) |
-| foundry-mcp   | `foundry-toolkit-mcp:<tag>`     | 8765    | internal only            |
-| player-portal | `foundry-toolkit-portal:<tag>`  | 3000    | players (via Caddy)      |
+| Service          | Image                                    | Port            | Audience                 |
+| ---------------- | ---------------------------------------- | --------------- | ------------------------ |
+| caddy            | `caddy:2.8`                              | 80, 443         | public internet (TLS)    |
+| foundry          | `foundry-toolkit-foundry:<tag>`          | 30000\*         | GM (via Caddy or direct) |
+| foundry-mcp      | `foundry-toolkit-mcp:<tag>`             | 8765            | internal only            |
+| player-portal    | `foundry-toolkit-portal:<tag>`           | 3000            | players (via Caddy)      |
+| headless-bridge  | `foundry-toolkit-headless-bridge:<tag>`  | none (internal) | automation               |
 
 \* Port 30000 is bound to `127.0.0.1` only — the GM can reach Foundry directly
 at `http://localhost:30000` without going through Caddy. Port 3000 is not
@@ -18,6 +19,10 @@ The `foundry-api-bridge` Foundry module is baked into the `foundry` image and
 seeded into the data volume on first boot. Once a world is created and the
 module enabled, it opens a WebSocket connection from the GM's browser tab to
 `foundry-mcp` (port 8765).
+
+The `headless-bridge` service (see [Headless bridge](#headless-bridge) below)
+automates this browser-tab requirement so the connection stays alive 24/7
+without any manual intervention.
 
 ---
 
@@ -140,19 +145,23 @@ simplest.
 
 ## Environment variables
 
-| Variable                | Service(s)                 | Required | Purpose                                                                            |
-| ----------------------- | -------------------------- | -------- | ---------------------------------------------------------------------------------- |
-| `FOUNDRY_USERNAME`      | foundry                    | yes      | Paizo account username for Foundry download                                        |
-| `FOUNDRY_PASSWORD`      | foundry                    | yes      | Paizo account password                                                             |
-| `FOUNDRY_ADMIN_KEY`     | foundry                    | rec.     | Foundry admin console password                                                     |
-| `FOUNDRY_ROUTE_PREFIX`  | foundry                    | no       | URL path prefix for Foundry (`foundry` → served at `/foundry/`); empty = no prefix |
-| `OPENAI_API_KEY`        | foundry-mcp                | no       | GPT-image-1 map editing (`edit_image` tool)                                        |
-| `ALLOW_EVAL`            | foundry-mcp                | no       | `1` enables `/api/eval` debug endpoint                                             |
-| `SHARED_SECRET`         | foundry-mcp, player-portal | yes      | Bearer token for `/api/live/*` POST writes                                         |
-| `SECURE_SESSION_SECRET` | player-portal              | no\*     | Cookie signing for portal user auth                                                |
-| `IMAGE_TAG`             | —                          | no       | Image tag to pull (default: `latest`)                                              |
+| Variable                | Service(s)                        | Required | Purpose                                                                             |
+| ----------------------- | --------------------------------- | -------- | ----------------------------------------------------------------------------------- |
+| `FOUNDRY_USERNAME`      | foundry                           | yes      | Paizo account username for Foundry download                                         |
+| `FOUNDRY_PASSWORD`      | foundry                           | yes      | Paizo account password                                                              |
+| `FOUNDRY_ADMIN_KEY`     | foundry, headless-bridge          | rec.     | Foundry admin console password                                                      |
+| `FOUNDRY_ROUTE_PREFIX`  | foundry                           | no       | URL path prefix for Foundry (`foundry` → served at `/foundry/`); empty = no prefix  |
+| `OPENAI_API_KEY`        | foundry-mcp                       | no       | GPT-image-1 map editing (`edit_image` tool)                                         |
+| `ALLOW_EVAL`            | foundry-mcp                       | no       | `1` enables `/api/eval` debug endpoint                                              |
+| `SHARED_SECRET`         | foundry-mcp, player-portal        | yes      | Bearer token for `/api/live/*` POST writes                                          |
+| `SECURE_SESSION_SECRET` | player-portal                     | no\*     | Cookie signing for portal user auth                                                 |
+| `BRIDGE_GM_USER`        | headless-bridge                   | yes†     | Foundry username for the headless GM                                                |
+| `BRIDGE_GM_PASS`        | headless-bridge                   | no       | Password for `BRIDGE_GM_USER`                                                       |
+| `BRIDGE_WORLD_ID`       | headless-bridge                   | yes†     | World directory slug to join                                                        |
+| `IMAGE_TAG`             | —                                 | no       | Image tag to pull (default: `latest`)                                               |
 
 \*Required once the portal user auth feature ships.
+†Required only when running the `headless-bridge` service.
 
 `MCP_URL` and `FOUNDRY_URL` are set by `compose.yaml` to the compose service
 names and should not be overridden in `.env`.
@@ -256,6 +265,96 @@ foundry:
 ```
 
 **Compatibility caveat**: The bundled `foundry-api-bridge` module is built against current Foundry APIs. Running it in v13 may or may not work depending on what APIs it uses. You are responsible for verifying compatibility with your chosen Foundry version. This PR publishes the image; no version-pinned bridge build is included yet.
+
+---
+
+## Headless bridge
+
+### Why it exists
+
+The `foundry-api-bridge` module runs inside the GM's browser and dials out over
+WebSocket to `foundry-mcp`. Without the browser open, there is no bridge — the
+`player-portal` and any MCP clients lose access to live Foundry data.
+
+The `headless-bridge` service eliminates this dependency. It launches a
+headless Chromium browser (via Playwright), logs into Foundry as a dedicated
+GM account, and holds the session open indefinitely. Docker's
+`restart: unless-stopped` policy means the bridge auto-recovers from crashes,
+world reloads, and container restarts.
+
+### Dedicated bridge-gm account (required)
+
+Foundry allows only one active session per user account. If the headless
+process and your real GM browser tab both authenticate as the same account,
+Foundry will boot the older session.
+
+**Create a separate account** for the headless bridge:
+
+1. Open `http://localhost:30000` and log in as admin.
+2. Go to **Game Settings → Server Settings → User Management**.
+3. Click **Create User** and fill in:
+   - **Name**: `bridge-gm` (or any name — record it as `BRIDGE_GM_USER`)
+   - **Role**: Gamemaster
+   - **Password**: any password — record it as `BRIDGE_GM_PASS`
+4. Save.
+
+Your primary GM account is unaffected. During a real game session your GM
+browser logs in as your normal Gamemaster user; the headless container stays
+connected as `bridge-gm`. Both exist on the Foundry instance simultaneously
+without conflict.
+
+### Finding your world ID
+
+`BRIDGE_WORLD_ID` is the world's **directory slug**, not its display title.
+It appears in small text beneath each world card on the Foundry setup page.
+You can also inspect the data volume:
+
+```sh
+docker compose -f deploy/compose.yaml exec foundry \
+  ls /data/Data/worlds/
+```
+
+Each directory name is a valid world ID.
+
+### Operations
+
+```sh
+# Tail logs
+docker compose -f deploy/compose.yaml logs -f headless-bridge
+
+# Stop just the headless bridge (Foundry keeps running)
+docker compose -f deploy/compose.yaml stop headless-bridge
+
+# Restart after credential change
+docker compose -f deploy/compose.yaml restart headless-bridge
+
+# Check whether the bridge module is connected to foundry-mcp
+curl http://localhost:8765/health   # requires port 8765 exposed; see README
+# → {"ok":true,"foundryConnected":true,...}
+```
+
+### Behaviour during real sessions
+
+When your primary GM account is active in a browser:
+
+- The `bridge-gm` headless session remains connected in parallel.
+- Both sessions share the same world state — actions taken by `bridge-gm` (via
+  MCP tools) appear in your GM view in real time.
+- Logging out of your GM browser does not affect the headless session.
+- There is no conflict as long as the two users are different Foundry accounts.
+
+### Caveats
+
+- **World must be enabled for the bridge-gm user.** Foundry worlds can
+  restrict which users can join. Verify in User Management that `bridge-gm`
+  has Gamemaster access to the world specified by `BRIDGE_WORLD_ID`.
+- **Foundry setup page selectors.** The login flow uses CSS selectors derived
+  from Foundry v14's HTML. If Foundry's UI changes in a future version, the
+  selectors in `apps/headless-bridge/src/foundry.ts` may need updating.
+- **First-boot delay.** If the stack starts fresh (Foundry downloading its
+  binaries), `headless-bridge` will fail and restart several times before
+  Foundry is ready. This is expected — Docker's restart policy backs off
+  exponentially and resumes once Foundry is reachable.
 
 ---
 

--- a/deploy/compose.override.yaml.example
+++ b/deploy/compose.override.yaml.example
@@ -23,3 +23,8 @@ services:
     build:
       context: ..
       dockerfile: deploy/Dockerfile.player-portal
+
+  headless-bridge:
+    build:
+      context: ..
+      dockerfile: deploy/Dockerfile.headless-bridge

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -80,6 +80,35 @@ services:
     networks:
       - internal
 
+  # ── headless-bridge ─────────────────────────────────────────────────────────
+  # Headless Chromium process that logs into Foundry as a dedicated GM account
+  # and holds the page open 24/7, keeping foundry-api-bridge connected to
+  # foundry-mcp without requiring a browser tab to stay open.
+  #
+  # Requires a dedicated Foundry user with Gamemaster role (e.g. "bridge-gm").
+  # Do NOT reuse your primary GM account — Foundry allows only one active
+  # session per user; logging in as the same GM will kick the other session.
+  #
+  # To build locally (from the monorepo root):
+  #   docker build -f deploy/Dockerfile.headless-bridge \
+  #     -t foundry-toolkit-headless-bridge:dev .
+  headless-bridge:
+    image: ghcr.io/alexdickerson/foundry-toolkit-headless-bridge:${IMAGE_TAG:-latest}
+    restart: unless-stopped
+    environment:
+      FOUNDRY_URL: http://foundry:30000
+      FOUNDRY_ADMIN_KEY: ${FOUNDRY_ADMIN_KEY:-}
+      FOUNDRY_MCP_URL: http://foundry-mcp:8765
+      BRIDGE_GM_USER: ${BRIDGE_GM_USER}
+      BRIDGE_GM_PASS: ${BRIDGE_GM_PASS:-}
+      BRIDGE_WORLD_ID: ${BRIDGE_WORLD_ID}
+    mem_limit: 768m
+    depends_on:
+      - foundry
+      - foundry-mcp
+    networks:
+      - internal
+
   # ── player-portal ────────────────────────────────────────────────────────────
   # Fastify server that serves the Vite SPA and reverse-proxies:
   #   /api/mcp/*              → foundry-mcp (MCP REST surface)

--- a/knip.json
+++ b/knip.json
@@ -12,6 +12,10 @@
         "lint-staged"
       ]
     },
+    "apps/headless-bridge": {
+      "entry": ["src/main.ts", "src/**/*.test.ts"],
+      "project": ["src/**/*.ts"]
+    },
     "apps/dm-tool": {
       "entry": ["electron.vite.config.ts", "electron/main.ts", "electron/preload.ts", "electron/**/*.test.ts"],
       "project": ["electron/**/*.ts", "src/**/*.{ts,tsx}"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -306,6 +306,18 @@
         "typescript-eslint": "^8.59.2"
       }
     },
+    "apps/headless-bridge": {
+      "name": "@foundry-toolkit/headless-bridge",
+      "version": "0.1.0",
+      "dependencies": {
+        "playwright": "1.49.0"
+      },
+      "devDependencies": {
+        "@types/node": "^25.0.0",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.4"
+      }
+    },
     "apps/player-portal": {
       "name": "@foundry-toolkit/player-portal",
       "version": "1.0.0",
@@ -2932,6 +2944,10 @@
     },
     "node_modules/@foundry-toolkit/dm-tool": {
       "resolved": "apps/dm-tool",
+      "link": true
+    },
+    "node_modules/@foundry-toolkit/headless-bridge": {
+      "resolved": "apps/headless-bridge",
       "link": true
     },
     "node_modules/@foundry-toolkit/launcher": {
@@ -18376,6 +18392,50 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.0.tgz",
+      "integrity": "sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.49.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.0.tgz",
+      "integrity": "sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plist": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -310,7 +310,7 @@
       "name": "@foundry-toolkit/headless-bridge",
       "version": "0.1.0",
       "dependencies": {
-        "playwright": "1.49.0"
+        "playwright": "1.59.1"
       },
       "devDependencies": {
         "@types/node": "^25.0.0",
@@ -18395,12 +18395,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.0.tgz",
-      "integrity": "sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.49.0"
+        "playwright-core": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -18413,9 +18413,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.0.tgz",
-      "integrity": "sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"


### PR DESCRIPTION
## Apps touched

- `apps/headless-bridge` — new workspace (`npm run start -w apps/headless-bridge` or via Docker)
- `deploy/` — new service, Dockerfile, .env docs, README

No existing apps (foundry-mcp, player-portal, foundry-api-bridge) were modified.

---

## Summary

- Adds `apps/headless-bridge/` — a small TypeScript/Playwright process that logs into Foundry as a dedicated GM account and holds the browser session open indefinitely, keeping `foundry-api-bridge` connected to `foundry-mcp` 24/7 without any manual browser tab.
- Adds `deploy/Dockerfile.headless-bridge` — two-stage build; stage 1 compiles TypeScript on `node:22-alpine`, stage 2 runs the compiled JS on `mcr.microsoft.com/playwright:v1.49.0-jammy` (pre-installed Chromium, non-root user).
- Adds `headless-bridge` service to `deploy/compose.yaml` — internal network only, no host ports, `mem_limit: 768m`, `restart: unless-stopped`, depends on `foundry` and `foundry-mcp`.
- Updates `deploy/.env.example` and `deploy/README.md` with `BRIDGE_GM_USER`, `BRIDGE_GM_PASS`, `BRIDGE_WORLD_ID`, full setup docs, and a dedicated "Headless bridge" section.

### Dedicated GM account requirement

Foundry allows **only one active session per user account**. The headless container must authenticate as a *different* Foundry user than the GM's regular login to avoid booting either session. The README and `.env.example` both explain the one-time setup:

1. Open Foundry → **Game Settings → Server Settings → User Management**
2. Create a new user (e.g. `bridge-gm`) with **Gamemaster** role and a password
3. Set `BRIDGE_GM_USER`, `BRIDGE_GM_PASS`, `BRIDGE_WORLD_ID` in `deploy/.env`

Once configured, your primary GM account and the headless container coexist without conflict.

### What happens during a real session

The `bridge-gm` headless session stays connected while the GM plays. Both accounts are valid GM users; actions taken through MCP tools appear in real time in the GM's view. Logging out of the GM's browser does not affect the headless session.

### Health monitoring

After login, the script polls `http://foundry-mcp:8765/health` every 30 s and checks `foundryConnected`. If the bridge disconnects for 3 consecutive checks (≈90 s), the process exits with code 1 and Docker restarts it. Page crashes and unexpected closes also trigger an immediate restart.

### Login flow caveats

The `handleSetup` and `handleJoin` functions in `apps/headless-bridge/src/foundry.ts` use CSS selectors derived from Foundry v14's HTML (`[data-id="<worldId>"]`, `select[name="userid"]`, etc.). If Foundry's UI changes in a future major version the selectors may need updating — they're isolated in one file for easy adjustment.

**World auto-launch behaviour:** If `BRIDGE_WORLD_ID` is not currently running, the headless browser authenticates to `/setup` using `FOUNDRY_ADMIN_KEY` and clicks the Launch button. If the world is already running (e.g. started by another client), it skips setup and goes straight to `/join`.

### Compose syntax validation

`docker` is not available in the development environment. Please run:

```sh
docker compose -f deploy/compose.yaml config --quiet
```

to verify syntax before merging. The YAML was manually validated against the existing service structure.

## Test plan

- [ ] `npm run typecheck -w apps/headless-bridge` passes (verified ✓)
- [ ] `npm run test -w apps/headless-bridge` passes — 8 unit tests for `parseEnv` (verified ✓)
- [ ] `npm run build -w apps/headless-bridge` produces clean `dist/` (verified ✓)
- [ ] `npm run lint` — no new errors (verified ✓, only pre-existing warnings in dm-tool/player-portal)
- [ ] `npm run format:check` — clean (verified ✓)
- [ ] `npm run knip` — no unused files/deps flagged for headless-bridge (verified ✓)
- [ ] `docker compose -f deploy/compose.yaml config` — validate YAML syntax (needs Docker)
- [ ] End-to-end: set `BRIDGE_GM_USER`, `BRIDGE_GM_PASS`, `BRIDGE_WORLD_ID` in `.env`, run `docker compose up headless-bridge`, confirm `foundryConnected: true` in `docker compose logs -f headless-bridge`

🤖 Generated with [Claude Code](https://claude.com/claude-code)