### PR TITLE
feat(deploy,ci): publish foundry-toolkit-foundry-v13 image variant

### DIFF
--- a/.github/workflows/pr-image.yml
+++ b/.github/workflows/pr-image.yml
@@ -32,12 +32,19 @@ jobs:
           - service: foundry
             image: ghcr.io/alexdickerson/foundry-toolkit-foundry
             dockerfile: deploy/Dockerfile.foundry
+            build-args: ''
+          - service: foundry-v13
+            image: ghcr.io/alexdickerson/foundry-toolkit-foundry-v13
+            dockerfile: deploy/Dockerfile.foundry
+            build-args: FOUNDRY_BASE_TAG=13
           - service: foundry-mcp
             image: ghcr.io/alexdickerson/foundry-toolkit-mcp
             dockerfile: deploy/Dockerfile.foundry-mcp
+            build-args: ''
           - service: player-portal
             image: ghcr.io/alexdickerson/foundry-toolkit-portal
             dockerfile: deploy/Dockerfile.player-portal
+            build-args: ''
 
     steps:
       - uses: actions/checkout@v6
@@ -73,6 +80,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
+          build-args: ${{ matrix.build-args }}
           # Shares the GHA cache with release builds — same Dockerfiles, so hits are likely.
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}
@@ -100,6 +108,7 @@ jobs:
           set -euo pipefail
           PACKAGES=(
             "foundry-toolkit-foundry"
+            "foundry-toolkit-foundry-v13"
             "foundry-toolkit-mcp"
             "foundry-toolkit-portal"
           )

--- a/.github/workflows/pr-image.yml
+++ b/.github/workflows/pr-image.yml
@@ -32,7 +32,6 @@ jobs:
           - service: foundry
             image: ghcr.io/alexdickerson/foundry-toolkit-foundry
             dockerfile: deploy/Dockerfile.foundry
-            build-args: ''
           - service: foundry-v13
             image: ghcr.io/alexdickerson/foundry-toolkit-foundry-v13
             dockerfile: deploy/Dockerfile.foundry
@@ -40,11 +39,9 @@ jobs:
           - service: foundry-mcp
             image: ghcr.io/alexdickerson/foundry-toolkit-mcp
             dockerfile: deploy/Dockerfile.foundry-mcp
-            build-args: ''
           - service: player-portal
             image: ghcr.io/alexdickerson/foundry-toolkit-portal
             dockerfile: deploy/Dockerfile.player-portal
-            build-args: ''
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -18,6 +18,7 @@ jobs:
           - service: foundry
             image: ghcr.io/alexdickerson/foundry-toolkit-foundry
             dockerfile: deploy/Dockerfile.foundry
+            build-args: ''
           - service: foundry-v13
             image: ghcr.io/alexdickerson/foundry-toolkit-foundry-v13
             dockerfile: deploy/Dockerfile.foundry
@@ -25,9 +26,11 @@ jobs:
           - service: foundry-mcp
             image: ghcr.io/alexdickerson/foundry-toolkit-mcp
             dockerfile: deploy/Dockerfile.foundry-mcp
+            build-args: ''
           - service: player-portal
             image: ghcr.io/alexdickerson/foundry-toolkit-portal
             dockerfile: deploy/Dockerfile.player-portal
+            build-args: ''
 
     steps:
       - uses: actions/checkout@v6
@@ -56,6 +59,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
-          build-args: ${{ matrix.build-args || '' }}
+          build-args: ${{ matrix.build-args }}
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -18,7 +18,6 @@ jobs:
           - service: foundry
             image: ghcr.io/alexdickerson/foundry-toolkit-foundry
             dockerfile: deploy/Dockerfile.foundry
-            build-args: ''
           - service: foundry-v13
             image: ghcr.io/alexdickerson/foundry-toolkit-foundry-v13
             dockerfile: deploy/Dockerfile.foundry
@@ -26,11 +25,9 @@ jobs:
           - service: foundry-mcp
             image: ghcr.io/alexdickerson/foundry-toolkit-mcp
             dockerfile: deploy/Dockerfile.foundry-mcp
-            build-args: ''
           - service: player-portal
             image: ghcr.io/alexdickerson/foundry-toolkit-portal
             dockerfile: deploy/Dockerfile.player-portal
-            build-args: ''
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -18,6 +18,10 @@ jobs:
           - service: foundry
             image: ghcr.io/alexdickerson/foundry-toolkit-foundry
             dockerfile: deploy/Dockerfile.foundry
+          - service: foundry-v13
+            image: ghcr.io/alexdickerson/foundry-toolkit-foundry-v13
+            dockerfile: deploy/Dockerfile.foundry
+            build-args: FOUNDRY_BASE_TAG=13
           - service: foundry-mcp
             image: ghcr.io/alexdickerson/foundry-toolkit-mcp
             dockerfile: deploy/Dockerfile.foundry-mcp
@@ -52,5 +56,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
+          build-args: ${{ matrix.build-args || '' }}
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}

--- a/deploy/Dockerfile.foundry
+++ b/deploy/Dockerfile.foundry
@@ -9,6 +9,9 @@
 #   docker build -f deploy/Dockerfile.foundry -t foundry-toolkit-foundry:dev .
 ###############################################################################
 
+# Global ARG for Foundry base image tag (before any FROM statements)
+ARG FOUNDRY_BASE_TAG=release
+
 ###############################################################################
 # Stage 1 — Build foundry-api-bridge Foundry module
 ###############################################################################
@@ -36,7 +39,6 @@ COPY apps/foundry-api-bridge/dist/templates   ./dist/templates
 ###############################################################################
 # Stage 2 — Runtime: felddy/foundryvtt (Debian trixie)
 ###############################################################################
