### PR TITLE
fix(headless-bridge): use data-package-id selector for Foundry v14 world cards

### DIFF
--- a/apps/headless-bridge/src/foundry.ts
+++ b/apps/headless-bridge/src/foundry.ts
@@ -54,9 +54,11 @@ async function handleSetup(page: Page, foundryUrl: string, adminKey: string, wor
   if (page.url().includes('/join')) return;
 
   // Find the world card by its ID (= directory slug under Data/worlds/).
-  // Foundry v14 renders each world as a list item with a data-id attribute.
+  // v14 uses data-package-id; older builds used data-id — try both.
   console.info(`${LOG} Locating world "${worldId}" in setup`);
-  const worldCard = page.locator(`[data-id="${worldId}"]`).first();
+  const worldCard = page
+    .locator(`[data-package-id="${worldId}"], [data-id="${worldId}"]`)
+    .first();
   const cardVisible = await worldCard.isVisible({ timeout: 15_000 }).catch(() => false);
   if (!cardVisible) {
     throw new Error(

--- a/apps/headless-bridge/src/foundry.ts
+++ b/apps/headless-bridge/src/foundry.ts
@@ -56,9 +56,7 @@ async function handleSetup(page: Page, foundryUrl: string, adminKey: string, wor
   // Find the world card by its ID (= directory slug under Data/worlds/).
   // v14 uses data-package-id; older builds used data-id — try both.
   console.info(`${LOG} Locating world "${worldId}" in setup`);
-  const worldCard = page
-    .locator(`[data-package-id="${worldId}"], [data-id="${worldId}"]`)
-    .first();
+  const worldCard = page.locator(`[data-package-id="${worldId}"], [data-id="${worldId}"]`).first();
   const cardVisible = await worldCard.isVisible({ timeout: 15_000 }).catch(() => false);
   if (!cardVisible) {
     throw new Error(


### PR DESCRIPTION
Foundry v14 renders world cards with `data-package-id` rather than `data-id`. The headless-bridge was looking for `[data-id="…"]` which never matched, causing the "World not found" error even when the directory slug was correct.

Now tries `[data-package-id="…"], [data-id="…"]` so it works on both v14 and older builds.

Reproducer: `BRIDGE_WORLD_ID=the-reclamation` with a v14 Foundry instance logged correctly "Locating world" but immediately threw the not-found error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)