### PR TITLE
fix(headless-bridge): add types:node to tsconfig so Docker build finds @types/node

### DIFF
--- a/apps/headless-bridge/tsconfig.json
+++ b/apps/headless-bridge/tsconfig.json
@@ -12,7 +12,8 @@
     "esModuleInterop": true,
     "declaration": false,
     "sourceMap": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
   },
   "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
The `tsc` build step in `Dockerfile.headless-bridge` fails with:

```
error TS2591: Cannot find name 'process'. Do you need to install type definitions for node?
```

The build stage only copies the `headless-bridge` workspace manifest (not all workspace manifests), so TypeScript cannot auto-discover `@types/node` by walking up the workspace tree the way it does locally. Adding `"types": ["node"]` to `compilerOptions` makes the lookup explicit and works regardless of the surrounding workspace layout.

One-line change, no behaviour impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)