### PR TITLE
feat(player-portal): character creator overhaul — mechanical previews, tips rail, richer prompts, …

### DIFF
--- a/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
+++ b/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
@@ -208,7 +208,7 @@ export function CharacterCreator(): React.ReactElement {
     // a phantom column on the right so the wizard stays centred on wide
     // screens. Both side columns hide on viewports narrower than `lg`.
     <div className="flex gap-6 py-6 font-sans">
-      <aside className="hidden w-[230px] shrink-0 pl-3 lg:block" aria-label="Player tips">
+      <aside className="hidden w-[280px] shrink-0 pl-3 lg:block" aria-label="Player tips">
         <TipsRail />
       </aside>
       <main className="mx-auto min-w-0 max-w-3xl flex-1 px-6">
@@ -389,7 +389,7 @@ export function CharacterCreator(): React.ReactElement {
       </main>
       {/* Phantom column mirrors the rail width so the wizard column
           stays horizontally centred between them on wide screens. */}
-      <div className="hidden w-[230px] shrink-0 lg:block" aria-hidden="true" />
+      <div className="hidden w-[280px] shrink-0 lg:block" aria-hidden="true" />
     </div>
   );
 }

--- a/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
+++ b/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { api } from '@/features/characters/api';
 import type { CompendiumMatch } from '@/features/characters/types';
-import { useCreatorPickerProps } from '@/features/characters/internal/useCreatorPickerProps';
+import { useCreatorPickerProps, type CreatorPickerOptions } from '@/features/characters/internal/useCreatorPickerProps';
 import { CompendiumDetailPanel } from '@/features/characters/internal/CompendiumDetailPanel';
 import { getHeritageArt } from '@/features/characters/internal/character-art';
 import { PromptQueue } from '@/features/characters/sheet/dialog/PromptQueue';
