### PR TITLE
feat(deploy,player-portal): obsidian notes via quartz, served under /notes/*

### DIFF
--- a/apps/player-portal/server/auth/middleware.ts
+++ b/apps/player-portal/server/auth/middleware.ts
@@ -14,7 +14,7 @@ const PUBLIC_PREFIXES = ['/api/auth/', '/health', '/assets/'];
 // Route prefixes that gate on a valid session.
 // SPA HTML routes (e.g. /, /globe, /login) are left unmatched so index.html
 // is served; the client-side auth guard then redirects to /login as needed.
-const GATED_PREFIXES = ['/api/', '/map/', '/icons/', '/systems/', '/modules/', '/worlds/'];
+const GATED_PREFIXES = ['/api/', '/map/', '/icons/', '/systems/', '/modules/', '/worlds/', '/notes/'];
 
 function isPublic(url: string): boolean {
   return PUBLIC_PREFIXES.some((p) => url === p.slice(0, -1) || url.startsWith(p));

--- a/apps/player-portal/server/index.ts
+++ b/apps/player-portal/server/index.ts
@@ -38,6 +38,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const PORT = parseInt(process.env['PORT'] ?? '3000', 10);
 const HOST = process.env['HOST'] ?? '0.0.0.0';
 const MCP_URL = process.env['MCP_URL'] ?? 'http://localhost:8765';
+const QUARTZ_URL = process.env['QUARTZ_URL'] ?? 'http://quartz:8080';
 // In prod the compiled server sits at server-dist/index.js and the SPA
 // build is at dist/. In dev Vite serves static from memory on :5173 and
 // proxies /api, /map, and the Foundry asset prefixes here, so dist/ may
@@ -131,6 +132,16 @@ export async function buildServer(): Promise<FastifyInstance> {
     upstream: MCP_URL,
     prefix: '/api/mcp',
     rewritePrefix: '/api',
+    http2: false,
+  });
+
+  // Proxy /notes/* → quartz (Obsidian notes static site, auth-gated).
+  // Quartz runs with --baseDir /notes so it expects the path prefix intact.
+  // rewritePrefix matches prefix so /notes/foo passes through as /notes/foo.
+  await app.register(fastifyHttpProxy, {
+    upstream: QUARTZ_URL,
+    prefix: '/notes',
+    rewritePrefix: '/notes',
     http2: false,
   });
 

--- a/apps/player-portal/server/routes/notes.test.ts
+++ b/apps/player-portal/server/routes/notes.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Fastify from 'fastify';
+import secureSession from '@fastify/secure-session';
+import { randomUUID } from 'node:crypto';
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { hashPassword, initUsers, persistUsers, type User } from '../auth/users.js';
+import { requireAuth } from '../auth/middleware.js';
+import { registerAuthRoutes } from './auth.js';
+
+const TEST_KEY = Buffer.alloc(32, 0xcd);
+
+let tmpDir: string;
+let tmpFile: string;
+let testUser: User;
+
+beforeEach(async () => {
+  tmpDir = join(tmpdir(), `portal-notes-test-${randomUUID()}`);
+  mkdirSync(tmpDir, { recursive: true });
+  tmpFile = join(tmpDir, 'users.json');
+
+  testUser = {
+    id: randomUUID(),
+    username: 'alice',
+    passwordHash: await hashPassword('correct-password'),
+    actorId: 'actor-abc',
+    createdAt: new Date().toISOString(),
+  };
+  persistUsers([testUser], tmpFile);
+  initUsers(tmpFile);
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// Minimal app with session + auth middleware + auth routes + stub /notes/* handler.
+// Tests verify that /notes/* is gated before any upstream connection attempt.
+async function buildApp() {
+  const app = Fastify({ logger: false });
+  await app.register(secureSession, {
+    key: TEST_KEY,
+    cookieName: 'portal-session',
+    cookie: { path: '/' },
+  });
+  app.decorateRequest<User | undefined>('user', undefined);
+  app.addHook('preHandler', requireAuth);
+  await registerAuthRoutes(app);
+
+  // Stub notes routes so successful auth has somewhere to land
+  app.get('/notes/', async () => ({ ok: true }));
+  app.get('/notes/*', async () => ({ ok: true }));
+
+  await app.ready();
+  return app;
+}
+
+describe('/notes/* auth gating', () => {
+  it('returns 401 for unauthenticated request to /notes/', async () => {
+    const app = await buildApp();
+    const res = await app.inject({ method: 'GET', url: '/notes/' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 401 for unauthenticated request to a nested note path', async () => {
+    const app = await buildApp();
+    const res = await app.inject({ method: 'GET', url: '/notes/session-1/encounter' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('passes through to the route when authenticated', async () => {
+    const app = await buildApp();
+
+    const loginRes = await app.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      payload: { username: 'alice', password: 'correct-password' },
+    });
+    expect(loginRes.statusCode).toBe(200);
+    const cookie = loginRes.headers['set-cookie'] as string;
+
+    const notesRes = await app.inject({
+      method: 'GET',
+      url: '/notes/',
+      headers: { cookie },
+    });
+    expect(notesRes.statusCode).toBe(200);
+  });
+});

--- a/apps/player-portal/src/app/Nav.tsx
+++ b/apps/player-portal/src/app/Nav.tsx
@@ -9,6 +9,10 @@ const tabs = [
   { to: '/characters', label: 'Characters' },
 ];
 
+// Notes lives outside the SPA (served by Quartz), so it uses a plain <a>.
+const NAV_LINK_CLASS =
+  'inline-flex items-center px-5 py-3 text-sm font-medium tracking-wide border-b-2 transition-colors duration-150 no-underline border-transparent text-portal-text-muted hover:text-portal-text';
+
 interface Props {
   theme: 'light' | 'dark';
   onToggleTheme: () => void;
@@ -49,6 +53,10 @@ export function Nav({ theme, onToggleTheme, user, onSignOut }: Props) {
           {tab.label}
         </NavLink>
       ))}
+      {/* Notes: external link to Quartz — navigates out of the SPA */}
+      <a href="/notes/" className={NAV_LINK_CLASS}>
+        Notes
+      </a>
 
       {/* Right-side controls */}
       <div className="ml-auto flex items-center gap-3 px-3">

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -88,6 +88,25 @@ BRIDGE_WORLD_ID=your-world-id
 # Leave blank to disable (route returns 404 cleanly; rest of system unaffected).
 FOUNDRY_MCP_BOOKS_DIR=
 
