### PR TITLE
fix(deploy): inline Caddyfile as compose config to fix Portainer deploy

### DIFF
--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -22,8 +22,10 @@ services:
     ports:
       - '80:80'
       - '443:443'
+    configs:
+      - source: caddyfile
+        target: /etc/caddy/Caddyfile
     volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data
       - caddy_config:/config
     networks:
@@ -100,6 +102,20 @@ volumes:
   foundry-data:
   caddy_data:
   caddy_config:
+
+# Inline Caddyfile — no host file needed, works with Portainer and plain compose.
+# Edit the content block below to change routing rules.
+configs:
+  caddyfile:
+    content: |
+      addnd.net {
+        handle /foundry* {
+          reverse_proxy foundry:30000
+        }
+        handle {
+          reverse_proxy player-portal:3000
+        }
+      }
 
 networks:
   internal:


### PR DESCRIPTION
## Apps touched

`deploy/` only — no app code changed.

## Problem

Portainer copies only the compose YAML to `/data/compose/<id>/` when deploying a stack — it does not copy sibling files. `./Caddyfile` therefore did not exist at the bind-mount source path, Docker created a directory there instead, and the container failed to start:

```
error mounting "/data/compose/6/Caddyfile" to rootfs at "/etc/caddy/Caddyfile":
cannot create subdirectories in "...merged/etc/caddy/Caddyfile": not a directory
```

## Fix

Replace the bind-mount (`./Caddyfile:/etc/caddy/Caddyfile:ro`) with a top-level `configs` block containing the Caddyfile content inline. Docker Compose injects this as a tmpfs-backed file inside the container — no host file needed. Works identically with plain `docker compose` and Portainer.

The `deploy/Caddyfile` file remains in the repo for reference but is no longer referenced by `compose.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)