### PR TITLE
feat(player-portal,foundry-mcp): upload PDFs to books catalog

### DIFF
--- a/apps/foundry-mcp/package.json
+++ b/apps/foundry-mcp/package.json
@@ -13,6 +13,7 @@
     "seed-item-art": "tsx --env-file-if-exists=../../.env --env-file-if-exists=.env src/cli/seed-item-art.ts"
   },
   "dependencies": {
+    "@fastify/multipart": "^10.0.0",
     "@foundry-toolkit/db": "*",
     "@foundry-toolkit/shared": "*",
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/apps/foundry-mcp/src/http/app.ts
+++ b/apps/foundry-mcp/src/http/app.ts
@@ -1,4 +1,5 @@
 import Fastify, { type FastifyInstance } from 'fastify';
+import multipart from '@fastify/multipart';
 import { ZodError } from 'zod/v4';
 import { log } from '../logger.js';
 import { LiveDb } from '../db/live-db.js';
@@ -23,6 +24,9 @@ export async function buildHttpApp(): Promise<FastifyInstance> {
   // Fastify instance via `app.routing(req, res)` — see src/index.ts. The
   // parent has its own logger, so Fastify's is off to avoid double logs.
   const app = Fastify({ logger: false });
+
+  // Multipart support for the /books/upload endpoint.
+  await app.register(multipart);
 
   // Permissive CORS for LAN-direct REST clients (player-portal dev server,
   // `_http/` scratchpads, etc.). In the deployed topology player-portal

--- a/apps/foundry-mcp/src/http/routes/books.ts
+++ b/apps/foundry-mcp/src/http/routes/books.ts
@@ -9,10 +9,13 @@
 //
 // If FOUNDRY_MCP_BOOKS_DIR is unset every route returns 404.
 
-import { createReadStream } from 'node:fs';
-import { readdir, stat } from 'node:fs/promises';
+import { createReadStream, createWriteStream } from 'node:fs';
+import { readdir, stat, mkdir, unlink } from 'node:fs/promises';
+import { pipeline } from 'node:stream/promises';
+import { Transform } from 'node:stream';
 import { join, resolve, extname, basename } from 'node:path';
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import type { MultipartFile } from '@fastify/multipart';
 import { FOUNDRY_MCP_BOOKS_DIR } from '../../config.js';
 import { log } from '../../logger.js';
 import { getPf2eDb, isPf2eDbOpen } from '@foundry-toolkit/db/pf2e';
@@ -49,6 +52,42 @@ interface BookDbRow {
   ai_title: string | null;
   ai_publisher: string | null;
   has_cover: number; // 0 or 1
+}
+
+const MAX_PDF_BYTES = 300 * 1024 * 1024; // 300 MB
+
+function sanitizeSegment(s: string): string {
+  return s
+    .replace(/\.{2,}/g, '')
+    .replace(/[/\\]/g, '')
+    .replace(/^\./g, '')
+    .replace(/\0/g, '')
+    .trim();
+}
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/[\s_]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function createPdfMagicTransform(): Transform {
+  let checked = false;
+  return new Transform({
+    transform(chunk: Buffer, _enc, cb) {
+      if (!checked) {
+        checked = true;
+        if (chunk.length < 4 || chunk.subarray(0, 4).toString('ascii') !== '%PDF') {
+          cb(Object.assign(new Error('Not a PDF'), { code: 'NOT_PDF' }));
+          return;
+        }
+      }
+      cb(null, chunk);
+    },
+  });
 }
 
 export function registerBooksRoute(app: FastifyInstance): void {
@@ -175,6 +214,128 @@ export function registerBooksRoute(app: FastifyInstance): void {
       .header('Accept-Ranges', 'bytes')
       .header('Content-Length', String(total))
       .send(createReadStream(filePath));
+  });
+
+  app.post('/books/upload', async (req, reply) => {
+    // Read from process.env at request time (not module constant) so tests can override.
+    const booksDir = process.env['FOUNDRY_MCP_BOOKS_DIR'];
+    if (!booksDir) {
+      reply.code(404).send({ error: 'Books directory not configured (FOUNDRY_MCP_BOOKS_DIR unset)' });
+      return;
+    }
+    if (!isPf2eDbOpen()) {
+      reply.code(503).send({ error: 'pf2e.db not configured' });
+      return;
+    }
+
+    const fields: Record<string, string> = {};
+    let coverBlob: Buffer | null = null;
+    let savedPath: string | null = null;
+    let fileSize = 0;
+    let finalTitle = '';
+    let finalCategory = 'Uncategorized';
+    let finalFilename = '';
+
+    try {
+      const parts = req.parts({ limits: { fileSize: MAX_PDF_BYTES } });
+      for await (const part of parts) {
+        if (part.type === 'field') {
+          fields[part.fieldname] = String(part.value);
+        } else if (part.fieldname === 'cover') {
+          const chunks: Buffer[] = [];
+          for await (const chunk of part.file) chunks.push(chunk as Buffer);
+          coverBlob = Buffer.concat(chunks);
+        } else if (part.fieldname === 'file') {
+          // Resolve names from text fields collected so far.
+          const rawCat = fields['category'] ?? 'Uncategorized';
+          finalCategory = sanitizeSegment(rawCat) || 'Uncategorized';
+          const stem = basename(part.filename ?? 'upload.pdf', '.pdf');
+          const rawTitle = fields['title'] || stem.replace(/_/g, ' ');
+          finalTitle = rawTitle;
+          const slug = slugify(finalTitle) || 'upload';
+          finalFilename = `${slug}.pdf`;
+
+          const subdir = join(resolve(booksDir), finalCategory);
+          await mkdir(subdir, { recursive: true });
+          const dest = join(subdir, finalFilename);
+
+          // 409 if file already exists.
+          let exists = false;
+          try {
+            await stat(dest);
+            exists = true;
+          } catch {
+            /* not found */
+          }
+          if (exists) {
+            part.file.resume();
+            reply.code(409).send({ error: `Book already exists: ${finalCategory}/${finalFilename}` });
+            return;
+          }
+
+          // Stream to disk with magic-bytes check.
+          try {
+            await pipeline(part.file, createPdfMagicTransform(), createWriteStream(dest));
+          } catch (err) {
+            await unlink(dest).catch(() => undefined);
+            if ((err as { code?: string }).code === 'NOT_PDF') {
+              reply.code(415).send({ error: 'Uploaded file is not a PDF' });
+              return;
+            }
+            throw err;
+          }
+
+          // Truncated means the file exceeded the size limit.
+          if ((part as MultipartFile).file.truncated) {
+            await unlink(dest).catch(() => undefined);
+            reply.code(413).send({ error: 'File exceeds the 300 MB limit' });
+            return;
+          }
+
+          const st = await stat(dest);
+          fileSize = st.size;
+          savedPath = dest;
+        }
+      }
+    } catch (err) {
+      if (savedPath) await unlink(savedPath).catch(() => undefined);
+      const msg = String(err instanceof Error ? err.message : err).toLowerCase();
+      if (msg.includes('file too large') || msg.includes('request file too large')) {
+        reply.code(413).send({ error: 'File exceeds the 300 MB limit' });
+        return;
+      }
+      throw err;
+    }
+
+    if (!savedPath) {
+      reply.code(400).send({ error: 'No PDF file was provided in the upload' });
+      return;
+    }
+
+    const st = await stat(savedPath);
+    const now = Date.now();
+    const rawPageCount = fields['pageCount'] ? parseInt(fields['pageCount'], 10) : NaN;
+    const pageCount = Number.isFinite(rawPageCount) && rawPageCount > 0 ? rawPageCount : null;
+    const rawSub = fields['subcategory'] ? sanitizeSegment(fields['subcategory']) : '';
+    const subcategory = rawSub || null;
+
+    const db = getPf2eDb();
+    db.prepare(
+      `INSERT INTO books (path, title, category, subcategory, page_count, file_size, cover_blob, mtime, ingested_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(savedPath, finalTitle, finalCategory, subcategory, pageCount, fileSize, coverBlob, Math.round(st.mtimeMs), now);
+    const row = db.prepare('SELECT id FROM books WHERE path = ?').get(savedPath) as { id: number } | undefined;
+
+    log.info(`books: uploaded "${finalTitle}" → ${finalCategory}/${finalFilename} (${fileSize} bytes)`);
+
+    return reply.code(200).send({
+      id: row?.id ?? 0,
+      title: finalTitle,
+      category: finalCategory,
+      subcategory,
+      pageCount,
+      sizeBytes: fileSize,
+    });
   });
 }
 

--- a/apps/foundry-mcp/test/books-upload.test.ts
+++ b/apps/foundry-mcp/test/books-upload.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, access } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import Fastify from 'fastify';
+import multipart from '@fastify/multipart';
+import { openPf2eDb, closePf2eDb, getPf2eDb } from '@foundry-toolkit/db/pf2e';
+import { registerBooksRoute } from '../src/http/routes/books.js';
+
+// Minimal valid PDF header.
+const FAKE_PDF = Buffer.concat([Buffer.from('%PDF-1.4 '), Buffer.alloc(32, 0x20)]);
+const NOT_PDF = Buffer.from('Not a PDF file!!!!');
+
+function buildMultipart(
+  fields: Array<{ name: string; value: string }>,
+  files: Array<{ name: string; filename: string; content: Buffer; contentType?: string }>,
+): { body: Buffer; contentType: string } {
+  const boundary = 'TestBoundary' + Date.now().toString(36);
+  const crlf = '\r\n';
+  const parts: Buffer[] = [];
+  for (const f of fields) {
+    parts.push(
+      Buffer.from(
+        `--${boundary}${crlf}Content-Disposition: form-data; name="${f.name}"${crlf}${crlf}${f.value}${crlf}`,
+      ),
+    );
+  }
+  for (const f of files) {
+    const ct = f.contentType ?? 'application/octet-stream';
+    parts.push(
+      Buffer.from(
+        `--${boundary}${crlf}Content-Disposition: form-data; name="${f.name}"; filename="${f.filename}"${crlf}Content-Type: ${ct}${crlf}${crlf}`,
+      ),
+    );
+    parts.push(f.content);
+    parts.push(Buffer.from(crlf));
+  }
+  parts.push(Buffer.from(`--${boundary}--${crlf}`));
+  return { body: Buffer.concat(parts), contentType: `multipart/form-data; boundary=${boundary}` };
+}
+
+let tmpBooksDir: string;
+let app: ReturnType<typeof Fastify>;
+
+describe('POST /books/upload', () => {
+  before(async () => {
+    tmpBooksDir = await mkdtemp(join(tmpdir(), 'books-upload-'));
+    const dbPath = join(tmpdir(), `books-upload-${process.pid}.db`);
+    process.env['FOUNDRY_MCP_BOOKS_DIR'] = tmpBooksDir;
+    openPf2eDb(dbPath);
+    // Create the books table (BookDb migration is dm-tool territory; just create it inline).
+    getPf2eDb().exec(`
+      CREATE TABLE IF NOT EXISTS books (
+        id INTEGER PRIMARY KEY,
+        path TEXT NOT NULL UNIQUE,
+        title TEXT NOT NULL,
+        category TEXT NOT NULL,
+        subcategory TEXT,
+        ruleset TEXT,
+        page_count INTEGER,
+        file_size INTEGER NOT NULL,
+        cover_blob BLOB,
+        mtime INTEGER NOT NULL,
+        ingested_at INTEGER,
+        ai_system TEXT, ai_category TEXT, ai_subcategory TEXT,
+        ai_title TEXT, ai_publisher TEXT, ai_classified_at INTEGER
+      )
+    `);
+    app = Fastify({ logger: false });
+    await app.register(multipart);
+    registerBooksRoute(app);
+    await app.ready();
+  });
+
+  after(async () => {
+    await app.close();
+    closePf2eDb();
+    delete process.env['FOUNDRY_MCP_BOOKS_DIR'];
+    await rm(tmpBooksDir, { recursive: true, force: true });
+  });
+
+  it('round-trips: file lands on disk and db row has correct shape', async () => {
+    const { body, contentType } = buildMultipart(
+      [
+        { name: 'category', value: 'Rulebooks' },
+        { name: 'title', value: 'Core Rules' },
+      ],
+      [{ name: 'file', filename: 'core-rules.pdf', content: FAKE_PDF, contentType: 'application/pdf' }],
+    );
+    const res = await app.inject({
+      method: 'POST',
+      url: '/books/upload',
+      headers: { 'content-type': contentType },
+      body,
+    });
+    assert.equal(res.statusCode, 200, `body: ${res.body}`);
+    const json = JSON.parse(res.body) as { id: number; title: string; category: string; sizeBytes: number };
+    assert.equal(json.title, 'Core Rules');
+    assert.equal(json.category, 'Rulebooks');
+    assert.ok(json.sizeBytes > 0);
+    // File exists on disk.
+    await access(join(tmpBooksDir, 'Rulebooks', 'core-rules.pdf'));
+    // DB row exists.
+    const row = getPf2eDb().prepare('SELECT * FROM books WHERE id = ?').get(json.id);
+    assert.ok(row);
+  });
+
+  it('returns 415 for non-PDF magic bytes', async () => {
+    const { body, contentType } = buildMultipart(
+      [{ name: 'category', value: 'Test' }],
+      [{ name: 'file', filename: 'bad.pdf', content: NOT_PDF, contentType: 'application/pdf' }],
+    );
+    const res = await app.inject({
+      method: 'POST',
+      url: '/books/upload',
+      headers: { 'content-type': contentType },
+      body,
+    });
+    assert.equal(res.statusCode, 415);
+  });
+
+  it('returns 409 on duplicate filename', async () => {
+    const { body: b1, contentType: ct1 } = buildMultipart(
+      [
+        { name: 'category', value: 'Dupes' },
+        { name: 'title', value: 'Same Book' },
+      ],
+      [{ name: 'file', filename: 'same.pdf', content: FAKE_PDF }],
+    );
+    await app.inject({ method: 'POST', url: '/books/upload', headers: { 'content-type': ct1 }, body: b1 });
+    const { body: b2, contentType: ct2 } = buildMultipart(
+      [
+        { name: 'category', value: 'Dupes' },
+        { name: 'title', value: 'Same Book' },
+      ],
+      [{ name: 'file', filename: 'same.pdf', content: FAKE_PDF }],
+    );
+    const res = await app.inject({
+      method: 'POST',
+      url: '/books/upload',
+      headers: { 'content-type': ct2 },
+      body: b2,
+    });
+    assert.equal(res.statusCode, 409);
+  });
+
+  it('sanitizes path traversal in category', async () => {
+    const { body, contentType } = buildMultipart(
+      [
+        { name: 'category', value: '../../../evil' },
+        { name: 'title', value: 'Evil Book' },
+      ],
+      [{ name: 'file', filename: 'evil.pdf', content: FAKE_PDF }],
+    );
+    const res = await app.inject({
+      method: 'POST',
+      url: '/books/upload',
+      headers: { 'content-type': contentType },
+      body,
+    });
+    assert.equal(res.statusCode, 200);
+    const json = JSON.parse(res.body) as { category: string };
+    // Category must not contain .. or slashes.
+    assert.ok(!json.category.includes('..'));
+    assert.ok(!json.category.includes('/'));
+    assert.ok(!json.category.includes('\\'));
+  });
+});

--- a/apps/player-portal/server/index.ts
+++ b/apps/player-portal/server/index.ts
@@ -157,6 +157,17 @@ export async function buildServer(): Promise<FastifyInstance> {
     http2: false,
   });
 
+  // Proxy /api/books/upload → foundry-mcp /books/upload. The /books/ wildcard
+  // proxy above only covers /books/* paths (file serving + index). This route
+  // allows the SPA to POST to /api/books/upload and have it reach the upload
+  // endpoint on foundry-mcp while staying inside the session-gated /api/ namespace.
+  await app.register(fastifyHttpProxy, {
+    upstream: MCP_URL,
+    prefix: '/api/books/upload',
+    rewritePrefix: '/books/upload',
+    http2: false,
+  });
+
   // --- SSE streams (proxy to foundry-mcp) -----------------------------------
   // All long-lived SSE endpoints must use makeSseProxy rather than the
   // general @fastify/http-proxy because the plugin's request timeout closes

--- a/apps/player-portal/src/features/books/Books.test.tsx
+++ b/apps/player-portal/src/features/books/Books.test.tsx
@@ -26,6 +26,14 @@ vi.mock('@foundry-toolkit/pdf-reader', () => ({
 // Stub the CSS import.
 vi.mock('./books-theme.css', () => ({}));
 
+vi.mock('./UploadBookModal', () => ({
+  UploadBookModal: ({ onClose }: { onClose: () => void }) => (
+    <div data-testid="upload-book-backdrop">
+      <button onClick={onClose}>Close</button>
+    </div>
+  ),
+}));
+
 const FAKE_INDEX = [
   { id: 'rulebooks/Core Rulebook', filename: 'rulebooks/Core Rulebook.pdf', title: 'Core Rulebook', sizeBytes: 1024, mtime: 0, category: 'rulebooks' },
   { id: 'adventures/Lost Mine', filename: 'adventures/Lost Mine.pdf', title: 'Lost Mine', sizeBytes: 512, mtime: 0, category: 'adventures' },
@@ -64,5 +72,28 @@ describe('Books page', () => {
     await waitFor(() => {
       expect(screen.getByText(/Could not load the book catalog/i)).toBeTruthy();
     });
+  });
+
+  it('shows Upload PDF button and opens modal on click', async () => {
+    const { Books } = await import('./Books');
+    const { unmount } = render(React.createElement(Books));
+
+    // Wait for the Upload PDF button to appear (may be multiple across renders
+    // due to module caching across tests; find a button element specifically).
+    let uploadBtn: HTMLElement | null = null;
+    await waitFor(() => {
+      const btns = screen.getAllByRole('button', { name: 'Upload PDF' });
+      expect(btns.length).toBeGreaterThan(0);
+      uploadBtn = btns[0] ?? null;
+    });
+
+    // Click the button to open modal
+    uploadBtn!.click();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('upload-book-backdrop')).toBeTruthy();
+    });
+
+    unmount();
   });
 });

--- a/apps/player-portal/src/features/books/Books.tsx
+++ b/apps/player-portal/src/features/books/Books.tsx
@@ -9,7 +9,9 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { BookCatalog, PdfReader, type BookEntry } from '@foundry-toolkit/pdf-reader';
 import { fetchBooksIndex, indexEntryToBookEntry } from './api';
+import type { UploadBookResult } from './api';
 import type { BookIndexEntry } from './types';
+import { UploadBookModal } from './UploadBookModal';
 import './books-theme.css';
 
 // One-time pdfjs worker setup for this page. We do it at module load so the
@@ -25,6 +27,7 @@ export function Books() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [openBook, setOpenBook] = useState<BookEntry | null>(null);
+  const [showUploadModal, setShowUploadModal] = useState(false);
 
   useEffect(() => {
     setLoading(true);
@@ -39,6 +42,30 @@ export function Books() {
         setLoading(false);
       });
   }, []);
+
+  const existingCategories = useMemo(
+    () =>
+      [...new Set(entries.map((e) => e.aiCategory ?? e.category).filter((c): c is string => Boolean(c)))].sort(),
+    [entries],
+  );
+
+  const handleUploadSuccess = useCallback(
+    (_result: UploadBookResult) => {
+      setShowUploadModal(false);
+      // Refetch the index so the new book appears immediately.
+      setLoading(true);
+      fetchBooksIndex()
+        .then((data) => {
+          setEntries(data);
+          setLoading(false);
+        })
+        .catch((err: unknown) => {
+          console.error('[Books] failed to reload index after upload:', err);
+          setLoading(false);
+        });
+    },
+    [],
+  );
 
   const books: BookEntry[] = entries.map(indexEntryToBookEntry);
 
@@ -75,8 +102,17 @@ export function Books() {
 
   return (
     <div className="books-reader-root absolute inset-0 flex flex-col">
-      <div className="shrink-0 border-b border-portal-border px-4 py-3">
+      <div className="shrink-0 border-b border-portal-border px-4 py-3 flex items-center justify-between">
         <h1 className="text-lg font-semibold text-portal-text">Library</h1>
+        {!openBook && (
+          <button
+            type="button"
+            onClick={() => setShowUploadModal(true)}
+            className="rounded border border-portal-border px-2 py-1 text-sm text-portal-text-muted hover:text-portal-text"
+          >
+            Upload PDF
+          </button>
+        )}
       </div>
       {error ? (
         <div className="flex flex-1 items-center justify-center text-sm text-portal-text-muted">
@@ -94,6 +130,13 @@ export function Books() {
             defaultCategory="PF2e — Rulebook"
           />
         </div>
+      )}
+      {showUploadModal && (
+        <UploadBookModal
+          existingCategories={existingCategories}
+          onClose={() => setShowUploadModal(false)}
+          onSuccess={handleUploadSuccess}
+        />
       )}
     </div>
   );

--- a/apps/player-portal/src/features/books/UploadBookModal.tsx
+++ b/apps/player-portal/src/features/books/UploadBookModal.tsx
@@ -1,0 +1,288 @@
+import { useState, useEffect, useCallback, type ChangeEvent } from 'react';
+import { createPortal } from 'react-dom';
+import * as pdfjsLib from 'pdfjs-dist';
+import { uploadBook, type UploadBookResult } from './api';
+
+interface Props {
+  existingCategories: string[];
+  onClose: () => void;
+  onSuccess: (result: UploadBookResult) => void;
+}
+
+async function extractPdfCover(file: File): Promise<{ coverBlob: Blob; numPages: number }> {
+  const arrayBuffer = await file.arrayBuffer();
+  const pdf = await pdfjsLib.getDocument({ data: arrayBuffer }).promise;
+  const numPages = pdf.numPages;
+  const page = await pdf.getPage(1);
+  const viewport = page.getViewport({ scale: 1 });
+  const scale = Math.min(300 / viewport.width, 1);
+  const scaled = page.getViewport({ scale });
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.round(scaled.width);
+  canvas.height = Math.round(scaled.height);
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('No canvas context');
+  await page.render({ canvas, canvasContext: ctx, viewport: scaled }).promise;
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (!blob) {
+        reject(new Error('Cover extraction failed'));
+        return;
+      }
+      resolve({ coverBlob: blob, numPages });
+    }, 'image/png');
+  });
+}
+
+export function UploadBookModal({ existingCategories, onClose, onSuccess }: Props): React.ReactElement {
+  const [file, setFile] = useState<File | null>(null);
+  const [category, setCategory] = useState('Uncategorized');
+  const [customCategory, setCustomCategory] = useState('');
+  const [useCustom, setUseCustom] = useState(false);
+  const [subcategory, setSubcategory] = useState('');
+  const [title, setTitle] = useState('');
+  const [coverBlob, setCoverBlob] = useState<Blob | null>(null);
+  const [previewUrl, setPreviewUrl] = useState('');
+  const [pageCount, setPageCount] = useState<number | null>(null);
+  const [extracting, setExtracting] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  // Cleanup object URL on unmount.
+  useEffect(() => {
+    return () => {
+      if (previewUrl) URL.revokeObjectURL(previewUrl);
+    };
+  }, [previewUrl]);
+
+  // Close on Escape.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const handleFilePick = useCallback(async (e: ChangeEvent<HTMLInputElement>) => {
+    const picked = e.target.files?.[0];
+    if (!picked) return;
+    setFile(picked);
+    setTitle(picked.name.replace(/\.pdf$/i, '').replace(/_/g, ' '));
+    setError(null);
+    setExtracting(true);
+    try {
+      const { coverBlob: blob, numPages } = await extractPdfCover(picked);
+      setCoverBlob(blob);
+      setPageCount(numPages);
+      const url = URL.createObjectURL(blob);
+      setPreviewUrl((prev) => {
+        if (prev) URL.revokeObjectURL(prev);
+        return url;
+      });
+    } catch (err) {
+      console.warn('[UploadBookModal] cover extraction failed:', err);
+    } finally {
+      setExtracting(false);
+    }
+  }, []);
+
+  const effectiveCategory = useCustom ? customCategory : category;
+
+  const handleUpload = useCallback(async () => {
+    if (!file) return;
+    setUploading(true);
+    setProgress(0);
+    setError(null);
+    try {
+      const fd = new FormData();
+      fd.append('category', effectiveCategory || 'Uncategorized');
+      if (subcategory.trim()) fd.append('subcategory', subcategory.trim());
+      fd.append('title', title.trim() || file.name.replace(/\.pdf$/i, ''));
+      if (pageCount != null) fd.append('pageCount', String(pageCount));
+      fd.append('file', file, file.name);
+      if (coverBlob) fd.append('cover', coverBlob, 'cover.png');
+      const result = await uploadBook(fd, setProgress);
+      onSuccess(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setUploading(false);
+    }
+  }, [file, effectiveCategory, subcategory, title, pageCount, coverBlob, onSuccess]);
+
+  const uniqueCategories = [...new Set(['Uncategorized', ...existingCategories])].sort();
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 p-4 pt-[10vh]"
+      onClick={onClose}
+      data-testid="upload-book-backdrop"
+    >
+      <div
+        className="flex max-h-[85vh] w-full max-w-md flex-col overflow-hidden rounded border border-portal-border bg-portal-bg shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <header className="flex items-center justify-between border-b border-portal-border px-4 py-3">
+          <h2 className="text-base font-semibold text-portal-text">Upload PDF</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-portal-text-muted hover:text-portal-text"
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </header>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto p-4 space-y-4">
+          {/* File picker */}
+          <div>
+            <label className="block text-sm font-medium text-portal-text mb-1">PDF file *</label>
+            <input
+              type="file"
+              accept=".pdf,application/pdf"
+              onChange={handleFilePick}
+              className="w-full text-sm text-portal-text file:mr-3 file:rounded file:border file:border-portal-border file:bg-transparent file:px-2 file:py-1 file:text-sm file:text-portal-text"
+              data-testid="file-input"
+            />
+          </div>
+
+          {/* Cover preview */}
+          {(extracting || previewUrl) && (
+            <div className="flex items-center gap-3">
+              {extracting && <span className="text-sm text-portal-text-muted">Extracting cover…</span>}
+              {previewUrl && !extracting && (
+                <img src={previewUrl} alt="Cover preview" className="h-24 rounded border border-portal-border object-contain" />
+              )}
+              {pageCount != null && !extracting && (
+                <span className="text-sm text-portal-text-muted">{pageCount} pages</span>
+              )}
+            </div>
+          )}
+
+          {/* Title */}
+          <div>
+            <label className="block text-sm font-medium text-portal-text mb-1">Title</label>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="w-full rounded border border-portal-border bg-transparent px-3 py-1.5 text-sm text-portal-text focus:outline-none focus:ring-1 focus:ring-portal-border"
+              placeholder="Derived from filename"
+              data-testid="title-input"
+            />
+          </div>
+
+          {/* Category */}
+          <div>
+            <label className="block text-sm font-medium text-portal-text mb-1">Category</label>
+            {!useCustom ? (
+              <div className="flex gap-2">
+                <select
+                  value={category}
+                  onChange={(e) => setCategory(e.target.value)}
+                  className="flex-1 rounded border border-portal-border bg-portal-bg px-3 py-1.5 text-sm text-portal-text focus:outline-none"
+                  data-testid="category-select"
+                >
+                  {uniqueCategories.map((c) => (
+                    <option key={c} value={c}>
+                      {c}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  onClick={() => setUseCustom(true)}
+                  className="rounded border border-portal-border px-2 py-1 text-sm text-portal-text-muted hover:text-portal-text"
+                >
+                  New…
+                </button>
+              </div>
+            ) : (
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={customCategory}
+                  onChange={(e) => setCustomCategory(e.target.value)}
+                  placeholder="Type new category"
+                  className="flex-1 rounded border border-portal-border bg-transparent px-3 py-1.5 text-sm text-portal-text focus:outline-none focus:ring-1 focus:ring-portal-border"
+                  // eslint-disable-next-line jsx-a11y/no-autofocus
+                  autoFocus
+                  data-testid="custom-category-input"
+                />
+                <button
+                  type="button"
+                  onClick={() => setUseCustom(false)}
+                  className="rounded border border-portal-border px-2 py-1 text-sm text-portal-text-muted hover:text-portal-text"
+                >
+                  ↩
+                </button>
+              </div>
+            )}
+          </div>
+
+          {/* Subcategory */}
+          <div>
+            <label className="block text-sm font-medium text-portal-text mb-1">
+              Subcategory <span className="text-portal-text-muted font-normal">(optional)</span>
+            </label>
+            <input
+              type="text"
+              value={subcategory}
+              onChange={(e) => setSubcategory(e.target.value)}
+              className="w-full rounded border border-portal-border bg-transparent px-3 py-1.5 text-sm text-portal-text focus:outline-none focus:ring-1 focus:ring-portal-border"
+              placeholder="e.g. Rulebook, Adventure Path"
+              data-testid="subcategory-input"
+            />
+          </div>
+
+          {/* Progress bar */}
+          {uploading && (
+            <div>
+              <div className="mb-1 flex justify-between text-xs text-portal-text-muted">
+                <span>Uploading…</span>
+                <span>{progress}%</span>
+              </div>
+              <div className="h-2 w-full overflow-hidden rounded-full bg-portal-border">
+                <div className="h-full rounded-full bg-portal-text transition-all" style={{ width: `${progress}%` }} />
+              </div>
+            </div>
+          )}
+
+          {/* Error */}
+          {error && (
+            <p className="rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700" role="alert">
+              {error}
+            </p>
+          )}
+        </div>
+
+        {/* Footer */}
+        <footer className="flex items-center justify-end gap-2 border-t border-portal-border px-4 py-3">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={uploading}
+            className="rounded border border-portal-border px-3 py-1.5 text-sm text-portal-text-muted hover:text-portal-text disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleUpload}
+            disabled={!file || uploading || extracting}
+            className="rounded border border-portal-border bg-portal-text px-3 py-1.5 text-sm text-portal-bg hover:opacity-90 disabled:opacity-40"
+            data-testid="upload-button"
+          >
+            {uploading ? 'Uploading…' : 'Upload'}
+          </button>
+        </footer>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/player-portal/src/features/books/api.ts
+++ b/apps/player-portal/src/features/books/api.ts
@@ -18,3 +18,37 @@ export function indexEntryToBookEntry(entry: BookIndexEntry): BookEntry {
   if (entry.pageCount != null) book.pageCount = entry.pageCount;
   return book;
 }
+
+export interface UploadBookResult {
+  id: number;
+  title: string;
+  category: string;
+  subcategory: string | null;
+  pageCount: number | null;
+  sizeBytes: number;
+}
+
+export function uploadBook(formData: FormData, onProgress: (pct: number) => void): Promise<UploadBookResult> {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open('POST', '/api/books/upload');
+    xhr.upload.addEventListener('progress', (e) => {
+      if (e.lengthComputable) onProgress(Math.round((e.loaded / e.total) * 100));
+    });
+    xhr.onload = () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        resolve(JSON.parse(xhr.responseText) as UploadBookResult);
+      } else {
+        let msg = `Upload failed (HTTP ${xhr.status})`;
+        try {
+          msg = (JSON.parse(xhr.responseText) as { error?: string }).error ?? msg;
+        } catch {
+          /* ignore */
+        }
+        reject(new Error(msg));
+      }
+    };
+    xhr.onerror = () => reject(new Error('Network error during upload'));
+    xhr.send(formData);
+  });
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -379,6 +379,16 @@ git push origin v0.2.0
 
 ---
 
+## Books
+
+PDFs are served from the path configured in `FOUNDRY_MCP_BOOKS_DIR`. There are two ways to add books to the library:
+
+**In-app upload (new):** Click **Upload PDF** on the Library page. Pick a PDF, choose a category, and submit — the file is streamed to the server, a cover thumbnail is extracted client-side, and the book appears in the catalog immediately. Files are stored under `$FOUNDRY_MCP_BOOKS_DIR/<category>/`. Maximum file size: 300 MB.
+
+**rsync (bulk/sysadmin):** Continue to rsync PDF directories to the server and mount them into the container. Files added this way will appear in the filesystem index but will NOT have a database row (no cover thumbnail, no page count) until a rescan is run. A dedicated rescan endpoint is not yet built; for now, uploaded files through the UI are the only way to get full catalog metadata for new books.
+
+---
+
 ## Migrating from v0.1.0 (all-in-one image)
 
 v0.1.0 shipped a single container (`ghcr.io/alexdickerson/foundry-toolkit`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -133,6 +133,7 @@
       "name": "@foundry-toolkit/mcp",
       "version": "1.3.0",
       "dependencies": {
+        "@fastify/multipart": "^10.0.0",
         "@foundry-toolkit/db": "*",
         "@foundry-toolkit/shared": "*",
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -2392,6 +2393,12 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/@fastify/busboy": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
+      "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
+      "license": "MIT"
+    },
     "node_modules/@fastify/cookie": {
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/@fastify/cookie/-/cookie-11.0.2.tgz",
@@ -2424,6 +2431,22 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/@fastify/deepmerge": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-3.2.1.tgz",
+      "integrity": "sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@fastify/error": {
       "version": "4.2.0",
@@ -2515,6 +2538,29 @@
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@fastify/multipart": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/multipart/-/multipart-10.0.0.tgz",
+      "integrity": "sha512-pUx3Z1QStY7E7kwvDTIvB6P+rF5lzP+iqPgZyJyG3yBJVPvQaZxzDHYbQD89rbY0ciXrMOyGi8ezHDVexLvJDA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^3.0.0",
+        "@fastify/deepmerge": "^3.0.0",
+        "@fastify/error": "^4.0.0",
+        "fastify-plugin": "^5.0.0",
+        "secure-json-parse": "^4.0.0"
       }
     },
     "node_modules/@fastify/proxy-addr": {


### PR DESCRIPTION
## Apps touched

- `apps/foundry-mcp` — `npm run dev:mcp`
- `apps/player-portal` — `npm run dev:player-portal`

## Summary

- Adds `POST /books/upload` on foundry-mcp: streams multipart PDF to `$FOUNDRY_MCP_BOOKS_DIR/<category>/`, validates PDF magic bytes, guards against path traversal, enforces 300 MB limit, inserts a `books` row into `pf2e.db`
- Adds `POST /api/books/upload` proxy in player-portal (session-gated; streams through to foundry-mcp without buffering)
- Adds Upload PDF button to the Library page: opens a modal with file picker, category combobox (existing + new), subcategory, title, cover preview, and progress bar

## Endpoint contract

**Request** `POST /books/upload` (multipart/form-data, fields must precede file part):

| Field | Type | Notes |
|---|---|---|
| `category` | text | Defaults to "Uncategorized"; path-traversal sanitized; becomes on-disk subdirectory |
| `subcategory` | text (optional) | Stored in DB only, no filesystem layout effect |
| `title` | text (optional) | Derived from filename if omitted |
| `pageCount` | text (optional) | Integer; client-supplied (extracted by pdfjs in the browser) |
| `file` | file (PDF) | The PDF — must start with `%PDF` magic bytes; max 300 MB |
| `cover` | file (PNG, optional) | Page-1 thumbnail extracted by pdfjs (~300px wide); stored as `cover_blob` |

**Responses:**
- `200` `{ id, title, category, subcategory, pageCount, sizeBytes }` — success
- `400` — no file provided
- `409` — file with that slugified title already exists in that category
- `413` — file exceeds 300 MB
- `415` — file does not start with `%PDF`
- `503` — `pf2e.db` not open

**Duplicate handling:** 409 (not auto-rename). The UI surfaces the error message; the user can change the title/category to try again.

## Why cover and page count are client-side

pdfjs-dist is already bundled into the player-portal SPA for the reader. Extracting cover and page count in the browser avoids pulling pdfjs into the foundry-mcp Node runtime (a substantial dependency for a server that doesn't need it). The server accepts them as optional multipart fields — if the client skips them, `cover_blob` stays null and `page_count` stays null.

## rsync limitation

Files rsync'd to `$FOUNDRY_MCP_BOOKS_DIR` appear in `/books/_index.json` (filesystem walk) but will NOT have a `pf2e.db` row — no cover, no page count. A "rescan/ingest existing files" endpoint is not part of this PR. For full catalog metadata, use the in-app upload. The deploy/README.md now documents both paths.

## Test coverage

- `apps/foundry-mcp/test/books-upload.test.ts` (Node test runner): round-trip (disk + DB), 415 non-PDF, 409 duplicate, path-traversal sanitization
- `apps/player-portal/src/features/books/Books.test.tsx`: upload button visible, modal opens on click

## Pre-existing test failures

`useShopMode.test.tsx` (14 tests) fail with `localStorage.clear is not a function` — this exists on `main` and is unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)