+# ── Obsidian Notes (quartz container) ───────────────────────────────────────
+# Host path to the directory you rsync your Obsidian vault to.
+# The quartz container mounts this read-only and rebuilds the site on change.
+# If unset, Docker defaults to /var/quartz-vault (auto-created, empty).
+#
+# Rsync your vault from your Mac/Windows machine (example):
+#   rsync -avz --delete /path/to/your/vault/ user@server:/var/quartz-vault/
+#
+# Only notes with `publish: true` in their YAML frontmatter appear in the
+# built site.  All other notes are excluded.  Example frontmatter:
+#
+#   ---
+#   title: My Session Notes
+#   publish: true
+#   ---
+#
+# Notes without `publish: true` (or with `publish: false`) are never included.
+QUARTZ_VAULT_DIR=
+
 # ── Image tag ────────────────────────────────────────────────────────────────
 # Which GHCR image tag to pull for all three services.
 # Use a pinned version (e.g. v0.2.0) for production; 'latest' for always-current.

--- a/deploy/Dockerfile.quartz
+++ b/deploy/Dockerfile.quartz
@@ -1,0 +1,47 @@
+###############################################################################
+# foundry-toolkit — quartz notes container
+#
+# Clones Quartz v4.5.2, installs deps, overlays the custom config, then
+# runs Quartz's built-in watch+serve mode pointed at the vault bind-mount.
+#
+# Build context: monorepo root
+#   docker build -f deploy/Dockerfile.quartz -t foundry-toolkit-quartz:dev .
+#
+# The container serves the static site at :8080/notes/*.  It is not mapped
+# to the host — player-portal reverse-proxies /notes/* to it.
+###############################################################################
+
+FROM node:22-alpine
+
+# git needed only at build time to clone Quartz; kept because apk cache is
+# cheap and removing it saves negligible space vs. the node_modules layer.
+RUN apk add --no-cache git
+
+WORKDIR /quartz
+
+# Pin to v4.5.2 — the latest stable v4 release as of 2026-05.
+# Using --depth 1 to avoid fetching full history.
+RUN git clone --depth 1 --branch v4.5.2 https://github.com/jackyzha0/quartz.git . && \
+    npm ci --ignore-scripts
+
+# Overlay the custom config:
+#   - ExplicitPublish filter (only publish: true notes appear)
+#   - baseUrl pointing to /notes path
+#   - pageTitle and minor cleanup (no analytics, no OG images)
+COPY deploy/quartz.config.ts ./quartz.config.ts
+
+# /vault is mounted read-only from the host at runtime via QUARTZ_VAULT_DIR.
+# The volume declaration is documentation; compose.yaml provides the mount.
+VOLUME ["/vault"]
+
+EXPOSE 8080
+
+# --baseDir /notes  makes the serve handler expect paths as /notes/...
+#                   and matches how player-portal proxies the prefix through
+#                   unchanged.  Generated HTML links also use /notes/ paths
+#                   because baseUrl in quartz.config.ts encodes the subpath.
+# --watch           is implied by --serve (Quartz sets it automatically).
+CMD ["node", "node_modules/.bin/quartz", "build", \
+     "--serve", "--port", "8080", \
+     "--directory", "/vault", \
+     "--baseDir", "/notes"]

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -358,6 +358,94 @@ When your primary GM account is active in a browser:
 
 ---
 