-ARG FOUNDRY_BASE_TAG=release
 FROM felddy/foundryvtt:${FOUNDRY_BASE_TAG}
 
 # Bake api-bridge module to /seed so a volume-mounted /data doesn't clobber it.

--- a/deploy/Dockerfile.foundry
+++ b/deploy/Dockerfile.foundry
@@ -36,7 +36,8 @@ COPY apps/foundry-api-bridge/dist/templates   ./dist/templates
 ###############################################################################
 # Stage 2 — Runtime: felddy/foundryvtt (Debian trixie)
 ###############################################################################
-FROM felddy/foundryvtt:release
+ARG FOUNDRY_BASE_TAG=release
+FROM felddy/foundryvtt:${FOUNDRY_BASE_TAG}
 
 # Bake api-bridge module to /seed so a volume-mounted /data doesn't clobber it.
 # docker-entrypoint.sh copies it into /data/Data/modules/ on first boot.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -241,15 +241,34 @@ the `caddy` service block from `compose.yaml`, add a host port mapping back to
 
 ---
 
+## Foundry version variants
+
+Two Foundry image variants are published:
+
+- **Default (`foundry-toolkit-foundry`)** — pins to `felddy/foundryvtt:release` (latest stable, currently v14). Use this unless you have a specific reason to stay on v13.
+- **v13 (`foundry-toolkit-foundry-v13`)** — pins to `felddy/foundryvtt:13`. Use this if your modules require v13 compatibility.
+
+To use the v13 variant, swap the `image:` line in `compose.yaml`:
+
+```yaml
+foundry:
+  image: ghcr.io/alexdickerson/foundry-toolkit-foundry-v13:${IMAGE_TAG:-latest}
+```
+
+**Compatibility caveat**: The bundled `foundry-api-bridge` module is built against current Foundry APIs. Running it in v13 may or may not work depending on what APIs it uses. You are responsible for verifying compatibility with your chosen Foundry version. This PR publishes the image; no version-pinned bridge build is included yet.
+
+---
+
 ## CI / releases
 
 Pushing a `v*` tag triggers `.github/workflows/release-image.yml`, which
-builds and pushes all three images:
+builds and pushes all four images:
 
 ```
-ghcr.io/alexdickerson/foundry-toolkit-foundry:<tag>   + :latest
-ghcr.io/alexdickerson/foundry-toolkit-mcp:<tag>       + :latest
-ghcr.io/alexdickerson/foundry-toolkit-portal:<tag>    + :latest
+ghcr.io/alexdickerson/foundry-toolkit-foundry:<tag>       + :latest
+ghcr.io/alexdickerson/foundry-toolkit-foundry-v13:<tag>   + :latest
+ghcr.io/alexdickerson/foundry-toolkit-mcp:<tag>           + :latest
+ghcr.io/alexdickerson/foundry-toolkit-portal:<tag>        + :latest
 ```
 
 Tag manually; the workflow does not bump versions automatically.

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -34,6 +34,9 @@ services:
   # ── Foundry VTT ─────────────────────────────────────────────────────────────
   # felddy/foundryvtt base image with the foundry-api-bridge module baked in.
   # The module is seeded into /data/Data/modules/ on first boot.
+  # A v13-pinned image variant is also published at:
+  #   ghcr.io/alexdickerson/foundry-toolkit-foundry-v13:${IMAGE_TAG:-latest}
+  # Swap the image: line below to use the v13 variant for Foundry v13 compatibility.
   foundry:
     image: ghcr.io/alexdickerson/foundry-toolkit-foundry:${IMAGE_TAG:-latest}
     restart: unless-stopped


### PR DESCRIPTION
## Summary

Publishes a second Foundry image variant pinned to Foundry **v13** alongside the existing one (which tracks `:release` = currently v14).

- New image: `ghcr.io/alexdickerson/foundry-toolkit-foundry-v13:${tag}` + `:latest`
- Uses the same `deploy/Dockerfile.foundry` with an `ARG` parameterization for the felddy base tag (defaults to `release`)
- Added as a fourth matrix entry in `release-image.yml` with `build-args: FOUNDRY_BASE_TAG=13`

## Implementation

**Dockerfile**: Added `ARG FOUNDRY_BASE_TAG=release` before `FROM` so the base image tag can be overridden at build time without duplicating the Dockerfile.

**Workflow**: New matrix entry `foundry-v13` passes `FOUNDRY_BASE_TAG=13` to `docker/build-push-action`. The existing three images (`foundry`, `foundry-mcp`, `player-portal`) are unchanged.

**Documentation**: Updated `compose.yaml` with a comment and `README.md` with a "Foundry version variants" section explaining when to use each image and the api-bridge compatibility caveat.

## API Bridge Compatibility

**Caveat**: The bundled `foundry-api-bridge` module is built against current Foundry APIs. Running it in v13 may or may not work depending on what APIs it touches. Users are responsible for verifying compatibility with their chosen Foundry version. This PR publishes the image; no version-pinned bridge build is included yet.

## Usage

To deploy Foundry v13, swap the `image:` line in `compose.yaml`:

```yaml
foundry:
  image: ghcr.io/alexdickerson/foundry-toolkit-foundry-v13:${IMAGE_TAG:-latest}
```

## Testing

- Dockerfile syntax validated: parameterization is correct
- YAML syntax validated: workflow matrix is well-formed, `build-args` field correctly placed
- Lint and format checks passed
- This is a template/config-only change; no runtime code modified

---

🤖 Generated with Claude Code