### PR TITLE
perf(headless-bridge): disable Chromium background-tab throttling

### DIFF
--- a/apps/headless-bridge/src/main.ts
+++ b/apps/headless-bridge/src/main.ts
@@ -26,10 +26,30 @@ async function main(): Promise<void> {
   console.info(`${LOG}   User:    ${env.bridgeGmUser}`);
   console.info(`${LOG}   MCP:     ${env.foundryMcpUrl}`);
 
-  const browser = await chromium.launch({ headless: true });
+  // Disable Chromium's "background tab" throttles. Headless tabs are always
+  // treated as backgrounded, which throttles setTimeout/setInterval/rAF and
+  // dramatically slows Foundry's canvas + scheduling work. The first three
+  // flags lift the throttles; the fourth keeps the renderer at full priority.
+  const browser = await chromium.launch({
+    headless: true,
+    args: [
+      '--disable-background-timer-throttling',
+      '--disable-backgrounding-occluded-windows',
+      '--disable-renderer-backgrounding',
+      '--disable-features=CalculateNativeWinOcclusion',
+    ],
+  });
   console.info(`${LOG} Chromium launched`);
 
   const context = await browser.newContext();
+
+  // Some web APIs (rAF in particular) consult document.visibilityState. Pin it
+  // to 'visible' before any page script runs so Foundry never sees 'hidden'.
+  await context.addInitScript(() => {
+    Object.defineProperty(document, 'visibilityState', { get: () => 'visible', configurable: true });
+    Object.defineProperty(document, 'hidden', { get: () => false, configurable: true });
+  });
+
   const page = await context.newPage();
 
   page.on('crash', () => {


### PR DESCRIPTION
The headless browser was significantly slower than a real GM tab because Chromium treats headless tabs as backgrounded — throttling setTimeout/setInterval/requestAnimationFrame, which Foundry's canvas loop and a lot of internal scheduling rely on.

Two changes, both at process startup:

**1. Launch flags** — lift the throttles at the browser level:
- `--disable-background-timer-throttling`
- `--disable-backgrounding-occluded-windows`
- `--disable-renderer-backgrounding`
- `--disable-features=CalculateNativeWinOcclusion`

**2. Init script** — pin `document.visibilityState` and `document.hidden` so any page code that consults the Page Visibility API (rAF dispatch, idle detection, some Foundry internals) always sees the tab as visible.

Expected impact: command roundtrip latency drops back toward the same range as a real GM browser tab. Compare `cmd >> X` / `cmd << X` timings in `foundry-mcp` logs before and after to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)