### PR TITLE
ci: add headless-bridge to release image pipeline

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -28,6 +28,9 @@ jobs:
           - service: player-portal
             image: ghcr.io/alexdickerson/foundry-toolkit-portal
             dockerfile: deploy/Dockerfile.player-portal
+          - service: headless-bridge
+            image: ghcr.io/alexdickerson/foundry-toolkit-headless-bridge
+            dockerfile: deploy/Dockerfile.headless-bridge
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Adds the `headless-bridge` service to the matrix in `release-image.yml` so `ghcr.io/alexdickerson/foundry-toolkit-headless-bridge` is built and pushed on every `v*` tag alongside the other four images.

Missed in the original headless-bridge PR (#221).

🤖 Generated with [Claude Code](https://claude.com/claude-code)