### PR TITLE
fix(headless-bridge): broaden launch-button selector for Foundry v14

### DIFF
--- a/apps/headless-bridge/src/foundry.ts
+++ b/apps/headless-bridge/src/foundry.ts
@@ -97,14 +97,25 @@ async function handleSetup(
     );
   }
 
+  // v14 uses <a data-action="worldLaunch"> inside the card; older builds used
+  // a <button>. Match a wide net of possible launch controls.
   const launchBtn = worldCard
-    .locator('button')
-    .filter({ hasText: /launch/i })
+    .locator(
+      [
+        '[data-action="worldLaunch"]',
+        '[data-action="launchWorld"]',
+        '[data-action="launch"]',
+        'button:has-text("Launch")',
+        'a:has-text("Launch")',
+      ].join(', '),
+    )
     .first();
   if (!(await launchBtn.isVisible({ timeout: 2_000 }).catch(() => false))) {
+    const cardHtml = await worldCard.evaluate((el) => el.outerHTML.slice(0, 2000)).catch(() => '');
+    console.error(`${LOG} World card HTML: ${cardHtml}`);
     throw new Error(
       `Could not find a Launch button for world "${worldId}". ` +
-        'The world card was found but the launch control is missing -- the world may already be launching.',
+        'The world card was found but no recognised launch control. See logged card HTML above.',
     );
   }
 


### PR DESCRIPTION
Foundry v14 renders the world card's launch control as `<a data-action=\"worldLaunch\">` rather than a `<button>` with \"Launch\" text. The current selector misses it entirely.

Now tries a wide set of selectors: `[data-action=\"worldLaunch\"]`, `[data-action=\"launchWorld\"]`, `[data-action=\"launch\"]`, plus button/anchor with \"Launch\" text. On failure, dumps the first 2 KB of the world card's outerHTML so the next failure mode is one log line away from a fix.

Reproducer: v14 Foundry server, world stopped, headless-bridge tries to launch and immediately throws \"Could not find a Launch button\". Confirmed the world card is found via `[data-package-id]` — only the inner control selector was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)