@@ -418,14 +418,29 @@ function CreatorPicker({
   return <DefaultCreatorPicker target={target} filters={filters} onPick={onPick} onClose={onClose} />;
 }
 
-// Targets where the picker should:
+// Per-target picker options. Each entry:
 //   - default to common-only rarity (new players default to the Player
 //     Core options; uncommon/rare picks typically need GM approval,
 //     surfaced as a Tips Rail card)
 //   - hide the unmet-prereq toggle (these picks have no prereqs)
 //   - hide the alpha/level sort (these picks aren't levelled; alpha
 //     order is fine without an explicit toggle)
-const RARITY_GATED_TARGETS = new Set<PickerTarget>(['ancestry', 'background']);
+//   - may scope source defaults (backgrounds default to the two Player
+//     Core books; ancestries leave sources unconstrained since Howl-
+//     of-the-Wild and others are common-rarity too).
+const PICKER_OPTIONS_BY_TARGET: Partial<Record<PickerTarget, CreatorPickerOptions>> = {
+  ancestry: {
+    initialRarities: ['common'],
+    showUnmetToggle: false,
+    showSortToggle: false,
+  },
+  background: {
+    initialSources: ['Pathfinder Player Core', 'Pathfinder Player Core 2'],
+    initialRarities: ['common'],
+    showUnmetToggle: false,
+    showSortToggle: false,
+  },
+};
 
 function DefaultCreatorPicker({
   target,
@@ -438,14 +453,7 @@ function DefaultCreatorPicker({
   onPick: (match: CompendiumMatch) => void;
   onClose: () => void;
 }): React.ReactElement {
-  const props = useCreatorPickerProps(
-    filters,
-    undefined,
-    onPick,
-    RARITY_GATED_TARGETS.has(target)
-      ? { initialRarities: ['common'], showUnmetToggle: false, showSortToggle: false }
-      : undefined,
-  );
+  const props = useCreatorPickerProps(filters, undefined, onPick, PICKER_OPTIONS_BY_TARGET[target]);
   return <CompendiumPicker title={`Choose a ${PICKER_LABEL[target]}`} {...props} onClose={onClose} />;
 }
 

--- a/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
+++ b/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
@@ -10,6 +10,7 @@ import { PromptQueue } from '@/features/characters/sheet/dialog/PromptQueue';
 import { CompendiumPicker } from '@/features/characters/internal/CompendiumPicker';
 
 import { CreatorSection } from '@/features/characters/creator/CreatorSection';
+import { TipsRail } from '@/features/characters/creator/TipsRail';
 import { EMPTY_DRAFT, PICKER_LABEL, STEPS, STEP_LABEL } from '@/features/characters/creator/constants';
 import {
   applyPickedSlot,
@@ -202,182 +203,194 @@ export function CharacterCreator(): React.ReactElement {
   const pickerFilters = openPicker !== null ? filtersForTarget(openPicker, draft) : undefined;
 
   return (
-    <main className="mx-auto max-w-3xl p-6 font-sans">
-      <div className="mb-4 flex items-center gap-3">
-        <button
-          type="button"
-          onClick={(): void => {
-            // Null the module-scope cache so re-entering the wizard
-            // allocates a fresh draft actor instead of reusing the
-            // one the user is stepping away from.
-            resetPendingActor();
-            onBack();
-          }}
-          className="rounded border border-pf-border bg-pf-bg px-2 py-1 text-xs text-pf-text hover:bg-pf-bg-dark"
-        >
-          ← Actors
-        </button>
-        <h1 className="font-serif text-2xl font-semibold text-pf-text">New Character</h1>
-      </div>
-
-      {creator.kind === 'creating' && (
-        <p className="rounded border border-pf-border bg-pf-bg p-4 text-sm italic text-pf-alt-dark">
-          Creating draft actor…
-        </p>
-      )}
-      {creator.kind === 'error' && (
-        <div className="rounded border border-red-200 bg-red-50 p-4 text-sm">
-          <p className="font-medium text-red-900">Couldn&apos;t create the draft actor</p>
-          <p className="mt-1 text-red-800">{creator.message}</p>
+    // Three-column shell mirroring the sheet layout: tips rail on the left
+    // (where the party rail lives in the sheet), wizard in the centre, and
+    // a phantom column on the right so the wizard stays centred on wide
+    // screens. Both side columns hide on viewports narrower than `lg`.
+    <div className="flex gap-6 py-6 font-sans">
+      <aside className="hidden w-[230px] shrink-0 pl-3 lg:block" aria-label="Player tips">
+        <TipsRail />
+      </aside>
+      <main className="mx-auto min-w-0 max-w-3xl flex-1 px-6">
+        <div className="mb-4 flex items-center gap-3">
+          <button
+            type="button"
+            onClick={(): void => {
+              // Null the module-scope cache so re-entering the wizard
+              // allocates a fresh draft actor instead of reusing the
+              // one the user is stepping away from.
+              resetPendingActor();
+              onBack();
+            }}
+            className="rounded border border-pf-border bg-pf-bg px-2 py-1 text-xs text-pf-text hover:bg-pf-bg-dark"
+          >
+            ← Actors
+          </button>
+          <h1 className="font-serif text-2xl font-semibold text-pf-text">New Character</h1>
         </div>
-      )}
 
-      {creator.kind === 'ready' && (
-        <>
-          {/* Sticky anchor nav — clicking a pill scrolls the matching
+        {creator.kind === 'creating' && (
+          <p className="rounded border border-pf-border bg-pf-bg p-4 text-sm italic text-pf-alt-dark">
+            Creating draft actor…
+          </p>
+        )}
+        {creator.kind === 'error' && (
+          <div className="rounded border border-red-200 bg-red-50 p-4 text-sm">
+            <p className="font-medium text-red-900">Couldn&apos;t create the draft actor</p>
+            <p className="mt-1 text-red-800">{creator.message}</p>
+          </div>
+        )}
+
+        {creator.kind === 'ready' && (
+          <>
+            {/* Sticky anchor nav — clicking a pill scrolls the matching
               section into view. Filled state still derives from
               `isStepFilled` so users can see what's outstanding. */}
-          <div className="sticky top-0 z-10 -mx-1 mb-4 bg-stage-gradient px-1 pb-2 pt-2">
-            <StepNav steps={STEPS} active={null} onJump={jumpToSection} draft={draft} />
-          </div>
-
-          <CreatorSection id="identity" title="Identity">
-            <IdentityStep
-              draft={draft}
-              onChange={(patch): void => {
-                setDraft((d) => ({ ...d, ...patch }));
-              }}
-              onPickDeity={(): void => {
-                setOpenPicker('deity');
-              }}
-            />
-          </CreatorSection>
-
-          <CreatorSection id="ancestry" title="Ancestry & Heritage">
-            <AncestryStep
-              ancestry={draft.ancestry?.match ?? null}
-              heritage={draft.heritage?.match ?? null}
-              ancestryFeat={draft.ancestryFeat?.match ?? null}
-              ancestrySlugResolved={draft.ancestrySlug !== null}
-              onPickAncestry={(): void => {
-                setOpenPicker('ancestry');
-              }}
-              onPickHeritage={(): void => {
-                setOpenPicker('heritage');
-              }}
-              onPickAncestryFeat={(): void => {
-                setOpenPicker('ancestry-feat');
-              }}
-            />
-          </CreatorSection>
-
-          <CreatorSection id="class" title="Class">
-            <ClassStep
-              classPick={draft.class?.match ?? null}
-              classFeat={draft.classFeat?.match ?? null}
-              classSlugResolved={draft.classSlug !== null}
-              onPickClass={(): void => {
-                setOpenPicker('class');
-              }}
-              onPickClassFeat={(): void => {
-                setOpenPicker('class-feat');
-              }}
-              onL1FeatAvailability={(grants): void => {
-                setDraft((d) => (d.classGrantsL1Feat === grants ? d : { ...d, classGrantsL1Feat: grants }));
-              }}
-            />
-          </CreatorSection>
-
-          <CreatorSection id="background" title="Background">
-            <PickerCard
-              label="Background"
-              selection={draft.background?.match ?? null}
-              onOpen={(): void => {
-                setOpenPicker('background');
-              }}
-            />
-          </CreatorSection>
-
-          <CreatorSection id="attributes" title="Attributes">
-            <AttributesStep
-              actorId={actorId}
-              ancestryPick={draft.ancestry?.match ?? null}
-              ancestryItemId={draft.ancestry?.itemId ?? null}
-              backgroundPick={draft.background?.match ?? null}
-              backgroundItemId={draft.background?.itemId ?? null}
-              classPick={draft.class?.match ?? null}
-              classItemId={draft.class?.itemId ?? null}
-              levelOneBoosts={draft.levelOneBoosts}
-              ancestryBoosts={draft.ancestryBoosts}
-              backgroundBoosts={draft.backgroundBoosts}
-              classKeyAbility={draft.classKeyAbility}
-              onDraftPatch={(patch): void => {
-                setDraft((d) => ({ ...d, ...patch }));
-              }}
-            />
-          </CreatorSection>
-
-          <CreatorSection id="skills" title="Skills">
-            <SkillsStep
-              actorId={actorId}
-              backgroundPick={draft.background?.match ?? null}
-              classPick={draft.class?.match ?? null}
-              classItemId={draft.class?.itemId ?? null}
-              skillPicks={draft.skillPicks}
-              intMod={computeIntMod(draft)}
-              onDraftPatch={(patch): void => {
-                setDraft((d) => ({ ...d, ...patch }));
-              }}
-            />
-          </CreatorSection>
-
-          <CreatorSection id="languages" title="Languages">
-            <LanguagesStep
-              actorId={actorId}
-              ancestryPick={draft.ancestry?.match ?? null}
-              languagePicks={draft.languagePicks}
-              intMod={computeIntMod(draft)}
-              onDraftPatch={(patch): void => {
-                setDraft((d) => ({ ...d, ...patch }));
-              }}
-              onAllowanceResolved={(n): void => {
-                setDraft((d) => (d.languageAllowance === n ? d : { ...d, languageAllowance: n }));
-              }}
-            />
-          </CreatorSection>
-
-          <CreatorSection id="review" title="Review">
-            <ReviewStep draft={draft} />
-            <div className="mt-4 flex justify-end">
-              <button
-                type="button"
-                onClick={handleFinish}
-                disabled={actorId === null}
-                className="rounded border border-pf-primary bg-pf-primary px-3 py-1.5 text-sm font-medium text-white hover:bg-pf-primary-dark disabled:opacity-40"
-              >
-                Open sheet →
-              </button>
+            <div className="sticky top-0 z-10 -mx-1 mb-4 bg-stage-gradient px-1 pb-2 pt-2">
+              <StepNav steps={STEPS} active={null} onJump={jumpToSection} draft={draft} />
             </div>
-          </CreatorSection>
 
-          {openPicker !== null && pickerFilters !== undefined && (
-            <CreatorPicker
-              key={openPicker}
-              target={openPicker}
-              filters={pickerFilters}
-              onPick={applyPick}
-              onClose={(): void => {
-                setOpenPicker(null);
-              }}
-            />
-          )}
-        </>
-      )}
+            <CreatorSection id="identity" title="Identity">
+              <IdentityStep
+                draft={draft}
+                onChange={(patch): void => {
+                  setDraft((d) => ({ ...d, ...patch }));
+                }}
+                onPickDeity={(): void => {
+                  setOpenPicker('deity');
+                }}
+              />
+            </CreatorSection>
 
-      {/* Module-driven prompts (pf2e ChoiceSets) render on top of
+            <CreatorSection id="ancestry" title="Ancestry & Heritage">
+              <AncestryStep
+                ancestry={draft.ancestry?.match ?? null}
+                heritage={draft.heritage?.match ?? null}
+                ancestryFeat={draft.ancestryFeat?.match ?? null}
+                ancestrySlugResolved={draft.ancestrySlug !== null}
+                onPickAncestry={(): void => {
+                  setOpenPicker('ancestry');
+                }}
+                onPickHeritage={(): void => {
+                  setOpenPicker('heritage');
+                }}
+                onPickAncestryFeat={(): void => {
+                  setOpenPicker('ancestry-feat');
+                }}
+              />
+            </CreatorSection>
+
+            <CreatorSection id="class" title="Class">
+              <ClassStep
+                classPick={draft.class?.match ?? null}
+                classFeat={draft.classFeat?.match ?? null}
+                classSlugResolved={draft.classSlug !== null}
+                onPickClass={(): void => {
+                  setOpenPicker('class');
+                }}
+                onPickClassFeat={(): void => {
+                  setOpenPicker('class-feat');
+                }}
+                onL1FeatAvailability={(grants): void => {
+                  setDraft((d) => (d.classGrantsL1Feat === grants ? d : { ...d, classGrantsL1Feat: grants }));
+                }}
+              />
+            </CreatorSection>
+
+            <CreatorSection id="background" title="Background">
+              <PickerCard
+                label="Background"
+                selection={draft.background?.match ?? null}
+                onOpen={(): void => {
+                  setOpenPicker('background');
+                }}
+              />
+            </CreatorSection>
+
+            <CreatorSection id="attributes" title="Attributes">
+              <AttributesStep
+                actorId={actorId}
+                ancestryPick={draft.ancestry?.match ?? null}
+                ancestryItemId={draft.ancestry?.itemId ?? null}
+                backgroundPick={draft.background?.match ?? null}
+                backgroundItemId={draft.background?.itemId ?? null}
+                classPick={draft.class?.match ?? null}
+                classItemId={draft.class?.itemId ?? null}
+                levelOneBoosts={draft.levelOneBoosts}
+                ancestryBoosts={draft.ancestryBoosts}
+                backgroundBoosts={draft.backgroundBoosts}
+                classKeyAbility={draft.classKeyAbility}
+                onDraftPatch={(patch): void => {
+                  setDraft((d) => ({ ...d, ...patch }));
+                }}
+              />
+            </CreatorSection>
+
+            <CreatorSection id="skills" title="Skills">
+              <SkillsStep
+                actorId={actorId}
+                backgroundPick={draft.background?.match ?? null}
+                classPick={draft.class?.match ?? null}
+                classItemId={draft.class?.itemId ?? null}
+                skillPicks={draft.skillPicks}
+                intMod={computeIntMod(draft)}
+                onDraftPatch={(patch): void => {
+                  setDraft((d) => ({ ...d, ...patch }));
+                }}
+              />
+            </CreatorSection>
+
+            <CreatorSection id="languages" title="Languages">
+              <LanguagesStep
+                actorId={actorId}
+                ancestryPick={draft.ancestry?.match ?? null}
+                languagePicks={draft.languagePicks}
+                intMod={computeIntMod(draft)}
+                onDraftPatch={(patch): void => {
+                  setDraft((d) => ({ ...d, ...patch }));
+                }}
+                onAllowanceResolved={(n): void => {
+                  setDraft((d) => (d.languageAllowance === n ? d : { ...d, languageAllowance: n }));
+                }}
+              />
+            </CreatorSection>
+
+            <CreatorSection id="review" title="Review">
+              <ReviewStep draft={draft} />
+              <div className="mt-4 flex justify-end">
+                <button
+                  type="button"
+                  onClick={handleFinish}
+                  disabled={actorId === null}
+                  className="rounded border border-pf-primary bg-pf-primary px-3 py-1.5 text-sm font-medium text-white hover:bg-pf-primary-dark disabled:opacity-40"
+                >
+                  Open sheet →
+                </button>
+              </div>
+            </CreatorSection>
+
+            {openPicker !== null && pickerFilters !== undefined && (
+              <CreatorPicker
+                key={openPicker}
+                target={openPicker}
+                filters={pickerFilters}
+                onPick={applyPick}
+                onClose={(): void => {
+                  setOpenPicker(null);
+                }}
+              />
+            )}
+          </>
+        )}
+
+        {/* Module-driven prompts (pf2e ChoiceSets) render on top of
           everything else so the wizard pauses until the user picks. */}
-      <PromptQueue />
-    </main>
+        <PromptQueue />
+      </main>
+      {/* Phantom column mirrors the rail width so the wizard column
+          stays horizontally centred between them on wide screens. */}
+      <div className="hidden w-[230px] shrink-0 lg:block" aria-hidden="true" />
+    </div>
   );
 }
 

--- a/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
+++ b/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
@@ -445,6 +445,12 @@ const PICKER_OPTIONS_BY_TARGET: Partial<Record<PickerTarget, CreatorPickerOption
     showUnmetToggle: false,
     showSortToggle: false,
   },
+  // Class detail panels carry a lot of body content (lore, initial
+  // proficiencies, L1 features); the header just duplicates the picker
+  // dialog's own title bar and eats vertical space.
+  class: {
+    hideDetailHeader: true,
+  },
 };
 
 function DefaultCreatorPicker({

--- a/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
+++ b/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
@@ -311,6 +311,7 @@ export function CharacterCreator(): React.ReactElement {
                 onOpen={(): void => {
                   setOpenPicker('background');
                 }}
+                helpText="The culture, society, or role your character developed in. Grants stat boosts and a small set of features that reflect that history."
               />
             </CreatorSection>
 

--- a/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
+++ b/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
@@ -203,13 +203,18 @@ export function CharacterCreator(): React.ReactElement {
   const pickerFilters = openPicker !== null ? filtersForTarget(openPicker, draft) : undefined;
 
   return (
-    // Two-column shell: tips rail on the left (where the party rail lives
-    // in the sheet) and the wizard next to it. Side rail hides on
-    // viewports narrower than `lg`; the wizard then takes the full row.
-    // No auto-centring on the wizard column — it sits flush after the
-    // rail so the visible gap between rail content and wizard content is
-    // just the flex gap + the wizard's internal padding.
-    <div className="flex gap-6 py-6 font-sans">
+    // Three-column shell: tips rail on the left, wizard in the middle, a
+    // phantom column of equal width on the right. The whole row is
+    // capped at the natural total width of those three columns + their
+    // gaps and `mx-auto`'d so the layout sits centred on the page — the
+    // rails take equal visual space, and the wizard exactly fills its
+    // slot (no auto-centring inside the slot, which is what created the
+    // earlier heavy margin between rail and wizard).
+    //
+    // 1376px = 280 (rail) + 24 (gap) + 768 (max-w-3xl) + 24 (gap) + 280
+    // (phantom). Below `lg` the rails collapse and the wizard takes the
+    // full row.
+    <div className="mx-auto flex max-w-[1376px] gap-6 py-6 font-sans">
       <aside className="hidden w-[280px] shrink-0 pl-3 lg:block" aria-label="Player tips">
         <TipsRail />
       </aside>
@@ -390,6 +395,7 @@ export function CharacterCreator(): React.ReactElement {
           everything else so the wizard pauses until the user picks. */}
         <PromptQueue />
       </main>
+      <div className="hidden w-[280px] shrink-0 lg:block" aria-hidden="true" />
     </div>
   );
 }

--- a/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
+++ b/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
@@ -418,6 +418,15 @@ function CreatorPicker({
   return <DefaultCreatorPicker target={target} filters={filters} onPick={onPick} onClose={onClose} />;
 }
 
+// Targets where the picker should:
+//   - default to common-only rarity (new players default to the Player
+//     Core options; uncommon/rare picks typically need GM approval,
+//     surfaced as a Tips Rail card)
+//   - hide the unmet-prereq toggle (these picks have no prereqs)
+//   - hide the alpha/level sort (these picks aren't levelled; alpha
+//     order is fine without an explicit toggle)
+const RARITY_GATED_TARGETS = new Set<PickerTarget>(['ancestry', 'background']);
+
 function DefaultCreatorPicker({
   target,
   filters,
@@ -429,7 +438,14 @@ function DefaultCreatorPicker({
   onPick: (match: CompendiumMatch) => void;
   onClose: () => void;
 }): React.ReactElement {
-  const props = useCreatorPickerProps(filters, undefined, onPick);
+  const props = useCreatorPickerProps(
+    filters,
+    undefined,
+    onPick,
+    RARITY_GATED_TARGETS.has(target)
+      ? { initialRarities: ['common'], showUnmetToggle: false, showSortToggle: false }
+      : undefined,
+  );
   return <CompendiumPicker title={`Choose a ${PICKER_LABEL[target]}`} {...props} onClose={onClose} />;
 }
 

--- a/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
+++ b/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
@@ -445,11 +445,24 @@ const PICKER_OPTIONS_BY_TARGET: Partial<Record<PickerTarget, CreatorPickerOption
     showUnmetToggle: false,
     showSortToggle: false,
   },
-  // Class detail panels carry a lot of body content (lore, initial
-  // proficiencies, L1 features); the header just duplicates the picker
-  // dialog's own title bar and eats vertical space.
+  // Class picker:
+  //   - default to common-only rarity (Player Core / Player Core 2
+  //     classes); the rarity pill row lets the player opt in to
+  //     uncommon supplements with GM approval
+  //   - hide source picker, unmet toggle, sort toggle — only the text
+  //     search and rarity filter add value here, and the row was
+  //     getting cramped
+  //   - tighten the list column so the detail panel (initial-
+  //     proficiencies block + L1 features) gets the room
+  //   - hide the detail panel header — the picker dialog's own title
+  //     bar already names the class
   class: {
+    initialRarities: ['common'],
+    showSourcePicker: false,
+    showUnmetToggle: false,
+    showSortToggle: false,
     hideDetailHeader: true,
+    listOpenWidthClass: 'w-56',
   },
 };
 

--- a/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
+++ b/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
@@ -5,7 +5,6 @@ import { api } from '@/features/characters/api';
 import type { CompendiumMatch } from '@/features/characters/types';
 import { useCreatorPickerProps, type CreatorPickerOptions } from '@/features/characters/internal/useCreatorPickerProps';
 import { CompendiumDetailPanel } from '@/features/characters/internal/CompendiumDetailPanel';
-import { getHeritageArt } from '@/features/characters/internal/character-art';
 import { PromptQueue } from '@/features/characters/sheet/dialog/PromptQueue';
 import { CompendiumPicker } from '@/features/characters/internal/CompendiumPicker';
 
@@ -594,8 +593,6 @@ function HeritageRow({
   active: boolean;
   onClick: (m: CompendiumMatch) => void;
 }): React.ReactElement {
-  const art = getHeritageArt(match.name);
-  const artSrc = art?.images[0] ?? null;
   return (
     <li>
       <button
@@ -611,13 +608,7 @@ function HeritageRow({
         data-pick-uuid={match.uuid}
         data-match-uuid={match.uuid}
       >
-        {artSrc !== null ? (
-          <img
-            src={artSrc}
-            alt=""
-            className="h-8 w-8 shrink-0 rounded border border-pf-border object-cover object-top"
-          />
-        ) : match.img ? (
+        {match.img ? (
           <img src={match.img} alt="" className="h-8 w-8 shrink-0 rounded border border-pf-border bg-pf-bg-dark" />
         ) : null}
         <span className="text-sm font-medium text-pf-text">{match.name}</span>

--- a/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
+++ b/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
@@ -320,6 +320,7 @@ export function CharacterCreator(): React.ReactElement {
                 ancestryBoosts={draft.ancestryBoosts}
                 backgroundBoosts={draft.backgroundBoosts}
                 classKeyAbility={draft.classKeyAbility}
+                alternateAncestryBoosts={draft.alternateAncestryBoosts}
                 onDraftPatch={(patch): void => {
                   setDraft((d) => ({ ...d, ...patch }));
                 }}

--- a/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
+++ b/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
@@ -1,8 +1,11 @@
 import { useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { api } from '@/features/characters/api';
 import type { CompendiumMatch } from '@/features/characters/types';
 import { useCreatorPickerProps } from '@/features/characters/internal/useCreatorPickerProps';
+import { CompendiumDetailPanel } from '@/features/characters/internal/CompendiumDetailPanel';
+import { getHeritageArt } from '@/features/characters/internal/character-art';
 import { PromptQueue } from '@/features/characters/sheet/dialog/PromptQueue';
 import { CompendiumPicker } from '@/features/characters/internal/CompendiumPicker';
 
@@ -12,6 +15,7 @@ import {
   applyPickedSlot,
   beginOrReusePendingActor,
   filtersForTarget,
+  groupHeritages,
   isStepFilled,
   persistPick,
   resetPendingActor,
@@ -44,7 +48,6 @@ export function CharacterCreator(): React.ReactElement {
   const [draft, setDraft] = useState<Draft>(EMPTY_DRAFT);
   const [openPicker, setOpenPicker] = useState<PickerTarget | null>(null);
   const [creator, setCreator] = useState<CreatorState>({ kind: 'creating' });
-
 
   useEffect(() => {
     let cancelled = false;
@@ -393,8 +396,163 @@ function CreatorPicker({
   onPick: (match: CompendiumMatch) => void;
   onClose: () => void;
 }): React.ReactElement {
+  // Heritage uses a grouped list with its own split-pane detail flow.
+  // Split into a dedicated component so hooks are not called conditionally.
+  if (target === 'heritage') {
+    return <HeritagePicker filters={filters} onPick={onPick} onClose={onClose} />;
+  }
+  return <DefaultCreatorPicker target={target} filters={filters} onPick={onPick} onClose={onClose} />;
+}
+
+function DefaultCreatorPicker({
+  target,
+  filters,
+  onPick,
+  onClose,
+}: {
+  target: PickerTarget;
+  filters: NonNullable<ReturnType<typeof filtersForTarget>>;
+  onPick: (match: CompendiumMatch) => void;
+  onClose: () => void;
+}): React.ReactElement {
   const props = useCreatorPickerProps(filters, undefined, onPick);
   return <CompendiumPicker title={`Choose a ${PICKER_LABEL[target]}`} {...props} onClose={onClose} />;
+}
+
+// Heritage picker: shows a grouped list (Primary / Versatile) with AoN art
+// thumbnails. Manages its own detail-panel state so the user can read a
+// heritage's description before committing. The split-pane is driven from
+// outside CompendiumPicker so we can control when `detailTarget` is set —
+// clicking a row opens the panel; the panel's Pick button calls `onPick`
+// and closes the whole dialog.
+function HeritagePicker({
+  filters,
+  onPick,
+  onClose,
+}: {
+  filters: NonNullable<ReturnType<typeof filtersForTarget>>;
+  onPick: (match: CompendiumMatch) => void;
+  onClose: () => void;
+}): React.ReactElement {
+  const [detailTarget, setDetailTarget] = useState<CompendiumMatch | null>(null);
+  const pickerProps = useCreatorPickerProps(filters, undefined, onPick);
+  const { docCache } = pickerProps;
+
+  const renderList = (items: CompendiumMatch[]): ReactNode => {
+    const { primary, versatile } = groupHeritages(items);
+    return (
+      <>
+        {primary.length > 0 && (
+          <HeritageSection
+            label="Primary Heritages"
+            items={primary}
+            activeUuid={detailTarget?.uuid ?? null}
+            onRowClick={setDetailTarget}
+          />
+        )}
+        {versatile.length > 0 && (
+          <HeritageSection
+            label="Versatile Heritages"
+            items={versatile}
+            activeUuid={detailTarget?.uuid ?? null}
+            onRowClick={setDetailTarget}
+          />
+        )}
+      </>
+    );
+  };
+
+  return (
+    <CompendiumPicker
+      title="Choose a Heritage"
+      {...pickerProps}
+      renderList={renderList}
+      splitPane={{
+        detailOpen: detailTarget !== null,
+        detailSlot:
+          detailTarget !== null ? (
+            <CompendiumDetailPanel
+              target={detailTarget}
+              onPick={(): void => {
+                onPick(detailTarget);
+                onClose();
+              }}
+              onClose={(): void => {
+                setDetailTarget(null);
+              }}
+              {...(docCache !== undefined ? { docCache } : {})}
+            />
+          ) : null,
+      }}
+      onClose={onClose}
+    />
+  );
+}
+
+function HeritageSection({
+  label,
+  items,
+  activeUuid,
+  onRowClick,
+}: {
+  label: string;
+  items: CompendiumMatch[];
+  activeUuid: string | null;
+  onRowClick: (m: CompendiumMatch) => void;
+}): React.ReactElement {
+  return (
+    <div>
+      <p className="border-b border-pf-border bg-pf-bg-dark px-4 py-1 text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark">
+        {label}
+      </p>
+      <ul className="divide-y divide-pf-border">
+        {items.map((m) => (
+          <HeritageRow key={m.uuid} match={m} active={activeUuid === m.uuid} onClick={onRowClick} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function HeritageRow({
+  match,
+  active,
+  onClick,
+}: {
+  match: CompendiumMatch;
+  active: boolean;
+  onClick: (m: CompendiumMatch) => void;
+}): React.ReactElement {
+  const art = getHeritageArt(match.name);
+  const artSrc = art?.images[0] ?? null;
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={(): void => {
+          onClick(match);
+        }}
+        aria-pressed={active}
+        className={[
+          'flex w-full items-center gap-3 px-4 py-2 text-left transition-colors',
+          active ? 'bg-pf-tertiary/50' : 'hover:bg-pf-tertiary/20',
+        ].join(' ')}
+        data-pick-uuid={match.uuid}
+        data-match-uuid={match.uuid}
+      >
+        {artSrc !== null ? (
+          <img
+            src={artSrc}
+            alt=""
+            className="h-8 w-8 shrink-0 rounded border border-pf-border object-cover object-top"
+          />
+        ) : match.img ? (
+          <img src={match.img} alt="" className="h-8 w-8 shrink-0 rounded border border-pf-border bg-pf-bg-dark" />
+        ) : null}
+        <span className="text-sm font-medium text-pf-text">{match.name}</span>
+      </button>
+    </li>
+  );
 }
 
 function StepNav({

--- a/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
+++ b/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
@@ -445,6 +445,14 @@ const PICKER_OPTIONS_BY_TARGET: Partial<Record<PickerTarget, CreatorPickerOption
     showUnmetToggle: false,
     showSortToggle: false,
   },
+  // Deity picker: no prereqs and no level dimension, so the hide-unmet
+  // toggle and the A-Z / Level sort are noise. Source and (default)
+  // rarity controls stay since pf2e ships hundreds of deities across
+  // many supplements.
+  deity: {
+    showUnmetToggle: false,
+    showSortToggle: false,
+  },
   // Class picker:
   //   - default to common-only rarity (Player Core / Player Core 2
   //     classes); the rarity pill row lets the player opt in to

--- a/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
+++ b/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
@@ -203,15 +203,17 @@ export function CharacterCreator(): React.ReactElement {
   const pickerFilters = openPicker !== null ? filtersForTarget(openPicker, draft) : undefined;
 
   return (
-    // Three-column shell mirroring the sheet layout: tips rail on the left
-    // (where the party rail lives in the sheet), wizard in the centre, and
-    // a phantom column on the right so the wizard stays centred on wide
-    // screens. Both side columns hide on viewports narrower than `lg`.
+    // Two-column shell: tips rail on the left (where the party rail lives
+    // in the sheet) and the wizard next to it. Side rail hides on
+    // viewports narrower than `lg`; the wizard then takes the full row.
+    // No auto-centring on the wizard column — it sits flush after the
+    // rail so the visible gap between rail content and wizard content is
+    // just the flex gap + the wizard's internal padding.
     <div className="flex gap-6 py-6 font-sans">
       <aside className="hidden w-[280px] shrink-0 pl-3 lg:block" aria-label="Player tips">
         <TipsRail />
       </aside>
-      <main className="mx-auto min-w-0 max-w-3xl flex-1 px-6">
+      <main className="min-w-0 max-w-3xl flex-1 px-6">
         <div className="mb-4 flex items-center gap-3">
           <button
             type="button"
@@ -388,9 +390,6 @@ export function CharacterCreator(): React.ReactElement {
           everything else so the wizard pauses until the user picks. */}
         <PromptQueue />
       </main>
-      {/* Phantom column mirrors the rail width so the wizard column
-          stays horizontally centred between them on wide screens. */}
-      <div className="hidden w-[280px] shrink-0 lg:block" aria-hidden="true" />
     </div>
   );
 }

--- a/apps/player-portal/src/features/characters/creator/PickerCard.tsx
+++ b/apps/player-portal/src/features/characters/creator/PickerCard.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import type { CompendiumMatch } from '@/features/characters/types';
 
 // Selected-pick card used by Identity (deity), Background, Ancestry,
@@ -9,16 +10,26 @@ export function PickerCard({
   onOpen,
   disabled,
   disabledHint,
+  helpText,
 }: {
   label: string;
   selection: CompendiumMatch | null;
   onOpen: () => void;
   disabled?: boolean;
   disabledHint?: string;
+  /** Short explanation of what this pick is for, shown above the
+   *  "Choose X" CTA in the empty state. Hidden once something is
+   *  selected — by then the player knows what they picked. */
+  helpText?: ReactNode;
 }): React.ReactElement {
   if (selection === null) {
     return (
       <div className="flex flex-col items-start gap-2" data-picker-card={label.toLowerCase()}>
+        {helpText !== undefined && (
+          <p className="text-xs leading-relaxed text-pf-alt-dark" data-role={`${label.toLowerCase()}-help`}>
+            {helpText}
+          </p>
+        )}
         <p className="text-sm text-pf-text">No {label.toLowerCase()} selected yet.</p>
         <button
           type="button"

--- a/apps/player-portal/src/features/characters/creator/PickerCard.tsx
+++ b/apps/player-portal/src/features/characters/creator/PickerCard.tsx
@@ -30,7 +30,6 @@ export function PickerCard({
             {helpText}
           </p>
         )}
-        <p className="text-sm text-pf-text">No {label.toLowerCase()} selected yet.</p>
         <button
           type="button"
           onClick={onOpen}

--- a/apps/player-portal/src/features/characters/creator/TipsRail.tsx
+++ b/apps/player-portal/src/features/characters/creator/TipsRail.tsx
@@ -39,6 +39,20 @@ const TIPS: readonly CreatorTip[] = [
     ],
     link: { url: 'https://2e.aonprd.com/Rules.aspx?ID=2530&Redirected=1', label: 'Read the Rarity rules' },
   },
+  {
+    title: 'Multiclassing',
+    body: [
+      'You pick a single class for your full progression. To branch into a second class’s tradecraft, spend a class feat to take that class’s Archetype Dedication — Rogue Archetype, Fighter Archetype, and so on.',
+      'Continuing to spend class feats on archetype feats unlocks the rest of that archetype’s features. There’s no second-class picker; everything lives on the class feat line.',
+    ],
+    link: { url: 'https://2e.aonprd.com/Rules.aspx?ID=2769', label: 'Multiclass Archetypes' },
+  },
+  {
+    title: 'Edits in Foundry',
+    body: [
+      'If the creator misses something you need, you can edit your character directly in Foundry after the wizard finishes — every field on the actor sheet stays editable.',
+    ],
+  },
 ];
 
 export function TipsRail(): React.ReactElement {

--- a/apps/player-portal/src/features/characters/creator/TipsRail.tsx
+++ b/apps/player-portal/src/features/characters/creator/TipsRail.tsx
@@ -1,0 +1,54 @@
+// Left-rail tip cards shown alongside the character-creator wizard.
+// The sheet uses the equivalent column for the party rail; the creator
+// has nothing actor-specific to put there before the character exists,
+// so we use the space to coach new players on PF2e conventions that
+// affect their picks (rarity, key-attribute math, etc.).
+//
+// Tip definitions are plain data so adding a new card is a one-entry
+// edit — no new component per tip. Cards stack vertically and the rail
+// hides on viewports narrower than `lg` to match the sheet's rail.
+
+interface CreatorTip {
+  /** Heading shown at the top of the card. Keep short — one or two words. */
+  title: string;
+  /** Body paragraphs. Plain strings; rendered as <p> blocks. */
+  body: string[];
+}
+
+const TIPS: readonly CreatorTip[] = [
+  {
+    title: 'Rarity',
+    body: [
+      'Elements in PF2e have a rarity value. It describes how frequently something appears in the world — not how strong it is. Rarity has no impact on a choice’s relative power.',
+      'If you’re picking something that is not Common, please check with your GM first so they can ensure it fits in the game.',
+    ],
+  },
+];
+
+export function TipsRail(): React.ReactElement {
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="px-1 text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark">Player tips</p>
+      {TIPS.map((tip) => (
+        <TipCard key={tip.title} tip={tip} />
+      ))}
+    </div>
+  );
+}
+
+function TipCard({ tip }: { tip: CreatorTip }): React.ReactElement {
+  return (
+    <article
+      className="rounded border border-pf-border bg-pf-bg-dark/40 px-3 py-3 text-xs text-pf-alt-dark"
+      data-role="creator-tip"
+      data-tip-title={tip.title}
+    >
+      <h3 className="mb-1.5 font-serif text-sm font-semibold text-pf-text">{tip.title}</h3>
+      {tip.body.map((para, i) => (
+        <p key={i.toString()} className={i > 0 ? 'mt-2' : undefined}>
+          {para}
+        </p>
+      ))}
+    </article>
+  );
+}

--- a/apps/player-portal/src/features/characters/creator/TipsRail.tsx
+++ b/apps/player-portal/src/features/characters/creator/TipsRail.tsx
@@ -13,15 +13,24 @@ interface CreatorTip {
   title: string;
   /** Body paragraphs. Plain strings; rendered as <p> blocks. */
   body: string[];
+  /** Optional follow-up link rendered as a footer on the card. Opens in a
+   *  new tab. */
+  link?: { url: string; label: string };
 }
 
 const TIPS: readonly CreatorTip[] = [
+  {
+    title: 'Archives of Nethys',
+    body: ['All rules for PF2e are available for free via the Archives of Nethys.'],
+    link: { url: 'https://2e.aonprd.com/', label: 'Visit Archives of Nethys' },
+  },
   {
     title: 'Rarity',
     body: [
       'Elements in PF2e have a rarity value. It describes how frequently something appears in the world — not how strong it is. Rarity has no impact on a choice’s relative power.',
       'If you’re picking something that is not Common, please check with your GM first so they can ensure it fits in the game.',
     ],
+    link: { url: 'https://2e.aonprd.com/Rules.aspx?ID=2530&Redirected=1', label: 'Read the Rarity rules' },
   },
 ];
 
@@ -49,6 +58,16 @@ function TipCard({ tip }: { tip: CreatorTip }): React.ReactElement {
           {para}
         </p>
       ))}
+      {tip.link && (
+        <a
+          href={tip.link.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-2 inline-block text-pf-primary underline decoration-pf-primary/40 underline-offset-2 hover:decoration-pf-primary"
+        >
+          {tip.link.label} ↗
+        </a>
+      )}
     </article>
   );
 }

--- a/apps/player-portal/src/features/characters/creator/TipsRail.tsx
+++ b/apps/player-portal/src/features/characters/creator/TipsRail.tsx
@@ -45,7 +45,7 @@ const TIPS: readonly CreatorTip[] = [
       'You pick a single class for your full progression. To branch into a second class’s tradecraft, spend a class feat to take that class’s Archetype Dedication — Rogue Archetype, Fighter Archetype, and so on.',
       'Continuing to spend class feats on archetype feats unlocks the rest of that archetype’s features. There’s no second-class picker; everything lives on the class feat line.',
     ],
-    link: { url: 'https://2e.aonprd.com/Rules.aspx?ID=2769', label: 'Multiclass Archetypes' },
+    link: { url: 'https://2e.aonprd.com/Archetypes.aspx', label: 'Multiclass Archetypes' },
   },
   {
     title: 'Edits in Foundry',

--- a/apps/player-portal/src/features/characters/creator/TipsRail.tsx
+++ b/apps/player-portal/src/features/characters/creator/TipsRail.tsx
@@ -25,6 +25,13 @@ const TIPS: readonly CreatorTip[] = [
     link: { url: 'https://2e.aonprd.com/', label: 'Visit Archives of Nethys' },
   },
   {
+    title: 'PF2e Remaster',
+    body: [
+      'Paizo transitioned to a “Remastered” version of PF2e beginning in November 2023. Books published under the Remaster are titled with “Core”.',
+      'The vast majority of the changes were made to accommodate legal licensing requirements (for example, renaming Aasimar to Nephilim). Rule changes are very minimal — non-remastered content can reliably be used with remastered content.',
+    ],
+  },
+  {
     title: 'Rarity',
     body: [
       'Elements in PF2e have a rarity value. It describes how frequently something appears in the world — not how strong it is. Rarity has no impact on a choice’s relative power.',

--- a/apps/player-portal/src/features/characters/creator/constants.ts
+++ b/apps/player-portal/src/features/characters/creator/constants.ts
@@ -21,6 +21,7 @@ export const EMPTY_DRAFT: Draft = {
   ancestryBoosts: [],
   backgroundBoosts: [],
   classKeyAbility: null,
+  alternateAncestryBoosts: null,
   skillPicks: [],
   languagePicks: [],
   classGrantsL1Feat: null,

--- a/apps/player-portal/src/features/characters/creator/helpers.test.ts
+++ b/apps/player-portal/src/features/characters/creator/helpers.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import type { CompendiumMatch } from '@/features/characters/types';
+import { groupHeritages } from './helpers';
+
+function makeHeritage(name: string, isVersatile?: boolean): CompendiumMatch {
+  return {
+    packId: 'pf2e.heritages',
+    packLabel: 'Heritages',
+    documentId: `heritage-${name.toLowerCase().replace(/\s/g, '-')}`,
+    uuid: `Compendium.pf2e.heritages.Item.${name}`,
+    name,
+    type: 'heritage',
+    img: '',
+    ...(isVersatile !== undefined ? { isVersatile } : {}),
+  };
+}
+
+describe('groupHeritages', () => {
+  it('puts items without isVersatile in primary', () => {
+    const items = [makeHeritage('Ancient Dwarf'), makeHeritage('Death Warden Dwarf')];
+    const { primary, versatile } = groupHeritages(items);
+    expect(primary).toHaveLength(2);
+    expect(versatile).toHaveLength(0);
+  });
+
+  it('puts isVersatile=true items in versatile', () => {
+    const items = [makeHeritage('Aiuvarin', true), makeHeritage('Changeling', true)];
+    const { primary, versatile } = groupHeritages(items);
+    expect(primary).toHaveLength(0);
+    expect(versatile).toHaveLength(2);
+  });
+
+  it('puts isVersatile=false items in primary', () => {
+    const item = makeHeritage('Ancient Dwarf', false);
+    const { primary, versatile } = groupHeritages([item]);
+    expect(primary).toHaveLength(1);
+    expect(versatile).toHaveLength(0);
+  });
+
+  it('splits a mixed list correctly', () => {
+    const items = [
+      makeHeritage('Ancient Dwarf'),
+      makeHeritage('Aiuvarin', true),
+      makeHeritage('Death Warden Dwarf'),
+      makeHeritage('Changeling', true),
+      makeHeritage('Strong-Blooded Dwarf'),
+    ];
+    const { primary, versatile } = groupHeritages(items);
+    expect(primary.map((m) => m.name)).toEqual(['Ancient Dwarf', 'Death Warden Dwarf', 'Strong-Blooded Dwarf']);
+    expect(versatile.map((m) => m.name)).toEqual(['Aiuvarin', 'Changeling']);
+  });
+
+  it('returns empty groups for an empty list', () => {
+    const { primary, versatile } = groupHeritages([]);
+    expect(primary).toHaveLength(0);
+    expect(versatile).toHaveLength(0);
+  });
+
+  it('preserves order within each group', () => {
+    const items = [
+      makeHeritage('Nephilim', true),
+      makeHeritage('Ancient Dwarf'),
+      makeHeritage('Aiuvarin', true),
+      makeHeritage('Strong-Blooded Dwarf'),
+    ];
+    const { primary, versatile } = groupHeritages(items);
+    expect(primary[0]?.name).toBe('Ancient Dwarf');
+    expect(primary[1]?.name).toBe('Strong-Blooded Dwarf');
+    expect(versatile[0]?.name).toBe('Nephilim');
+    expect(versatile[1]?.name).toBe('Aiuvarin');
+  });
+});

--- a/apps/player-portal/src/features/characters/creator/helpers.ts
+++ b/apps/player-portal/src/features/characters/creator/helpers.ts
@@ -171,8 +171,8 @@ export function applyPickedSlot(draft: Draft, target: PickerTarget, slot: Slot):
   switch (target) {
     case 'ancestry':
       // A new ancestry wipes the heritage + cached slug + ancestry
-      // feat + ancestry boost picks + language picks (the old
-      // choices may not be valid under the new ancestry).
+      // feat + ancestry boost picks + language picks + alternate-boost
+      // opt-in (the old choices may not be valid under the new ancestry).
       return {
         ...draft,
         ancestry: slot,
@@ -181,6 +181,7 @@ export function applyPickedSlot(draft: Draft, target: PickerTarget, slot: Slot):
         heritageSlug: null,
         ancestryFeat: null,
         ancestryBoosts: [],
+        alternateAncestryBoosts: null,
         languagePicks: [],
         languageAllowance: null,
       };

--- a/apps/player-portal/src/features/characters/creator/helpers.ts
+++ b/apps/player-portal/src/features/characters/creator/helpers.ts
@@ -222,6 +222,20 @@ export function prettySkillLabel(slug: string): string {
     .join(' ');
 }
 
+// Splits a flat heritage list into primary (ancestry-specific) and versatile
+// (any-ancestry) groups. The `isVersatile` flag is set by the server when
+// `system.ancestry === null` on the heritage item — pf2e's signal for
+// versatile heritages (Aiuvarin, Changeling, Beastkin, …).
+export function groupHeritages(items: CompendiumMatch[]): {
+  primary: CompendiumMatch[];
+  versatile: CompendiumMatch[];
+} {
+  return {
+    primary: items.filter((m) => m.isVersatile !== true),
+    versatile: items.filter((m) => m.isVersatile === true),
+  };
+}
+
 // Used by LanguagesStep and ReviewStep. Same shape as
 // `prettySkillLabel` but kept as its own export so the call sites
 // document what's being humanised.

--- a/apps/player-portal/src/features/characters/creator/steps/AncestryStep.tsx
+++ b/apps/player-portal/src/features/characters/creator/steps/AncestryStep.tsx
@@ -27,7 +27,12 @@ export function AncestryStep({
       onMouseOver={uuidHover.delegationHandlers.onMouseOver}
       onMouseOut={uuidHover.delegationHandlers.onMouseOut}
     >
-      <PickerCard label="Ancestry" selection={ancestry} onOpen={onPickAncestry} />
+      <PickerCard
+        label="Ancestry"
+        selection={ancestry}
+        onOpen={onPickAncestry}
+        helpText="Your character's species — drives their appearance, baseline stats, and innate abilities."
+      />
       {ancestry !== null && (
         <div className="space-y-3 border-t border-pf-border pt-4">
           <div data-creator-subpicker="heritage">
@@ -36,6 +41,13 @@ export function AncestryStep({
               selection={heritage}
               onOpen={onPickHeritage}
               disabled={!ancestrySlugResolved}
+              helpText={
+                <>
+                  <strong>Standard heritages</strong> are sub-variants of the parent ancestry.{' '}
+                  <strong>Versatile heritages</strong> are lineages that can apply to any ancestry — divine blood, a hag
+                  mother, etc.
+                </>
+              }
               {...(ancestrySlugResolved ? {} : { disabledHint: 'Resolving ancestry…' })}
             />
           </div>

--- a/apps/player-portal/src/features/characters/creator/steps/AttributesStep.test.ts
+++ b/apps/player-portal/src/features/characters/creator/steps/AttributesStep.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { BOOST_CAP, tallyBoosts, mergeBoostTallies, flawCountsFromSlots, disabledKeysForSlot } from './AttributesStep';
+import type { ParsedSlot } from './AttributesStep';
+import { ABILITY_KEYS } from '@/features/characters/types';
+
+// Helper: build an allBoosts record with all zeros for easy test setup.
+function zeroBoosts(): Record<string, number> {
+  return Object.fromEntries(ABILITY_KEYS.map((k) => [k, 0]));
+}
+
+describe('tallyBoosts', () => {
+  it('counts each ability', () => {
+    expect(tallyBoosts(['str', 'dex', 'str'])).toEqual({ str: 2, dex: 1 });
+  });
+
+  it('ignores null picks', () => {
+    expect(tallyBoosts([null, 'con', null])).toEqual({ con: 1 });
+  });
+
+  it('returns empty object for all-null array', () => {
+    expect(tallyBoosts([null, null])).toEqual({});
+  });
+});
+
+describe('mergeBoostTallies', () => {
+  it('sums across tallies and fills zero for unmentioned keys', () => {
+    const result = mergeBoostTallies({ str: 2 }, { str: 1, dex: 1 });
+    expect(result.str).toBe(3);
+    expect(result.dex).toBe(1);
+    expect(result.con).toBe(0);
+  });
+
+  it('handles empty input', () => {
+    const result = mergeBoostTallies();
+    expect(Object.values(result).every((v) => v === 0)).toBe(true);
+  });
+});
+
+describe('flawCountsFromSlots', () => {
+  it('counts fixed-flaw slots', () => {
+    const slots: ParsedSlot[] = [{ kind: 'fixed', options: ['cha'] }];
+    expect(flawCountsFromSlots(slots)).toEqual({ cha: 1 });
+  });
+
+  it('ignores free flaw slots (choice flaws — rare)', () => {
+    const slots: ParsedSlot[] = [{ kind: 'free', options: ['str', 'dex'] }];
+    expect(flawCountsFromSlots(slots)).toEqual({});
+  });
+
+  it('returns empty for no slots', () => {
+    expect(flawCountsFromSlots([])).toEqual({});
+  });
+});
+
+describe('disabledKeysForSlot', () => {
+  it('disables an ability already at the 4-boost cap', () => {
+    const allBoosts = { ...zeroBoosts(), str: BOOST_CAP } as Record<string, number>;
+    const disabled = disabledKeysForSlot(0, [null], allBoosts as never, {});
+    expect(disabled.has('str')).toBe(true);
+    expect(disabled.has('dex')).toBe(false);
+  });
+
+  it('allows re-picking the current slot selection even when at cap', () => {
+    // str is already at cap, but it's the current pick for slot 0 —
+    // keeping it should be allowed (not disabled).
+    const allBoosts = { ...zeroBoosts(), str: BOOST_CAP } as Record<string, number>;
+    const disabled = disabledKeysForSlot(0, ['str'], allBoosts as never, {});
+    expect(disabled.has('str')).toBe(false);
+  });
+
+  it('raises the cap by 1 per flaw', () => {
+    // cha has 4 boosts but also 1 flaw → cap is 5, so it's not disabled.
+    const allBoosts = { ...zeroBoosts(), cha: BOOST_CAP } as Record<string, number>;
+    const disabled = disabledKeysForSlot(0, [null], allBoosts as never, { cha: 1 });
+    expect(disabled.has('cha')).toBe(false);
+
+    // cha at 5 boosts with 1 flaw → now at cap, disabled.
+    const atCapBoosts = { ...zeroBoosts(), cha: BOOST_CAP + 1 } as Record<string, number>;
+    const disabledAtCap = disabledKeysForSlot(0, [null], atCapBoosts as never, { cha: 1 });
+    expect(disabledAtCap.has('cha')).toBe(true);
+  });
+
+  it('disables an ability already picked by a different slot in the same source', () => {
+    const allBoosts = zeroBoosts() as Record<string, number>;
+    // sourcePicks[0] = 'str'; we're computing disabled for slot 1.
+    const disabled = disabledKeysForSlot(1, ['str', null], allBoosts as never, {});
+    expect(disabled.has('str')).toBe(true);
+    expect(disabled.has('dex')).toBe(false);
+  });
+
+  it('does not disable the current slot pick due to same-source rule', () => {
+    const allBoosts = { ...zeroBoosts(), str: 1 } as Record<string, number>;
+    // Slot 1 currently holds 'str'; it should not be self-blocked.
+    const disabled = disabledKeysForSlot(1, ['dex', 'str'], allBoosts as never, {});
+    expect(disabled.has('str')).toBe(false);
+  });
+});

--- a/apps/player-portal/src/features/characters/creator/steps/AttributesStep.tsx
+++ b/apps/player-portal/src/features/characters/creator/steps/AttributesStep.tsx
@@ -243,6 +243,16 @@ export function AttributesStep({
         boosts) contributes one boost per attribute, and no ability can take more than 4 boosts total. An ancestry flaw
         raises the cap by 1 boost for that attribute. Options at the cap are disabled.
       </p>
+      <p
+        className="rounded border border-pf-border bg-pf-bg-dark/40 px-3 py-2 text-xs text-pf-alt-dark"
+        data-role="attributes-key-note"
+      >
+        <span className="font-semibold text-pf-alt-dark">Key attribute tip:</span> PF2e's encounter math is tight —
+        attack rolls, class DC, and trained-skill checks all key off your{' '}
+        <span className="font-semibold text-pf-text">class key attribute</span>. Most characters want to start at{' '}
+        <span className="font-semibold text-pf-text">+4</span> in that attribute (the class boost plus one of your free
+        boosts). Falling short of +4 here usually costs you accuracy at every level.
+      </p>
       <BoostSourceBlock
         label={ancestryPick !== null ? `Ancestry · ${ancestryPick.name}` : 'Ancestry'}
         state={ancestryDoc}

--- a/apps/player-portal/src/features/characters/creator/steps/AttributesStep.tsx
+++ b/apps/player-portal/src/features/characters/creator/steps/AttributesStep.tsx
@@ -12,7 +12,7 @@ import type { Draft } from '../types';
 // `value` array is: one entry for fixed, 2+ entries for a
 // constrained choice, all six (or empty) for a free pick.
 type SlotKind = 'fixed' | 'free';
-interface ParsedSlot {
+export interface ParsedSlot {
   kind: SlotKind;
   options: AbilityKey[];
 }
@@ -21,6 +21,77 @@ type SourceDocState =
   | { kind: 'loading'; uuid: string }
   | { kind: 'ready'; uuid: string; slots: ParsedSlot[] }
   | { kind: 'error'; uuid: string; message: string };
+
+// ─── 18-cap enforcement ──────────────────────────────────────────────────────
+// PF2e level-1 rule: ability scores can't exceed 18. Starting at 10,
+// each boost adds +2, so no ability can be boosted more than 4 times
+// across all sources. An ancestry flaw lowers the floor by 2, allowing
+// one extra boost (5 total) before hitting 18.
+
+export const BOOST_CAP = 4;
+
+export function tallyBoosts(picks: (AbilityKey | null)[]): Partial<Record<AbilityKey, number>> {
+  const out: Partial<Record<AbilityKey, number>> = {};
+  for (const k of picks) {
+    if (k !== null) out[k] = (out[k] ?? 0) + 1;
+  }
+  return out;
+}
+
+export function mergeBoostTallies(...tallies: Partial<Record<AbilityKey, number>>[]): Record<AbilityKey, number> {
+  const out = Object.fromEntries(ABILITY_KEYS.map((k) => [k, 0])) as Record<AbilityKey, number>;
+  for (const tally of tallies) {
+    for (const [k, n] of Object.entries(tally) as [AbilityKey, number][]) {
+      out[k] += n;
+    }
+  }
+  return out;
+}
+
+export function flawCountsFromSlots(slots: ParsedSlot[]): Partial<Record<AbilityKey, number>> {
+  const out: Partial<Record<AbilityKey, number>> = {};
+  for (const slot of slots) {
+    if (slot.kind === 'fixed') {
+      for (const k of slot.options) {
+        out[k] = (out[k] ?? 0) + 1;
+      }
+    }
+  }
+  return out;
+}
+
+// Returns keys that are disabled for slot `slotIdx` in a source.
+// A key is disabled when either:
+//   (a) it would push the ability past the 18-cap across all sources, or
+//   (b) it is already picked by a different slot within the same source
+//       (each source can only boost a given ability once).
+export function disabledKeysForSlot(
+  slotIdx: number,
+  sourcePicks: (AbilityKey | null)[],
+  allBoosts: Record<AbilityKey, number>,
+  flawCounts: Partial<Record<AbilityKey, number>>,
+): Set<AbilityKey> {
+  const currentPick = sourcePicks[slotIdx] ?? null;
+  const disabled = new Set<AbilityKey>();
+  for (const key of ABILITY_KEYS) {
+    // (a) Cap: strip this slot's own contribution, then test if adding it
+    //     would hit the ceiling.
+    const cap = BOOST_CAP + (flawCounts[key] ?? 0);
+    const boostedExcludingThisSlot = allBoosts[key] - (currentPick === key ? 1 : 0);
+    if (boostedExcludingThisSlot >= cap) {
+      disabled.add(key);
+      continue;
+    }
+    // (b) Same-source duplicate: another slot in this source already holds key.
+    for (let i = 0; i < sourcePicks.length; i++) {
+      if (i !== slotIdx && sourcePicks[i] === key) {
+        disabled.add(key);
+        break;
+      }
+    }
+  }
+  return disabled;
+}
 
 export function AttributesStep({
   actorId,
@@ -113,14 +184,18 @@ export function AttributesStep({
   };
 
   const toggleFreeBoost = (key: AbilityKey): void => {
-    let next: AbilityKey[];
+    // Deselecting is always allowed.
     if (levelOneBoosts.includes(key)) {
-      next = levelOneBoosts.filter((k) => k !== key);
-    } else if (levelOneBoosts.length >= BOOSTS_REQUIRED) {
+      const next = levelOneBoosts.filter((k) => k !== key);
+      onDraftPatch({ levelOneBoosts: next });
+      patchFreeBoosts(next);
       return;
-    } else {
-      next = [...levelOneBoosts, key];
     }
+    if (levelOneBoosts.length >= BOOSTS_REQUIRED) return;
+    // Enforce 18-cap: don't add a free boost to an ability already at the ceiling.
+    const cap = BOOST_CAP + (flawCounts[key] ?? 0);
+    if (allBoosts[key] >= cap) return;
+    const next = [...levelOneBoosts, key];
     onDraftPatch({ levelOneBoosts: next });
     patchFreeBoosts(next);
   };
@@ -144,6 +219,19 @@ export function AttributesStep({
     patchItem(classItemId, 'keyAbility.selected', key);
   };
 
+  // Compute all committed boosts across every source so child pickers
+  // can enforce the 18-cap. Flaws from ancestry raise the cap by 1 per
+  // flaw (e.g. a Dwarf's CHA flaw lets CHA reach 18 with 5 boosts).
+  const flawCounts = flawCountsFromSlots(ancestryFlaws.kind === 'ready' ? ancestryFlaws.slots : []);
+  const allBoosts = mergeBoostTallies(
+    tallyBoosts(ancestryBoosts),
+    tallyBoosts(backgroundBoosts),
+    tallyBoosts(classKeyAbility !== null ? [classKeyAbility] : []),
+    tallyBoosts(levelOneBoosts),
+  );
+
+  const classPicks: (AbilityKey | null)[] = classKeyAbility !== null ? [classKeyAbility] : [null];
+
   return (
     <div className="space-y-5">
       <BoostSourceBlock
@@ -153,6 +241,8 @@ export function AttributesStep({
         picks={ancestryBoosts}
         onPick={setAncestrySlot}
         flaws={ancestryFlaws}
+        allBoosts={allBoosts}
+        flawCounts={flawCounts}
       />
       <BoostSourceBlock
         label={backgroundPick !== null ? `Background · ${backgroundPick.name}` : 'Background'}
@@ -160,17 +250,26 @@ export function AttributesStep({
         placeholderText="Pick a background on the previous step to see its boosts."
         picks={backgroundBoosts}
         onPick={setBackgroundSlot}
+        allBoosts={allBoosts}
+        flawCounts={flawCounts}
       />
       <BoostSourceBlock
         label={classPick !== null ? `Class · ${classPick.name} key attribute` : 'Class key attribute'}
         state={classDoc}
         placeholderText="Pick a class on the previous step to choose its key attribute."
-        picks={classKeyAbility !== null ? [classKeyAbility] : [null]}
+        picks={classPicks}
         onPick={(_slot, key): void => {
           setClassKeyAbility(key);
         }}
+        allBoosts={allBoosts}
+        flawCounts={flawCounts}
       />
-      <FreeBoostBlock selected={levelOneBoosts} onToggle={toggleFreeBoost} />
+      <FreeBoostBlock
+        selected={levelOneBoosts}
+        allBoosts={allBoosts}
+        flawCounts={flawCounts}
+        onToggle={toggleFreeBoost}
+      />
     </div>
   );
 }
@@ -217,6 +316,8 @@ function BoostSourceBlock({
   picks,
   onPick,
   flaws,
+  allBoosts,
+  flawCounts,
 }: {
   label: string;
   state: SourceDocState;
@@ -227,6 +328,8 @@ function BoostSourceBlock({
    *  picks aren't ours — pf2e applies them automatically — so we
    *  just display them as context. */
   flaws?: SourceDocState;
+  allBoosts: Record<AbilityKey, number>;
+  flawCounts: Partial<Record<AbilityKey, number>>;
 }): React.ReactElement {
   const flawSlots = flaws?.kind === 'ready' ? flaws.slots : [];
   return (
@@ -246,6 +349,7 @@ function BoostSourceBlock({
               <BoostSlotPicker
                 slot={slot}
                 selected={picks[idx] ?? null}
+                disabledKeys={disabledKeysForSlot(idx, picks, allBoosts, flawCounts)}
                 onPick={(key): void => {
                   onPick(idx, key);
                 }}
@@ -310,10 +414,14 @@ function parseAncestryFlaws(system: unknown): ParsedSlot[] {
 function BoostSlotPicker({
   slot,
   selected,
+  disabledKeys,
   onPick,
 }: {
   slot: ParsedSlot;
   selected: AbilityKey | null;
+  /** Abilities that cannot be picked: at the 18-cap or already used by
+   *  another slot in this source. */
+  disabledKeys: Set<AbilityKey>;
   onPick: (key: AbilityKey) => void;
 }): React.ReactElement {
   if (slot.kind === 'fixed') {
@@ -331,20 +439,25 @@ function BoostSlotPicker({
     <div className="flex flex-wrap gap-1">
       {slot.options.map((key) => {
         const isActive = selected === key;
+        const isDisabled = !isActive && disabledKeys.has(key);
         return (
           <button
             key={key}
             type="button"
             aria-pressed={isActive}
+            disabled={isDisabled}
             onClick={(): void => {
               onPick(key);
             }}
             data-boost-option={key}
+            title={isDisabled ? 'Already at 18 — cannot boost further' : undefined}
             className={[
               'rounded border px-2 py-1 text-xs font-semibold uppercase tracking-widest transition-colors',
               isActive
                 ? 'border-pf-primary bg-pf-tertiary/40 text-pf-primary'
-                : 'border-pf-border bg-pf-bg text-pf-alt-dark hover:bg-pf-tertiary/20',
+                : isDisabled
+                  ? 'cursor-not-allowed border-pf-border bg-pf-bg text-pf-alt-dark opacity-40'
+                  : 'border-pf-border bg-pf-bg text-pf-alt-dark hover:bg-pf-tertiary/20',
             ].join(' ')}
           >
             {key.toUpperCase()}
@@ -357,9 +470,14 @@ function BoostSlotPicker({
 
 function FreeBoostBlock({
   selected,
+  allBoosts,
+  flawCounts,
   onToggle,
 }: {
   selected: AbilityKey[];
+  /** Total boosts per ability across all sources (including free picks). */
+  allBoosts: Record<AbilityKey, number>;
+  flawCounts: Partial<Record<AbilityKey, number>>;
   onToggle: (key: AbilityKey) => void;
 }): React.ReactElement {
   const remaining = BOOSTS_REQUIRED - selected.length;
@@ -375,7 +493,10 @@ function FreeBoostBlock({
       <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
         {ABILITY_KEYS.map((key) => {
           const picked = selected.includes(key);
-          const locked = !picked && selected.length >= BOOSTS_REQUIRED;
+          // `allBoosts[key]` does NOT include key as a free pick when `!picked`,
+          // so checking against cap tells us whether a new free boost is allowed.
+          const atCap = !picked && allBoosts[key] >= BOOST_CAP + (flawCounts[key] ?? 0);
+          const locked = !picked && (selected.length >= BOOSTS_REQUIRED || atCap);
           return (
             <button
               key={key}
@@ -386,6 +507,7 @@ function FreeBoostBlock({
               onClick={(): void => {
                 onToggle(key);
               }}
+              title={atCap ? 'Already at 18 — cannot boost further' : undefined}
               className={[
                 'flex flex-col items-center rounded border px-2 py-3 transition-colors',
                 picked

--- a/apps/player-portal/src/features/characters/creator/steps/AttributesStep.tsx
+++ b/apps/player-portal/src/features/characters/creator/steps/AttributesStep.tsx
@@ -234,6 +234,15 @@ export function AttributesStep({
 
   return (
     <div className="space-y-5">
+      <p
+        className="rounded border border-pf-border bg-pf-bg-dark/40 px-3 py-2 text-xs text-pf-alt-dark"
+        data-role="attributes-cap-note"
+      >
+        <span className="font-semibold text-pf-alt-dark">Level 1 cap:</span> no attribute can be raised above{' '}
+        <span className="font-semibold text-pf-text">18 (+4)</span>. Each source (ancestry, background, class key, free
+        boosts) contributes one boost per attribute, and no ability can take more than 4 boosts total. An ancestry flaw
+        raises the cap by 1 boost for that attribute. Options at the cap are disabled.
+      </p>
       <BoostSourceBlock
         label={ancestryPick !== null ? `Ancestry · ${ancestryPick.name}` : 'Ancestry'}
         state={ancestryDoc}

--- a/apps/player-portal/src/features/characters/creator/steps/AttributesStep.tsx
+++ b/apps/player-portal/src/features/characters/creator/steps/AttributesStep.tsx
@@ -93,6 +93,11 @@ export function disabledKeysForSlot(
   return disabled;
 }
 
+// PF2e "Alternative Ancestry Boosts" optional rule (Player Core p. 27):
+// a character may forgo their ancestry's listed boosts/flaws and instead
+// take exactly two free ability boosts.
+const ALTERNATE_BOOST_COUNT = 2;
+
 export function AttributesStep({
   actorId,
   ancestryPick,
@@ -105,6 +110,7 @@ export function AttributesStep({
   ancestryBoosts,
   backgroundBoosts,
   classKeyAbility,
+  alternateAncestryBoosts,
   onDraftPatch,
 }: {
   actorId: string | null;
@@ -118,8 +124,12 @@ export function AttributesStep({
   ancestryBoosts: (AbilityKey | null)[];
   backgroundBoosts: (AbilityKey | null)[];
   classKeyAbility: AbilityKey | null;
+  /** Null when the optional rule is off; an array — possibly empty —
+   *  when on, with the two picks. */
+  alternateAncestryBoosts: AbilityKey[] | null;
   onDraftPatch: (patch: Partial<Draft>) => void;
 }): React.ReactElement {
+  const useAlternateBoosts = alternateAncestryBoosts !== null;
   const ancestryDoc = useSourceSlots(ancestryPick, parseAncestryOrBackgroundSlots);
   // Flaws are parsed separately from the same ancestry doc — pf2e
   // applies them automatically when the item attaches, so we surface
@@ -219,12 +229,51 @@ export function AttributesStep({
     patchItem(classItemId, 'keyAbility.selected', key);
   };
 
+  // PF2e "Alternative Ancestry Boosts" toggle. Truthy presence of
+  // `ancestry.system.alternateAncestryBoosts` (any array, even empty)
+  // makes pf2e's ancestry-prep skip the listed boosts AND flaws and
+  // instead grant the picks recorded in the array. `null` disables the
+  // rule. We send `null` for off so the system's `if (...alternateAncestryBoosts)`
+  // check evaluates false; the field then sits as null in the embedded
+  // item — pf2e treats null and absent identically.
+  const toggleAlternateBoosts = (enabled: boolean): void => {
+    const next: AbilityKey[] | null = enabled ? [] : null;
+    onDraftPatch({ alternateAncestryBoosts: next });
+    patchItem(ancestryItemId, 'alternateAncestryBoosts', next);
+  };
+  // Tile-toggle picker for the alternate boosts: click an ability to
+  // add/remove it. Order doesn't matter to pf2e (the array is just
+  // pushed into `build.attributes.boosts.ancestry` verbatim), and a
+  // grid avoids the positional-hole problem a two-slot row would have
+  // if the user clicked slot 2 first.
+  const toggleAlternateBoost = (key: AbilityKey): void => {
+    if (alternateAncestryBoosts === null) return;
+    let next: AbilityKey[];
+    if (alternateAncestryBoosts.includes(key)) {
+      next = alternateAncestryBoosts.filter((k) => k !== key);
+    } else {
+      if (alternateAncestryBoosts.length >= ALTERNATE_BOOST_COUNT) return;
+      // 18-cap still applies here — these picks count toward the
+      // per-ability cap like any other boost.
+      const cap = BOOST_CAP + (flawCounts[key] ?? 0);
+      if (allBoosts[key] >= cap) return;
+      next = [...alternateAncestryBoosts, key];
+    }
+    onDraftPatch({ alternateAncestryBoosts: next });
+    patchItem(ancestryItemId, 'alternateAncestryBoosts', next);
+  };
+
   // Compute all committed boosts across every source so child pickers
-  // can enforce the 18-cap. Flaws from ancestry raise the cap by 1 per
-  // flaw (e.g. a Dwarf's CHA flaw lets CHA reach 18 with 5 boosts).
-  const flawCounts = flawCountsFromSlots(ancestryFlaws.kind === 'ready' ? ancestryFlaws.slots : []);
+  // can enforce the 18-cap. When the alternative-ancestry-boosts rule
+  // is on we tally the two alternate picks instead of the ancestry's
+  // normal slots, and we zero out flaw counts (flaws don't apply under
+  // the alternate rule).
+  const flawCounts = useAlternateBoosts
+    ? {}
+    : flawCountsFromSlots(ancestryFlaws.kind === 'ready' ? ancestryFlaws.slots : []);
+  const ancestryTally = useAlternateBoosts ? tallyBoosts(alternateAncestryBoosts ?? []) : tallyBoosts(ancestryBoosts);
   const allBoosts = mergeBoostTallies(
-    tallyBoosts(ancestryBoosts),
+    ancestryTally,
     tallyBoosts(backgroundBoosts),
     tallyBoosts(classKeyAbility !== null ? [classKeyAbility] : []),
     tallyBoosts(levelOneBoosts),
@@ -253,13 +302,16 @@ export function AttributesStep({
         <span className="font-semibold text-pf-text">+4</span> in that attribute (the class boost plus one of your free
         boosts). Falling short of +4 here usually costs you accuracy at every level.
       </p>
-      <BoostSourceBlock
-        label={ancestryPick !== null ? `Ancestry · ${ancestryPick.name}` : 'Ancestry'}
-        state={ancestryDoc}
-        placeholderText="Pick an ancestry on the previous step to see its boosts."
-        picks={ancestryBoosts}
-        onPick={setAncestrySlot}
-        flaws={ancestryFlaws}
+      <AncestryBoostSection
+        ancestryPick={ancestryPick}
+        ancestryDoc={ancestryDoc}
+        ancestryFlaws={ancestryFlaws}
+        ancestryBoosts={ancestryBoosts}
+        alternateAncestryBoosts={alternateAncestryBoosts}
+        useAlternateBoosts={useAlternateBoosts}
+        onPickSlot={setAncestrySlot}
+        onToggleAlternateBoost={toggleAlternateBoost}
+        onToggleAlternate={toggleAlternateBoosts}
         allBoosts={allBoosts}
         flawCounts={flawCounts}
       />
@@ -328,6 +380,152 @@ function useSourceSlots(pick: CompendiumMatch | null, parse: (system: unknown) =
   return state;
 }
 
+// Ancestry section composes the standard BoostSourceBlock with the
+// "Alternative Ancestry Boosts" toggle. When the rule is on, the
+// ancestry's listed boosts/flaws are replaced by a two-slot free-boost
+// picker — same wire format pf2e uses internally
+// (`system.alternateAncestryBoosts: AbilityKey[]`).
+function AncestryBoostSection({
+  ancestryPick,
+  ancestryDoc,
+  ancestryFlaws,
+  ancestryBoosts,
+  alternateAncestryBoosts,
+  useAlternateBoosts,
+  onPickSlot,
+  onToggleAlternateBoost,
+  onToggleAlternate,
+  allBoosts,
+  flawCounts,
+}: {
+  ancestryPick: CompendiumMatch | null;
+  ancestryDoc: SourceDocState;
+  ancestryFlaws: SourceDocState;
+  ancestryBoosts: (AbilityKey | null)[];
+  alternateAncestryBoosts: AbilityKey[] | null;
+  useAlternateBoosts: boolean;
+  onPickSlot: (slotIdx: number, key: AbilityKey) => void;
+  onToggleAlternateBoost: (key: AbilityKey) => void;
+  onToggleAlternate: (enabled: boolean) => void;
+  allBoosts: Record<AbilityKey, number>;
+  flawCounts: Partial<Record<AbilityKey, number>>;
+}): React.ReactElement {
+  return (
+    <section>
+      <div className="mb-2 flex items-baseline justify-between gap-3">
+        <h3 className="font-serif text-xs font-semibold uppercase tracking-widest text-pf-alt-dark">
+          {ancestryPick !== null ? `Ancestry · ${ancestryPick.name}` : 'Ancestry'}
+        </h3>
+        {ancestryPick !== null && (
+          <label
+            className="flex cursor-pointer items-center gap-1.5 text-[10px] uppercase tracking-widest text-pf-alt-dark"
+            data-role="alternate-ancestry-boosts-toggle"
+            title="Forgo the ancestry's listed boosts and flaws; take two free ability boosts instead."
+          >
+            <input
+              type="checkbox"
+              checked={useAlternateBoosts}
+              onChange={(e): void => {
+                onToggleAlternate(e.target.checked);
+              }}
+              className="h-3.5 w-3.5 rounded border-pf-border"
+            />
+            Use 2 free boosts
+          </label>
+        )}
+      </div>
+      {useAlternateBoosts ? (
+        <AlternateAncestryBoostPicker
+          picks={alternateAncestryBoosts ?? []}
+          onToggle={onToggleAlternateBoost}
+          allBoosts={allBoosts}
+          flawCounts={flawCounts}
+        />
+      ) : (
+        <BoostSourceBlock
+          label=""
+          state={ancestryDoc}
+          placeholderText="Pick an ancestry on the previous step to see its boosts."
+          picks={ancestryBoosts}
+          onPick={onPickSlot}
+          flaws={ancestryFlaws}
+          allBoosts={allBoosts}
+          flawCounts={flawCounts}
+          hideHeading
+        />
+      )}
+    </section>
+  );
+}
+
+// Tile-grid picker for the two alternate ancestry boosts. Mirrors the
+// L1 free-boost tiles below so the visual language is identical — the
+// only differences are the cap (2 vs 4) and the source the picks land on
+// (the ancestry item's `alternateAncestryBoosts` field, not the actor's
+// `build.attributes.boosts.1`).
+function AlternateAncestryBoostPicker({
+  picks,
+  onToggle,
+  allBoosts,
+  flawCounts,
+}: {
+  picks: AbilityKey[];
+  onToggle: (key: AbilityKey) => void;
+  allBoosts: Record<AbilityKey, number>;
+  flawCounts: Partial<Record<AbilityKey, number>>;
+}): React.ReactElement {
+  const remaining = ALTERNATE_BOOST_COUNT - picks.length;
+  return (
+    <>
+      <p className="mb-2 text-xs text-pf-alt-dark">
+        Pick {ALTERNATE_BOOST_COUNT} attributes — these replace your ancestry’s listed boosts and flaws.{' '}
+        <span className="tabular-nums">{picks.length}</span>/{ALTERNATE_BOOST_COUNT} selected.
+      </p>
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+        {ABILITY_KEYS.map((key) => {
+          const picked = picks.includes(key);
+          // 18-cap: `allBoosts` already includes this picker's contribution
+          // when `picked`, so the cap test only blocks adding a new boost.
+          const atCap = !picked && allBoosts[key] >= BOOST_CAP + (flawCounts[key] ?? 0);
+          const locked = !picked && (picks.length >= ALTERNATE_BOOST_COUNT || atCap);
+          return (
+            <button
+              key={key}
+              type="button"
+              disabled={locked}
+              data-alt-ancestry-tile={key}
+              aria-pressed={picked}
+              onClick={(): void => {
+                onToggle(key);
+              }}
+              title={atCap ? 'Already at 18 — cannot boost further' : undefined}
+              className={[
+                'flex flex-col items-center rounded border px-2 py-3 transition-colors',
+                picked
+                  ? 'border-pf-primary bg-pf-tertiary/40'
+                  : locked
+                    ? 'cursor-not-allowed border-pf-border bg-pf-bg opacity-40'
+                    : 'border-pf-border bg-pf-bg hover:bg-pf-tertiary/20',
+              ].join(' ')}
+            >
+              <span className="text-[11px] font-semibold uppercase tracking-widest text-pf-alt-dark">
+                {key.toUpperCase()}
+              </span>
+              <BoostedMod mod={0} boosted={picked} />
+              <span className="text-[10px] text-pf-alt">{ABILITY_LABEL[key]}</span>
+            </button>
+          );
+        })}
+      </div>
+      {remaining > 0 && (
+        <p className="mt-1 text-xs italic text-pf-alt-dark">
+          {remaining} more pick{remaining === 1 ? '' : 's'} remaining.
+        </p>
+      )}
+    </>
+  );
+}
+
 function BoostSourceBlock({
   label,
   state,
@@ -337,6 +535,7 @@ function BoostSourceBlock({
   flaws,
   allBoosts,
   flawCounts,
+  hideHeading = false,
 }: {
   label: string;
   state: SourceDocState;
@@ -349,11 +548,16 @@ function BoostSourceBlock({
   flaws?: SourceDocState;
   allBoosts: Record<AbilityKey, number>;
   flawCounts: Partial<Record<AbilityKey, number>>;
+  /** Suppress the block's own heading when the caller is providing one
+   *  (Ancestry section wraps this with its own header + toggle row). */
+  hideHeading?: boolean;
 }): React.ReactElement {
   const flawSlots = flaws?.kind === 'ready' ? flaws.slots : [];
   return (
     <section>
-      <h3 className="mb-2 font-serif text-xs font-semibold uppercase tracking-widest text-pf-alt-dark">{label}</h3>
+      {!hideHeading && (
+        <h3 className="mb-2 font-serif text-xs font-semibold uppercase tracking-widest text-pf-alt-dark">{label}</h3>
+      )}
       {state.kind === 'idle' && <p className="text-xs italic text-pf-alt-dark">{placeholderText}</p>}
       {state.kind === 'loading' && <p className="text-xs italic text-pf-alt-dark">Loading…</p>}
       {state.kind === 'error' && <p className="text-xs text-pf-primary">Couldn&apos;t load: {state.message}</p>}

--- a/apps/player-portal/src/features/characters/creator/steps/ClassStep.tsx
+++ b/apps/player-portal/src/features/characters/creator/steps/ClassStep.tsx
@@ -90,7 +90,20 @@ export function ClassStep({
 
   return (
     <div className="space-y-4">
-      <PickerCard label="Class" selection={classPick} onOpen={onPickClass} />
+      <PickerCard
+        label="Class"
+        selection={classPick}
+        onOpen={onPickClass}
+        helpText={
+          <>
+            Defines how your character plays — usually the most important element in deciding your role in the party.{' '}
+            <em>
+              After picking, you may be prompted for additional selections (subclass, weapon group, focus skill, etc.) —
+              give the wizard a moment to present them.
+            </em>
+          </>
+        }
+      />
       {classPick !== null && (
         <div
           className="space-y-4 border-t border-pf-border pt-4"

--- a/apps/player-portal/src/features/characters/creator/steps/IdentityStep.tsx
+++ b/apps/player-portal/src/features/characters/creator/steps/IdentityStep.tsx
@@ -58,7 +58,12 @@ export function IdentityStep({
         ))}
       </div>
       <div className="border-t border-pf-border pt-4" data-creator-subpicker="deity">
-        <PickerCard label="Deity" selection={draft.deity?.match ?? null} onOpen={onPickDeity} />
+        <PickerCard
+          label="Deity"
+          selection={draft.deity?.match ?? null}
+          onOpen={onPickDeity}
+          helpText="The deity your character is most devoted to. Gods in Golarion are very real and most people place faith in at least one. Atheists typically reject the divinity of the Gods rather than their existence."
+        />
       </div>
     </div>
   );

--- a/apps/player-portal/src/features/characters/creator/types.ts
+++ b/apps/player-portal/src/features/characters/creator/types.ts
@@ -82,6 +82,14 @@ export interface Draft {
   ancestryBoosts: (AbilityKey | null)[];
   backgroundBoosts: (AbilityKey | null)[];
   classKeyAbility: AbilityKey | null;
+  // PF2e optional rule "Alternative Ancestry Boosts": the player can
+  // forgo their ancestry's listed boosts and flaws in exchange for two
+  // free ability boosts. `null` means the rule is off (use the ancestry's
+  // normal boosts/flaws); an array — possibly empty — means it's on,
+  // with the array tracking the two picks. Persisted as
+  // `ancestry.system.alternateAncestryBoosts` (presence/absence drives
+  // pf2e's prepare-step branching).
+  alternateAncestryBoosts: AbilityKey[] | null;
 }
 
 // Actor lifecycle: wizard opens → creating → ready (actor exists in

--- a/apps/player-portal/src/features/characters/internal/CompendiumDetailPanel.tsx
+++ b/apps/player-portal/src/features/characters/internal/CompendiumDetailPanel.tsx
@@ -61,12 +61,7 @@ export function CompendiumDetailPanel({
       })
       .catch((err: unknown) => {
         if (cancelled) return;
-        const message =
-          err instanceof ApiRequestError
-            ? err.message
-            : err instanceof Error
-              ? err.message
-              : String(err);
+        const message = err instanceof ApiRequestError ? err.message : err instanceof Error ? err.message : String(err);
         setState({ kind: 'error', message });
       });
     return (): void => {
@@ -75,6 +70,7 @@ export function CompendiumDetailPanel({
   }, [target.uuid, docCache]);
 
   const doc = state.kind === 'ok' ? state.document : null;
+  const ancestryStats = doc && target.type === 'ancestry' ? readAncestryStats(doc) : null;
   const docTraits = doc ? readTraits(doc) : null;
   const traits = docTraits ?? target.traits ?? [];
   const rarity = doc ? readRarity(doc) : null;
@@ -110,11 +106,7 @@ export function CompendiumDetailPanel({
     >
       <header className="flex items-start gap-3 border-b border-pf-border px-4 py-3">
         {target.img && (
-          <img
-            src={target.img}
-            alt=""
-            className="h-12 w-12 shrink-0 rounded border border-pf-border bg-pf-bg-dark"
-          />
+          <img src={target.img} alt="" className="h-12 w-12 shrink-0 rounded border border-pf-border bg-pf-bg-dark" />
         )}
         <div className="min-w-0 flex-1">
           <h3 className="font-serif text-base font-semibold text-pf-text">{target.name}</h3>
@@ -150,17 +142,27 @@ export function CompendiumDetailPanel({
       {/* When art is present we need overflow-hidden here so the flex chain can
           drive the image to fill the exact available height without creating an
           outer scroll. The description column gets its own overflow-y-auto. */}
-      <div className={`flex-1 text-sm text-pf-text ${characterArt ? 'flex min-h-0 flex-col overflow-hidden' : 'overflow-y-auto px-4 py-3'}`}>
+      <div
+        className={`flex-1 text-sm text-pf-text ${characterArt ? 'flex min-h-0 flex-col overflow-hidden' : 'overflow-y-auto px-4 py-3'}`}
+      >
         {state.kind === 'loading' && <p className="px-4 py-3 italic text-pf-alt">Loading…</p>}
-        {state.kind === 'error' && (
-          <p className="px-4 py-3 text-pf-primary">Failed to load: {state.message}</p>
-        )}
-        {state.kind === 'ok' && (
-          characterArt ? (
+        {state.kind === 'error' && <p className="px-4 py-3 text-pf-primary">Failed to load: {state.message}</p>}
+        {state.kind === 'ok' &&
+          (characterArt ? (
             // ── Ancestry / class: side-by-side, art fills available height ──
             <div className="flex min-h-0 flex-1 flex-col">
+              {/* Ancestry mechanical stats — HP, size, speed, boosts, languages, vision */}
+              {ancestryStats !== null && <AncestryMechanics stats={ancestryStats} />}
               {/* Detail rows (rare for ancestry/class, but possible) */}
-              {(prerequisites?.length || actions || trigger || frequency || requirements || price || range || area || targetField) && (
+              {(prerequisites?.length ||
+                actions ||
+                trigger ||
+                frequency ||
+                requirements ||
+                price ||
+                range ||
+                area ||
+                targetField) && (
                 <div className="space-y-2 border-b border-pf-border px-4 py-3">
                   {prerequisites && prerequisites.length > 0 && (
                     <DetailRow label="Prerequisites" value={prerequisites.join('; ')} fail={failed} />
@@ -197,8 +199,9 @@ export function CompendiumDetailPanel({
               {uuidHover.popover}
             </div>
           ) : (
-            // ── All other types: original stacked layout ──
+            // ── All other types (and ancestries without art): stacked layout ──
             <div className="space-y-3">
+              {ancestryStats !== null && <AncestryMechanics stats={ancestryStats} />}
               {prerequisites && prerequisites.length > 0 && (
                 <DetailRow label="Prerequisites" value={prerequisites.join('; ')} fail={failed} />
               )}
@@ -221,8 +224,7 @@ export function CompendiumDetailPanel({
               )}
               {uuidHover.popover}
             </div>
-          )
-        )}
+          ))}
       </div>
 
       <footer className="flex items-center justify-end gap-2 border-t border-pf-border px-4 py-2">
@@ -246,20 +248,10 @@ export function CompendiumDetailPanel({
   );
 }
 
-function DetailRow({
-  label,
-  value,
-  fail,
-}: {
-  label: string;
-  value: string;
-  fail?: boolean;
-}): React.ReactElement {
+function DetailRow({ label, value, fail }: { label: string; value: string; fail?: boolean }): React.ReactElement {
   return (
     <div className="flex flex-col gap-0.5 sm:flex-row sm:gap-3">
-      <dt className="w-32 shrink-0 text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark">
-        {label}
-      </dt>
+      <dt className="w-32 shrink-0 text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark">{label}</dt>
       <dd className={fail === true ? 'text-pf-primary' : 'text-pf-text'}>{value}</dd>
     </div>
   );
@@ -356,8 +348,7 @@ function readArea(doc: CompendiumDocument): string | null {
   if (!area) return null;
   const value = area.value;
   if (value === undefined || value === '' || value === 0) return null;
-  const v =
-    typeof value === 'number' ? `${value.toString()}-foot` : typeof value === 'string' ? value : null;
+  const v = typeof value === 'number' ? `${value.toString()}-foot` : typeof value === 'string' ? value : null;
   if (v === null) return null;
   return typeof area.type === 'string' && area.type !== '' ? `${v} ${area.type}` : v;
 }
@@ -367,4 +358,212 @@ function humanizeSlug(slug: string): string {
     .split('-')
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
     .join(' ');
+}
+
+// ─── Ancestry mechanical stats ───────────────────────────────────────────────
+
+interface BoostSlot {
+  options: string[];
+}
+
+interface AncestryStats {
+  hp: number | null;
+  size: string | null;
+  speed: number | null;
+  boosts: BoostSlot[];
+  flaws: BoostSlot[];
+  fixedLanguages: string[];
+  bonusLanguageCount: number;
+  vision: string | null;
+  features: { uuid: string; name: string; img: string }[];
+}
+
+function readAncestryStats(doc: CompendiumDocument): AncestryStats {
+  const sys = doc.system as {
+    hp?: unknown;
+    size?: unknown;
+    speed?: unknown;
+    boosts?: unknown;
+    flaws?: unknown;
+    languages?: { value?: unknown };
+    additionalLanguages?: { count?: unknown };
+    vision?: unknown;
+    items?: Record<string, unknown>;
+  };
+
+  const hp = typeof sys.hp === 'number' ? sys.hp : null;
+  const size = typeof sys.size === 'string' ? sys.size : null;
+  const speed = typeof sys.speed === 'number' ? sys.speed : null;
+  const vision = typeof sys.vision === 'string' && sys.vision !== 'normal' ? sys.vision : null;
+
+  const boosts = readBoostRecord(sys.boosts);
+  const flaws = readBoostRecord(sys.flaws);
+
+  const fixedLanguages = Array.isArray(sys.languages?.value)
+    ? sys.languages.value.filter((v): v is string => typeof v === 'string')
+    : [];
+
+  const bonusLanguageCount = typeof sys.additionalLanguages?.count === 'number' ? sys.additionalLanguages.count : 0;
+
+  const features = readAncestryFeatures(sys.items);
+
+  return { hp, size, speed, boosts, flaws, fixedLanguages, bonusLanguageCount, vision, features };
+}
+
+function readBoostRecord(raw: unknown): BoostSlot[] {
+  if (!raw || typeof raw !== 'object') return [];
+  const slots: BoostSlot[] = [];
+  const keys = Object.keys(raw)
+    .filter((k) => /^\d+$/.test(k))
+    .sort((a, b) => Number(a) - Number(b));
+  for (const k of keys) {
+    const slot = (raw as Record<string, unknown>)[k];
+    if (!slot || typeof slot !== 'object') continue;
+    const value = (slot as { value?: unknown }).value;
+    if (!Array.isArray(value)) continue;
+    const options = value.filter((v): v is string => typeof v === 'string');
+    slots.push({ options });
+  }
+  return slots;
+}
+
+function readAncestryFeatures(
+  items: Record<string, unknown> | undefined,
+): { uuid: string; name: string; img: string }[] {
+  if (!items) return [];
+  const out: { uuid: string; name: string; img: string }[] = [];
+  for (const raw of Object.values(items)) {
+    if (!raw || typeof raw !== 'object') continue;
+    const entry = raw as { uuid?: unknown; name?: unknown; img?: unknown };
+    if (typeof entry.uuid !== 'string' || typeof entry.name !== 'string') continue;
+    out.push({ uuid: entry.uuid, name: entry.name, img: typeof entry.img === 'string' ? entry.img : '' });
+  }
+  out.sort((a, b) => a.name.localeCompare(b.name));
+  return out;
+}
+
+const SIZE_LABELS: Record<string, string> = {
+  tiny: 'Tiny',
+  sm: 'Small',
+  med: 'Medium',
+  lg: 'Large',
+  huge: 'Huge',
+  grg: 'Gargantuan',
+};
+
+const ABILITY_LABELS: Record<string, string> = {
+  str: 'STR',
+  dex: 'DEX',
+  con: 'CON',
+  int: 'INT',
+  wis: 'WIS',
+  cha: 'CHA',
+};
+
+function formatBoostSlot(slot: BoostSlot): string {
+  if (slot.options.length === 0) return 'Free';
+  if (slot.options.length === 1) return ABILITY_LABELS[slot.options[0] ?? ''] ?? slot.options[0] ?? 'Free';
+  const labels = slot.options.map((o) => ABILITY_LABELS[o] ?? o.toUpperCase());
+  return `Free (${labels.join('/')})`;
+}
+
+function formatVision(vision: string): string {
+  if (vision === 'darkvision') return 'Darkvision';
+  if (vision === 'lowLightVision') return 'Low-Light Vision';
+  return humanizeSlug(vision);
+}
+
+function AncestryMechanics({ stats }: { stats: AncestryStats }): React.ReactElement {
+  const hasCoreStats = stats.hp !== null || stats.size !== null || stats.speed !== null;
+  const hasBoosts = stats.boosts.length > 0;
+  const hasFlaws = stats.flaws.some((f) => f.options.length > 0);
+  const hasLanguages = stats.fixedLanguages.length > 0 || stats.bonusLanguageCount > 0;
+  const hasVision = stats.vision !== null;
+  const hasFeatures = stats.features.length > 0;
+
+  return (
+    <div className="border-b border-pf-border px-4 py-3 text-xs text-pf-text">
+      <p className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark">Mechanical effects</p>
+
+      {hasCoreStats && (
+        <dl className="mb-2 grid grid-cols-3 gap-x-2 gap-y-1">
+          {stats.hp !== null && (
+            <>
+              <dt className="text-pf-alt-dark">HP</dt>
+              <dd className="col-span-2 font-medium">{stats.hp}</dd>
+            </>
+          )}
+          {stats.size !== null && (
+            <>
+              <dt className="text-pf-alt-dark">Size</dt>
+              <dd className="col-span-2 font-medium">{SIZE_LABELS[stats.size] ?? humanizeSlug(stats.size)}</dd>
+            </>
+          )}
+          {stats.speed !== null && (
+            <>
+              <dt className="text-pf-alt-dark">Speed</dt>
+              <dd className="col-span-2 font-medium">{stats.speed} ft.</dd>
+            </>
+          )}
+        </dl>
+      )}
+
+      {hasBoosts && (
+        <div className="mb-1">
+          <span className="text-pf-alt-dark">Boosts: </span>
+          <span className="font-medium">{stats.boosts.map(formatBoostSlot).join(', ')}</span>
+        </div>
+      )}
+
+      {hasFlaws && (
+        <div className="mb-1">
+          <span className="text-pf-alt-dark">Flaws: </span>
+          <span className="font-medium">
+            {stats.flaws
+              .filter((f) => f.options.length > 0)
+              .map(formatBoostSlot)
+              .join(', ')}
+          </span>
+        </div>
+      )}
+
+      {hasLanguages && (
+        <div className="mb-1">
+          <span className="text-pf-alt-dark">Languages: </span>
+          <span className="font-medium">
+            {stats.fixedLanguages.map(humanizeSlug).join(', ')}
+            {stats.bonusLanguageCount > 0 && (
+              <span className="ml-1 text-pf-alt-dark">(+{stats.bonusLanguageCount} bonus)</span>
+            )}
+          </span>
+        </div>
+      )}
+
+      {hasVision && (
+        <div className="mb-1">
+          <span className="text-pf-alt-dark">Senses: </span>
+          <span className="font-medium">{stats.vision !== null ? formatVision(stats.vision) : ''}</span>
+        </div>
+      )}
+
+      {hasFeatures && (
+        <details className="mt-2">
+          <summary className="cursor-pointer text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark">
+            Ancestry features ({stats.features.length})
+          </summary>
+          <ul className="mt-1 flex flex-wrap gap-1">
+            {stats.features.map((f) => (
+              <li
+                key={f.uuid}
+                className="inline-flex items-center gap-1 rounded border border-pf-border bg-pf-bg px-1.5 py-0.5 text-[11px] text-pf-text"
+              >
+                {f.img && <img src={f.img} alt="" className="h-3.5 w-3.5 rounded" />}
+                {f.name}
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </div>
+  );
 }

--- a/apps/player-portal/src/features/characters/internal/CompendiumDetailPanel.tsx
+++ b/apps/player-portal/src/features/characters/internal/CompendiumDetailPanel.tsx
@@ -72,6 +72,7 @@ export function CompendiumDetailPanel({
   const doc = state.kind === 'ok' ? state.document : null;
   const ancestryStats = doc && target.type === 'ancestry' ? readAncestryStats(doc) : null;
   const backgroundStats = doc && target.type === 'background' ? readBackgroundStats(doc) : null;
+  const classStats = doc && target.type === 'class' ? readClassStats(doc) : null;
   const docTraits = doc ? readTraits(doc) : null;
   const traits = docTraits ?? target.traits ?? [];
   const rarity = doc ? readRarity(doc) : null;
@@ -203,6 +204,7 @@ export function CompendiumDetailPanel({
                   )}
                   {/* Mechanical effects sit below the lore so the flavor text reads first. */}
                   {ancestryStats !== null && <AncestryMechanics stats={ancestryStats} />}
+                  {classStats !== null && <ClassMechanics stats={classStats} />}
                 </div>
                 {/* Art column: flex-col so the gallery can fill h-full */}
                 <div className="flex w-[28rem] shrink-0 flex-col">
@@ -239,6 +241,7 @@ export function CompendiumDetailPanel({
               {/* Mechanical effects sit below the lore so the flavor text reads first. */}
               {ancestryStats !== null && <AncestryMechanics stats={ancestryStats} />}
               {backgroundStats !== null && <BackgroundMechanics stats={backgroundStats} />}
+              {classStats !== null && <ClassMechanics stats={classStats} />}
               {uuidHover.popover}
             </div>
           ))}
@@ -689,6 +692,224 @@ function BackgroundMechanics({ stats }: { stats: BackgroundStats }): React.React
           </ul>
         </details>
       )}
+    </div>
+  );
+}
+
+// ─── Class mechanical stats ──────────────────────────────────────────────────
+
+interface ClassStats {
+  perception: number;
+  savingThrows: { fortitude: number; reflex: number; will: number };
+  trainedSkills: string[];
+  additionalSkills: number;
+  attacks: {
+    simple: number;
+    martial: number;
+    advanced: number;
+    unarmed: number;
+    other: { name: string; rank: number } | null;
+  };
+  defenses: { unarmored: number; light: number; medium: number; heavy: number };
+  classDC: number | null;
+  spellcasting: number | null;
+  features: { uuid: string; name: string; img: string }[];
+}
+
+function readClassStats(doc: CompendiumDocument): ClassStats {
+  const sys = doc.system as {
+    perception?: unknown;
+    savingThrows?: { fortitude?: unknown; reflex?: unknown; will?: unknown };
+    trainedSkills?: { value?: unknown; additional?: unknown };
+    attacks?: { simple?: unknown; martial?: unknown; advanced?: unknown; unarmed?: unknown; other?: unknown };
+    defenses?: { unarmored?: unknown; light?: unknown; medium?: unknown; heavy?: unknown };
+    classDC?: unknown;
+    spellcasting?: unknown;
+    items?: Record<string, unknown>;
+  };
+
+  const num = (raw: unknown): number => (typeof raw === 'number' ? raw : 0);
+
+  const perception = num(sys.perception);
+  const savingThrows = {
+    fortitude: num(sys.savingThrows?.fortitude),
+    reflex: num(sys.savingThrows?.reflex),
+    will: num(sys.savingThrows?.will),
+  };
+  const trainedSkills = Array.isArray(sys.trainedSkills?.value)
+    ? sys.trainedSkills.value.filter((v): v is string => typeof v === 'string')
+    : [];
+  const additionalSkills = num(sys.trainedSkills?.additional);
+  const attacks = {
+    simple: num(sys.attacks?.simple),
+    martial: num(sys.attacks?.martial),
+    advanced: num(sys.attacks?.advanced),
+    unarmed: num(sys.attacks?.unarmed),
+    other: readOtherAttack(sys.attacks?.other),
+  };
+  const defenses = {
+    unarmored: num(sys.defenses?.unarmored),
+    light: num(sys.defenses?.light),
+    medium: num(sys.defenses?.medium),
+    heavy: num(sys.defenses?.heavy),
+  };
+  // pf2e omits `classDC` on classes without one (e.g. Bard). Treat any
+  // non-number — including missing — as null so the section is hidden.
+  const classDC = typeof sys.classDC === 'number' ? sys.classDC : null;
+  // Single rank covers both spell attack and spell DC; null for
+  // non-spellcasters.
+  const spellcasting = typeof sys.spellcasting === 'number' && sys.spellcasting > 0 ? sys.spellcasting : null;
+
+  const features = readAncestryFeatures(sys.items);
+
+  return {
+    perception,
+    savingThrows,
+    trainedSkills,
+    additionalSkills,
+    attacks,
+    defenses,
+    classDC,
+    spellcasting,
+    features,
+  };
+}
+
+function readOtherAttack(raw: unknown): { name: string; rank: number } | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const o = raw as { name?: unknown; rank?: unknown };
+  if (typeof o.name !== 'string' || o.name.length === 0) return null;
+  if (typeof o.rank !== 'number' || o.rank <= 0) return null;
+  return { name: o.name, rank: o.rank };
+}
+
+// PF2e proficiency ladder: 0 untrained, 1 trained, 2 expert, 3 master,
+// 4 legendary. Used only to format display strings.
+const RANK_LABELS = ['Untrained', 'Trained', 'Expert', 'Master', 'Legendary'] as const;
+function rankLabel(rank: number): string {
+  return RANK_LABELS[rank] ?? 'Untrained';
+}
+
+// Group entries by rank tier so we can render a single line per tier
+// like "Trained in simple weapons · martial weapons · unarmed attacks".
+// Drops anything at rank 0 — the Player Core's class block omits
+// untrained categories and we mirror that to keep the panel scannable.
+function groupByRank(entries: { rank: number; label: string }[]): { rank: number; labels: string[] }[] {
+  const byRank = new Map<number, string[]>();
+  for (const e of entries) {
+    if (e.rank <= 0) continue;
+    const list = byRank.get(e.rank) ?? [];
+    list.push(e.label);
+    byRank.set(e.rank, list);
+  }
+  // Sort descending so higher proficiencies surface first.
+  return [...byRank.entries()].sort((a, b) => b[0] - a[0]).map(([rank, labels]) => ({ rank, labels }));
+}
+
+function ClassMechanics({ stats }: { stats: ClassStats }): React.ReactElement {
+  const attackEntries = [
+    { rank: stats.attacks.simple, label: 'simple weapons' },
+    { rank: stats.attacks.martial, label: 'martial weapons' },
+    { rank: stats.attacks.advanced, label: 'advanced weapons' },
+    { rank: stats.attacks.unarmed, label: 'unarmed attacks' },
+    ...(stats.attacks.other ? [{ rank: stats.attacks.other.rank, label: stats.attacks.other.name }] : []),
+  ];
+  const defenseEntries = [
+    { rank: stats.defenses.light, label: 'light armor' },
+    { rank: stats.defenses.medium, label: 'medium armor' },
+    { rank: stats.defenses.heavy, label: 'heavy armor' },
+    { rank: stats.defenses.unarmored, label: 'unarmored defense' },
+  ];
+  const saveEntries = [
+    { rank: stats.savingThrows.fortitude, label: 'Fortitude' },
+    { rank: stats.savingThrows.reflex, label: 'Reflex' },
+    { rank: stats.savingThrows.will, label: 'Will' },
+  ];
+
+  const hasFeatures = stats.features.length > 0;
+
+  return (
+    <div className="mt-4 border-t border-pf-border pt-3 text-xs text-pf-text">
+      <p className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark">Initial proficiencies</p>
+
+      <ProficiencyRow heading="Perception">
+        <p>{rankLabel(stats.perception)} in Perception</p>
+      </ProficiencyRow>
+
+      <ProficiencyRow heading="Saving throws">
+        {groupByRank(saveEntries).map(({ rank, labels }) => (
+          <p key={rank}>
+            {rankLabel(rank)} in {labels.join(' · ')}
+          </p>
+        ))}
+      </ProficiencyRow>
+
+      <ProficiencyRow heading="Skills">
+        {stats.trainedSkills.length > 0 && <p>Trained in {stats.trainedSkills.map(humanizeSlug).join(', ')}</p>}
+        {stats.additionalSkills > 0 && (
+          <p>
+            Trained in {stats.additionalSkills} additional skill{stats.additionalSkills === 1 ? '' : 's'} plus your
+            Intelligence modifier
+          </p>
+        )}
+      </ProficiencyRow>
+
+      <ProficiencyRow heading="Attacks">
+        {groupByRank(attackEntries).map(({ rank, labels }) => (
+          <p key={rank}>
+            {rankLabel(rank)} in {labels.join(' · ')}
+          </p>
+        ))}
+      </ProficiencyRow>
+
+      <ProficiencyRow heading="Defenses">
+        {groupByRank(defenseEntries).map(({ rank, labels }) => (
+          <p key={rank}>
+            {rankLabel(rank)} in {labels.join(' · ')}
+          </p>
+        ))}
+      </ProficiencyRow>
+
+      {stats.classDC !== null && stats.classDC > 0 && (
+        <ProficiencyRow heading="Class DC">
+          <p>{rankLabel(stats.classDC)} in class DC</p>
+        </ProficiencyRow>
+      )}
+
+      {stats.spellcasting !== null && (
+        <ProficiencyRow heading="Spells">
+          <p>{rankLabel(stats.spellcasting)} in spell attack modifier and spell DC</p>
+        </ProficiencyRow>
+      )}
+
+      {hasFeatures && (
+        <details className="mt-2">
+          <summary className="cursor-pointer text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark">
+            Class features ({stats.features.length})
+          </summary>
+          <ul className="mt-1 flex flex-wrap gap-1">
+            {stats.features.map((f) => (
+              <li
+                key={f.uuid}
+                data-uuid={f.uuid}
+                className="inline-flex cursor-default items-center gap-1 rounded border border-pf-border bg-pf-bg px-1.5 py-0.5 text-[11px] text-pf-text transition-colors hover:border-pf-primary/60 hover:bg-pf-tertiary/20"
+              >
+                {f.img && <img src={f.img} alt="" className="h-3.5 w-3.5 rounded" />}
+                {f.name}
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </div>
+  );
+}
+
+function ProficiencyRow({ heading, children }: { heading: string; children: React.ReactNode }): React.ReactElement {
+  return (
+    <div className="mb-2">
+      <p className="text-[10px] font-semibold uppercase tracking-wide text-pf-alt-dark">{heading}</p>
+      <div className="ml-1 [&_p]:leading-tight">{children}</div>
     </div>
   );
 }

--- a/apps/player-portal/src/features/characters/internal/CompendiumDetailPanel.tsx
+++ b/apps/player-portal/src/features/characters/internal/CompendiumDetailPanel.tsx
@@ -152,8 +152,6 @@ export function CompendiumDetailPanel({
           (characterArt ? (
             // ── Ancestry / class: side-by-side, art fills available height ──
             <div className="flex min-h-0 flex-1 flex-col">
-              {/* Ancestry mechanical stats — HP, size, speed, boosts, languages, vision */}
-              {ancestryStats !== null && <AncestryMechanics stats={ancestryStats} />}
               {/* Detail rows (rare for ancestry/class, but possible) */}
               {(prerequisites?.length ||
                 actions ||
@@ -178,7 +176,7 @@ export function CompendiumDetailPanel({
                   {targetField != null && <DetailRow label="Targets" value={targetField} />}
                 </div>
               )}
-              {/* Two-column: description left, art right. flex-1 min-h-0 lets
+              {/* Two-column: description+mechanics left, art right. flex-1 min-h-0 lets
                   this row consume all remaining body height. */}
               <div className="flex min-h-0 flex-1 gap-4 px-4 py-3">
                 <div className="min-w-0 flex-1 overflow-y-auto">
@@ -191,6 +189,8 @@ export function CompendiumDetailPanel({
                   ) : (
                     <p className="italic text-pf-alt">No description.</p>
                   )}
+                  {/* Mechanical effects sit below the lore so the flavor text reads first. */}
+                  {ancestryStats !== null && <AncestryMechanics stats={ancestryStats} />}
                 </div>
                 {/* Art column: flex-col so the gallery can fill h-full */}
                 <div className="flex w-[28rem] shrink-0 flex-col">
@@ -202,8 +202,6 @@ export function CompendiumDetailPanel({
           ) : (
             // ── All other types (and ancestries without art): stacked layout ──
             <div className="space-y-3">
-              {ancestryStats !== null && <AncestryMechanics stats={ancestryStats} />}
-              {backgroundStats !== null && <BackgroundMechanics stats={backgroundStats} />}
               {prerequisites && prerequisites.length > 0 && (
                 <DetailRow label="Prerequisites" value={prerequisites.join('; ')} fail={failed} />
               )}
@@ -224,6 +222,9 @@ export function CompendiumDetailPanel({
               ) : (
                 <p className="italic text-pf-alt">No description.</p>
               )}
+              {/* Mechanical effects sit below the lore so the flavor text reads first. */}
+              {ancestryStats !== null && <AncestryMechanics stats={ancestryStats} />}
+              {backgroundStats !== null && <BackgroundMechanics stats={backgroundStats} />}
               {uuidHover.popover}
             </div>
           ))}
@@ -462,8 +463,12 @@ const ABILITY_LABELS: Record<string, string> = {
   cha: 'CHA',
 };
 
+const ABILITY_LABEL_COUNT = Object.keys(ABILITY_LABELS).length;
+
 function formatBoostSlot(slot: BoostSlot): string {
-  if (slot.options.length === 0) return 'Free';
+  // Empty array OR all six abilities listed both encode an unconstrained
+  // free boost — render plainly as "Free" without a redundant ability list.
+  if (slot.options.length === 0 || slot.options.length === ABILITY_LABEL_COUNT) return 'Free';
   if (slot.options.length === 1) return ABILITY_LABELS[slot.options[0] ?? ''] ?? slot.options[0] ?? 'Free';
   const labels = slot.options.map((o) => ABILITY_LABELS[o] ?? o.toUpperCase());
   return `Free (${labels.join('/')})`;
@@ -484,7 +489,7 @@ function AncestryMechanics({ stats }: { stats: AncestryStats }): React.ReactElem
   const hasFeatures = stats.features.length > 0;
 
   return (
-    <div className="border-b border-pf-border px-4 py-3 text-xs text-pf-text">
+    <div className="mt-4 border-t border-pf-border pt-3 text-xs text-pf-text">
       <p className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark">Mechanical effects</p>
 
       {hasCoreStats && (
@@ -607,7 +612,7 @@ function BackgroundMechanics({ stats }: { stats: BackgroundStats }): React.React
   const hasFeatures = stats.features.length > 0;
 
   return (
-    <div className="border-b border-pf-border px-4 py-3 text-xs text-pf-text">
+    <div className="mt-4 border-t border-pf-border pt-3 text-xs text-pf-text">
       <p className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark">Mechanical effects</p>
 
       {hasBoosts && (

--- a/apps/player-portal/src/features/characters/internal/CompendiumDetailPanel.tsx
+++ b/apps/player-portal/src/features/characters/internal/CompendiumDetailPanel.tsx
@@ -23,6 +23,13 @@ interface Props {
   docCache?: Map<string, CompendiumDocument>;
   /** Prefix for the detail panel + Pick button data-testid attributes. */
   testIdPrefix?: string;
+  /** When true, suppress the top header (image + name + meta + traits).
+   *  Useful when the surrounding picker dialog already shows the name
+   *  and the body content carries enough visual identity on its own
+   *  (e.g. class panels, where the lore + initial-proficiencies block
+   *  is long enough that the header just costs vertical space). The
+   *  footer's "Back" button still provides a way to close the panel. */
+  hideHeader?: boolean;
 }
 
 // Generic detail panel for the built-in CompendiumPicker detail flow.
@@ -37,6 +44,7 @@ export function CompendiumDetailPanel({
   evaluation,
   docCache,
   testIdPrefix,
+  hideHeader = false,
 }: Props): React.ReactElement {
   const uuidHover = useUuidHover();
   const [state, setState] = useState<Resolution>(() => {
@@ -106,50 +114,52 @@ export function CompendiumDetailPanel({
       data-testid={testIdPrefix !== undefined ? `${testIdPrefix}-detail` : undefined}
       data-detail-uuid={target.uuid}
     >
-      <header className="flex items-start gap-3 border-b border-pf-border px-4 py-3">
-        {target.img && (
-          <img src={target.img} alt="" className="h-12 w-12 shrink-0 rounded border border-pf-border bg-pf-bg-dark" />
-        )}
-        <div className="min-w-0 flex-1">
-          <h3 className="font-serif text-base font-semibold text-pf-text">{target.name}</h3>
-          <p className="mt-0.5 text-[10px] uppercase tracking-widest text-pf-alt">
-            {target.packLabel}
-            {target.level !== undefined && ` · L${target.level.toString()}`}
-            {rarity != null && rarity !== 'common' && ` · ${rarity}`}
-            {castCost !== null && ` · Cast ${castCost}`}
-          </p>
-          {(target.type === 'ancestry' && rarity !== null) || traits.length > 0 ? (
-            <ul className="mt-1 flex flex-wrap gap-1">
-              {/* Ancestries always show their rarity as the first pill so
+      {!hideHeader && (
+        <header className="flex items-start gap-3 border-b border-pf-border px-4 py-3">
+          {target.img && (
+            <img src={target.img} alt="" className="h-12 w-12 shrink-0 rounded border border-pf-border bg-pf-bg-dark" />
+          )}
+          <div className="min-w-0 flex-1">
+            <h3 className="font-serif text-base font-semibold text-pf-text">{target.name}</h3>
+            <p className="mt-0.5 text-[10px] uppercase tracking-widest text-pf-alt">
+              {target.packLabel}
+              {target.level !== undefined && ` · L${target.level.toString()}`}
+              {rarity != null && rarity !== 'common' && ` · ${rarity}`}
+              {castCost !== null && ` · Cast ${castCost}`}
+            </p>
+            {(target.type === 'ancestry' && rarity !== null) || traits.length > 0 ? (
+              <ul className="mt-1 flex flex-wrap gap-1">
+                {/* Ancestries always show their rarity as the first pill so
                   players can spot uncommon/rare ancestries at a glance.
                   Other doc types keep rarity in the meta line only. */}
-              {target.type === 'ancestry' && rarity !== null && (
-                <li
-                  className={`rounded-full px-1.5 py-0.5 text-[10px] uppercase tracking-wide ${rarityPillClasses(rarity)}`}
-                >
-                  {humanizeSlug(rarity)}
-                </li>
-              )}
-              {traits.map((t) => (
-                <li
-                  key={t}
-                  className="rounded-full border border-pf-tertiary-dark bg-pf-tertiary/40 px-1.5 py-0.5 text-[10px] text-pf-alt-dark"
-                >
-                  {humanizeSlug(t)}
-                </li>
-              ))}
-            </ul>
-          ) : null}
-        </div>
-        <button
-          type="button"
-          onClick={onClose}
-          aria-label="Close detail"
-          className="rounded px-2 py-0.5 text-lg text-pf-alt-dark hover:bg-pf-bg-dark hover:text-pf-primary"
-        >
-          ×
-        </button>
-      </header>
+                {target.type === 'ancestry' && rarity !== null && (
+                  <li
+                    className={`rounded-full px-1.5 py-0.5 text-[10px] uppercase tracking-wide ${rarityPillClasses(rarity)}`}
+                  >
+                    {humanizeSlug(rarity)}
+                  </li>
+                )}
+                {traits.map((t) => (
+                  <li
+                    key={t}
+                    className="rounded-full border border-pf-tertiary-dark bg-pf-tertiary/40 px-1.5 py-0.5 text-[10px] text-pf-alt-dark"
+                  >
+                    {humanizeSlug(t)}
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close detail"
+            className="rounded px-2 py-0.5 text-lg text-pf-alt-dark hover:bg-pf-bg-dark hover:text-pf-primary"
+          >
+            ×
+          </button>
+        </header>
+      )}
 
       {/* When art is present we need overflow-hidden here so the flex chain can
           drive the image to fill the exact available height without creating an

--- a/apps/player-portal/src/features/characters/internal/CompendiumDetailPanel.tsx
+++ b/apps/player-portal/src/features/characters/internal/CompendiumDetailPanel.tsx
@@ -179,10 +179,12 @@ export function CompendiumDetailPanel({
               {/* Two-column: description+mechanics left, art right. flex-1 min-h-0 lets
                   this row consume all remaining body height. */}
               <div className="flex min-h-0 flex-1 gap-4 px-4 py-3">
-                <div className="min-w-0 flex-1 overflow-y-auto">
+                {/* Delegation handlers live on this scroller so they catch
+                    [data-uuid] hovers in BOTH the enriched description and
+                    the mechanical-feature chips below it. */}
+                <div {...uuidHover.delegationHandlers} className="min-w-0 flex-1 overflow-y-auto">
                   {enriched.length > 0 ? (
                     <div
-                      {...uuidHover.delegationHandlers}
                       className="leading-relaxed [&_.pf-damage]:font-semibold [&_.pf-damage]:text-pf-primary [&_.pf-damage-heightened]:text-pf-prof-master [&_.pf-template]:italic [&_.pf-template]:text-pf-secondary [&_a]:cursor-pointer [&_a]:text-pf-primary [&_a]:underline [&_p]:my-2"
                       dangerouslySetInnerHTML={{ __html: enriched }}
                     />
@@ -201,7 +203,10 @@ export function CompendiumDetailPanel({
             </div>
           ) : (
             // ── All other types (and ancestries without art): stacked layout ──
-            <div className="space-y-3">
+            // Delegation handlers on the outer wrapper so [data-uuid] hovers
+            // fire for both the enriched description and the mechanical-feature
+            // chips below it.
+            <div {...uuidHover.delegationHandlers} className="space-y-3">
               {prerequisites && prerequisites.length > 0 && (
                 <DetailRow label="Prerequisites" value={prerequisites.join('; ')} fail={failed} />
               )}
@@ -215,7 +220,6 @@ export function CompendiumDetailPanel({
               {targetField != null && <DetailRow label="Targets" value={targetField} />}
               {enriched.length > 0 ? (
                 <div
-                  {...uuidHover.delegationHandlers}
                   className="leading-relaxed [&_.pf-damage]:font-semibold [&_.pf-damage]:text-pf-primary [&_.pf-damage-heightened]:text-pf-prof-master [&_.pf-template]:italic [&_.pf-template]:text-pf-secondary [&_a]:cursor-pointer [&_a]:text-pf-primary [&_a]:underline [&_p]:my-2"
                   dangerouslySetInnerHTML={{ __html: enriched }}
                 />
@@ -562,7 +566,8 @@ function AncestryMechanics({ stats }: { stats: AncestryStats }): React.ReactElem
             {stats.features.map((f) => (
               <li
                 key={f.uuid}
-                className="inline-flex items-center gap-1 rounded border border-pf-border bg-pf-bg px-1.5 py-0.5 text-[11px] text-pf-text"
+                data-uuid={f.uuid}
+                className="inline-flex cursor-default items-center gap-1 rounded border border-pf-border bg-pf-bg px-1.5 py-0.5 text-[11px] text-pf-text transition-colors hover:border-pf-primary/60 hover:bg-pf-tertiary/20"
               >
                 {f.img && <img src={f.img} alt="" className="h-3.5 w-3.5 rounded" />}
                 {f.name}
@@ -640,7 +645,8 @@ function BackgroundMechanics({ stats }: { stats: BackgroundStats }): React.React
             {stats.features.map((f) => (
               <li
                 key={f.uuid}
-                className="inline-flex items-center gap-1 rounded border border-pf-border bg-pf-bg px-1.5 py-0.5 text-[11px] text-pf-text"
+                data-uuid={f.uuid}
+                className="inline-flex cursor-default items-center gap-1 rounded border border-pf-border bg-pf-bg px-1.5 py-0.5 text-[11px] text-pf-text transition-colors hover:border-pf-primary/60 hover:bg-pf-tertiary/20"
               >
                 {f.img && <img src={f.img} alt="" className="h-3.5 w-3.5 rounded" />}
                 {f.name}

--- a/apps/player-portal/src/features/characters/internal/CompendiumDetailPanel.tsx
+++ b/apps/player-portal/src/features/characters/internal/CompendiumDetailPanel.tsx
@@ -117,8 +117,18 @@ export function CompendiumDetailPanel({
             {rarity != null && rarity !== 'common' && ` · ${rarity}`}
             {castCost !== null && ` · Cast ${castCost}`}
           </p>
-          {traits.length > 0 && (
+          {(target.type === 'ancestry' && rarity !== null) || traits.length > 0 ? (
             <ul className="mt-1 flex flex-wrap gap-1">
+              {/* Ancestries always show their rarity as the first pill so
+                  players can spot uncommon/rare ancestries at a glance.
+                  Other doc types keep rarity in the meta line only. */}
+              {target.type === 'ancestry' && rarity !== null && (
+                <li
+                  className={`rounded-full px-1.5 py-0.5 text-[10px] uppercase tracking-wide ${rarityPillClasses(rarity)}`}
+                >
+                  {humanizeSlug(rarity)}
+                </li>
+              )}
               {traits.map((t) => (
                 <li
                   key={t}
@@ -128,7 +138,7 @@ export function CompendiumDetailPanel({
                 </li>
               ))}
             </ul>
-          )}
+          ) : null}
         </div>
         <button
           type="button"
@@ -365,6 +375,23 @@ function humanizeSlug(slug: string): string {
     .split('-')
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
     .join(' ');
+}
+
+// PF2e rarity tiers map to standard system colors — amber for uncommon,
+// blue for rare, purple for unique. Common gets a muted grey pill.
+function rarityPillClasses(rarity: string): string {
+  switch (rarity.toLowerCase()) {
+    case 'uncommon':
+      return 'border border-amber-500 bg-amber-100 text-amber-900';
+    case 'rare':
+      return 'border border-blue-500 bg-blue-100 text-blue-900';
+    case 'unique':
+      return 'border border-purple-500 bg-purple-100 text-purple-900';
+    default:
+      // common — neutral chip so the field is always visible without
+      // shouting.
+      return 'border border-pf-border bg-pf-bg-dark text-pf-alt-dark';
+  }
 }
 
 // ─── Ancestry mechanical stats ───────────────────────────────────────────────

--- a/apps/player-portal/src/features/characters/internal/CompendiumDetailPanel.tsx
+++ b/apps/player-portal/src/features/characters/internal/CompendiumDetailPanel.tsx
@@ -71,6 +71,7 @@ export function CompendiumDetailPanel({
 
   const doc = state.kind === 'ok' ? state.document : null;
   const ancestryStats = doc && target.type === 'ancestry' ? readAncestryStats(doc) : null;
+  const backgroundStats = doc && target.type === 'background' ? readBackgroundStats(doc) : null;
   const docTraits = doc ? readTraits(doc) : null;
   const traits = docTraits ?? target.traits ?? [];
   const rarity = doc ? readRarity(doc) : null;
@@ -202,6 +203,7 @@ export function CompendiumDetailPanel({
             // ── All other types (and ancestries without art): stacked layout ──
             <div className="space-y-3">
               {ancestryStats !== null && <AncestryMechanics stats={ancestryStats} />}
+              {backgroundStats !== null && <BackgroundMechanics stats={backgroundStats} />}
               {prerequisites && prerequisites.length > 0 && (
                 <DetailRow label="Prerequisites" value={prerequisites.join('; ')} fail={failed} />
               )}
@@ -550,6 +552,84 @@ function AncestryMechanics({ stats }: { stats: AncestryStats }): React.ReactElem
         <details className="mt-2">
           <summary className="cursor-pointer text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark">
             Ancestry features ({stats.features.length})
+          </summary>
+          <ul className="mt-1 flex flex-wrap gap-1">
+            {stats.features.map((f) => (
+              <li
+                key={f.uuid}
+                className="inline-flex items-center gap-1 rounded border border-pf-border bg-pf-bg px-1.5 py-0.5 text-[11px] text-pf-text"
+              >
+                {f.img && <img src={f.img} alt="" className="h-3.5 w-3.5 rounded" />}
+                {f.name}
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </div>
+  );
+}
+
+// ─── Background mechanical stats ─────────────────────────────────────────────
+
+interface BackgroundStats {
+  boosts: BoostSlot[];
+  trainedSkills: string[];
+  loreSkills: string[];
+  features: { uuid: string; name: string; img: string }[];
+}
+
+function readBackgroundStats(doc: CompendiumDocument): BackgroundStats {
+  const sys = doc.system as {
+    boosts?: unknown;
+    trainedSkills?: { value?: unknown; lore?: unknown };
+    items?: Record<string, unknown>;
+  };
+
+  const boosts = readBoostRecord(sys.boosts);
+
+  const trainedSkills = Array.isArray(sys.trainedSkills?.value)
+    ? sys.trainedSkills.value.filter((v): v is string => typeof v === 'string')
+    : [];
+
+  const loreSkills = Array.isArray(sys.trainedSkills?.lore)
+    ? sys.trainedSkills.lore.filter((v): v is string => typeof v === 'string')
+    : [];
+
+  const features = readAncestryFeatures(sys.items);
+
+  return { boosts, trainedSkills, loreSkills, features };
+}
+
+function BackgroundMechanics({ stats }: { stats: BackgroundStats }): React.ReactElement {
+  const hasBoosts = stats.boosts.length > 0;
+  const hasSkills = stats.trainedSkills.length > 0 || stats.loreSkills.length > 0;
+  const hasFeatures = stats.features.length > 0;
+
+  return (
+    <div className="border-b border-pf-border px-4 py-3 text-xs text-pf-text">
+      <p className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark">Mechanical effects</p>
+
+      {hasBoosts && (
+        <div className="mb-1">
+          <span className="text-pf-alt-dark">Boosts: </span>
+          <span className="font-medium">{stats.boosts.map(formatBoostSlot).join(', ')}</span>
+        </div>
+      )}
+
+      {hasSkills && (
+        <div className="mb-1">
+          <span className="text-pf-alt-dark">Trained skills: </span>
+          <span className="font-medium">
+            {[...stats.trainedSkills.map(humanizeSlug), ...stats.loreSkills].join(', ')}
+          </span>
+        </div>
+      )}
+
+      {hasFeatures && (
+        <details className="mt-2">
+          <summary className="cursor-pointer text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark">
+            Background abilities ({stats.features.length})
           </summary>
           <ul className="mt-1 flex flex-wrap gap-1">
             {stats.features.map((f) => (

--- a/apps/player-portal/src/features/characters/internal/CompendiumDetailPanel.tsx
+++ b/apps/player-portal/src/features/characters/internal/CompendiumDetailPanel.tsx
@@ -4,7 +4,7 @@ import { api, ApiRequestError } from '@/features/characters/api';
 import type { CompendiumDocument, CompendiumMatch } from '@/features/characters/types';
 import { useUuidHover } from '@/shared/hooks/useUuidHover';
 import type { Evaluation } from '@/features/characters/internal/prereqs';
-import { getAncestryArt, getClassArt } from './character-art';
+import { getAncestryArt, getClassArt, getHeritageArt } from './character-art';
 import { CharacterArtGallery } from './CharacterArtGallery';
 
 type Resolution =
@@ -97,14 +97,18 @@ export function CompendiumDetailPanel({
   const area = doc ? readArea(doc) : null;
   const enriched = description.length > 0 ? enrichDescription(description) : '';
 
-  // Decorative AoN reference art for ancestry / class detail panels.
-  // Picks up images bundled in src/data/pf2e-art.json. No-op for other types.
+  // Decorative AoN reference art for ancestry / heritage / class detail
+  // panels. Heritage art is stored alongside ancestry art in
+  // pf2e-art.json — versatile heritages (Aiuvarin, Changeling, etc.)
+  // get their own entries. No-op for other types.
   const characterArt =
     target.type === 'ancestry'
       ? getAncestryArt(target.name)
-      : target.type === 'class'
-        ? getClassArt(target.name)
-        : null;
+      : target.type === 'heritage'
+        ? getHeritageArt(target.name)
+        : target.type === 'class'
+          ? getClassArt(target.name)
+          : null;
 
   const failed = evaluation === 'fails';
 

--- a/apps/player-portal/src/features/characters/internal/CompendiumDetailPanel.tsx
+++ b/apps/player-portal/src/features/characters/internal/CompendiumDetailPanel.tsx
@@ -760,7 +760,10 @@ function readClassStats(doc: CompendiumDocument): ClassStats {
   // non-spellcasters.
   const spellcasting = typeof sys.spellcasting === 'number' && sys.spellcasting > 0 ? sys.spellcasting : null;
 
-  const features = readAncestryFeatures(sys.items);
+  // Classes pack their full per-level feature progression into
+  // `system.items`. The detail panel is a level-1 preview, so only
+  // surface the features granted at L1.
+  const features = readClassL1Features(sys.items);
 
   return {
     perception,
@@ -781,6 +784,27 @@ function readOtherAttack(raw: unknown): { name: string; rank: number } | null {
   if (typeof o.name !== 'string' || o.name.length === 0) return null;
   if (typeof o.rank !== 'number' || o.rank <= 0) return null;
   return { name: o.name, rank: o.rank };
+}
+
+// pf2e class items embed every level's class feature in `system.items`,
+// each tagged with the level it's granted at. The detail panel is a
+// level-1 preview, so only surface entries with `level === 1` — the
+// rest (subclass picks, level-3 ability boosts, level-5 features, etc.)
+// don't apply yet and would otherwise crowd the chip list.
+function readClassL1Features(
+  items: Record<string, unknown> | undefined,
+): { uuid: string; name: string; img: string }[] {
+  if (!items) return [];
+  const out: { uuid: string; name: string; img: string }[] = [];
+  for (const raw of Object.values(items)) {
+    if (!raw || typeof raw !== 'object') continue;
+    const entry = raw as { uuid?: unknown; name?: unknown; img?: unknown; level?: unknown };
+    if (typeof entry.uuid !== 'string' || typeof entry.name !== 'string') continue;
+    if (typeof entry.level !== 'number' || entry.level !== 1) continue;
+    out.push({ uuid: entry.uuid, name: entry.name, img: typeof entry.img === 'string' ? entry.img : '' });
+  }
+  out.sort((a, b) => a.name.localeCompare(b.name));
+  return out;
 }
 
 // PF2e proficiency ladder: 0 untrained, 1 trained, 2 expert, 3 master,

--- a/apps/player-portal/src/features/characters/internal/CompendiumDetailPanel.tsx
+++ b/apps/player-portal/src/features/characters/internal/CompendiumDetailPanel.tsx
@@ -5,6 +5,7 @@ import type { CompendiumDocument, CompendiumMatch } from '@/features/characters/
 import { useUuidHover } from '@/shared/hooks/useUuidHover';
 import type { Evaluation } from '@/features/characters/internal/prereqs';
 import { getAncestryArt, getClassArt, getHeritageArt } from './character-art';
+import { getClassNote } from './class-notes';
 import { CharacterArtGallery } from './CharacterArtGallery';
 
 type Resolution =
@@ -81,6 +82,7 @@ export function CompendiumDetailPanel({
   const ancestryStats = doc && target.type === 'ancestry' ? readAncestryStats(doc) : null;
   const backgroundStats = doc && target.type === 'background' ? readBackgroundStats(doc) : null;
   const classStats = doc && target.type === 'class' ? readClassStats(doc) : null;
+  const classNote = target.type === 'class' ? getClassNote(target.name) : null;
   const docTraits = doc ? readTraits(doc) : null;
   const traits = docTraits ?? target.traits ?? [];
   const rarity = doc ? readRarity(doc) : null;
@@ -219,6 +221,7 @@ export function CompendiumDetailPanel({
                   {/* Mechanical effects sit below the lore so the flavor text reads first. */}
                   {ancestryStats !== null && <AncestryMechanics stats={ancestryStats} />}
                   {classStats !== null && <ClassMechanics stats={classStats} />}
+                  {classNote !== null && <ClassNotesFromAlex note={classNote} />}
                 </div>
                 {/* Art column: flex-col so the gallery can fill h-full */}
                 <div className="flex w-[28rem] shrink-0 flex-col">
@@ -256,6 +259,7 @@ export function CompendiumDetailPanel({
               {ancestryStats !== null && <AncestryMechanics stats={ancestryStats} />}
               {backgroundStats !== null && <BackgroundMechanics stats={backgroundStats} />}
               {classStats !== null && <ClassMechanics stats={classStats} />}
+              {classNote !== null && <ClassNotesFromAlex note={classNote} />}
               {uuidHover.popover}
             </div>
           ))}
@@ -950,6 +954,19 @@ function ProficiencyRow({ heading, children }: { heading: string; children: Reac
     <div className="mb-2">
       <p className="text-[10px] font-semibold uppercase tracking-wide text-pf-alt-dark">{heading}</p>
       <div className="ml-1 [&_p]:leading-tight">{children}</div>
+    </div>
+  );
+}
+
+// "Notes from Alex" — opinionated, role-flavored take on each class.
+// Sits beneath the mechanical proficiencies block so a player who's
+// scanning a class for "what is this class actually like to play" gets
+// a paragraph of GM commentary right where they're already reading.
+function ClassNotesFromAlex({ note }: { note: string }): React.ReactElement {
+  return (
+    <div className="mt-4 border-t border-pf-border pt-3 text-xs text-pf-text" data-role="class-notes-from-alex">
+      <p className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark">Notes from Alex</p>
+      <p className="leading-relaxed">{note}</p>
     </div>
   );
 }

--- a/apps/player-portal/src/features/characters/internal/CompendiumDetailPanel.tsx
+++ b/apps/player-portal/src/features/characters/internal/CompendiumDetailPanel.tsx
@@ -456,6 +456,13 @@ function readBoostRecord(raw: unknown): BoostSlot[] {
     const value = (slot as { value?: unknown }).value;
     if (!Array.isArray(value)) continue;
     const options = value.filter((v): v is string => typeof v === 'string');
+    // pf2e compendium docs ship a fixed-size boost record where unused
+    // slots are encoded as `{ "value": [] }` — a placeholder, not a real
+    // boost. The actual encodings for a slot the player can fill are
+    // either all six abilities listed (free pick) or a constrained subset
+    // (fixed / choice). Skip the placeholder so a 3-slot Human ancestry
+    // renders the correct "Free, Free" instead of "Free, Free, Free".
+    if (options.length === 0) continue;
     slots.push({ options });
   }
   return slots;

--- a/apps/player-portal/src/features/characters/internal/CompendiumDetailPanel.tsx
+++ b/apps/player-portal/src/features/characters/internal/CompendiumDetailPanel.tsx
@@ -917,11 +917,13 @@ function ClassMechanics({ stats }: { stats: ClassStats }): React.ReactElement {
       )}
 
       {hasFeatures && (
-        <details className="mt-2">
-          <summary className="cursor-pointer text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark">
-            Class features ({stats.features.length})
-          </summary>
-          <ul className="mt-1 flex flex-wrap gap-1">
+        // Class features are always-visible: there are only a handful at
+        // L1 (Composition Spells, the muse pick, etc. for Bard) and they
+        // matter for the build decision the player is making right now.
+        // Other panels (ancestry / background) keep their <details>
+        // wrapper because their lists can be longer and less central.
+        <ProficiencyRow heading={`Class features (${stats.features.length})`}>
+          <ul className="flex flex-wrap gap-1">
             {stats.features.map((f) => (
               <li
                 key={f.uuid}
@@ -933,7 +935,7 @@ function ClassMechanics({ stats }: { stats: ClassStats }): React.ReactElement {
               </li>
             ))}
           </ul>
-        </details>
+        </ProficiencyRow>
       )}
     </div>
   );

--- a/apps/player-portal/src/features/characters/internal/CompendiumFilters.tsx
+++ b/apps/player-portal/src/features/characters/internal/CompendiumFilters.tsx
@@ -169,6 +169,74 @@ export function SourcePicker({
   );
 }
 
+// ─── Rarity multi-select ────────────────────────────────────────────────
+// Fixed set of four rarities — small enough to render inline as pills.
+// Matches the server-side `rarities` filter on /api/compendium/search.
+
+const RARITY_TIERS = ['common', 'uncommon', 'rare', 'unique'] as const;
+type RarityTier = (typeof RARITY_TIERS)[number];
+
+function rarityPillClasses(tier: RarityTier, active: boolean): string {
+  if (!active) return 'border-pf-border bg-pf-bg text-pf-alt-dark hover:bg-pf-tertiary/40 hover:text-pf-primary';
+  switch (tier) {
+    case 'uncommon':
+      return 'border-amber-500 bg-amber-100 text-amber-900';
+    case 'rare':
+      return 'border-blue-500 bg-blue-100 text-blue-900';
+    case 'unique':
+      return 'border-purple-500 bg-purple-100 text-purple-900';
+    default:
+      return 'border-pf-border bg-pf-bg-dark text-pf-alt-dark';
+  }
+}
+
+export function RarityPicker({
+  selected,
+  onChange,
+}: {
+  selected: string[];
+  onChange: (next: string[]) => void;
+}): React.ReactElement {
+  const lowered = useMemo(() => new Set(selected.map((s) => s.toLowerCase())), [selected]);
+  const toggle = (tier: RarityTier): void => {
+    if (lowered.has(tier)) {
+      onChange(selected.filter((s) => s.toLowerCase() !== tier));
+    } else {
+      onChange([...selected, tier]);
+    }
+  };
+  return (
+    <div
+      role="group"
+      aria-label="Filter by rarity"
+      data-testid="rarity-picker"
+      className="inline-flex items-center gap-1"
+    >
+      <span className="text-[10px] uppercase tracking-widest text-pf-alt-dark">Rarity</span>
+      {RARITY_TIERS.map((tier) => {
+        const active = lowered.has(tier);
+        return (
+          <button
+            key={tier}
+            type="button"
+            aria-pressed={active}
+            data-rarity-option={tier}
+            onClick={(): void => {
+              toggle(tier);
+            }}
+            className={[
+              'rounded-full border px-1.5 py-0.5 text-[10px] uppercase tracking-wide transition-colors',
+              rarityPillClasses(tier, active),
+            ].join(' ')}
+          >
+            {tier.charAt(0).toUpperCase() + tier.slice(1)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 // ─── Sort toggle ────────────────────────────────────────────────────────
 
 export function SortToggle({

--- a/apps/player-portal/src/features/characters/internal/CompendiumPicker.tsx
+++ b/apps/player-portal/src/features/characters/internal/CompendiumPicker.tsx
@@ -9,6 +9,24 @@ import type { Evaluation } from '@/features/characters/internal/prereqs';
 import { CompendiumDetailPanel } from './CompendiumDetailPanel';
 import { PickerDialog } from '@/shared/ui/PickerDialog';
 
+// Selected-row background. Tints by rarity so the highlight visually
+// echoes the rarity pills in the filter row above — clicking the
+// "Uncommon" pill and then selecting an item makes the row's highlight
+// amber, etc. Items with `rarity = 'common'` (or rarity missing —
+// uncached search results) fall back to the neutral tertiary tint.
+function activeRowClass(rarity: string | undefined): string {
+  switch (rarity?.toLowerCase()) {
+    case 'uncommon':
+      return 'bg-amber-100/60';
+    case 'rare':
+      return 'bg-blue-100/60';
+    case 'unique':
+      return 'bg-purple-100/60';
+    default:
+      return 'bg-pf-tertiary/50';
+  }
+}
+
 // ─── Internal list + states area ──────────────────────────────────────────────
 
 interface SplitPane {
@@ -288,7 +306,7 @@ export function CompendiumPicker({
                 title={rowTitle}
                 className={[
                   'flex w-full items-center gap-3 px-4 py-2 text-left transition-colors',
-                  active ? 'bg-pf-tertiary/50' : 'hover:bg-pf-tertiary/20',
+                  active ? activeRowClass(m.rarity) : 'hover:bg-pf-tertiary/20',
                   fails ? 'opacity-60' : '',
                 ].join(' ')}
                 data-pick-uuid={m.uuid}

--- a/apps/player-portal/src/features/characters/internal/CompendiumPicker.tsx
+++ b/apps/player-portal/src/features/characters/internal/CompendiumPicker.tsx
@@ -29,6 +29,11 @@ export interface PickerResultListProps<TItem> {
   remainingCount?: number;
   loadMoreTestId?: string | undefined;
   splitPane?: SplitPane | undefined;
+  /** Tailwind width class applied to the list column when a detail
+   *  panel is open beside it. Defaults to `w-80` (320px) — feat/spell
+   *  rows benefit from the room, but short-name targets like classes
+   *  can be tightened to `w-56` so the detail column gets the space. */
+  listOpenWidthClass?: string;
 }
 
 export function PickerResultList<TItem>({
@@ -44,6 +49,7 @@ export function PickerResultList<TItem>({
   remainingCount,
   loadMoreTestId,
   splitPane,
+  listOpenWidthClass = 'w-80',
 }: PickerResultListProps<TItem>): React.ReactElement {
   const detailOpen = splitPane?.detailOpen ?? false;
 
@@ -51,7 +57,7 @@ export function PickerResultList<TItem>({
     <div
       className={[
         'overflow-y-auto',
-        splitPane ? (detailOpen ? 'w-80 shrink-0 border-r border-pf-border' : 'flex-1') : 'flex-1',
+        splitPane ? (detailOpen ? `${listOpenWidthClass} shrink-0 border-r border-pf-border` : 'flex-1') : 'flex-1',
       ].join(' ')}
       data-testid={resultsTestId}
     >
@@ -149,6 +155,9 @@ export interface CompendiumPickerProps {
    *  dialog's own title bar. Has no effect when the caller provides
    *  their own `splitPane`. */
   detailHideHeader?: boolean | undefined;
+  /** Tailwind width class for the list column when a detail panel is
+   *  open beside it. See PickerResultListProps for the rationale. */
+  listOpenWidthClass?: string | undefined;
   onPick: (match: CompendiumMatch) => void;
   onClose: () => void;
   testId?: string | undefined;
@@ -178,6 +187,7 @@ export function CompendiumPicker({
   emptyMessage = 'No matches.',
   allFilteredMessage,
   detailHideHeader,
+  listOpenWidthClass,
   onPick,
   onClose,
   testId = 'compendium-picker',
@@ -385,6 +395,7 @@ export function CompendiumPicker({
         {...(state.kind === 'ready' ? { remainingCount: state.total - state.items.length } : {})}
         loadMoreTestId={loadMoreTestId}
         splitPane={effectiveSplitPane}
+        {...(listOpenWidthClass !== undefined ? { listOpenWidthClass } : {})}
       />
     </PickerDialog>
   );

--- a/apps/player-portal/src/features/characters/internal/CompendiumPicker.tsx
+++ b/apps/player-portal/src/features/characters/internal/CompendiumPicker.tsx
@@ -143,6 +143,12 @@ export interface CompendiumPickerProps {
   emptyMessage?: string | undefined;
   /** Shown instead of emptyMessage when filterItem removes all server results. */
   allFilteredMessage?: string | undefined;
+  /** Forwarded to the internal CompendiumDetailPanel when the default
+   *  click-row → split-pane flow is in use. Hides the panel's header
+   *  (image + name + meta + traits) so it doesn't duplicate the picker
+   *  dialog's own title bar. Has no effect when the caller provides
+   *  their own `splitPane`. */
+  detailHideHeader?: boolean | undefined;
   onPick: (match: CompendiumMatch) => void;
   onClose: () => void;
   testId?: string | undefined;
@@ -171,6 +177,7 @@ export function CompendiumPicker({
   splitPane,
   emptyMessage = 'No matches.',
   allFilteredMessage,
+  detailHideHeader,
   onPick,
   onClose,
   testId = 'compendium-picker',
@@ -335,6 +342,7 @@ export function CompendiumPicker({
               {...(internalDetailEvaluation !== undefined ? { evaluation: internalDetailEvaluation } : {})}
               {...(docCache !== undefined ? { docCache } : {})}
               {...(testId !== undefined ? { testIdPrefix: testId } : {})}
+              {...(detailHideHeader === true ? { hideHeader: true } : {})}
             />
           ) : null,
       }

--- a/apps/player-portal/src/features/characters/internal/CompendiumPicker.tsx
+++ b/apps/player-portal/src/features/characters/internal/CompendiumPicker.tsx
@@ -55,12 +55,8 @@ export function PickerResultList<TItem>({
       ].join(' ')}
       data-testid={resultsTestId}
     >
-      {isLoading && items.length === 0 && (
-        <p className="p-4 text-sm italic text-pf-alt">Searching…</p>
-      )}
-      {error != null && (
-        <p className="p-4 text-sm text-pf-primary">Search failed: {error}</p>
-      )}
+      {isLoading && items.length === 0 && <p className="p-4 text-sm italic text-pf-alt">Searching…</p>}
+      {error != null && <p className="p-4 text-sm text-pf-primary">Search failed: {error}</p>}
       {!isLoading && error == null && items.length === 0 && (
         <p className="p-4 text-sm italic text-pf-alt">{emptyMessage}</p>
       )}
@@ -119,6 +115,8 @@ export interface CompendiumPickerProps {
   maxLevel?: number | undefined;
   /** OR-filter on publication source title (drives the source-book picker). */
   sources?: string[] | undefined;
+  /** OR-filter on `system.traits.rarity` (drives the rarity picker). */
+  rarities?: string[] | undefined;
   ancestrySlug?: string | undefined;
   /** Client-side predicate applied after server results land. */
   filterItem?: ((match: CompendiumMatch) => boolean) | undefined;
@@ -160,6 +158,7 @@ export function CompendiumPicker({
   anyTraits,
   maxLevel,
   sources,
+  rarities,
   ancestrySlug,
   filterItem,
   sortItems,
@@ -193,9 +192,10 @@ export function CompendiumPicker({
         anyTraits: [...(anyTraits ?? [])].sort(),
         maxLevel: maxLevel ?? null,
         sources: [...(sources ?? [])].sort(),
+        rarities: [...(rarities ?? [])].sort(),
         ancestrySlug: ancestrySlug ?? null,
       }),
-    [packIds, documentType, traits, anyTraits, maxLevel, sources, ancestrySlug],  
+    [packIds, documentType, traits, anyTraits, maxLevel, sources, rarities, ancestrySlug],
   );
 
   const { state, hasMore, isLoadingMore, loadMore } = usePaginatedSearch<CompendiumMatch>(
@@ -207,6 +207,7 @@ export function CompendiumPicker({
       if (anyTraits?.length) opts.anyTraits = [...anyTraits];
       if (maxLevel != null) opts.maxLevel = maxLevel;
       if (sources?.length) opts.sources = [...sources];
+      if (rarities?.length) opts.rarities = [...rarities];
       if (ancestrySlug) opts.ancestrySlug = ancestrySlug;
       return api.searchCompendium(opts);
     },
@@ -231,9 +232,7 @@ export function CompendiumPicker({
   }, [allItems, filterItem, sortItems]);
 
   const effectiveEmptyMessage =
-    allFilteredMessage != null && allItems.length > 0 && visible.length === 0
-      ? allFilteredMessage
-      : emptyMessage;
+    allFilteredMessage != null && allItems.length > 0 && visible.length === 0 ? allFilteredMessage : emptyMessage;
 
   // Internal detail flow: when the caller doesn't provide a custom splitPane
   // or renderList, clicking a row opens a built-in CompendiumDetailPanel
@@ -251,8 +250,7 @@ export function CompendiumPicker({
           const evaluation = evaluations?.get(m.uuid);
           const fails = evaluation === 'fails';
           const unknown = evaluation === 'unknown';
-          const traitsSummary =
-            m.traits && m.traits.length > 0 ? m.traits.slice(0, 5).join(', ') : '';
+          const traitsSummary = m.traits && m.traits.length > 0 ? m.traits.slice(0, 5).join(', ') : '';
           const rowTitle = fails
             ? "Character doesn't meet this entry's prerequisites"
             : unknown
@@ -281,11 +279,7 @@ export function CompendiumPicker({
                 data-prereq-state={evaluation ?? 'pending'}
               >
                 {m.img && (
-                  <img
-                    src={m.img}
-                    alt=""
-                    className="h-8 w-8 shrink-0 rounded border border-pf-border bg-pf-bg-dark"
-                  />
+                  <img src={m.img} alt="" className="h-8 w-8 shrink-0 rounded border border-pf-border bg-pf-bg-dark" />
                 )}
                 <div className="min-w-0 flex-1">
                   <div className="flex items-baseline justify-between gap-2">
@@ -323,8 +317,7 @@ export function CompendiumPicker({
   // When the caller didn't supply splitPane and we're in internal-detail mode,
   // render a built-in CompendiumDetailPanel beside the list.
   const internalDetailUuid = internalDetailTarget?.uuid;
-  const internalDetailEvaluation =
-    internalDetailUuid !== undefined ? evaluations?.get(internalDetailUuid) : undefined;
+  const internalDetailEvaluation = internalDetailUuid !== undefined ? evaluations?.get(internalDetailUuid) : undefined;
   const effectiveSplitPane: CompendiumPickerSplitPane | undefined = useInternalDetail
     ? {
         detailOpen: internalDetailTarget !== null,
@@ -339,9 +332,7 @@ export function CompendiumPicker({
               onClose={(): void => {
                 setInternalDetailTarget(null);
               }}
-              {...(internalDetailEvaluation !== undefined
-                ? { evaluation: internalDetailEvaluation }
-                : {})}
+              {...(internalDetailEvaluation !== undefined ? { evaluation: internalDetailEvaluation } : {})}
               {...(docCache !== undefined ? { docCache } : {})}
               {...(testId !== undefined ? { testIdPrefix: testId } : {})}
             />
@@ -373,22 +364,20 @@ export function CompendiumPicker({
         />
         {filterControls}
       </div>
-        <PickerResultList
-          isLoading={state.kind === 'loading'}
-          error={state.kind === 'error' ? state.message : null}
-          items={visible}
-          emptyMessage={effectiveEmptyMessage}
-          renderList={renderList ?? defaultRenderList}
-          resultsTestId={resultsTestId}
-          hasMore={hasMore}
-          isLoadingMore={isLoadingMore}
-          onLoadMore={loadMore}
-          {...(state.kind === 'ready'
-            ? { remainingCount: state.total - state.items.length }
-            : {})}
-          loadMoreTestId={loadMoreTestId}
-          splitPane={effectiveSplitPane}
-        />
+      <PickerResultList
+        isLoading={state.kind === 'loading'}
+        error={state.kind === 'error' ? state.message : null}
+        items={visible}
+        emptyMessage={effectiveEmptyMessage}
+        renderList={renderList ?? defaultRenderList}
+        resultsTestId={resultsTestId}
+        hasMore={hasMore}
+        isLoadingMore={isLoadingMore}
+        onLoadMore={loadMore}
+        {...(state.kind === 'ready' ? { remainingCount: state.total - state.items.length } : {})}
+        loadMoreTestId={loadMoreTestId}
+        splitPane={effectiveSplitPane}
+      />
     </PickerDialog>
   );
 }

--- a/apps/player-portal/src/features/characters/internal/CompendiumPicker.tsx
+++ b/apps/player-portal/src/features/characters/internal/CompendiumPicker.tsx
@@ -12,8 +12,9 @@ import { PickerDialog } from '@/shared/ui/PickerDialog';
 // Selected-row background. Tints by rarity so the highlight visually
 // echoes the rarity pills in the filter row above — clicking the
 // "Uncommon" pill and then selecting an item makes the row's highlight
-// amber, etc. Items with `rarity = 'common'` (or rarity missing —
-// uncached search results) fall back to the neutral tertiary tint.
+// amber, etc. Common items (and rows without a rarity field — uncached
+// search results) use the same neutral gray the Common rarity pill
+// uses, so the four rarity tiers each read with a distinct colour.
 function activeRowClass(rarity: string | undefined): string {
   switch (rarity?.toLowerCase()) {
     case 'uncommon':
@@ -23,7 +24,7 @@ function activeRowClass(rarity: string | undefined): string {
     case 'unique':
       return 'bg-purple-100/60';
     default:
-      return 'bg-pf-tertiary/50';
+      return 'bg-pf-bg-dark';
   }
 }
 

--- a/apps/player-portal/src/features/characters/internal/character-art.ts
+++ b/apps/player-portal/src/features/characters/internal/character-art.ts
@@ -35,6 +35,13 @@ export function getClassArt(name: string): CharacterArt | null {
   return lookup(artData.classes, name);
 }
 
+// Heritage art is stored alongside ancestry art in pf2e-art.json because
+// versatile heritages (Aiuvarin, Changeling, Beastkin, etc.) are indexed by
+// their own name, not by their parent ancestry.
+export function getHeritageArt(name: string): CharacterArt | null {
+  return lookup(artData.ancestries, name);
+}
+
 function lookup(table: Record<string, CharacterArt>, name: string): CharacterArt | null {
   // Exact match first — covers the vast majority of cases.
   const direct = table[name];

--- a/apps/player-portal/src/features/characters/internal/class-notes.ts
+++ b/apps/player-portal/src/features/characters/internal/class-notes.ts
@@ -1,0 +1,65 @@
+// "Notes from Alex" blurbs surfaced on the class detail panel beneath
+// the mechanical proficiencies block. Keyed by the class compendium
+// document's display name (matching `CompendiumMatch.name`); a
+// missing entry suppresses the section, so adding support for a new
+// class is a one-line addition here.
+
+export const CLASS_NOTES: Readonly<Record<string, string>> = {
+  Alchemist:
+    'A daily-prep support and weakness-abuse class. You brew alchemical items each morning (bombs, elixirs, mutagens, poisons) and distribute or throw them in combat. Research Field tilts the kit: Bomber leans striker via splash and persistent damage, Chirurgeon plays party medic, Mutagenist buffs a single frontline ally (often themselves), Toxicologist applies persistent poison damage.',
+  Barbarian:
+    'A melee striker with the deepest HP pool in the game. Rage trades a small amount of AC for a flat damage bonus on every Strike. Instinct (Animal, Dragon, Giant, Spirit, Fury) reskins damage type and flavor without changing the core role. Default kit is a two-handed weapon and forward movement.',
+  Bard: 'An occult support caster. Composition cantrips (Courage, Defense) are sustained buffs that affect the whole party while you cast and skill-check around them. Muse tilts the class: Maestro for buff support, Polymath for utility and skills, Warrior for a martial dabble, Enigma for lore and recall.',
+  Champion:
+    "A heavily-armored defender. The class's Reaction triggers when an enemy hits an ally near you, allowing you to interrupt, redirect, or punish. Cause (Paladin, Redeemer, Liberator, and others) reshapes the Reaction and your behavioral edicts. Default kit is heavy armor, martial weapons, focus spells, and the staying power to stand next to vulnerable allies.",
+  Cleric:
+    'A divine caster with two default builds. Cloistered Doctrine leans caster-support: expert spellcasting and a divine focus spell from your Deity. Warpriest Doctrine leans frontline-support: medium armor, martial weapons, slower spell progression. Both get the Font feature, which grants a daily pool of dedicated heal-or-harm slots in addition to your normal slots. Deity dictates spells, weapons, and edicts.',
+  Druid:
+    'A primal caster who picks an Order at level 1. Orders steer the class significantly: Animal grants a pet, Leaf leans healing and plant support, Storm leans area damage and weather control, Untamed shapeshifts for melee, and so on. Default kit is light armor, a primal spell list with strong control and area options, and one focus spell from your Order.',
+  Fighter:
+    'The simplest martial and the most accurate one in the game. Weapon proficiency progresses faster than any other class, which translates to more hits and more critical hits. Class feats cover shield work, weapon maneuvers (Trip, Disarm, Power Attack, Sudden Charge), and Attack of Opportunity by default. Picks any weapon and excels with it.',
+  Gunslinger:
+    "A firearm-focused striker built around critical hits. Way (Pistolero, Sniper, Vanguard, Drifter) determines range, weapon style, and supporting feats. The class's math favors crit fishing, which compounds when allies stack buffs and debuffs on a target. Reload management is a real part of every turn.",
+  Inventor:
+    'A martial built around one signature Innovation: a Weapon, Armor, Construct, or Vehicle that you modify over time. Innovation type tilts the kit: Weapon is striker, Armor is defender, Construct is a pet/companion build, Vehicle is its own niche. Overdrive boosts your damage on demand; the Unstable trait gates the strongest options behind self-damage risk.',
+  Investigator:
+    'A skill-driven martial. Devise a Stratagem pre-rolls one attack die before you commit an action, letting you decide whether to attack now or do something else. Methodology (Alchemical Sciences, Empiricism, Forensic Medicine, Interrogation, and others) steers your skill focus. Lower damage than most martials but more consistent. Best at tables that engage meaningfully with investigation and exploration.',
+  Kineticist:
+    'An at-will elemental martial with no spell slots. You pick one or two of six elements (Air, Earth, Fire, Metal, Water, Wood) and gain Impulses: action-based elemental abilities. Element choice steers the class: Fire leans damage, Earth leans defense, Wood leans support, Water leans control, and so on. Highly modular within element constraints.',
+  Magus:
+    "A “spellstriker” hybrid. The class's signature is Spellstrike: a two-action combination of a weapon attack and a spell into a single attack roll. Hybrid Study (Inexorable Iron, Sparkling Targe, Starlit Span, Twisting Tree, Laughing Shadow, and others) tilts you toward two-handed, sword-and-shield, ranged, reach, or mobile builds. All are striker-leaning.",
+  Monk: 'A mobile martial. Default kit is unarmed strikes, the fastest base speed in the game, and Flurry of Blows (two strikes for one action with a reduced multiple attack penalty). Stances reshape your damage profile: Mountain Stance hits heavy, Tiger and Stumbling enable trip and critical-effect builds, Crane is defensive and mobile. Strong at maneuvers and battlefield positioning.',
+  Oracle:
+    "A divine caster whose class identity is built around a Mystery (Battle, Bones, Cosmos, Flames, Life, Lore, Tempest, and others). Mystery determines themed focus spells, granted spells, and a Curse that escalates as you channel your Mystery's power. Default kit leans Leader or Controller; Life Mystery is the prototype healer.",
+  Psychic:
+    "An occult caster with fewer spell slots than other casters but stronger cantrips. The class's signature is the Amped cantrip, which can be supercharged for stronger effects. Conscious Mind (Distant Grasp, Oscillating Wave, Silent Whisper, Tangible Dream, etc.) determines theme. Low HP and armor proficiency mean stay-back play.",
+  Ranger:
+    "A single-target focused martial. Hunt Prey marks one enemy and grants tracking and perception benefits against them. Hunter's Edge tilts how you fight that prey: Flurry leans multi-attack output, Precision leans burst damage on the first hit, Outwit leans skill-based control. Strong with bows or two-weapon fighting.",
+  Rogue:
+    'A skill-rich martial built around Sneak Attack damage against off-guard enemies. Default kit excels at finesse weapons and out-of-combat utility (Thievery, Stealth, social skills). Racket (Ruffian, Scoundrel, Thief, Mastermind, Eldritch Trickster) tilts the class: Ruffian wields heavier weapons, Scoundrel and Mastermind lean on charisma and intelligence, Thief and Eldritch Trickster lean traditional dex-based sneaking.',
+  Sorcerer:
+    'A spontaneous spellcaster whose Bloodline determines spell tradition (arcane, divine, occult, or primal) and adds bloodline-specific spells. Bloodline choice is what shapes the class: picking the right one gives you a damage caster, a controller, a support caster, or a hybrid. Spontaneous casting means a smaller spell repertoire with more daily flexibility on which slot to spend.',
+  Summoner:
+    'A class split between the Summoner (caster chassis) and an Eidolon (a martial creature with its own stats and actions). The pair share HP, focus points, and action economy. Default kit is striker via the Eidolon, with the Summoner providing tactical support spells. Eidolon type (Angel, Beast, Construct, Dragon, Plant, and others) determines visual and mechanical theme.',
+  Swashbuckler:
+    "A charisma-driven mobile martial. The class's signature is the Panache and Finisher loop: gain Panache by performing flashy actions (Tumble Through, Feint, Demoralize, depending on Style), then spend it on a Finisher for a damage spike. Default kit emphasizes movement, single-target damage, and skill-based combat tricks.",
+  Thaumaturge:
+    'A martial whose power comes from a thematic Implement (Amulet, Bell, Chalice, Lantern, Mirror, Regalia, Tome, Wand, Weapon). Implement choice steers the class substantially. The signature ability, Exploit Vulnerability, identifies a creature and inflicts a personalized weakness on it, making Thaumaturges strong against single tough targets.',
+  Witch:
+    'A spellcaster whose Patron determines spell tradition (any of the four) and the theme of your class features. Your Familiar is the link between you and the Patron. Default kit centers on hexes (focus-spell debuffs and effects) and a spell list shaped by Patron type. Builds typically lean Controller; Resentment Patron is a frequently-cited strong option.',
+  Wizard:
+    'The default arcane caster. Largest base spell list and most spell slots in the game. Arcane School subclass tilts the kit toward a theme (battle magic, mentalism, illusion, etc.). Strong on battlefield control, area damage, and utility; weaker on healing and buffs compared to divine or occult casters.',
+};
+
+// Direct + case-insensitive name lookup. Returns null when no note has
+// been written for the class; the detail panel suppresses the section
+// in that case.
+export function getClassNote(name: string): string | null {
+  const direct = CLASS_NOTES[name];
+  if (typeof direct === 'string') return direct;
+  const target = name.toLowerCase();
+  for (const [key, value] of Object.entries(CLASS_NOTES)) {
+    if (key.toLowerCase() === target) return value;
+  }
+  return null;
+}

--- a/apps/player-portal/src/features/characters/internal/useCreatorPickerProps.tsx
+++ b/apps/player-portal/src/features/characters/internal/useCreatorPickerProps.tsx
@@ -48,6 +48,11 @@ type CreatorPickerProps = Pick<
 };
 
 export interface CreatorPickerOptions {
+  /** Default source-book filter on first mount. Pass e.g.
+   *  `['Pathfinder Player Core', 'Pathfinder Player Core 2']` to scope
+   *  the initial list to Player Core options; the player can broaden it
+   *  via the source picker. Defaults to undefined (no source filter). */
+  initialSources?: string[];
   /** Default rarities filter on first mount. Pass `['common']` to hide
    *  uncommon/rare/unique by default (the player can still toggle them
    *  on via the rarity pills). Defaults to undefined (no rarity filter). */
@@ -78,7 +83,7 @@ export function useCreatorPickerProps(
   options?: CreatorPickerOptions,
 ): CreatorPickerProps {
   const [sort, setSort] = useState<SortState>({ mode: 'alpha', dir: 'asc' });
-  const [selectedSources, setSelectedSources] = useState<string[]>([]);
+  const [selectedSources, setSelectedSources] = useState<string[]>(() => options?.initialSources ?? []);
   const [selectedRarities, setSelectedRarities] = useState<string[]>(() => options?.initialRarities ?? []);
   const [evaluations, setEvaluations] = useState<Map<string, Evaluation>>(new Map());
   const [hideUnmet, setHideUnmet] = useState(true);

--- a/apps/player-portal/src/features/characters/internal/useCreatorPickerProps.tsx
+++ b/apps/player-portal/src/features/characters/internal/useCreatorPickerProps.tsx
@@ -11,7 +11,15 @@ import type { CharacterContext, Evaluation } from '@/features/characters/interna
 import { evaluateDocument } from '@/features/characters/internal/prereqs';
 import type { CompendiumPickerProps } from '@/features/characters/internal/CompendiumPicker';
 import { prefetchDocuments } from './compendium-prefetch';
-import { type SortMode, type SortState, FilterSummary, SourcePicker, SortToggle, UnmetToggle } from './CompendiumFilters';
+import {
+  type SortMode,
+  type SortState,
+  FilterSummary,
+  RarityPicker,
+  SourcePicker,
+  SortToggle,
+  UnmetToggle,
+} from './CompendiumFilters';
 
 type CreatorFilters = Pick<
   CompendiumSearchOptions,
@@ -27,6 +35,7 @@ type CreatorPickerProps = Pick<
   | 'maxLevel'
   | 'ancestrySlug'
   | 'sources'
+  | 'rarities'
   | 'onPage'
   | 'onQueryChange'
   | 'filterItem'
@@ -38,6 +47,24 @@ type CreatorPickerProps = Pick<
   onPick: (match: CompendiumMatch) => void;
 };
 
+export interface CreatorPickerOptions {
+  /** Default rarities filter on first mount. Pass `['common']` to hide
+   *  uncommon/rare/unique by default (the player can still toggle them
+   *  on via the rarity pills). Defaults to undefined (no rarity filter). */
+  initialRarities?: string[];
+  /** Filter-row visibility flags. Each filter is on by default; set to
+   *  `false` to suppress it for a target that doesn't need it (e.g.
+   *  ancestry/background pickers hide the unmet-prereq toggle and the
+   *  alpha/level sort because those targets have no prereqs and are
+   *  all the same level). */
+  showSourcePicker?: boolean;
+  /** Explicit override. When omitted, the rarity picker is shown iff
+   *  `initialRarities` was provided. */
+  showRarityPicker?: boolean;
+  showUnmetToggle?: boolean;
+  showSortToggle?: boolean;
+}
+
 // Builds the props the character creator's picks need on top of the
 // shared CompendiumPicker: source-book filter, alpha/level sort, prereq
 // evaluation + hide-unmet toggle, and a doc/eval cache fed by background
@@ -48,9 +75,11 @@ export function useCreatorPickerProps(
   filters: CreatorFilters,
   characterContext: CharacterContext | undefined,
   onPickCallback: (match: CompendiumMatch) => void,
+  options?: CreatorPickerOptions,
 ): CreatorPickerProps {
   const [sort, setSort] = useState<SortState>({ mode: 'alpha', dir: 'asc' });
   const [selectedSources, setSelectedSources] = useState<string[]>([]);
+  const [selectedRarities, setSelectedRarities] = useState<string[]>(() => options?.initialRarities ?? []);
   const [evaluations, setEvaluations] = useState<Map<string, Evaluation>>(new Map());
   const [hideUnmet, setHideUnmet] = useState(true);
   const [currentQuery, setCurrentQuery] = useState('');
@@ -60,30 +89,25 @@ export function useCreatorPickerProps(
   const callerPackIdsKey = (filters.packIds ?? []).join('|');
   const traitsKey = (filters.traits ?? []).join('|');
 
-  const sourcesState: RemoteDataState<CompendiumSource[]> = useRemoteData<CompendiumSource[]>(
-    async () => {
-      const opts: {
-        documentType?: string;
-        packIds?: string[];
-        q?: string;
-        traits?: string[];
-        maxLevel?: number;
-      } = {};
-      if (filters.documentType !== undefined) opts.documentType = filters.documentType;
-      if (filters.packIds !== undefined && filters.packIds.length > 0) opts.packIds = filters.packIds;
-      if (currentQuery.length > 0) opts.q = currentQuery;
-      if (filters.traits !== undefined && filters.traits.length > 0) opts.traits = filters.traits;
-      if (filters.maxLevel !== undefined) opts.maxLevel = filters.maxLevel;
-      const result = await api.listCompendiumSources(opts);
-      return result.sources;
-    },
-    [filters.documentType, callerPackIdsKey, currentQuery, traitsKey, filters.maxLevel],
-  );
+  const sourcesState: RemoteDataState<CompendiumSource[]> = useRemoteData<CompendiumSource[]>(async () => {
+    const opts: {
+      documentType?: string;
+      packIds?: string[];
+      q?: string;
+      traits?: string[];
+      maxLevel?: number;
+    } = {};
+    if (filters.documentType !== undefined) opts.documentType = filters.documentType;
+    if (filters.packIds !== undefined && filters.packIds.length > 0) opts.packIds = filters.packIds;
+    if (currentQuery.length > 0) opts.q = currentQuery;
+    if (filters.traits !== undefined && filters.traits.length > 0) opts.traits = filters.traits;
+    if (filters.maxLevel !== undefined) opts.maxLevel = filters.maxLevel;
+    const result = await api.listCompendiumSources(opts);
+    return result.sources;
+  }, [filters.documentType, callerPackIdsKey, currentQuery, traitsKey, filters.maxLevel]);
 
   const onSortClick = (mode: SortMode): void => {
-    setSort((prev) =>
-      prev.mode === mode ? { mode, dir: prev.dir === 'asc' ? 'desc' : 'asc' } : { mode, dir: 'asc' },
-    );
+    setSort((prev) => (prev.mode === mode ? { mode, dir: prev.dir === 'asc' ? 'desc' : 'asc' } : { mode, dir: 'asc' }));
   };
 
   const onPage = useCallback(
@@ -145,14 +169,34 @@ export function useCreatorPickerProps(
     [sourcesKey],
   );
 
+  const raritiesKey = selectedRarities.join('|');
+  const searchRarities = useMemo(
+    () => (selectedRarities.length > 0 ? selectedRarities : undefined),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [raritiesKey],
+  );
+
+  // Per-control visibility. Each filter defaults to on; callers opt out
+  // for targets where the control doesn't earn its space (ancestry /
+  // background hide the unmet toggle and the sort toggle). The rarity
+  // picker also requires `initialRarities` to be provided so callers
+  // can't accidentally render an unbound rarity control.
+  const showSourcePicker = options?.showSourcePicker ?? true;
+  const showRarityPicker = (options?.showRarityPicker ?? options?.initialRarities !== undefined) === true;
+  const showUnmetToggle = options?.showUnmetToggle ?? true;
+  const showSortToggle = options?.showSortToggle ?? true;
+
   const filterControls = (
     <div className="flex flex-wrap items-center justify-between gap-2">
-      <div className="flex items-center gap-2">
-        <SourcePicker sources={sourcesState} selected={selectedSources} onChange={setSelectedSources} />
-        <UnmetToggle hide={hideUnmet} onChange={setHideUnmet} />
+      <div className="flex flex-wrap items-center gap-2">
+        {showSourcePicker && (
+          <SourcePicker sources={sourcesState} selected={selectedSources} onChange={setSelectedSources} />
+        )}
+        {showRarityPicker && <RarityPicker selected={selectedRarities} onChange={setSelectedRarities} />}
+        {showUnmetToggle && <UnmetToggle hide={hideUnmet} onChange={setHideUnmet} />}
         <FilterSummary filters={filters} />
       </div>
-      <SortToggle sort={sort} onChange={onSortClick} />
+      {showSortToggle && <SortToggle sort={sort} onChange={onSortClick} />}
     </div>
   );
 
@@ -175,5 +219,6 @@ export function useCreatorPickerProps(
   if (filters.maxLevel !== undefined) props.maxLevel = filters.maxLevel;
   if (filters.ancestrySlug !== undefined) props.ancestrySlug = filters.ancestrySlug;
   if (searchSources !== undefined) props.sources = searchSources;
+  if (searchRarities !== undefined) props.rarities = searchRarities;
   return props;
 }

--- a/apps/player-portal/src/features/characters/internal/useCreatorPickerProps.tsx
+++ b/apps/player-portal/src/features/characters/internal/useCreatorPickerProps.tsx
@@ -44,6 +44,7 @@ type CreatorPickerProps = Pick<
   | 'evaluations'
   | 'docCache'
   | 'detailHideHeader'
+  | 'listOpenWidthClass'
 > & {
   onPick: (match: CompendiumMatch) => void;
 };
@@ -74,6 +75,10 @@ export interface CreatorPickerOptions {
    *  already shows the name and the panel body has enough visual
    *  identity on its own (class panels). Defaults to false. */
   hideDetailHeader?: boolean;
+  /** Tailwind width class for the list column when the detail panel is
+   *  open. Tightens the list so the detail panel — usually the more
+   *  information-dense side — gets the room. */
+  listOpenWidthClass?: string;
 }
 
 // Builds the props the character creator's picks need on top of the
@@ -232,5 +237,6 @@ export function useCreatorPickerProps(
   if (searchSources !== undefined) props.sources = searchSources;
   if (searchRarities !== undefined) props.rarities = searchRarities;
   if (options?.hideDetailHeader === true) props.detailHideHeader = true;
+  if (options?.listOpenWidthClass !== undefined) props.listOpenWidthClass = options.listOpenWidthClass;
   return props;
 }

--- a/apps/player-portal/src/features/characters/internal/useCreatorPickerProps.tsx
+++ b/apps/player-portal/src/features/characters/internal/useCreatorPickerProps.tsx
@@ -43,6 +43,7 @@ type CreatorPickerProps = Pick<
   | 'filterControls'
   | 'evaluations'
   | 'docCache'
+  | 'detailHideHeader'
 > & {
   onPick: (match: CompendiumMatch) => void;
 };
@@ -68,6 +69,11 @@ export interface CreatorPickerOptions {
   showRarityPicker?: boolean;
   showUnmetToggle?: boolean;
   showSortToggle?: boolean;
+  /** Hide the CompendiumDetailPanel's top header (image + name + meta +
+   *  traits) for this target. Useful when the picker dialog's title bar
+   *  already shows the name and the panel body has enough visual
+   *  identity on its own (class panels). Defaults to false. */
+  hideDetailHeader?: boolean;
 }
 
 // Builds the props the character creator's picks need on top of the
@@ -225,5 +231,6 @@ export function useCreatorPickerProps(
   if (filters.ancestrySlug !== undefined) props.ancestrySlug = filters.ancestrySlug;
   if (searchSources !== undefined) props.sources = searchSources;
   if (searchRarities !== undefined) props.rarities = searchRarities;
+  if (options?.hideDetailHeader === true) props.detailHideHeader = true;
   return props;
 }

--- a/apps/player-portal/src/features/characters/sheet/dialog/PromptDialog.test.tsx
+++ b/apps/player-portal/src/features/characters/sheet/dialog/PromptDialog.test.tsx
@@ -22,13 +22,15 @@ beforeEach(() => {
 
 // ─── Test builders ────────────────────────────────────────────────────────
 
-function makePromptRequest(overrides: Partial<{
-  bridgeId: string;
-  title: string;
-  prompt: string;
-  choices: Array<{ value: string; label: string; img: string | null; group: string | null }>;
-  allowNoSelection: boolean;
-}>= {}): PendingPrompt {
+function makePromptRequest(
+  overrides: Partial<{
+    bridgeId: string;
+    title: string;
+    prompt: string;
+    choices: Array<{ value: string; label: string; img: string | null; group: string | null }>;
+    allowNoSelection: boolean;
+  }> = {},
+): PendingPrompt {
   return {
     bridgeId: overrides.bridgeId ?? 'test-bridge-id',
     type: 'prompt-request',
@@ -72,16 +74,17 @@ function makeDialogRequest(spec: Partial<DialogSpec> = {}): PendingPrompt {
 describe('PromptDialog — prompt-request (ChoiceSet)', () => {
   it('renders dialog title and prompt text', () => {
     const { container } = render(
-      <PromptDialog prompt={makePromptRequest({ title: 'Damage Type', prompt: 'Pick a type:' })} onResolved={() => undefined} />,
+      <PromptDialog
+        prompt={makePromptRequest({ title: 'Damage Type', prompt: 'Pick a type:' })}
+        onResolved={() => undefined}
+      />,
     );
     expect(container.querySelector('[data-testid="dialog-title"]')?.textContent).toBe('Damage Type');
     expect(container.textContent).toContain('Pick a type:');
   });
 
   it('renders one button per choice', () => {
-    const { container } = render(
-      <PromptDialog prompt={makePromptRequest()} onResolved={() => undefined} />,
-    );
+    const { container } = render(<PromptDialog prompt={makePromptRequest()} onResolved={() => undefined} />);
     const buttons = container.querySelectorAll('[data-testid="choice-button"]');
     expect(buttons).toHaveLength(2);
     expect(buttons[0]?.getAttribute('data-choice-label')).toBe('Fire');
@@ -90,9 +93,7 @@ describe('PromptDialog — prompt-request (ChoiceSet)', () => {
 
   it('calls resolvePrompt with the choice value on click', async () => {
     const onResolved = vi.fn();
-    const { container } = render(
-      <PromptDialog prompt={makePromptRequest()} onResolved={onResolved} />,
-    );
+    const { container } = render(<PromptDialog prompt={makePromptRequest()} onResolved={onResolved} />);
     const fireBtn = Array.from(container.querySelectorAll('[data-testid="choice-button"]')).find(
       (b) => b.getAttribute('data-choice-label') === 'Fire',
     );
@@ -135,6 +136,53 @@ describe('PromptDialog — prompt-request (ChoiceSet)', () => {
     const img = container.querySelector('[data-testid="choice-button"] img');
     expect(img?.getAttribute('src')).toBe('/icons/fire.png');
   });
+
+  // Scalar-valued choices ("1 action / 2 actions / 3 actions" pick, etc.)
+  // stay on the simple button-grid path — there's no compendium document
+  // behind those values for the detail panel to load.
+  it('uses the button-grid path when choice values are scalars', () => {
+    const prompt = makePromptRequest({
+      choices: [
+        { value: '1', label: 'One action', img: null, group: null },
+        { value: '2', label: 'Two actions', img: null, group: null },
+      ],
+    });
+    const { container } = render(<PromptDialog prompt={prompt} onResolved={() => undefined} />);
+    expect(container.querySelector('[data-testid="prompt-detail-list"]')).toBeNull();
+    expect(container.querySelectorAll('[data-testid="choice-button"]').length).toBe(2);
+  });
+
+  // When every choice is a Compendium UUID (heritages, subclass picks,
+  // etc.) the dialog routes to the detail-panel layout instead of the
+  // button grid. The detail-panel path uses PickerDialog which portals
+  // to document.body, so query off there rather than the render
+  // container.
+  it('uses the detail-panel path when every choice value is a Compendium UUID', () => {
+    const prompt = makePromptRequest({
+      title: 'Heritage',
+      choices: [
+        { value: 'Compendium.pf2e.heritages.Item.ancient-elf', label: 'Ancient Elf', img: null, group: null },
+        { value: 'Compendium.pf2e.heritages.Item.arctic-elf', label: 'Arctic Elf', img: null, group: null },
+      ],
+    });
+    render(<PromptDialog prompt={prompt} onResolved={() => undefined} />);
+    expect(document.body.querySelector('[data-testid="prompt-detail-list"]')).not.toBeNull();
+    expect(document.body.querySelectorAll('[data-testid="choice-button"]').length).toBe(2);
+  });
+
+  // Mixed choice shapes (one UUID + one scalar) fall back to the simple
+  // grid — partial routing would lose the scalar option entirely.
+  it('falls back to the button-grid when choice shapes are mixed', () => {
+    const prompt = makePromptRequest({
+      choices: [
+        { value: 'Compendium.pf2e.heritages.Item.ancient-elf', label: 'Ancient Elf', img: null, group: null },
+        { value: 'custom', label: 'Custom', img: null, group: null },
+      ],
+    });
+    const { container } = render(<PromptDialog prompt={prompt} onResolved={() => undefined} />);
+    expect(container.querySelector('[data-testid="prompt-detail-list"]')).toBeNull();
+    expect(container.querySelectorAll('[data-testid="choice-button"]').length).toBe(2);
+  });
 });
 
 // ─── Generic dialog (dialog-request) tests ────────────────────────────────
@@ -142,7 +190,10 @@ describe('PromptDialog — prompt-request (ChoiceSet)', () => {
 describe('PromptDialog — dialog-request (Dialog/V2)', () => {
   it('renders dialog title and text', () => {
     const { container } = render(
-      <PromptDialog prompt={makeDialogRequest({ title: 'Roll Damage', text: 'Roll now?' })} onResolved={() => undefined} />,
+      <PromptDialog
+        prompt={makeDialogRequest({ title: 'Roll Damage', text: 'Roll now?' })}
+        onResolved={() => undefined}
+      />,
     );
     expect(container.querySelector('[data-testid="dialog-title"]')?.textContent).toBe('Roll Damage');
     expect(container.textContent).toContain('Roll now?');
@@ -290,10 +341,7 @@ describe('PromptDialog — dismiss', () => {
   it('calls resolvePrompt with null when Skip is clicked', async () => {
     const onResolved = vi.fn();
     const { container } = render(
-      <PromptDialog
-        prompt={makePromptRequest({ allowNoSelection: true })}
-        onResolved={onResolved}
-      />,
+      <PromptDialog prompt={makePromptRequest({ allowNoSelection: true })} onResolved={onResolved} />,
     );
     const skipBtn = container.querySelector('[data-testid="dismiss-button"]');
     fireEvent.click(skipBtn!);

--- a/apps/player-portal/src/features/characters/sheet/dialog/PromptDialog.tsx
+++ b/apps/player-portal/src/features/characters/sheet/dialog/PromptDialog.tsx
@@ -10,11 +10,14 @@
 // pf2e or Foundry classes, only the spec shapes defined in
 // @foundry-toolkit/shared/rpc.
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import type { DialogSpec, DialogField, DialogResolution } from '@foundry-toolkit/shared/rpc';
 import type { PendingPrompt } from '@/features/characters/sheet/hooks/usePromptStream';
+import type { CompendiumMatch } from '@/features/characters/types';
 import { api } from '@/features/characters/api';
 import { BRIDGE_EVENT_DIALOG_REQUEST, BRIDGE_EVENT_PROMPT_REQUEST } from '@foundry-toolkit/shared/rpc';
+import { CompendiumDetailPanel } from '@/features/characters/internal/CompendiumDetailPanel';
+import { PickerDialog } from '@/shared/ui/PickerDialog';
 
 // ─── ChoiceSet prompt payload ─────────────────────────────────────────────
 // Mirrors PromptRequestPayload from foundry-api-bridge/src/creator/prompt-intercept.ts.
@@ -56,13 +59,7 @@ export function PromptDialog({ prompt, onResolved }: PromptDialogProps): React.R
   }
 
   if (prompt.type === BRIDGE_EVENT_DIALOG_REQUEST) {
-    return (
-      <GenericDialog
-        bridgeId={prompt.bridgeId}
-        spec={prompt.payload as DialogSpec}
-        onResolved={onResolved}
-      />
-    );
+    return <GenericDialog bridgeId={prompt.bridgeId} spec={prompt.payload as DialogSpec} onResolved={onResolved} />;
   }
 
   // Future / unknown event kind — offer a plain dismiss.
@@ -85,7 +82,22 @@ interface ChoiceSetProps {
   onResolved: () => void;
 }
 
+// Dispatcher: when every choice carries a Compendium UUID value, route
+// through the rich detail panel (description, traits, rarity,
+// mechanical block, etc. — same view as the regular ancestry/class
+// picker). Otherwise fall back to the simple button grid; some pf2e
+// ChoiceSets use scalar string/number values (e.g. "1 / 2 / 3 actions"
+// picks) that have no compendium document to render.
 function ChoiceSetDialog({ bridgeId, payload, onResolved }: ChoiceSetProps): React.ReactElement {
+  const allUuid = payload.choices.length > 0 && payload.choices.every((c) => isCompendiumUuid(c.value));
+  return allUuid ? (
+    <PromptDetailDialog bridgeId={bridgeId} payload={payload} onResolved={onResolved} />
+  ) : (
+    <ChoiceSetButtonGrid bridgeId={bridgeId} payload={payload} onResolved={onResolved} />
+  );
+}
+
+function ChoiceSetButtonGrid({ bridgeId, payload, onResolved }: ChoiceSetProps): React.ReactElement {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -114,13 +126,9 @@ function ChoiceSetDialog({ bridgeId, payload, onResolved }: ChoiceSetProps): Rea
           <span className="text-sm font-medium text-neutral-800">{payload.item.name}</span>
         </div>
       )}
-      {payload.prompt.length > 0 && (
-        <p className="mb-3 text-sm text-neutral-700">{payload.prompt}</p>
-      )}
+      {payload.prompt.length > 0 && <p className="mb-3 text-sm text-neutral-700">{payload.prompt}</p>}
 
-      {error != null && (
-        <p className="mb-2 text-xs text-red-600">{error}</p>
-      )}
+      {error != null && <p className="mb-2 text-xs text-red-600">{error}</p>}
 
       <div className="flex flex-col gap-2">
         {grouped.map(({ group, choices }) => (
@@ -134,14 +142,14 @@ function ChoiceSetDialog({ bridgeId, payload, onResolved }: ChoiceSetProps): Rea
                   key={i}
                   type="button"
                   disabled={busy}
-                  onClick={(): void => { void pick(choice.value); }}
+                  onClick={(): void => {
+                    void pick(choice.value);
+                  }}
                   className="flex items-center gap-1.5 rounded border border-neutral-300 bg-white px-3 py-1.5 text-sm text-neutral-800 hover:bg-neutral-50 disabled:opacity-50"
                   data-testid="choice-button"
                   data-choice-label={choice.label}
                 >
-                  {choice.img != null && (
-                    <img src={choice.img} alt="" className="h-5 w-5 rounded object-cover" />
-                  )}
+                  {choice.img != null && <img src={choice.img} alt="" className="h-5 w-5 rounded object-cover" />}
                   {choice.label}
                 </button>
               ))}
@@ -150,11 +158,214 @@ function ChoiceSetDialog({ bridgeId, payload, onResolved }: ChoiceSetProps): Rea
         ))}
       </div>
 
-      {payload.allowNoSelection && (
-        <DismissButton bridgeId={bridgeId} onResolved={onResolved} className="mt-3" />
-      )}
+      {payload.allowNoSelection && <DismissButton bridgeId={bridgeId} onResolved={onResolved} className="mt-3" />}
     </DialogShell>
   );
+}
+
+// ─── ChoiceSet detail dialog ──────────────────────────────────────────────
+// Used for pf2e ChoiceSets whose choices are Compendium UUIDs —
+// heritage picks, subclass picks (Druid Order, Cleric Doctrine, Sorcerer
+// Bloodline, etc.). Renders a two-column picker dialog: the choice list
+// on the left, the full CompendiumDetailPanel on the right.
+
+function PromptDetailDialog({ bridgeId, payload, onResolved }: ChoiceSetProps): React.ReactElement {
+  const [target, setTarget] = useState<CompendiumMatch | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Convert each prompt choice to a CompendiumMatch shape the detail
+  // panel can consume. UUID parse + pack-name → doc-type inference give
+  // the panel the type it needs to route to the right mechanics block
+  // (ancestry / heritage / class / etc.) before the doc fetch lands.
+  const groupedChoices = useMemo(() => {
+    const enriched: { match: CompendiumMatch; group: string | null }[] = [];
+    for (const c of payload.choices) {
+      if (typeof c.value !== 'string') continue;
+      const parsed = parseCompendiumUuid(c.value);
+      if (parsed === null) continue;
+      enriched.push({
+        match: {
+          uuid: c.value,
+          name: c.label,
+          img: c.img ?? '',
+          packId: parsed.packId,
+          packLabel: '',
+          documentId: parsed.documentId,
+          type: inferDocType(parsed.packId),
+        },
+        group: c.group,
+      });
+    }
+    // Preserve insertion order; just bucket by group label.
+    const groups: { group: string | null; items: { match: CompendiumMatch }[] }[] = [];
+    const byKey = new Map<string | null, (typeof groups)[number]>();
+    for (const item of enriched) {
+      const key = item.group ?? null;
+      let bucket = byKey.get(key);
+      if (!bucket) {
+        bucket = { group: key, items: [] };
+        groups.push(bucket);
+        byKey.set(key, bucket);
+      }
+      bucket.items.push({ match: item.match });
+    }
+    return groups;
+  }, [payload.choices]);
+
+  const commit = async (uuid: string): Promise<void> => {
+    setBusy(true);
+    setError(null);
+    try {
+      await api.resolvePrompt(bridgeId, uuid);
+      onResolved();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to send choice');
+      setBusy(false);
+    }
+  };
+
+  const cancel = async (): Promise<void> => {
+    setBusy(true);
+    try {
+      await api.resolvePrompt(bridgeId, null);
+      onResolved();
+    } catch {
+      setBusy(false);
+    }
+  };
+
+  const detailOpen = target !== null;
+
+  return (
+    <PickerDialog
+      title={payload.title}
+      onClose={(): void => {
+        if (!busy) void cancel();
+      }}
+      maxWidthClass={detailOpen ? 'max-w-6xl' : 'max-w-md'}
+      animateMaxWidth
+      testId="prompt-detail-dialog"
+    >
+      {payload.prompt.length > 0 && (
+        <p className="border-b border-pf-border px-4 py-2 text-xs text-pf-alt">{payload.prompt}</p>
+      )}
+      {error !== null && <p className="border-b border-red-200 bg-red-50 px-4 py-2 text-xs text-red-700">{error}</p>}
+      <div className="flex min-h-0 flex-1">
+        <ul
+          className={[
+            'divide-y divide-pf-border overflow-y-auto',
+            detailOpen ? 'w-72 shrink-0 border-r border-pf-border' : 'flex-1',
+          ].join(' ')}
+          data-testid="prompt-detail-list"
+        >
+          {groupedChoices.flatMap(({ group, items }) => {
+            const rows: React.ReactNode[] = [];
+            if (group !== null) {
+              rows.push(
+                <li
+                  key={`group-${group}`}
+                  className="border-b border-pf-border bg-pf-bg-dark px-4 py-1 text-[10px] font-semibold uppercase tracking-widest text-pf-alt-dark"
+                >
+                  {group}
+                </li>,
+              );
+            }
+            for (const { match } of items) {
+              const active = target?.uuid === match.uuid;
+              rows.push(
+                <li key={match.uuid}>
+                  <button
+                    type="button"
+                    onClick={(): void => {
+                      setTarget(match);
+                    }}
+                    disabled={busy}
+                    aria-pressed={active}
+                    className={[
+                      'flex w-full items-center gap-3 px-4 py-2 text-left transition-colors',
+                      active ? 'bg-pf-tertiary/50' : 'hover:bg-pf-tertiary/20',
+                      busy ? 'opacity-60' : '',
+                    ].join(' ')}
+                    data-testid="choice-button"
+                    data-choice-label={match.name}
+                  >
+                    {match.img !== '' && (
+                      <img
+                        src={match.img}
+                        alt=""
+                        className="h-8 w-8 shrink-0 rounded border border-pf-border bg-pf-bg-dark"
+                      />
+                    )}
+                    <span className="truncate text-sm font-medium text-pf-text">{match.name}</span>
+                  </button>
+                </li>,
+              );
+            }
+            return rows;
+          })}
+        </ul>
+        {detailOpen && target !== null && (
+          <CompendiumDetailPanel
+            target={target}
+            onPick={(): void => {
+              void commit(target.uuid);
+            }}
+            onClose={(): void => {
+              setTarget(null);
+            }}
+          />
+        )}
+      </div>
+      {payload.allowNoSelection && (
+        <div className="flex items-center justify-end border-t border-pf-border px-4 py-2">
+          <button
+            type="button"
+            onClick={(): void => {
+              if (!busy) void cancel();
+            }}
+            disabled={busy}
+            data-testid="dismiss-button"
+            className="text-xs text-pf-alt-dark underline hover:text-pf-primary disabled:opacity-50"
+          >
+            Skip
+          </button>
+        </div>
+      )}
+    </PickerDialog>
+  );
+}
+
+// Compendium UUID guard. The bridge sends choice values as `unknown`;
+// only strings of the shape `Compendium.{module}.{pack}.{Type}.{id}` go
+// through the rich detail panel.
+function isCompendiumUuid(value: unknown): value is string {
+  return typeof value === 'string' && value.startsWith('Compendium.') && value.split('.').length === 5;
+}
+
+function parseCompendiumUuid(uuid: string): { packId: string; type: string; documentId: string } | null {
+  const parts = uuid.split('.');
+  if (parts.length !== 5 || parts[0] !== 'Compendium') return null;
+  const [, mod, pack, type, id] = parts;
+  if (!mod || !pack || !type || !id) return null;
+  return { packId: `${mod}.${pack}`, type, documentId: id };
+}
+
+// PF2e pack → document subtype mapping. The CompendiumDetailPanel
+// routes its mechanics blocks off `target.type`; without inference,
+// every UUID-fed choice would render as a plain "Item" with no special
+// treatment. The actual `doc.type` is correct after the panel's fetch
+// lands, but the inference gives the panel a sensible default during
+// the loading state too.
+function inferDocType(packId: string): string {
+  if (packId === 'pf2e.heritages') return 'heritage';
+  if (packId === 'pf2e.ancestries') return 'ancestry';
+  if (packId === 'pf2e.classes') return 'class';
+  if (packId === 'pf2e.backgrounds') return 'background';
+  if (packId === 'pf2e.deities') return 'deity';
+  if (packId === 'pf2e.classfeatures') return 'feature';
+  if (packId.includes('feats')) return 'feat';
+  return 'Item';
 }
 
 // ─── Generic dialog ───────────────────────────────────────────────────────
@@ -197,14 +408,17 @@ function GenericDialog({ bridgeId, spec, onResolved }: GenericDialogProps): Reac
       {spec.fields.length > 0 && (
         <div className="mb-4 flex flex-col gap-3">
           {spec.fields.map((field) => (
-            <FieldRow key={field.name} field={field} value={formData[field.name] ?? field.value} onChange={updateField} />
+            <FieldRow
+              key={field.name}
+              field={field}
+              value={formData[field.name] ?? field.value}
+              onChange={updateField}
+            />
           ))}
         </div>
       )}
 
-      {error != null && (
-        <p className="mb-2 text-xs text-red-600">{error}</p>
-      )}
+      {error != null && <p className="mb-2 text-xs text-red-600">{error}</p>}
 
       <div className="flex justify-end gap-2">
         {spec.buttons.map((btn) => (
@@ -212,7 +426,9 @@ function GenericDialog({ bridgeId, spec, onResolved }: GenericDialogProps): Reac
             key={btn.id}
             type="button"
             disabled={busy}
-            onClick={(): void => { void handleButton(btn.id); }}
+            onClick={(): void => {
+              void handleButton(btn.id);
+            }}
             className={[
               'rounded px-4 py-1.5 text-sm font-medium disabled:opacity-50',
               btn.isDefault
@@ -246,7 +462,9 @@ function FieldRow({ field, value, onChange }: FieldRowProps): React.ReactElement
         <input
           type="checkbox"
           checked={Boolean(value)}
-          onChange={(e): void => { onChange(field.name, e.target.checked); }}
+          onChange={(e): void => {
+            onChange(field.name, e.target.checked);
+          }}
           className="h-4 w-4 rounded border-neutral-300"
         />
         {field.label}
@@ -260,7 +478,9 @@ function FieldRow({ field, value, onChange }: FieldRowProps): React.ReactElement
         {field.label}
         <select
           value={String(value)}
-          onChange={(e): void => { onChange(field.name, e.target.value); }}
+          onChange={(e): void => {
+            onChange(field.name, e.target.value);
+          }}
           className="rounded border border-neutral-300 bg-white px-2 py-1 text-sm"
         >
           {field.options.map((opt) => (
@@ -280,7 +500,9 @@ function FieldRow({ field, value, onChange }: FieldRowProps): React.ReactElement
         <input
           type="number"
           value={Number(value)}
-          onChange={(e): void => { onChange(field.name, Number(e.target.value)); }}
+          onChange={(e): void => {
+            onChange(field.name, Number(e.target.value));
+          }}
           className="rounded border border-neutral-300 bg-white px-2 py-1 text-sm"
         />
       </label>
@@ -294,7 +516,9 @@ function FieldRow({ field, value, onChange }: FieldRowProps): React.ReactElement
       <input
         type="text"
         value={String(value)}
-        onChange={(e): void => { onChange(field.name, e.target.value); }}
+        onChange={(e): void => {
+          onChange(field.name, e.target.value);
+        }}
         className="rounded border border-neutral-300 bg-white px-2 py-1 text-sm"
       />
     </label>
@@ -351,11 +575,12 @@ function DismissButton({ bridgeId, onResolved, className }: DismissButtonProps):
     <button
       type="button"
       disabled={busy}
-      onClick={(): void => { void dismiss(); }}
-      className={[
-        'text-xs text-neutral-500 underline hover:text-neutral-700 disabled:opacity-50',
-        className,
-      ].filter(Boolean).join(' ')}
+      onClick={(): void => {
+        void dismiss();
+      }}
+      className={['text-xs text-neutral-500 underline hover:text-neutral-700 disabled:opacity-50', className]
+        .filter(Boolean)
+        .join(' ')}
       data-testid="dismiss-button"
     >
       Skip

--- a/packages/shared/src/foundry-enrichers.test.ts
+++ b/packages/shared/src/foundry-enrichers.test.ts
@@ -18,6 +18,34 @@ describe('enrichDescription', () => {
     expect(out).toContain('>Item<');
   });
 
+  it('strips non-hoverable @UUID types (JournalEntryPage, etc.) entirely', () => {
+    // PF2e class descriptions ship a `<p><em>@UUID[...JournalEntryPage...]
+    // {ClassName}</em></p>` marker after the flavor blurb that just
+    // duplicates the class name. We can't load journal pages in the
+    // hover popover, and the label adds nothing, so the reference
+    // disappears entirely along with the paragraph it lived in.
+    const out = enrichDescription(
+      '<p><em>You are a master of artistry.</em></p><p><em>@UUID[Compendium.pf2e.journals.JournalEntry.kzxu2dI7tFxv6Ix6.JournalEntryPage.Tz0NWVqhZyt8EyUV]{Bard}</em></p>',
+    );
+    expect(out).not.toContain('pf-uuid-link');
+    expect(out).not.toContain('data-uuid');
+    expect(out).not.toContain('Bard');
+    // The flavor paragraph above the marker is preserved.
+    expect(out).toContain('You are a master of artistry.');
+  });
+
+  it('strips empty <p><em></em></p> shells left by other transforms', () => {
+    const out = enrichDescription('<p>Real content.</p><p><em></em></p><p>More content.</p>');
+    expect(out).toBe('<p>Real content.</p><p>More content.</p>');
+  });
+
+  it('still renders Actor @UUIDs as hoverable links', () => {
+    const out = enrichDescription('@UUID[Compendium.pf2e.bestiary.Actor.abc123]{Dragon}');
+    expect(out).toContain('class="pf-uuid-link"');
+    expect(out).toContain('data-uuid="Compendium.pf2e.bestiary.Actor.abc123"');
+    expect(out).toContain('Dragon');
+  });
+
   // ─── @Damage ─────────────────────────────────────────────────────────────
 
   it('formats @Damage tokens to plain readable text', () => {

--- a/packages/shared/src/foundry-enrichers.test.ts
+++ b/packages/shared/src/foundry-enrichers.test.ts
@@ -86,4 +86,52 @@ describe('enrichDescription', () => {
     const out = enrichDescription('<p><em>Flavour intro paragraph.</em></p>');
     expect(out).toBe('<p>Flavour intro paragraph.</p>');
   });
+
+  // ─── @actor.* formula humanizer ──────────────────────────────────────────
+  // pf2e level-scaling formulas can't be evaluated client-side without an
+  // actor context (compendium previews, picker hovers); rewrite them to
+  // compact symbolic forms instead of leaking the raw `@actor.level` syntax.
+
+  it('humanizes (max(1, (ceil(@actor.level/N))))dM formulas', () => {
+    const out = enrichDescription('they recover (max(1, (ceil(@actor.level/2))))d8 healing Hit Points');
+    expect(out).toContain('⌈L/2⌉d8');
+    expect(out).not.toContain('@actor.level');
+  });
+
+  it('humanizes the no-inner-paren variant max(1, ceil(...))', () => {
+    const out = enrichDescription('damage equal to (max(1, ceil(@actor.level/4)))d6');
+    expect(out).toContain('⌈L/4⌉d6');
+  });
+
+  it('humanizes (ceil(@actor.level/N))dM without the max wrapper', () => {
+    const out = enrichDescription('deals (ceil(@actor.level/3))d10 damage');
+    expect(out).toContain('⌈L/3⌉d10');
+  });
+
+  it('humanizes (floor(@actor.level/N))dM with floor brackets', () => {
+    const out = enrichDescription('regains (floor(@actor.level/2))d6 HP');
+    expect(out).toContain('⌊L/2⌋d6');
+  });
+
+  it('humanizes (@actor.level)dM as LdM', () => {
+    const out = enrichDescription('takes (@actor.level)d4 damage');
+    expect(out).toContain('Ld4');
+  });
+
+  it('replaces standalone @actor.level with L', () => {
+    const out = enrichDescription('your hit points equal @actor.level × 5');
+    expect(out).toContain('L × 5');
+    expect(out).not.toContain('@actor.level');
+  });
+
+  it('humanizes formulas inside an inline-roll label', () => {
+    // pf2e wraps these formulas in [[/r ...]]{label} where the label is
+    // often the raw expression. Our inline-roll handler outputs the label
+    // inside a pf-damage span; the final humanizer pass cleans it up.
+    const out = enrichDescription(
+      '[[/r {max(1,ceil(@actor.level/2))}d8 #healing]]{(max(1, (ceil(@actor.level/2))))d8}',
+    );
+    expect(out).toContain('⌈L/2⌉d8');
+    expect(out).not.toContain('@actor.level');
+  });
 });

--- a/packages/shared/src/foundry-enrichers.ts
+++ b/packages/shared/src/foundry-enrichers.ts
@@ -74,6 +74,54 @@ export function enrichDescription(html: string, opts?: EnrichOptions): string {
     const displayLabel = label !== undefined && label.trim().length > 0 ? label : extractFallbackLabel(uuid);
     return `<a data-uuid="${escapeAttr(uuid)}" class="pf-uuid-link" title="${escapeAttr(uuid)}">${escapeText(displayLabel)}</a>`;
   });
+  // Final pass: collapse pf2e level-scaling formulas like
+  // `(max(1, (ceil(@actor.level/2))))d8` into compact readable forms.
+  // Runs over the entire output so it catches both prose-literal
+  // formulas and ones that landed inside a pf-damage label.
+  out = humanizeActorFormulas(out);
+  return out;
+}
+
+// ─── @actor.* formula humanizer ────────────────────────────────────────
+//
+// pf2e descriptions reference `@actor.level` in roll formulas the client
+// can't resolve without a target actor. The compendium-preview path has
+// no actor context, so the raw formulas leak through as ugly text like
+// `(max(1, (ceil(@actor.level/2))))d8`. This pass rewrites the most
+// common shapes into compact symbolic forms ("⌈L/2⌉d8") that read at a
+// glance for a Pathfinder player.
+//
+// Order matters — the most-specific patterns run first so the standalone
+// `@actor.level` fallback only catches what the structural patterns miss.
+
+function humanizeActorFormulas(input: string): string {
+  let out = input;
+  // (max(1, [(]ceil(@actor.level/N)[)]))dM   — outer parens + optional
+  // inner-paren wrapper around the ceil() call.
+  out = out.replace(
+    /\(max\(\s*1\s*,\s*\(?ceil\(@actor\.level\s*\/\s*(\d+)\)\)?\s*\)\)d(\d+)/gi,
+    (_m, n: string, die: string) => `⌈L/${n}⌉d${die}`,
+  );
+  // (max(1, [(]floor(@actor.level/N)[)]))dM
+  out = out.replace(
+    /\(max\(\s*1\s*,\s*\(?floor\(@actor\.level\s*\/\s*(\d+)\)\)?\s*\)\)d(\d+)/gi,
+    (_m, n: string, die: string) => `⌊L/${n}⌋d${die}`,
+  );
+  // (ceil(@actor.level/N))dM
+  out = out.replace(
+    /\(ceil\(@actor\.level\s*\/\s*(\d+)\)\)d(\d+)/gi,
+    (_m, n: string, die: string) => `⌈L/${n}⌉d${die}`,
+  );
+  // (floor(@actor.level/N))dM
+  out = out.replace(
+    /\(floor\(@actor\.level\s*\/\s*(\d+)\)\)d(\d+)/gi,
+    (_m, n: string, die: string) => `⌊L/${n}⌋d${die}`,
+  );
+  // (@actor.level)dM
+  out = out.replace(/\(@actor\.level\)d(\d+)/gi, (_m, die: string) => `Ld${die}`);
+  // Standalone @actor.level — last so the structural patterns above
+  // can capture their level reference inside the formula first.
+  out = out.replace(/@actor\.level/g, 'L');
   return out;
 }
 

--- a/packages/shared/src/foundry-enrichers.ts
+++ b/packages/shared/src/foundry-enrichers.ts
@@ -72,6 +72,19 @@ export function enrichDescription(html: string, opts?: EnrichOptions): string {
   // be re-matched by the earlier passes.
   out = out.replace(UUID_PATTERN, (_match, uuid: string, label?: string) => {
     const displayLabel = label !== undefined && label.trim().length > 0 ? label : extractFallbackLabel(uuid);
+    // Only Item / Actor UUIDs resolve via our compendium-document
+    // fetcher; the hover popover for anything else (JournalEntry pages,
+    // RollTables, Macros) loads forever and shows nothing. PF2e class
+    // descriptions in particular embed `@UUID[...JournalEntryPage...]
+    // {ClassName}` markers after their flavor blurb, which we don't
+    // want to render at all — there's nothing useful behind the link
+    // and the visible label is just the class name duplicated.
+    // Stripping the reference entirely (rather than leaving plain text)
+    // lets the empty-paragraph pass below clean up the leftover
+    // `<p><em></em></p>` wrapper that hosted only this reference.
+    if (!isHoverableUuid(uuid)) {
+      return '';
+    }
     return `<a data-uuid="${escapeAttr(uuid)}" class="pf-uuid-link" title="${escapeAttr(uuid)}">${escapeText(displayLabel)}</a>`;
   });
   // Final pass: collapse pf2e level-scaling formulas like
@@ -79,6 +92,11 @@ export function enrichDescription(html: string, opts?: EnrichOptions): string {
   // Runs over the entire output so it catches both prose-literal
   // formulas and ones that landed inside a pf-damage label.
   out = humanizeActorFormulas(out);
+  // Empty-paragraph cleanup. The non-hoverable-UUID stripper above can
+  // leave behind `<p></p>` or `<p><em></em></p>` shells when the
+  // paragraph existed solely to host that reference. Drop those so the
+  // class-name marker line doesn't appear as a blank gap.
+  out = stripEmptyParagraphs(out);
   return out;
 }
 
@@ -367,6 +385,27 @@ function extractFallbackLabel(uuid: string): string {
   return parts.length >= 2 ? (parts[parts.length - 2] ?? 'link') : 'link';
 }
 
+// Document types the consumer's hover popover can resolve. Compendium
+// UUIDs encode the type as a segment in the path; anything not in this
+// set has no working fetch path and would render a forever-loading
+// hover. Used to skip the anchor wrapping for journal pages, macros,
+// roll tables, etc. — those still display their label as plain text,
+// just without the broken interactive treatment.
+const HOVERABLE_DOC_TYPES = new Set(['Item', 'Actor']);
+
+function isHoverableUuid(uuid: string): boolean {
+  // Compendium UUIDs are `Compendium.{pack}.{Type}.{id}` for top-level
+  // documents, or extended with `.JournalEntryPage.{id}` for journal
+  // pages. World UUIDs are `{Type}.{id}`. Either way, the type segment
+  // is the second-to-last "containing" segment. The simplest robust
+  // check: does *any* segment match a hoverable type?
+  const parts = uuid.split('.');
+  for (const p of parts) {
+    if (HOVERABLE_DOC_TYPES.has(p)) return true;
+  }
+  return false;
+}
+
 // ─── Italic-wrapper normalisation ──────────────────────────────────────
 
 // Match `<p>` optional whitespace, `<em>` opening, content up to the
@@ -379,6 +418,21 @@ const BLOCK_EM_PATTERN = /<p>\s*<em>([\s\S]*?)<\/em>\s*<\/p>/gi;
 
 function stripBlockItalicWrappers(html: string): string {
   return html.replace(BLOCK_EM_PATTERN, (_match, inner: string) => `<p>${inner}</p>`);
+}
+
+// Drop paragraphs whose only content is whitespace and/or an empty
+// `<em>` wrapper. We end up with these after the non-hoverable-UUID
+// stripper above eats the reference that was the paragraph's whole
+// content — `<p><em>@UUID[...]{Bard}</em></p>` becomes `<p><em></em></p>`
+// once the UUID handler runs and we don't want a blank gap left over.
+//
+// Conservative regex: only matches paragraphs with at most one empty
+// `<em>` (possibly with whitespace) inside. Paragraphs holding real
+// content remain untouched.
+const EMPTY_PARAGRAPH_PATTERN = /<p>\s*(?:<em>\s*<\/em>)?\s*<\/p>/gi;
+
+function stripEmptyParagraphs(html: string): string {
+  return html.replace(EMPTY_PARAGRAPH_PATTERN, '');
 }
 
 // ─── HTML escaping ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Long-running branch that started as a heritage-grouping regression fix and grew into a broader pass over the character creator. 35 commits total. **Apps touched: `apps/player-portal` (`npm run dev:player-portal`), `packages/shared` (consumed by player-portal).**

### Compendium detail panel — mechanical previews

Each picker's detail panel now renders a structured mechanics block below the flavor text:

- **Ancestry** — HP / Size / Speed / Ability Boosts / Flaws / Languages (granted + bonus) / Senses / Ancestry features chip list. Rarity surfaces as a coloured pill in the header (amber Uncommon / blue Rare / purple Unique / grey Common). Verified the upstream pf2e data shape on GitHub: `system.boosts` is a fixed 3-entry record with `{"value": []}` for unused slots — the reader now drops those so Human renders as "Free, Free" instead of "Free, Free, Free", and most other ancestries lose a trailing phantom slot too.
- **Background** — Boosts / Trained skills (regular + lore) / Background abilities chip list. Same `formatBoostSlot` path as ancestry, so "Free (STR/DEX/CON/INT/WIS/CHA)" collapses to plain "Free".
- **Class** — Full "Initial Proficiencies" block (Perception / Saves / Skills / Attacks / Defenses / Class DC / Spells), entries grouped by tier (`"Trained in simple weapons · martial weapons · unarmed attacks"`). Class features chip list shows only the L1-grants. Plus a "Notes from Alex" paragraph keyed by class name — 22 classes covered out of the gate.
- **Heritage** — Side-by-side art layout (description on the left, AoN art on the right) using the same `pf2e-art.json` data ancestries already use; versatile heritages have their own entries in that table.
- Mechanical content sits **below** the lore text. Mechanics sections also work in the no-art stacked layout.
- Feature chips throughout (ancestry / background / class) carry `data-uuid` and use the existing `useUuidHover` hover popover.

### Heritage picker

- Grouped list: **Primary Heritages** and **Versatile Heritages** sections (drove the original bug fix — `isVersatile` was carried on `CompendiumMatch` from the start but never surfaced).
- Heritage detail panel renders AoN art on the right (via `getHeritageArt`).

### Attributes step

- **18-cap enforcement.** No ability score above 18 at level 1 — disabled buttons + "Already at 18" tooltip. Ancestry flaws raise the cap by 1. Same-source uniqueness rule (no double-picking within ancestry/background) also enforced.
- **Alternative Ancestry Boosts** optional rule — a "Use 2 free boosts" checkbox in the Ancestry section header. When on, ancestry boosts/flaws are replaced by a 2-tile free-boost picker and flaws stop contributing to the cap. Wire-format matches pf2e exactly: `ancestry.system.alternateAncestryBoosts: AbilityKey[] | null`.
- Two orientation notes at the top: the 18-cap rule + a "your class key attribute wants to start at +4" tip explaining why.
- 13 unit tests covering tally, cap, and same-source-duplicate logic in `AttributesStep.test.ts`.

### Picker filter row (per-target)

`useCreatorPickerProps` got per-target options:
- `initialSources` — Background defaults to **Pathfinder Player Core + Pathfinder Player Core 2**.
- `initialRarities` — Ancestry / Background / Class default to `['common']`.
- `showSourcePicker` / `showRarityPicker` / `showUnmetToggle` / `showSortToggle` — explicit per-target visibility flags. Class picker for example shows only the text search + rarity pills.
- `hideDetailHeader` — class panels skip the duplicate-of-dialog-title-bar header.
- `listOpenWidthClass` — class picker uses `w-56` for a narrower list column.

Active picker row is tinted by `m.rarity` (amber / blue / purple / Common-pill grey) so the highlight visually echoes the rarity filter pills above.

### Tips Rail

New left-rail column on the creator (parallels the sheet's party rail). Five orientation cards: **Archives of Nethys**, **PF2e Remaster**, **Rarity**, **Multiclassing**, **Edits in Foundry**. Cards with external rules links open in a new tab.

Plus per-section `helpText` on each empty `PickerCard` (Ancestry / Heritage / Class / Background / Deity) that disappears once a pick is made. Dropped the redundant "No X selected yet" line that used to sit above the Choose button.

### Bridge ChoiceSet prompts

Heritage / subclass / bloodline / etc. prompts from pf2e ChoiceSets (the "modal that fires after you pick a class") now route through the rich `CompendiumDetailPanel` when every choice value is a Compendium UUID. Falls back to the existing button grid for scalar-valued prompts ("1 / 2 / 3 actions" picks etc.).

### Foundry-markup enricher

- `@actor.level` formula humanizer — `(max(1, (ceil(@actor.level/2))))d8` → `⌈L/2⌉d8`. Six patterns covered (with/without `max`, `ceil`/`floor`, etc.).
- Non-hoverable `@UUID` references (JournalEntry pages, RollTables, Macros) render as empty string instead of a broken-hover anchor, and an empty-paragraph pass strips the leftover `<p><em></em></p>` shell. Fixes the dangling "Bard" link with an empty hover that pf2e ships in class flavor blurbs.

### Layout

- Creator is now centred between two equal-width rails (tips on the left, phantom column on the right) so the wizard column reads as horizontally balanced on wide viewports.
- Class detail panel hides its top header (image + name + meta + traits) — duplicate of the picker dialog's title bar and was eating vertical space the proficiencies block needed.

## Test plan

- [ ] `npm run dev:player-portal` and open `/characters/new`
- [ ] Pick an ancestry; verify the detail panel shows HP/Size/Speed, Boosts, Flaws, Languages, Senses, Features (only L1), feature chips have hover popovers, rarity pill at top, AoN art on the right where available
- [ ] Heritage picker shows Primary / Versatile sections; clicking a heritage opens the detail panel with AoN art for versatile heritages
- [ ] Pick a Dwarf, scroll to Attributes; flip "Use 2 free boosts" — slots collapse to a 2-tile free-boost grid, flaw section disappears, 18-cap math drops the +1 flaw bonus
- [ ] Pick a class with a subclass prompt (Druid, Cleric, Sorcerer) — the bridge modal now shows the same two-column rich layout as the regular pickers
- [ ] Background picker opens with Player Core + Player Core 2 sources pre-selected
- [ ] Tips rail visible on `lg:` and up; collapses on narrower viewports
- [ ] `npm run build -w @foundry-toolkit/player-portal` passes
- [ ] `npm test -w @foundry-toolkit/player-portal` — pre-existing `window.localStorage.clear` failures in Chat/useShopMode are not from this PR; all other 555 tests pass
- [ ] `npm test -w @foundry-toolkit/shared` — 238 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)