+## Notes (Quartz)
+
+The `quartz` service builds a static site from an Obsidian vault directory and
+serves it at `/notes/*` behind player-portal's existing cookie auth. It uses
+[Quartz v4](https://quartz.jzhao.xyz/) — a Node-based static site generator
+with full Obsidian support (wikilinks, backlinks, graph, search).
+
+### Frontmatter convention
+
+Only notes with `publish: true` in their YAML frontmatter appear in the built
+site. All other notes — including those with no frontmatter at all — are
+excluded. This is enforced by the `ExplicitPublish` filter in `quartz.config.ts`.
+
+Minimal example of a publishable note:
+
+```markdown
+---
+title: Session 12 — The Iron Keep
+publish: true
+tags: [session, combat]
+---
+
+The party descended into the dungeon...
+```
+
+Use Obsidian's Templater or Templates plugin to stamp `publish: false` on new
+notes by default, and flip them to `true` when you're ready to share.
+
+### Directory layout on the server
+
+Set `QUARTZ_VAULT_DIR` in `deploy/.env` to the absolute host path where you
+want to land your vault:
+
+```
+/var/quartz-vault/         ← QUARTZ_VAULT_DIR
+  index.md                 ← root note (publish: true to appear as homepage)
+  sessions/
+    session-12.md
+    session-13.md
+  npcs/
+    big-boss.md
+```
+
+The quartz container mounts this as `/vault` (read-only) and Quartz watches it
+for changes. Every time you rsync a new batch of notes, Quartz detects the
+change and rebuilds automatically — no manual rebuild required.
+
+### Rsync flow
+
+From your Mac or Windows machine, after editing notes in Obsidian:
+
+```sh
+# Mac / Linux
+rsync -avz --delete /path/to/your/vault/ user@addnd.net:/var/quartz-vault/
+
+# Windows (WSL or Git Bash)
+rsync -avz --delete /mnt/c/Users/you/Documents/Vault/ user@addnd.net:/var/quartz-vault/
+```
+
+The `--delete` flag removes files on the server that you've deleted locally,
+keeping the published site in sync with your vault.
+
+`QUARTZ_VAULT_DIR` is intentionally not managed by compose volumes — you own
+the host directory and sync into it on your schedule.
+
+### Auth model
+
+`/notes/*` is served exclusively through player-portal. The Quartz container
+is on the compose internal network and is not mapped to any host port — it is
+not reachable from the public internet. A logged-out user hitting `/notes/`
+receives a `401 Unauthorized` from player-portal's cookie-session middleware
+and is redirected to the login page.
+
+### Theme
+
+The site uses Quartz's default theme. Matching it to player-portal's visual
+style is a follow-up.
+
+### Hot-reload WebSocket
+
+Quartz's watch+serve mode broadcasts a hot-reload signal over a WebSocket
+(port 3001 internally). Because the browser connects through player-portal's
+HTTP proxy, the WebSocket is not forwarded and in-browser auto-refresh doesn't
+work. Content still rebuilds on every vault change; a manual browser refresh
+picks it up.
+
+---
+
 ## CI / releases
 
 Pushing a `v*` tag triggers `.github/workflows/release-image.yml`, which

--- a/deploy/compose.override.yaml.example
+++ b/deploy/compose.override.yaml.example
@@ -28,3 +28,8 @@ services:
     build:
       context: ..
       dockerfile: deploy/Dockerfile.headless-bridge
+
+  quartz:
+    build:
+      context: ..
+      dockerfile: deploy/Dockerfile.quartz

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -119,10 +119,32 @@ services:
     networks:
       - internal
 
+  # ── quartz (Obsidian notes) ──────────────────────────────────────────────────
+  # Quartz v4 static site generator.  Watches the vault directory (mounted
+  # read-only from the host) and rebuilds on change.  The generated site is
+  # served at :8080/notes/* on the internal network only — player-portal
+  # reverse-proxies /notes/* here so notes are gated by the portal's auth.
+  #
+  # Populate the vault by rsyncing your Obsidian vault to the host path set in
+  # QUARTZ_VAULT_DIR.  Only notes with `publish: true` in their frontmatter
+  # appear in the built site (configured via ExplicitPublish in quartz.config.ts).
+  quartz:
+    image: ghcr.io/alexdickerson/foundry-toolkit-quartz:${IMAGE_TAG:-latest}
+    restart: unless-stopped
+    volumes:
+      # QUARTZ_VAULT_DIR: host path to the directory you rsync your Obsidian
+      # vault to.  Docker creates the path if it does not exist, giving Quartz
+      # an empty vault that renders an empty site until notes are rsynced in.
+      - ${QUARTZ_VAULT_DIR:-/var/quartz-vault}:/vault:ro
+    networks:
+      - internal
+    mem_limit: 512m
+
   # ── player-portal ────────────────────────────────────────────────────────────
   # Fastify server that serves the Vite SPA and reverse-proxies:
   #   /api/mcp/*              → foundry-mcp (MCP REST surface)
   #   /icons /systems /worlds → foundry (asset resolution for prepared actors)
+  #   /notes/*                → quartz (Obsidian notes, auth-gated)
   # Port 3000 is not mapped to the host — Caddy routes traffic here via the
   # compose internal network.  No direct external access needed.
   player-portal:
@@ -133,10 +155,12 @@ services:
       SECURE_SESSION_SECRET: ${SECURE_SESSION_SECRET:-}
       MCP_URL: http://foundry-mcp:8765
       FOUNDRY_URL: http://foundry:30000
+      QUARTZ_URL: http://quartz:8080
       PORT: '3000'
       HOST: 0.0.0.0
     depends_on:
       - foundry-mcp
+      - quartz
     networks:
       - internal
 

--- a/deploy/quartz.config.ts
+++ b/deploy/quartz.config.ts
@@ -1,0 +1,96 @@
+import { QuartzConfig } from './quartz/cfg';
+import * as Plugin from './quartz/plugins';
+
+const config: QuartzConfig = {
+  configuration: {
+    pageTitle: 'Campaign Notes',
+    pageTitleSuffix: '',
+    enableSPA: true,
+    enablePopovers: true,
+    analytics: { provider: 'none' },
+    locale: 'en-US',
+    // Must match where the site is served: player-portal proxies /notes/* here.
+    // Quartz uses this to generate canonical URLs and to prefix internal links
+    // in the built output so navigation works under /notes/ rather than /.
+    baseUrl: 'addnd.net/notes',
+    ignorePatterns: ['.obsidian', 'templates', 'Templates', 'private'],
+    defaultDateType: 'modified',
+    theme: {
+      // Use system fonts to avoid Google Fonts network dependency in the container.
+      fontOrigin: 'local',
+      cdnCaching: false,
+      typography: {
+        header: 'Schibsted Grotesk',
+        body: 'Source Sans Pro',
+        code: 'IBM Plex Mono',
+      },
+      colors: {
+        lightMode: {
+          light: '#faf8f8',
+          lightgray: '#e5e5e5',
+          gray: '#b8b8b8',
+          darkgray: '#4e4e4e',
+          dark: '#2b2b2b',
+          secondary: '#284b63',
+          tertiary: '#84a59d',
+          highlight: 'rgba(143, 159, 169, 0.15)',
+          textHighlight: '#fff23688',
+        },
+        darkMode: {
+          light: '#161618',
+          lightgray: '#393639',
+          gray: '#646464',
+          darkgray: '#d4d4d4',
+          dark: '#ebebec',
+          secondary: '#7b97aa',
+          tertiary: '#84a59d',
+          highlight: 'rgba(143, 159, 169, 0.15)',
+          textHighlight: '#b3aa0288',
+        },
+      },
+    },
+  },
+  plugins: {
+    transformers: [
+      Plugin.FrontMatter(),
+      Plugin.CreatedModifiedDate({
+        priority: ['frontmatter', 'git', 'filesystem'],
+      }),
+      Plugin.SyntaxHighlighting({
+        theme: {
+          light: 'github-light',
+          dark: 'github-dark',
+        },
+        keepBackground: false,
+      }),
+      Plugin.ObsidianFlavoredMarkdown({ enableInHtmlEmbed: false }),
+      Plugin.GitHubFlavoredMarkdown(),
+      Plugin.TableOfContents(),
+      Plugin.CrawlLinks({ markdownLinkResolution: 'shortest' }),
+      Plugin.Description(),
+      Plugin.Latex({ renderEngine: 'katex' }),
+    ],
+    // ExplicitPublish: only notes with `publish: true` in frontmatter appear
+    // in the built site.  All other notes (no frontmatter or publish: false)
+    // are excluded.  Set `publish: true` on a note to include it.
+    filters: [Plugin.ExplicitPublish()],
+    emitters: [
+      Plugin.AliasRedirects(),
+      Plugin.ComponentResources(),
+      Plugin.ContentPage(),
+      Plugin.FolderPage(),
+      Plugin.TagPage(),
+      Plugin.ContentIndex({
+        enableSiteMap: true,
+        enableRSS: false,
+      }),
+      Plugin.Assets(),
+      Plugin.Static(),
+      Plugin.Favicon(),
+      Plugin.NotFoundPage(),
+      // CustomOgImages omitted — slow and unnecessary for an internal tool.
+    ],
+  },
+};
+
+export default config;

--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "ignoreExportsUsedInFile": true,
+  "ignore": [
+    "deploy/quartz.config.ts"
+  ],
   "workspaces": {
     ".": {
       "ignoreDependencies": [

--- a/knip.json
+++ b/knip.json
@@ -1,9 +1,7 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "ignoreExportsUsedInFile": true,
-  "ignore": [
-    "deploy/quartz.config.ts"
-  ],
+  "ignore": ["deploy/quartz.config.ts"],
   "workspaces": {
     ".": {
       "ignoreDependencies": [


### PR DESCRIPTION
## Summary

- Adds a `quartz` Docker service that builds a static site from an Obsidian vault using [Quartz v4.5.2](https://github.com/jackyzha0/quartz/releases/tag/v4.5.2)
- Player-portal reverse-proxies `/notes/*` → the Quartz container (internal network only); all requests are gated by the existing cookie-session auth
- Notes nav tab added to the player-portal SPA nav bar

**Apps touched**
- `deploy/` — new `Dockerfile.quartz`, `quartz.config.ts`, `compose.yaml` service, `.env.example`, `README.md`, `compose.override.yaml.example`
- `apps/player-portal` — `dev:player-portal` (`npm run dev:player-portal`)

## What ships

| File | Purpose |
|------|---------|
| `deploy/Dockerfile.quartz` | Clones Quartz v4.5.2, runs `npm ci`, overlays custom config, serves at `:8080` |
| `deploy/quartz.config.ts` | ExplicitPublish filter; `baseUrl: "addnd.net/notes"`; no analytics; local fonts |
| `deploy/compose.yaml` | New `quartz` service (internal network, 512 MB limit); `QUARTZ_URL` env in player-portal |
| `apps/player-portal/server/index.ts` | `/notes` proxy → `QUARTZ_URL` with prefix passthrough |
| `apps/player-portal/server/auth/middleware.ts` | `/notes/` added to `GATED_PREFIXES` |
| `apps/player-portal/src/app/Nav.tsx` | "Notes" `<a href="/notes/">` in nav bar |
| `apps/player-portal/server/routes/notes.test.ts` | Auth-gating tests (3 passing) |
| `deploy/README.md` | New "Notes (Quartz)" section |

## Quartz version pinned

`v4.5.2` — the latest stable v4 release tag as of 2026-05. Cloned at Docker build time with `git clone --depth 1 --branch v4.5.2`.

## Frontmatter convention

Only notes with `publish: true` in their YAML frontmatter appear in the built site (enforced by `Plugin.ExplicitPublish()` in `quartz.config.ts`):

```markdown
---
title: Session 12 — The Iron Keep
publish: true
---
```

All other notes (no frontmatter, or `publish: false`) are excluded.

## User rsync step

The user populates the vault directory on the server, then sets `QUARTZ_VAULT_DIR` in `deploy/.env`:

```sh
# from Mac/Windows
rsync -avz --delete /path/to/vault/ user@addnd.net:/var/quartz-vault/

# deploy/.env
QUARTZ_VAULT_DIR=/var/quartz-vault
```

The Quartz container mounts the dir read-only and watches for changes — no manual rebuild needed.

## Auth model

- `quartz` is on the compose internal network only (no host port mapping)
- player-portal gates `/notes/` in `GATED_PREFIXES` → unauthenticated → 401
- Caddy routes all traffic through player-portal; Quartz is never directly reachable

## Path prefix / link rewriting

Quartz runs with `--baseDir /notes` so its built-in HTTP server expects the `/notes/` prefix on all incoming paths. The player-portal proxy passes the full path through unchanged (`rewritePrefix: '/notes'`). The `baseUrl: "addnd.net/notes"` in `quartz.config.ts` ensures all generated canonical URLs and internal navigation links use the `/notes/` subpath.

## Caveats

- **Hot-reload WebSocket**: Quartz's watch+serve mode opens a WebSocket on port 3001 for browser hot-reload. This port is not proxied through player-portal, so auto-refresh doesn't work — a manual browser refresh picks up rebuilt content.
- **Docker not available locally**: `docker compose -f deploy/compose.yaml config` validation skipped (Docker not in PATH on this machine); YAML structure verified by inspection.
- **Theme**: Default Quartz theme. Matching player-portal's palette is a follow-up.

## Test plan

- [ ] Server tests pass: `cd apps/player-portal && npx vitest run server/` (26 tests green, including 3 new `/notes/*` auth-gating tests)
- [ ] TypeScript clean: `npm run typecheck -w @foundry-toolkit/player-portal`
- [ ] Verify `GET /notes/` → 401 without session cookie
- [ ] Verify `GET /notes/` → proxies to Quartz with valid session
- [ ] Verify "Notes" nav tab appears and links to `/notes/`
- [ ] Populate vault with a note containing `publish: true`, confirm it appears; confirm a note without `publish: true` does not

🤖 Generated with [Claude Code](https://claude.com/claude-code)