### PR TITLE
fix(foundry-api-bridge): prepend Foundry route prefix when fetching assets

### DIFF
--- a/apps/foundry-api-bridge/src/commands/handlers/FetchAssetHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/FetchAssetHandler.ts
@@ -5,10 +5,29 @@
 // Foundry's built-in HTTP server. A plain `fetch()` with a root-relative path
 // therefore reaches Foundry's file system without any additional config.
 //
+// When Foundry is started with `FOUNDRY_ROUTE_PREFIX=foundry` (typical in our
+// reverse-proxy setup behind Caddy on `addnd.net`), Foundry serves everything
+// under `/foundry/...`. A bare `fetch('/icons/foo.webp')` from the bridge
+// would resolve against the current origin without the prefix, hit Caddy,
+// and route to the player-portal — which doesn't host the asset and bounces
+// it back through this same handler in an infinite loop. We read the prefix
+// off the `game` global and prepend it before the fetch.
+//
 // foundry-mcp's GET /modules/* (and /systems/*, /icons/*, …) route calls this
 // command and re-serves the response body to consumers (dm-tool renderer,
 // player-portal). The mcp server caches hits indefinitely so each asset is
 // only fetched once per server process lifetime.
+
+interface FoundryGameWithOptions {
+  data?: { options?: { routePrefix?: string } };
+}
+
+function getRoutePrefix(): string {
+  const g = (globalThis as unknown as { game?: FoundryGameWithOptions }).game;
+  const prefix = g?.data?.options?.routePrefix;
+  if (typeof prefix !== 'string' || prefix.length === 0) return '';
+  return prefix.startsWith('/') ? prefix : `/${prefix}`;
+}
 
 interface FetchAssetParams {
   /** Root-relative Foundry asset path, e.g.
@@ -41,9 +60,13 @@ export async function fetchAssetHandler(params: FetchAssetParams): Promise<Fetch
     return { ok: false, status: 400, error: `Invalid asset path: ${rawPath}` };
   }
 
+  // Prepend Foundry's configured route prefix so the fetch lands on Foundry's
+  // file server even when it's mounted under a sub-path (e.g. /foundry/...).
+  const url = `${getRoutePrefix()}${path}`;
+
   let response: Response;
   try {
-    response = await fetch(path);
+    response = await fetch(url);
   } catch (err) {
     return {
       ok: false,


### PR DESCRIPTION
## Apps touched

- `apps/foundry-api-bridge` — bundled into the Foundry container; needs a deploy + browser hard-refresh to take effect

No other apps need to be spun up — this only affects asset proxying behaviour.

## Summary

Default Foundry icons (`/icons/...`, `/systems/...`, `/modules/...`, `/worlds/...`) stopped loading on the production deploy after the Caddy + `FOUNDRY_ROUTE_PREFIX=foundry` setup. Custom item-art (`/item-art/...`) kept working because it's served directly by player-portal.

### Root cause

The bridge's `fetchAssetHandler` does a bare `fetch('/icons/foo.webp')` from the GM's Foundry browser tab. With `FOUNDRY_ROUTE_PREFIX=foundry`, Foundry's HTML lives at `/foundry/game`, so a root-relative fetch resolves to `https://addnd.net/icons/foo.webp` — Caddy's `/foundry*` matcher doesn't catch it, so the request goes to player-portal, which proxies it back through `/api/mcp/icons/...` → foundry-mcp asset-cache → bridge `fetch-asset` → `fetch('/icons/...')` again. Infinite bounce / wrong upstream.

### Fix

Read `game.data.options.routePrefix` and prepend it before the fetch:

```typescript
const url = `${getRoutePrefix()}${path}`;
const response = await fetch(url);
```

`getRoutePrefix()` returns `''` when no prefix is configured, so dev / direct-access deployments are unaffected and existing tests pass without changes.

## Test plan

- [x] `npm run test -w apps/foundry-api-bridge` — 847 tests pass (no fixture updates needed; defaults match unprefixed behaviour)
- [x] Live verified on `addnd.net`: rebuilt module hot-patched into the running container, hard-refreshed Foundry browser tab, default icons + custom item-art both load
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)