### PR TITLE
feat(player-portal): resume/edit existing characters in creator flow

### DIFF
--- a/apps/foundry-api-bridge/src/commands/handlers/actor/GetActorsHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/GetActorsHandler.ts
@@ -5,6 +5,7 @@ interface ActorEntry {
   name: string;
   type: string;
   img: string | undefined;
+  flags?: Record<string, Record<string, unknown>>;
 }
 
 interface ActorsCollection {
@@ -33,6 +34,7 @@ export function getActorsHandler(_params: Record<string, never>): Promise<ActorS
       name: actor.name,
       type: actor.type,
       img: actor.img ?? '',
+      ...(actor.flags !== undefined ? { flags: actor.flags } : {}),
     });
   });
 

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/GetPreparedActorHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/GetPreparedActorHandler.ts
@@ -101,6 +101,7 @@ export function getPreparedActorHandler(params: GetActorParams): Promise<Prepare
       type: item.type,
       img: item.img ?? '',
       system: obj.system,
+      ...(obj.flags !== undefined ? { flags: obj.flags } : {}),
     });
     const effect = normalizeStatusEffect(item, obj.system);
     if (effect !== null) statusEffects.push(effect);

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/__tests__/GetActorsHandler.test.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/__tests__/GetActorsHandler.test.ts
@@ -5,6 +5,7 @@ interface MockActor {
   name: string;
   type: string;
   img: string | undefined;
+  flags?: Record<string, Record<string, unknown>>;
 }
 
 function createMockActor(overrides?: Partial<MockActor>): MockActor {
@@ -101,5 +102,26 @@ describe('getActorsHandler', () => {
     expect(result).toHaveLength(1);
     expect(result[0]?.id).toBe('c1');
     expect(result[0]?.type).toBe('character');
+  });
+
+  it('passes through foundry-toolkit flags when present', async () => {
+    setGame([
+      createMockActor({
+        id: 'a1',
+        flags: { 'foundry-toolkit': { creatorInProgress: true, creatorVersion: 1 } },
+      }),
+    ]);
+
+    const result = await getActorsHandler({} as Record<string, never>);
+
+    expect(result[0]?.flags?.['foundry-toolkit']?.['creatorInProgress']).toBe(true);
+  });
+
+  it('omits flags field when actor has no flags', async () => {
+    setGame([createMockActor({ id: 'a1' })]);
+
+    const result = await getActorsHandler({} as Record<string, never>);
+
+    expect(result[0]?.flags).toBeUndefined();
   });
 });

--- a/apps/foundry-api-bridge/src/commands/types/actor.ts
+++ b/apps/foundry-api-bridge/src/commands/types/actor.ts
@@ -70,6 +70,7 @@ export interface ActorSummary {
   name: string;
   type: string;
   img: string;
+  flags?: Record<string, Record<string, unknown>>;
 }
 
 export interface ItemSummary {
@@ -78,6 +79,7 @@ export interface ItemSummary {
   type: string;
   img: string;
   system: Record<string, unknown>;
+  flags?: Record<string, Record<string, unknown>>;
 }
 
 export interface ActorDetailResult {

--- a/apps/player-portal/src/app/App.tsx
+++ b/apps/player-portal/src/app/App.tsx
@@ -91,6 +91,7 @@ const router = createBrowserRouter([
         children: [
           { index: true, Component: Characters },
           { path: 'new', Component: CharacterCreator },
+          { path: ':actorId/edit', Component: CharacterCreator },
           { path: ':actorId', Component: CharacterSheet },
         ],
       },

--- a/apps/player-portal/src/features/books/Books.tsx
+++ b/apps/player-portal/src/features/books/Books.tsx
@@ -18,7 +18,7 @@ import * as pdfjsLib from 'pdfjs-dist';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore — Vite resolves the ?url suffix at build time
 import pdfjsWorkerUrl from 'pdfjs-dist/build/pdf.worker.min.mjs?url';
-pdfjsLib.GlobalWorkerOptions.workerSrc = pdfjsWorkerUrl as string;
+pdfjsLib.GlobalWorkerOptions.workerSrc = pdfjsWorkerUrl;
 
 export function Books() {
   const [entries, setEntries] = useState<BookIndexEntry[]>([]);
@@ -67,7 +67,7 @@ export function Books() {
           getBookUrl={(id) => `/books/${id.split('/').map(encodeURIComponent).join('/')}`}
           scrollStorageKey={`portal.reader.scroll.${openBook.id}`}
           zoomStorageKey="portal.reader.zoom"
-          onClose={() => setOpenBook(null)}
+          onClose={() => { setOpenBook(null); }}
         />
       </div>
     );

--- a/apps/player-portal/src/features/characters/ActorList.test.tsx
+++ b/apps/player-portal/src/features/characters/ActorList.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react';
 import { ActorList } from './ActorList';
 
 function mockFetch(body: unknown, ok = true, status = 200): ReturnType<typeof vi.fn> {
@@ -61,6 +61,110 @@ describe('ActorList', () => {
     render(<ActorList />);
     await waitFor(() => {
       expect(screen.getByText(/No player characters in the world yet/)).toBeTruthy();
+    });
+  });
+});
+
+describe('ActorList — Continue / Edit buttons', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('shows Edit button for actors without creatorInProgress flag', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch([{ id: 'a1', name: 'Kyra', type: 'character', img: '', flags: {} }]),
+    );
+    const onEdit = vi.fn();
+    render(<ActorList onEdit={onEdit} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('edit-button')).toBeTruthy();
+    });
+    expect(screen.queryByTestId('continue-button')).toBeNull();
+  });
+
+  it('shows Continue button for actors with creatorInProgress=true', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch([
+        {
+          id: 'a1',
+          name: 'Kyra',
+          type: 'character',
+          img: '',
+          flags: { 'foundry-toolkit': { creatorInProgress: true } },
+        },
+      ]),
+    );
+    const onEdit = vi.fn();
+    render(<ActorList onEdit={onEdit} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('continue-button')).toBeTruthy();
+    });
+    expect(screen.queryByTestId('edit-button')).toBeNull();
+  });
+
+  it('calls onEdit when Edit button is clicked', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch([{ id: 'a1', name: 'Kyra', type: 'character', img: '' }]),
+    );
+    const onEdit = vi.fn();
+    render(<ActorList onEdit={onEdit} />);
+    await waitFor(() => screen.getByTestId('edit-button'));
+    fireEvent.click(screen.getByTestId('edit-button'));
+    expect(onEdit).toHaveBeenCalledWith(expect.objectContaining({ id: 'a1' }));
+  });
+
+  it('calls onEdit when Continue button is clicked', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch([
+        {
+          id: 'a1',
+          name: 'Kyra',
+          type: 'character',
+          img: '',
+          flags: { 'foundry-toolkit': { creatorInProgress: true } },
+        },
+      ]),
+    );
+    const onEdit = vi.fn();
+    render(<ActorList onEdit={onEdit} />);
+    await waitFor(() => screen.getByTestId('continue-button'));
+    fireEvent.click(screen.getByTestId('continue-button'));
+    expect(onEdit).toHaveBeenCalledWith(expect.objectContaining({ id: 'a1' }));
+  });
+
+  it('does not render Edit/Continue buttons when onEdit is not provided', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch([{ id: 'a1', name: 'Kyra', type: 'character', img: '' }]),
+    );
+    render(<ActorList />);
+    await waitFor(() => screen.getByText('Kyra'));
+    expect(screen.queryByTestId('edit-button')).toBeNull();
+    expect(screen.queryByTestId('continue-button')).toBeNull();
+  });
+
+  it('shows Edit for completed actors (creatorInProgress=false)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch([
+        {
+          id: 'a1',
+          name: 'Kyra',
+          type: 'character',
+          img: '',
+          flags: { 'foundry-toolkit': { creatorCompleted: true, creatorInProgress: false } },
+        },
+      ]),
+    );
+    const onEdit = vi.fn();
+    render(<ActorList onEdit={onEdit} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('edit-button')).toBeTruthy();
     });
   });
 });

--- a/apps/player-portal/src/features/characters/ActorList.tsx
+++ b/apps/player-portal/src/features/characters/ActorList.tsx
@@ -10,9 +10,10 @@ type State =
 
 interface Props {
   onSelect?: (actor: ActorSummary) => void;
+  onEdit?: (actor: ActorSummary) => void;
 }
 
-export function ActorList({ onSelect }: Props = {}): React.ReactElement {
+export function ActorList({ onSelect, onEdit }: Props = {}): React.ReactElement {
   const [state, setState] = useState<State>({ kind: 'loading' });
 
   useEffect(() => {
@@ -58,24 +59,48 @@ export function ActorList({ onSelect }: Props = {}): React.ReactElement {
   return (
     <ul className="divide-y divide-pf-border rounded border border-pf-border">
       {characters.map((actor) => {
+        const isInProgress = actor.flags?.['foundry-toolkit']?.['creatorInProgress'] === true;
         const clickable = onSelect !== undefined;
         return (
           <li
             key={actor.id}
-            className={[
-              'flex items-center gap-3 px-4 py-3',
-              clickable ? 'cursor-pointer hover:bg-pf-bg-dark' : '',
-            ].join(' ')}
-            onClick={
-              clickable
-                ? (): void => {
-                    onSelect(actor);
-                  }
-                : undefined
-            }
+            className="flex items-center gap-3 px-4 py-3"
           >
-            <span className="flex-1 truncate font-medium">{actor.name}</span>
-            {clickable && <span className="text-pf-text-muted">→</span>}
+            <button
+              type="button"
+              disabled={!clickable}
+              onClick={
+                clickable
+                  ? (): void => {
+                      onSelect(actor);
+                    }
+                  : undefined
+              }
+              className={[
+                'flex-1 truncate text-left font-medium',
+                clickable ? 'cursor-pointer hover:text-pf-primary' : '',
+              ].join(' ')}
+            >
+              {actor.name}
+            </button>
+            {onEdit !== undefined && (
+              <button
+                type="button"
+                onClick={(): void => {
+                  onEdit(actor);
+                }}
+                data-testid={isInProgress ? 'continue-button' : 'edit-button'}
+                className={[
+                  'shrink-0 rounded border px-2 py-1 text-xs font-medium transition-colors',
+                  isInProgress
+                    ? 'border-pf-primary bg-pf-primary text-white hover:bg-pf-primary-dark'
+                    : 'border-pf-border bg-pf-bg text-pf-text hover:bg-pf-bg-dark',
+                ].join(' ')}
+              >
+                {isInProgress ? 'Continue' : 'Edit'}
+              </button>
+            )}
+            {clickable && onEdit === undefined && <span className="text-pf-text-muted">→</span>}
           </li>
         );
       })}

--- a/apps/player-portal/src/features/characters/Characters.tsx
+++ b/apps/player-portal/src/features/characters/Characters.tsx
@@ -25,6 +25,9 @@ export function Characters(): React.ReactElement {
         onSelect={(a): void => {
           void navigate(`/characters/${a.id}`);
         }}
+        onEdit={(a): void => {
+          void navigate(`/characters/${a.id}/edit`);
+        }}
       />
     </main>
   );

--- a/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
+++ b/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { api } from '@/features/characters/api';
 import type { CompendiumMatch } from '@/features/characters/types';
 import { useCreatorPickerProps, type CreatorPickerOptions } from '@/features/characters/internal/useCreatorPickerProps';
@@ -16,9 +16,11 @@ import {
   beginOrReusePendingActor,
   filtersForTarget,
   groupHeritages,
+  hydrateFromActor,
   isStepFilled,
   persistPick,
   resetPendingActor,
+  saveDraftFlags,
 } from '@/features/characters/creator/helpers';
 import { PickerCard } from '@/features/characters/creator/PickerCard';
 import { AncestryStep } from '@/features/characters/creator/steps/AncestryStep';
@@ -39,6 +41,11 @@ import type { CreatorState, Draft, PickerTarget, Step } from '@/features/charact
 
 export function CharacterCreator(): React.ReactElement {
   const navigate = useNavigate();
+  // When mounted under `/characters/:actorId/edit`, the param is set.
+  // When mounted under `/characters/new`, it is undefined.
+  const { actorId: editActorId } = useParams<{ actorId?: string }>();
+  const isEditMode = editActorId !== undefined;
+
   const onBack = (): void => {
     void navigate('/characters');
   };
@@ -48,23 +55,46 @@ export function CharacterCreator(): React.ReactElement {
   const [draft, setDraft] = useState<Draft>(EMPTY_DRAFT);
   const [openPicker, setOpenPicker] = useState<PickerTarget | null>(null);
   const [creator, setCreator] = useState<CreatorState>({ kind: 'creating' });
+  const [isSaving, setIsSaving] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
-    beginOrReusePendingActor()
-      .then((actorId) => {
-        if (cancelled) return;
-        setCreator({ kind: 'ready', actorId });
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        const message = err instanceof Error ? err.message : String(err);
-        setCreator({ kind: 'error', message });
-      });
+
+    if (isEditMode && editActorId !== undefined) {
+      // Edit mode — hydrate draft from the existing actor, don't spawn a new one.
+      hydrateFromActor(editActorId)
+        .then(({ draft: loadedDraft, error }) => {
+          if (cancelled) return;
+          if (error !== null) {
+            setCreator({ kind: 'error', message: error });
+            return;
+          }
+          setDraft(loadedDraft);
+          setCreator({ kind: 'ready', actorId: editActorId });
+        })
+        .catch((err: unknown) => {
+          if (cancelled) return;
+          const message = err instanceof Error ? err.message : String(err);
+          setCreator({ kind: 'error', message });
+        });
+    } else {
+      // Create mode — spawn a blank draft actor in Foundry.
+      beginOrReusePendingActor()
+        .then((actorId) => {
+          if (cancelled) return;
+          setCreator({ kind: 'ready', actorId });
+        })
+        .catch((err: unknown) => {
+          if (cancelled) return;
+          const message = err instanceof Error ? err.message : String(err);
+          setCreator({ kind: 'error', message });
+        });
+    }
+
     return (): void => {
       cancelled = true;
     };
-  }, []);
+  }, [isEditMode, editActorId]);
 
   const actorId = creator.kind === 'ready' ? creator.actorId : null;
 
@@ -101,8 +131,26 @@ export function CharacterCreator(): React.ReactElement {
     if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
   };
 
+  const handleSaveAndContinue = (): void => {
+    if (actorId === null) return;
+    setIsSaving(true);
+    saveDraftFlags(actorId, draft, 'in-progress')
+      .catch(() => {
+        // Best-effort — navigate away even if the flag write fails.
+        // On next resume the fallback hydration path applies.
+      })
+      .finally(() => {
+        resetPendingActor();
+        void navigate('/characters');
+      });
+  };
+
   const handleFinish = (): void => {
     if (actorId === null) return;
+    // Write completion flags best-effort — navigate regardless.
+    saveDraftFlags(actorId, draft, 'completed').catch(() => {
+      /* ignore */
+    });
     resetPendingActor();
     onFinish(actorId);
   };
@@ -222,22 +270,26 @@ export function CharacterCreator(): React.ReactElement {
           <button
             type="button"
             onClick={(): void => {
-              // Null the module-scope cache so re-entering the wizard
-              // allocates a fresh draft actor instead of reusing the
-              // one the user is stepping away from.
-              resetPendingActor();
+              if (!isEditMode) {
+                // Null the module-scope cache so re-entering the wizard
+                // allocates a fresh draft actor instead of reusing the
+                // one the user is stepping away from.
+                resetPendingActor();
+              }
               onBack();
             }}
             className="rounded border border-pf-border bg-pf-bg px-2 py-1 text-xs text-pf-text hover:bg-pf-bg-dark"
           >
             ← Actors
           </button>
-          <h1 className="font-serif text-2xl font-semibold text-pf-text">New Character</h1>
+          <h1 className="font-serif text-2xl font-semibold text-pf-text">
+            {isEditMode ? 'Edit Character' : 'New Character'}
+          </h1>
         </div>
 
         {creator.kind === 'creating' && (
           <p className="rounded border border-pf-border bg-pf-bg p-4 text-sm italic text-pf-alt-dark">
-            Creating draft actor…
+            {isEditMode ? 'Loading character…' : 'Creating draft actor…'}
           </p>
         )}
         {creator.kind === 'error' && (
@@ -365,7 +417,15 @@ export function CharacterCreator(): React.ReactElement {
 
             <CreatorSection id="review" title="Review">
               <ReviewStep draft={draft} />
-              <div className="mt-4 flex justify-end">
+              <div className="mt-4 flex items-center justify-between gap-3">
+                <button
+                  type="button"
+                  onClick={handleSaveAndContinue}
+                  disabled={actorId === null || isSaving}
+                  className="rounded border border-pf-border bg-pf-bg px-3 py-1.5 text-sm text-pf-text hover:bg-pf-bg-dark disabled:opacity-40"
+                >
+                  {isSaving ? 'Saving…' : 'Save & continue later'}
+                </button>
                 <button
                   type="button"
                   onClick={handleFinish}

--- a/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
+++ b/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
@@ -147,12 +147,19 @@ export function CharacterCreator(): React.ReactElement {
 
   const handleFinish = (): void => {
     if (actorId === null) return;
-    // Write completion flags best-effort — navigate regardless.
-    saveDraftFlags(actorId, draft, 'completed').catch(() => {
-      /* ignore */
-    });
-    resetPendingActor();
-    onFinish(actorId);
+    // Await the flag write before navigating so "Edit" on the next visit
+    // finds creatorDraft and can do a full restore. The isSaving flag
+    // disables the button to prevent double-clicks.
+    setIsSaving(true);
+    saveDraftFlags(actorId, draft, 'completed')
+      .catch(() => {
+        /* best-effort — navigate regardless if the write fails */
+      })
+      .finally(() => {
+        setIsSaving(false);
+        resetPendingActor();
+        onFinish(actorId);
+      });
   };
 
   const applyPick = (match: CompendiumMatch): void => {
@@ -429,10 +436,10 @@ export function CharacterCreator(): React.ReactElement {
                 <button
                   type="button"
                   onClick={handleFinish}
-                  disabled={actorId === null}
+                  disabled={actorId === null || isSaving}
                   className="rounded border border-pf-primary bg-pf-primary px-3 py-1.5 text-sm font-medium text-white hover:bg-pf-primary-dark disabled:opacity-40"
                 >
-                  Open sheet →
+                  {isSaving ? 'Saving…' : 'Open sheet →'}
                 </button>
               </div>
             </CreatorSection>

--- a/apps/player-portal/src/features/characters/creator/helpers.test.ts
+++ b/apps/player-portal/src/features/characters/creator/helpers.test.ts
@@ -259,6 +259,111 @@ describe('hydrateFromActor', () => {
     expect(result.draft?.alternateAncestryBoosts).toEqual(['str', 'con']);
   });
 
+  it('reconstructs languagePicks by subtracting ancestry fixed languages from actor language list', async () => {
+    const actor = makeActor({
+      system: {
+        details: {
+          // actor has fixed + user-picked languages merged
+          languages: { value: ['common', 'elven', 'draconic', 'sylvan'] },
+        },
+      },
+      items: [
+        {
+          id: 'item-anc',
+          name: 'Elf',
+          type: 'ancestry',
+          img: '',
+          system: {
+            languages: { value: ['common', 'elven'] }, // ancestry's fixed languages
+            boosts: {},
+          },
+          flags: { core: { sourceId: 'Compendium.pf2e.ancestries.Item.elfId' } },
+        },
+      ],
+    });
+    mockFetch(actor);
+
+    const result = await hydrateFromActor('actor-1');
+    // draconic and sylvan were the user's picks; common and elven are fixed
+    expect(result.draft?.languagePicks).toEqual(expect.arrayContaining(['draconic', 'sylvan']));
+    expect(result.draft?.languagePicks).toHaveLength(2);
+  });
+
+  it('reconstructs skillPicks by subtracting original class skills from merged class item skills', async () => {
+    const classDoc = {
+      document: {
+        system: {
+          trainedSkills: { value: ['stealth', 'thievery'] }, // original class skills
+        },
+      },
+    };
+    const actor = makeActor({
+      items: [
+        {
+          id: 'item-cls',
+          name: 'Rogue',
+          type: 'class',
+          img: '',
+          system: {
+            // class item has original + user-added skills merged
+            trainedSkills: { value: ['stealth', 'thievery', 'acrobatics', 'deception'] },
+            keyAbility: { value: ['dex'], selected: 'dex' },
+          },
+          flags: { core: { sourceId: 'Compendium.pf2e.classes.Item.rogueId' } },
+        },
+      ],
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: (): Promise<unknown> => Promise.resolve(actor),
+        } as Response)
+        .mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: (): Promise<unknown> => Promise.resolve(classDoc),
+        } as Response),
+    );
+
+    const result = await hydrateFromActor('actor-1');
+    // acrobatics and deception are user picks; stealth and thievery are class grants
+    expect(result.draft?.skillPicks).toEqual(expect.arrayContaining(['acrobatics', 'deception']));
+    expect(result.draft?.skillPicks).toHaveLength(2);
+  });
+
+  it('leaves skillPicks empty when class compendium fetch fails', async () => {
+    const actor = makeActor({
+      items: [
+        {
+          id: 'item-cls',
+          name: 'Fighter',
+          type: 'class',
+          img: '',
+          system: { trainedSkills: { value: ['athletics'] }, keyAbility: { value: ['str'], selected: 'str' } },
+          flags: { core: { sourceId: 'Compendium.pf2e.classes.Item.fighterId' } },
+        },
+      ],
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: (): Promise<unknown> => Promise.resolve(actor),
+        } as Response)
+        .mockResolvedValue({ ok: false, status: 503, json: (): Promise<unknown> => Promise.resolve({}) } as Response),
+    );
+
+    const result = await hydrateFromActor('actor-1');
+    expect(result.draft?.skillPicks).toEqual([]);
+    // Class key ability should still be set
+    expect(result.draft?.classKeyAbility).toBe('str');
+  });
+
   it('falls back to compendium name search when item has no sourceId', async () => {
     const actor = makeActor({
       items: [

--- a/apps/player-portal/src/features/characters/creator/helpers.test.ts
+++ b/apps/player-portal/src/features/characters/creator/helpers.test.ts
@@ -160,6 +160,105 @@ describe('hydrateFromActor', () => {
     expect(result.draft?.ancestryFeat?.itemId).toBe('item-af');
   });
 
+  it('reads level-1 free boosts from actor.system.build.attributes.boosts["1"]', async () => {
+    const actor = makeActor({
+      system: {
+        build: { attributes: { boosts: { '1': ['str', 'dex', 'con', 'int'] } } },
+      },
+    });
+    mockFetch(actor);
+
+    const result = await hydrateFromActor('actor-1');
+    expect(result.draft?.levelOneBoosts).toEqual(['str', 'dex', 'con', 'int']);
+  });
+
+  it('reads ancestry boost selections from embedded item system.boosts.*.selected', async () => {
+    const actor = makeActor({
+      items: [
+        {
+          id: 'item-anc',
+          name: 'Elf',
+          type: 'ancestry',
+          img: '',
+          system: {
+            boosts: {
+              '0': { value: ['dex'], selected: 'dex' },     // fixed slot
+              '1': { value: ['int'], selected: 'int' },     // fixed slot
+              '2': { value: ['str', 'dex', 'con', 'int', 'wis', 'cha'], selected: 'wis' }, // choice slot
+            },
+          },
+          flags: { core: { sourceId: 'Compendium.pf2e.ancestries.Item.elfId' } },
+        },
+      ],
+    });
+    mockFetch(actor);
+
+    const result = await hydrateFromActor('actor-1');
+    expect(result.draft?.ancestryBoosts).toEqual(['dex', 'int', 'wis']);
+  });
+
+  it('reads class key ability from embedded class item system.keyAbility.selected', async () => {
+    const actor = makeActor({
+      items: [
+        {
+          id: 'item-cls',
+          name: 'Wizard',
+          type: 'class',
+          img: '',
+          system: { keyAbility: { value: ['int', 'wis'], selected: 'int' } },
+          flags: { core: { sourceId: 'Compendium.pf2e.classes.Item.wizardId' } },
+        },
+      ],
+    });
+    mockFetch(actor);
+
+    const result = await hydrateFromActor('actor-1');
+    expect(result.draft?.classKeyAbility).toBe('int');
+  });
+
+  it('reads background boost selections from embedded background item', async () => {
+    const actor = makeActor({
+      items: [
+        {
+          id: 'item-bg',
+          name: 'Acolyte',
+          type: 'background',
+          img: '',
+          system: {
+            boosts: {
+              '0': { value: ['int', 'wis'], selected: 'wis' },
+              '1': { value: ['str', 'dex', 'con', 'int', 'wis', 'cha'], selected: 'cha' },
+            },
+          },
+          flags: { core: { sourceId: 'Compendium.pf2e.backgrounds.Item.acolyteId' } },
+        },
+      ],
+    });
+    mockFetch(actor);
+
+    const result = await hydrateFromActor('actor-1');
+    expect(result.draft?.backgroundBoosts).toEqual(['wis', 'cha']);
+  });
+
+  it('reads alternateAncestryBoosts from embedded ancestry item', async () => {
+    const actor = makeActor({
+      items: [
+        {
+          id: 'item-anc',
+          name: 'Human',
+          type: 'ancestry',
+          img: '',
+          system: { alternateAncestryBoosts: ['str', 'con'], boosts: {} },
+          flags: { core: { sourceId: 'Compendium.pf2e.ancestries.Item.humanId' } },
+        },
+      ],
+    });
+    mockFetch(actor);
+
+    const result = await hydrateFromActor('actor-1');
+    expect(result.draft?.alternateAncestryBoosts).toEqual(['str', 'con']);
+  });
+
   it('falls back to compendium name search when item has no sourceId', async () => {
     const actor = makeActor({
       items: [

--- a/apps/player-portal/src/features/characters/creator/helpers.test.ts
+++ b/apps/player-portal/src/features/characters/creator/helpers.test.ts
@@ -160,13 +160,70 @@ describe('hydrateFromActor', () => {
     expect(result.draft?.ancestryFeat?.itemId).toBe('item-af');
   });
 
-  it('ignores items without a sourceId flag', async () => {
+  it('falls back to compendium name search when item has no sourceId', async () => {
     const actor = makeActor({
       items: [
-        { id: 'item-x', name: 'Unknown', type: 'ancestry', img: '', system: {}, flags: {} },
+        { id: 'item-anc', name: 'Dwarf', type: 'ancestry', img: 'dwarf.webp', system: {}, flags: {} },
       ],
     });
-    mockFetch(actor);
+    const searchResult = {
+      matches: [
+        {
+          packId: 'pf2e.ancestries',
+          packLabel: 'Ancestries',
+          documentId: 'dwarfId',
+          uuid: 'Compendium.pf2e.ancestries.Item.dwarfId',
+          name: 'Dwarf',
+          type: 'ancestry',
+          img: 'dwarf.webp',
+        },
+      ],
+      total: 1,
+    };
+    // First call: getPreparedActor; subsequent calls: searchCompendium for each item
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: (): Promise<unknown> => Promise.resolve(actor),
+        } as Response)
+        .mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: (): Promise<unknown> => Promise.resolve(searchResult),
+        } as Response),
+    );
+
+    const result = await hydrateFromActor('actor-1');
+    expect(result.draft?.ancestry).toEqual({
+      match: expect.objectContaining({ packId: 'pf2e.ancestries', name: 'Dwarf' }),
+      itemId: 'item-anc',
+    });
+  });
+
+  it('leaves pick null when name search returns no results', async () => {
+    const actor = makeActor({
+      items: [
+        { id: 'item-x', name: 'Homebrew Ancestry', type: 'ancestry', img: '', system: {}, flags: {} },
+      ],
+    });
+    const emptySearch = { matches: [], total: 0 };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: (): Promise<unknown> => Promise.resolve(actor),
+        } as Response)
+        .mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: (): Promise<unknown> => Promise.resolve(emptySearch),
+        } as Response),
+    );
 
     const result = await hydrateFromActor('actor-1');
     expect(result.draft?.ancestry).toBeNull();

--- a/apps/player-portal/src/features/characters/creator/helpers.test.ts
+++ b/apps/player-portal/src/features/characters/creator/helpers.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from 'vitest';
-import type { CompendiumMatch } from '@/features/characters/types';
-import { groupHeritages } from './helpers';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { CompendiumMatch, PreparedActor } from '@/features/characters/types';
+import { EMPTY_DRAFT } from './constants';
+import { groupHeritages, hydrateFromActor } from './helpers';
 
 function makeHeritage(name: string, isVersatile?: boolean): CompendiumMatch {
   return {
@@ -14,6 +15,180 @@ function makeHeritage(name: string, isVersatile?: boolean): CompendiumMatch {
     ...(isVersatile !== undefined ? { isVersatile } : {}),
   };
 }
+
+// ─── hydrateFromActor ───────────────────────────────────────────────────────
+
+function makeActor(overrides: Partial<PreparedActor> = {}): PreparedActor {
+  return {
+    id: 'actor-1',
+    uuid: 'Actor.actor-1',
+    name: 'Seraphina',
+    type: 'character',
+    img: '',
+    system: {},
+    items: [],
+    statusEffects: [],
+    flags: {},
+    ...overrides,
+  };
+}
+
+function mockFetch(body: unknown, ok = true): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok,
+      status: ok ? 200 : 500,
+      json: (): Promise<unknown> => Promise.resolve(body),
+    } as Response),
+  );
+}
+
+describe('hydrateFromActor', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('restores full draft from creatorDraft flag', async () => {
+    const draft = { ...EMPTY_DRAFT, name: 'Zara', age: '24' };
+    mockFetch(makeActor({ flags: { 'foundry-toolkit': { creatorDraft: JSON.stringify(draft) } } }));
+
+    const result = await hydrateFromActor('actor-1');
+    expect(result.error).toBeNull();
+    expect(result.draft?.name).toBe('Zara');
+    expect(result.draft?.age).toBe('24');
+  });
+
+  it('merges stored draft with EMPTY_DRAFT so missing fields get defaults', async () => {
+    // A partial draft (simulates an older stored draft missing new fields)
+    const partialDraft = { name: 'Aria' };
+    mockFetch(makeActor({ flags: { 'foundry-toolkit': { creatorDraft: JSON.stringify(partialDraft) } } }));
+
+    const result = await hydrateFromActor('actor-1');
+    expect(result.draft?.name).toBe('Aria');
+    // Fields absent from the stored draft fall back to EMPTY_DRAFT values
+    expect(result.draft?.skillPicks).toEqual([]);
+    expect(result.draft?.ancestry).toBeNull();
+  });
+
+  it('falls back to partial hydration when no creatorDraft flag', async () => {
+    const actor = makeActor({
+      name: 'Liara',
+      system: {
+        details: {
+          gender: { value: 'she/her' },
+          age: { value: '30' },
+          ethnicity: { value: 'Garundi' },
+          nationality: { value: 'Osiriani' },
+        },
+      },
+      flags: {},
+    });
+    mockFetch(actor);
+
+    const result = await hydrateFromActor('actor-1');
+    expect(result.draft?.name).toBe('Liara');
+    expect(result.draft?.gender).toBe('she/her');
+    expect(result.draft?.age).toBe('30');
+    expect(result.draft?.ethnicity).toBe('Garundi');
+  });
+
+  it('reconstructs ancestry and class slots from embedded items when no draft flag', async () => {
+    const actor = makeActor({
+      items: [
+        {
+          id: 'item-anc',
+          name: 'Elf',
+          type: 'ancestry',
+          img: 'elf.webp',
+          system: {},
+          flags: { core: { sourceId: 'Compendium.pf2e.ancestries.Item.elfId1' } },
+        },
+        {
+          id: 'item-cls',
+          name: 'Wizard',
+          type: 'class',
+          img: 'wizard.webp',
+          system: {},
+          flags: { core: { sourceId: 'Compendium.pf2e.classes.Item.wizardId1' } },
+        },
+      ],
+    });
+    mockFetch(actor);
+
+    const result = await hydrateFromActor('actor-1');
+    expect(result.draft?.ancestry).toEqual({
+      match: expect.objectContaining({
+        packId: 'pf2e.ancestries',
+        documentId: 'elfId1',
+        uuid: 'Compendium.pf2e.ancestries.Item.elfId1',
+        name: 'Elf',
+      }),
+      itemId: 'item-anc',
+    });
+    expect(result.draft?.class).toEqual({
+      match: expect.objectContaining({ packId: 'pf2e.classes', name: 'Wizard' }),
+      itemId: 'item-cls',
+    });
+  });
+
+  it('reconstructs class and ancestry feat slots from feat location field', async () => {
+    const actor = makeActor({
+      items: [
+        {
+          id: 'item-cf',
+          name: 'Spell Substitution',
+          type: 'feat',
+          img: '',
+          system: { location: 'class-1' },
+          flags: { core: { sourceId: 'Compendium.pf2e.feats-srd.Item.cfId1' } },
+        },
+        {
+          id: 'item-af',
+          name: 'Elven Weapon Elegance',
+          type: 'feat',
+          img: '',
+          system: { location: 'ancestry-1' },
+          flags: { core: { sourceId: 'Compendium.pf2e.feats-srd.Item.afId1' } },
+        },
+      ],
+    });
+    mockFetch(actor);
+
+    const result = await hydrateFromActor('actor-1');
+    expect(result.draft?.classFeat?.itemId).toBe('item-cf');
+    expect(result.draft?.ancestryFeat?.itemId).toBe('item-af');
+  });
+
+  it('ignores items without a sourceId flag', async () => {
+    const actor = makeActor({
+      items: [
+        { id: 'item-x', name: 'Unknown', type: 'ancestry', img: '', system: {}, flags: {} },
+      ],
+    });
+    mockFetch(actor);
+
+    const result = await hydrateFromActor('actor-1');
+    expect(result.draft?.ancestry).toBeNull();
+  });
+
+  it('returns an error when the actor fetch fails', async () => {
+    mockFetch({ error: 'Actor not found', suggestion: undefined }, false);
+
+    const result = await hydrateFromActor('missing-id');
+    expect(result.error).not.toBeNull();
+    expect(result.draft).toBeNull();
+  });
+
+  it('returns empty picks for actors with no items (no crash on partial actor)', async () => {
+    mockFetch(makeActor({ name: 'Blank', items: [], flags: {} }));
+
+    const result = await hydrateFromActor('actor-1');
+    expect(result.draft?.ancestry).toBeNull();
+    expect(result.draft?.class).toBeNull();
+    expect(result.error).toBeNull();
+  });
+});
 
 describe('groupHeritages', () => {
   it('puts items without isVersatile in primary', () => {

--- a/apps/player-portal/src/features/characters/creator/helpers.ts
+++ b/apps/player-portal/src/features/characters/creator/helpers.ts
@@ -1,5 +1,6 @@
 import { api } from '@/features/characters/api';
-import type { CompendiumMatch } from '@/features/characters/types';
+import type { AbilityKey, CompendiumMatch } from '@/features/characters/types';
+import { ABILITY_KEYS } from '@/features/characters/types';
 import { BOOSTS_REQUIRED, EMPTY_DRAFT, STATIC_PICKER_FILTERS } from './constants';
 import type { Draft, PickerFilters, PickerTarget, Slot, Step } from './types';
 
@@ -328,11 +329,28 @@ export async function hydrateFromActor(actorId: string): Promise<HydrateResult> 
   draft.ethnicity = extractDemographicValue(details?.['ethnicity']);
   draft.nationality = extractDemographicValue(details?.['nationality']);
 
+  // Level-1 free boosts — stored on the actor under build.attributes.boosts['1']
+  // (written by AttributesStep via api.updateActor with system.build.attributes.boosts).
+  const buildBoosts = (
+    (actor.system['build'] as Record<string, unknown> | undefined)?.['attributes'] as
+      | Record<string, unknown>
+      | undefined
+  )?.['boosts'] as Record<string, unknown> | undefined;
+  const lvl1Raw = buildBoosts?.['1'];
+  if (Array.isArray(lvl1Raw)) {
+    draft.levelOneBoosts = lvl1Raw.filter(isAbilityKey);
+  }
+
   // Reconstruct pick slots from embedded items.
   // Try flags.core.sourceId first (fast, no network call). If that's missing
   // — which happens when item.toObject(false) doesn't surface item flags, or
   // for actors created before this PR — fall back to a compendium name search
   // so the user sees their existing picks pre-selected in the creator.
+  //
+  // For ancestry/background/class items, also read back the user's boost
+  // selections from the embedded item's system data — choice slots store the
+  // picked ability in `system.boosts[idx].selected`; class stores it in
+  // `system.keyAbility.selected`.
   for (const item of actor.items) {
     let match: CompendiumMatch | null = null;
 
@@ -351,12 +369,23 @@ export async function hydrateFromActor(actorId: string): Promise<HydrateResult> 
 
     if (item.type === 'ancestry' && draft.ancestry === null) {
       draft.ancestry = { match, itemId: item.id };
+      draft.ancestryBoosts = readSelectedBoosts(item.system);
+      // Alternative ancestry boosts optional rule — stored as an array (or null)
+      const altRaw = item.system['alternateAncestryBoosts'];
+      if (Array.isArray(altRaw)) {
+        draft.alternateAncestryBoosts = altRaw.filter(isAbilityKey);
+      }
     } else if (item.type === 'heritage' && draft.heritage === null) {
       draft.heritage = { match, itemId: item.id };
     } else if (item.type === 'class' && draft.class === null) {
       draft.class = { match, itemId: item.id };
+      const keySelected = (item.system['keyAbility'] as { selected?: unknown } | undefined)?.['selected'];
+      if (isAbilityKey(keySelected)) {
+        draft.classKeyAbility = keySelected;
+      }
     } else if (item.type === 'background' && draft.background === null) {
       draft.background = { match, itemId: item.id };
+      draft.backgroundBoosts = readSelectedBoosts(item.system);
     } else if (item.type === 'deity' && draft.deity === null) {
       draft.deity = { match, itemId: item.id };
     } else if (item.type === 'feat') {
@@ -370,6 +399,26 @@ export async function hydrateFromActor(actorId: string): Promise<HydrateResult> 
   }
 
   return { draft, error: null };
+}
+
+// Reads the user's selected boost per slot from an embedded ancestry or
+// background item's system.boosts record. Each slot stores the chosen ability
+// under `boosts[idx].selected`. Returns null for slots without a selection.
+function readSelectedBoosts(system: Record<string, unknown>): (AbilityKey | null)[] {
+  const boosts = system['boosts'];
+  if (!boosts || typeof boosts !== 'object') return [];
+  const keys = Object.keys(boosts as object)
+    .filter((k) => /^\d+$/.test(k))
+    .sort((a, b) => Number(a) - Number(b));
+  return keys.map((k) => {
+    const slot = (boosts as Record<string, unknown>)[k] as { selected?: unknown } | null;
+    const sel = slot?.['selected'];
+    return isAbilityKey(sel) ? sel : null;
+  });
+}
+
+function isAbilityKey(v: unknown): v is AbilityKey {
+  return typeof v === 'string' && (ABILITY_KEYS as readonly string[]).includes(v);
 }
 
 // Canonical packs to search for each item type in the fallback hydration.

--- a/apps/player-portal/src/features/characters/creator/helpers.ts
+++ b/apps/player-portal/src/features/characters/creator/helpers.ts
@@ -347,10 +347,14 @@ export async function hydrateFromActor(actorId: string): Promise<HydrateResult> 
   // for actors created before this PR — fall back to a compendium name search
   // so the user sees their existing picks pre-selected in the creator.
   //
-  // For ancestry/background/class items, also read back the user's boost
-  // selections from the embedded item's system data — choice slots store the
-  // picked ability in `system.boosts[idx].selected`; class stores it in
-  // `system.keyAbility.selected`.
+  // Collect references needed for skill/language reconstruction after the loop:
+  //   ancestryFixedLanguages — from ancestry item's unmodified system.languages.value
+  //   classItemSkills — merged trainedSkills on the class item (class original + user picks)
+  //   classCompendiumUuid — UUID to fetch the class's ORIGINAL trainedSkills for comparison
+  let ancestryFixedLanguages: string[] = [];
+  let classItemSkills: string[] = [];
+  let classCompendiumUuid: string | null = null;
+
   for (const item of actor.items) {
     let match: CompendiumMatch | null = null;
 
@@ -370,11 +374,15 @@ export async function hydrateFromActor(actorId: string): Promise<HydrateResult> 
     if (item.type === 'ancestry' && draft.ancestry === null) {
       draft.ancestry = { match, itemId: item.id };
       draft.ancestryBoosts = readSelectedBoosts(item.system);
-      // Alternative ancestry boosts optional rule — stored as an array (or null)
       const altRaw = item.system['alternateAncestryBoosts'];
       if (Array.isArray(altRaw)) {
         draft.alternateAncestryBoosts = altRaw.filter(isAbilityKey);
       }
+      // The embedded ancestry item is an unmodified copy from the compendium —
+      // system.languages.value is the ancestry's fixed language list.
+      ancestryFixedLanguages = readStringArray(
+        (item.system['languages'] as { value?: unknown } | undefined)?.['value'],
+      );
     } else if (item.type === 'heritage' && draft.heritage === null) {
       draft.heritage = { match, itemId: item.id };
     } else if (item.type === 'class' && draft.class === null) {
@@ -383,6 +391,12 @@ export async function hydrateFromActor(actorId: string): Promise<HydrateResult> 
       if (isAbilityKey(keySelected)) {
         draft.classKeyAbility = keySelected;
       }
+      // SkillsStep merges class-original skills + user picks into this field.
+      // Store both for skillPicks reconstruction after the loop.
+      classItemSkills = readStringArray(
+        (item.system['trainedSkills'] as { value?: unknown } | undefined)?.['value'],
+      );
+      classCompendiumUuid = match.uuid;
     } else if (item.type === 'background' && draft.background === null) {
       draft.background = { match, itemId: item.id };
       draft.backgroundBoosts = readSelectedBoosts(item.system);
@@ -398,7 +412,38 @@ export async function hydrateFromActor(actorId: string): Promise<HydrateResult> 
     }
   }
 
+  // Reconstruct languagePicks: actor.system.details.languages.value is the merged
+  // set (ancestry fixed + user picks). Subtract the ancestry's fixed languages to
+  // isolate what the user actually chose.
+  const actorLangRaw = (details?.['languages'] as { value?: unknown } | undefined)?.['value'];
+  const actorLanguages = readStringArray(actorLangRaw);
+  if (actorLanguages.length > 0) {
+    const ancestryFixedSet = new Set(ancestryFixedLanguages);
+    draft.languagePicks = actorLanguages.filter((l) => !ancestryFixedSet.has(l));
+  }
+
+  // Reconstruct skillPicks: fetch the class's original trainedSkills from the
+  // compendium, then subtract to find the user's free additions. The class item
+  // embedded on the actor has the MERGED value (original + user picks), written
+  // by SkillsStep via updateActorItem.
+  if (classCompendiumUuid !== null && classItemSkills.length > 0) {
+    try {
+      const classDoc = await api.getCompendiumDocument(classCompendiumUuid);
+      const originalSkillsRaw = (
+        classDoc.document.system as { trainedSkills?: { value?: unknown } } | undefined
+      )?.trainedSkills?.value;
+      const originalSkillSet = new Set(readStringArray(originalSkillsRaw));
+      draft.skillPicks = classItemSkills.filter((s) => !originalSkillSet.has(s));
+    } catch {
+      // Leave skillPicks empty — user can re-pick in the editor
+    }
+  }
+
   return { draft, error: null };
+}
+
+function readStringArray(raw: unknown): string[] {
+  return Array.isArray(raw) ? raw.filter((v): v is string => typeof v === 'string') : [];
 }
 
 // Reads the user's selected boost per slot from an embedded ancestry or

--- a/apps/player-portal/src/features/characters/creator/helpers.ts
+++ b/apps/player-portal/src/features/characters/creator/helpers.ts
@@ -1,6 +1,6 @@
 import { api } from '@/features/characters/api';
 import type { CompendiumMatch } from '@/features/characters/types';
-import { BOOSTS_REQUIRED, STATIC_PICKER_FILTERS } from './constants';
+import { BOOSTS_REQUIRED, EMPTY_DRAFT, STATIC_PICKER_FILTERS } from './constants';
 import type { Draft, PickerFilters, PickerTarget, Slot, Step } from './types';
 
 // Module-scoped so React 18 StrictMode's dev-only double-mount
@@ -245,4 +245,146 @@ export function prettyLanguageLabel(slug: string): string {
     .split('-')
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
     .join(' ');
+}
+
+// ─── Creator lifecycle flags ────────────────────────────────────────────────
+
+// Persists creator state flags to the actor. Called on "Save & Continue Later"
+// (mode='in-progress') and on "Open sheet →" (mode='completed'). Uses Foundry's
+// merge semantics — only the specified keys are touched; other flags survive.
+export async function saveDraftFlags(
+  actorId: string,
+  draft: Draft,
+  mode: 'in-progress' | 'completed',
+): Promise<void> {
+  const tkFlags: Record<string, unknown> =
+    mode === 'in-progress'
+      ? {
+          creatorInProgress: true,
+          creatorCompleted: false,
+          creatorDraft: JSON.stringify(draft),
+        }
+      : {
+          creatorInProgress: false,
+          creatorCompleted: true,
+          creatorVersion: 1,
+          creatorDraft: null,
+        };
+
+  await api.updateActor(actorId, {
+    flags: { 'foundry-toolkit': tkFlags },
+  });
+}
+
+// ─── Hydration ──────────────────────────────────────────────────────────────
+
+export type HydrateResult =
+  | { draft: Draft; error: null }
+  | { draft: null; error: string };
+
+// Loads an existing actor and reconstructs a wizard Draft from it.
+//
+// Primary path: restore from the `creatorDraft` JSON stored in
+// flags['foundry-toolkit'] — written by "Save & Continue Later".
+//
+// Fallback (manually-created actor or pre-PR actor with no stored draft):
+// partial hydration from system.details (identity text fields) + embedded
+// items (ancestry/heritage/class/background/feats — needs flags.core.sourceId
+// on each item, which GetPreparedActorHandler now populates). Boost/skill/
+// language picks are left at their empty defaults — impossible to separate
+// "what the user chose" from "what the class granted" without the draft.
+export async function hydrateFromActor(actorId: string): Promise<HydrateResult> {
+  let actor;
+  try {
+    actor = await api.getPreparedActor(actorId);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { draft: null, error: msg };
+  }
+
+  // Primary path: sidecar draft flag
+  const tkFlags = actor.flags?.['foundry-toolkit'] ?? {};
+  const storedDraft = tkFlags['creatorDraft'];
+  if (typeof storedDraft === 'string') {
+    try {
+      const parsed = JSON.parse(storedDraft) as Partial<Draft>;
+      return { draft: { ...EMPTY_DRAFT, ...parsed }, error: null };
+    } catch {
+      // Fall through to partial hydration if the JSON is corrupt.
+    }
+  }
+
+  // Fallback: reconstruct what we can from actor state
+  const draft: Draft = { ...EMPTY_DRAFT };
+
+  // Identity fields — pf2e stores these as { value: string } objects
+  const details = actor.system['details'] as Record<string, unknown> | undefined;
+  draft.name = actor.name !== 'New Character' ? actor.name : '';
+  draft.gender = extractDemographicValue(details?.['gender']);
+  draft.age = extractDemographicValue(details?.['age']);
+  draft.ethnicity = extractDemographicValue(details?.['ethnicity']);
+  draft.nationality = extractDemographicValue(details?.['nationality']);
+
+  // Picks — build CompendiumMatch from embedded item + its sourceId flag
+  for (const item of actor.items) {
+    const sourceId = item.flags?.['core']?.['sourceId'];
+    if (typeof sourceId !== 'string') continue;
+    const match = buildMatchFromSourceId(item.name, item.type, item.img, sourceId);
+    if (match === null) continue;
+
+    if (item.type === 'ancestry' && draft.ancestry === null) {
+      draft.ancestry = { match, itemId: item.id };
+    } else if (item.type === 'heritage' && draft.heritage === null) {
+      draft.heritage = { match, itemId: item.id };
+    } else if (item.type === 'class' && draft.class === null) {
+      draft.class = { match, itemId: item.id };
+    } else if (item.type === 'background' && draft.background === null) {
+      draft.background = { match, itemId: item.id };
+    } else if (item.type === 'deity' && draft.deity === null) {
+      draft.deity = { match, itemId: item.id };
+    } else if (item.type === 'feat') {
+      const location = typeof item.system['location'] === 'string' ? item.system['location'] : '';
+      if (location === 'class-1' && draft.classFeat === null) {
+        draft.classFeat = { match, itemId: item.id };
+      } else if (location === 'ancestry-1' && draft.ancestryFeat === null) {
+        draft.ancestryFeat = { match, itemId: item.id };
+      }
+    }
+  }
+
+  return { draft, error: null };
+}
+
+// Extracts the string value from a pf2e demographic field (stored as
+// `{ value: string }` on the actor system object).
+function extractDemographicValue(field: unknown): string {
+  if (field === null || field === undefined) return '';
+  if (typeof field === 'string') return field;
+  if (typeof field === 'object' && 'value' in (field)) {
+    const v = (field).value;
+    return typeof v === 'string' ? v : '';
+  }
+  return '';
+}
+
+// Parses a Foundry compendium UUID (e.g. "Compendium.pf2e.ancestries.Item.abc")
+// into a minimal CompendiumMatch. packLabel is left empty — not available from
+// the embedded item, and not used for functionality (only display in the picker).
+function buildMatchFromSourceId(
+  name: string,
+  type: string,
+  img: string,
+  sourceId: string,
+): CompendiumMatch | null {
+  const m = /^Compendium\.([^.]+\.[^.]+)\.\w+\.(.+)$/.exec(sourceId);
+  if (m === null) return null;
+  return {
+    packId: m[1]!,
+    packLabel: '',
+    documentId: m[2]!,
+    uuid: sourceId,
+    name,
+    type,
+    img,
+  };
 }

--- a/apps/player-portal/src/features/characters/creator/helpers.ts
+++ b/apps/player-portal/src/features/characters/creator/helpers.ts
@@ -287,14 +287,15 @@ export type HydrateResult =
 // Loads an existing actor and reconstructs a wizard Draft from it.
 //
 // Primary path: restore from the `creatorDraft` JSON stored in
-// flags['foundry-toolkit'] — written by "Save & Continue Later".
+// flags['foundry-toolkit'] — written by "Save & Continue Later" and by
+// "Open sheet →". Full fidelity: all picks, boosts, skill/language choices.
 //
-// Fallback (manually-created actor or pre-PR actor with no stored draft):
-// partial hydration from system.details (identity text fields) + embedded
-// items (ancestry/heritage/class/background/feats — needs flags.core.sourceId
-// on each item, which GetPreparedActorHandler now populates). Boost/skill/
-// language picks are left at their empty defaults — impossible to separate
-// "what the user chose" from "what the class granted" without the draft.
+// Fallback (manually-created actor or very old actor without the flag):
+// Identity fields come from system.details. Picks (ancestry, heritage, class,
+// background, deity, feats) are reconstructed from the actor's embedded items
+// by searching the compendium for a matching name — no item sourceId needed.
+// Boost/skill/language picks are left at defaults (impossible to separate the
+// user's free choices from class/ancestry grants without the stored draft).
 export async function hydrateFromActor(actorId: string): Promise<HydrateResult> {
   let actor;
   try {
@@ -304,7 +305,7 @@ export async function hydrateFromActor(actorId: string): Promise<HydrateResult> 
     return { draft: null, error: msg };
   }
 
-  // Primary path: sidecar draft flag
+  // Primary path: sidecar draft flag (set on finish + save-and-continue)
   const tkFlags = actor.flags?.['foundry-toolkit'] ?? {};
   const storedDraft = tkFlags['creatorDraft'];
   if (typeof storedDraft === 'string') {
@@ -312,11 +313,11 @@ export async function hydrateFromActor(actorId: string): Promise<HydrateResult> 
       const parsed = JSON.parse(storedDraft) as Partial<Draft>;
       return { draft: { ...EMPTY_DRAFT, ...parsed }, error: null };
     } catch {
-      // Fall through to partial hydration if the JSON is corrupt.
+      // Fall through to partial hydration if the JSON is somehow corrupt.
     }
   }
 
-  // Fallback: reconstruct what we can from actor state
+  // Fallback: reconstruct from actor state
   const draft: Draft = { ...EMPTY_DRAFT };
 
   // Identity fields — pf2e stores these as { value: string } objects
@@ -327,11 +328,25 @@ export async function hydrateFromActor(actorId: string): Promise<HydrateResult> 
   draft.ethnicity = extractDemographicValue(details?.['ethnicity']);
   draft.nationality = extractDemographicValue(details?.['nationality']);
 
-  // Picks — build CompendiumMatch from embedded item + its sourceId flag
+  // Reconstruct pick slots from embedded items.
+  // Try flags.core.sourceId first (fast, no network call). If that's missing
+  // — which happens when item.toObject(false) doesn't surface item flags, or
+  // for actors created before this PR — fall back to a compendium name search
+  // so the user sees their existing picks pre-selected in the creator.
   for (const item of actor.items) {
+    let match: CompendiumMatch | null = null;
+
+    // Fast path: parse the compendium source UUID off the embedded item flag
     const sourceId = item.flags?.['core']?.['sourceId'];
-    if (typeof sourceId !== 'string') continue;
-    const match = buildMatchFromSourceId(item.name, item.type, item.img, sourceId);
+    if (typeof sourceId === 'string') {
+      match = buildMatchFromSourceId(item.name, item.type, item.img, sourceId);
+    }
+
+    // Slow path: name search against the canonical pack for this item type
+    if (match === null) {
+      match = await searchMatchByName(item.name, item.type);
+    }
+
     if (match === null) continue;
 
     if (item.type === 'ancestry' && draft.ancestry === null) {
@@ -355,6 +370,29 @@ export async function hydrateFromActor(actorId: string): Promise<HydrateResult> 
   }
 
   return { draft, error: null };
+}
+
+// Canonical packs to search for each item type in the fallback hydration.
+const FALLBACK_PACKS_BY_TYPE: Partial<Record<string, string[]>> = {
+  ancestry: ['pf2e.ancestries'],
+  heritage: ['pf2e.heritages'],
+  class: ['pf2e.classes'],
+  background: ['pf2e.backgrounds'],
+  deity: ['pf2e.deities'],
+  feat: ['pf2e.feats-srd'],
+};
+
+// Searches the appropriate pack for an item by exact name (case-insensitive).
+// Returns null if the type has no known pack, the search fails, or no match found.
+async function searchMatchByName(name: string, type: string): Promise<CompendiumMatch | null> {
+  const packIds = FALLBACK_PACKS_BY_TYPE[type];
+  if (packIds === undefined) return null;
+  try {
+    const { matches } = await api.searchCompendium({ packIds, documentType: 'Item', q: name });
+    return matches.find((m) => m.name.toLowerCase() === name.toLowerCase()) ?? null;
+  } catch {
+    return null;
+  }
 }
 
 // Extracts the string value from a pf2e demographic field (stored as

--- a/apps/player-portal/src/features/characters/creator/helpers.ts
+++ b/apps/player-portal/src/features/characters/creator/helpers.ts
@@ -268,7 +268,9 @@ export async function saveDraftFlags(
           creatorInProgress: false,
           creatorCompleted: true,
           creatorVersion: 1,
-          creatorDraft: null,
+          // Keep the draft so "Edit" can restore the full wizard state
+          // rather than falling back to the partial item-scan path.
+          creatorDraft: JSON.stringify(draft),
         };
 
   await api.updateActor(actorId, {

--- a/apps/player-portal/src/features/characters/creator/steps/AttributesStep.tsx
+++ b/apps/player-portal/src/features/characters/creator/steps/AttributesStep.tsx
@@ -488,6 +488,10 @@ function AlternateAncestryBoostPicker({
           // when `picked`, so the cap test only blocks adding a new boost.
           const atCap = !picked && allBoosts[key] >= BOOST_CAP + (flawCounts[key] ?? 0);
           const locked = !picked && (picks.length >= ALTERNATE_BOOST_COUNT || atCap);
+          // Pre-boost modifier: boosts from other sources minus flaws.
+          // When `picked`, allBoosts[key] already includes this tile's +1,
+          // so subtract it back to get the base.
+          const preBoostMod = allBoosts[key] - (flawCounts[key] ?? 0) - (picked ? 1 : 0);
           return (
             <button
               key={key}
@@ -511,7 +515,7 @@ function AlternateAncestryBoostPicker({
               <span className="text-[11px] font-semibold uppercase tracking-widest text-pf-alt-dark">
                 {key.toUpperCase()}
               </span>
-              <BoostedMod mod={0} boosted={picked} />
+              <BoostedMod mod={preBoostMod} boosted={picked} />
               <span className="text-[10px] text-pf-alt">{ABILITY_LABEL[key]}</span>
             </button>
           );
@@ -720,6 +724,7 @@ function FreeBoostBlock({
           // so checking against cap tells us whether a new free boost is allowed.
           const atCap = !picked && allBoosts[key] >= BOOST_CAP + (flawCounts[key] ?? 0);
           const locked = !picked && (selected.length >= BOOSTS_REQUIRED || atCap);
+          const preBoostMod = allBoosts[key] - (flawCounts[key] ?? 0) - (picked ? 1 : 0);
           return (
             <button
               key={key}
@@ -743,7 +748,7 @@ function FreeBoostBlock({
               <span className="text-[11px] font-semibold uppercase tracking-widest text-pf-alt-dark">
                 {key.toUpperCase()}
               </span>
-              <BoostedMod mod={0} boosted={picked} />
+              <BoostedMod mod={preBoostMod} boosted={picked} />
               <span className="text-[10px] text-pf-alt">{ABILITY_LABEL[key]}</span>
             </button>
           );

--- a/apps/player-portal/src/features/characters/internal/CharacterArtGallery.tsx
+++ b/apps/player-portal/src/features/characters/internal/CharacterArtGallery.tsx
@@ -39,14 +39,14 @@ export function CharacterArtGallery({ art, subjectName }: Props): React.ReactEle
             src={current}
             alt={`${subjectName} reference art`}
             loading="lazy"
-            onClick={() => setLightboxOpen(true)}
+            onClick={() => { setLightboxOpen(true); }}
             className="h-full w-full cursor-zoom-in rounded border border-pf-border bg-pf-bg-dark object-contain"
           />
           {hasMultiple && (
             <div className="pointer-events-none absolute inset-0 flex items-center justify-between p-1">
               <button
                 type="button"
-                onClick={() => step(-1)}
+                onClick={() => { step(-1); }}
                 aria-label="Previous image"
                 className="pointer-events-auto rounded-full bg-pf-bg/80 px-2 py-1 text-pf-text shadow hover:bg-pf-bg hover:text-pf-primary"
               >
@@ -54,7 +54,7 @@ export function CharacterArtGallery({ art, subjectName }: Props): React.ReactEle
               </button>
               <button
                 type="button"
-                onClick={() => step(1)}
+                onClick={() => { step(1); }}
                 aria-label="Next image"
                 className="pointer-events-auto rounded-full bg-pf-bg/80 px-2 py-1 text-pf-text shadow hover:bg-pf-bg hover:text-pf-primary"
               >
@@ -84,13 +84,13 @@ export function CharacterArtGallery({ art, subjectName }: Props): React.ReactEle
             aria-modal="true"
             aria-label={`${subjectName} reference art – full size`}
             className="fixed inset-0 z-[60] flex cursor-zoom-out items-center justify-center bg-black/80 p-4"
-            onClick={() => setLightboxOpen(false)}
+            onClick={() => { setLightboxOpen(false); }}
           >
             <img
               src={current}
               alt={`${subjectName} reference art`}
               className="max-h-full max-w-full rounded shadow-2xl"
-              onClick={(e) => e.stopPropagation()}
+              onClick={(e) => { e.stopPropagation(); }}
             />
           </div>,
           document.body,

--- a/apps/player-portal/src/features/characters/internal/character-art.ts
+++ b/apps/player-portal/src/features/characters/internal/character-art.ts
@@ -25,7 +25,7 @@ interface ArtData {
   classes: Record<string, CharacterArt>;
 }
 
-const artData: ArtData = artDataJson as ArtData;
+const artData: ArtData = artDataJson;
 
 export function getAncestryArt(name: string): CharacterArt | null {
   return lookup(artData.ancestries, name);

--- a/apps/player-portal/src/features/characters/internal/useCreatorPickerProps.tsx
+++ b/apps/player-portal/src/features/characters/internal/useCreatorPickerProps.tsx
@@ -198,7 +198,7 @@ export function useCreatorPickerProps(
   // picker also requires `initialRarities` to be provided so callers
   // can't accidentally render an unbound rarity control.
   const showSourcePicker = options?.showSourcePicker ?? true;
-  const showRarityPicker = (options?.showRarityPicker ?? options?.initialRarities !== undefined) === true;
+  const showRarityPicker = options?.showRarityPicker ?? options?.initialRarities !== undefined;
   const showUnmetToggle = options?.showUnmetToggle ?? true;
   const showSortToggle = options?.showSortToggle ?? true;
 

--- a/apps/player-portal/src/features/characters/sheet/tabs/inventory/InventoryItemRow.tsx
+++ b/apps/player-portal/src/features/characters/sheet/tabs/inventory/InventoryItemRow.tsx
@@ -63,13 +63,13 @@ function ItemThumb({
             aria-modal="true"
             aria-label={`${item.name} – full art`}
             className="fixed inset-0 z-[60] flex cursor-zoom-out items-center justify-center bg-black/80 p-4"
-            onClick={() => setOpen(false)}
+            onClick={() => { setOpen(false); }}
           >
             <img
               src={item.img}
               alt={item.name}
               className="max-h-full max-w-full rounded shadow-2xl"
-              onClick={(e) => e.stopPropagation()}
+              onClick={(e) => { e.stopPropagation(); }}
             />
           </div>,
           document.body,
@@ -304,13 +304,13 @@ export function GridTile({
             aria-modal="true"
             aria-label={`${item.name} – full art`}
             className="fixed inset-0 z-[60] flex cursor-zoom-out items-center justify-center bg-black/80 p-4"
-            onClick={() => setLightboxOpen(false)}
+            onClick={() => { setLightboxOpen(false); }}
           >
             <img
               src={item.img}
               alt={item.name}
               className="max-h-full max-w-full rounded shadow-2xl"
-              onClick={(e) => e.stopPropagation()}
+              onClick={(e) => { e.stopPropagation(); }}
             />
           </div>,
           document.body,

--- a/packages/shared/src/foundry-api.ts
+++ b/packages/shared/src/foundry-api.ts
@@ -22,6 +22,11 @@ export interface ActorSummary {
   name: string;
   type: string;
   img: string;
+  /** Foundry module flags keyed by scope name. The `foundry-toolkit` scope
+   *  carries creator lifecycle flags (`creatorInProgress`, `creatorCompleted`,
+   *  `creatorDraft`, `creatorVersion`). Absent when the actor has no flags or
+   *  the bridge version pre-dates this field. */
+  flags?: Record<string, Record<string, unknown>>;
 }
 
 /** Narrow result shape returned by create-actor / update-actor — just
@@ -54,6 +59,12 @@ export interface PreparedActorItem {
   type: string;
   img: string;
   system: Record<string, unknown>;
+  /** Foundry document flags. `flags.core.sourceId` carries the compendium
+   *  UUID the item was imported from — used by the creator to reconstruct
+   *  pick slots when resuming an actor without a stored draft. Absent when
+   *  the item wasn't imported from a compendium or the bridge pre-dates
+   *  this field. */
+  flags?: Record<string, Record<string, unknown>>;
 }
 
 /** A single PF2e condition or active effect on an actor, normalized for


### PR DESCRIPTION
## Apps touched

- `apps/player-portal` — `npm run dev:player-portal`
- `apps/foundry-api-bridge` — `npm run dev:api-bridge` (bridge: `GetActorsHandler` + `GetPreparedActorHandler` include flags)

## Summary

Adds resume and edit entry points to the character creator so players can finish an in-progress character or revisit a completed one.

### Entry points on the character list

- **"Continue"** — shown for actors with `flags['foundry-toolkit'].creatorInProgress === true`. Opens the creator with the full wizard state restored.
- **"Edit"** — shown for every other actor (completed, pre-PR, or manually created in Foundry). Same route, hydrates what it can.
- Clicking the actor row still goes to the sheet view.

### In-creator actions

- **"Save & continue later"** — writes the current `Draft` JSON to `flags['foundry-toolkit'].creatorDraft`, sets `creatorInProgress = true`, and returns to the character list.
- **"Open sheet →"** — now awaits the flag write before navigating, ensuring the draft is always stored for the next Edit visit.

### Flag schema (`flags['foundry-toolkit']`)

| Key | Type | Set when |
|-----|------|----------|
| `creatorInProgress` | `boolean` | Save & continue later (true); Finish (false) |
| `creatorCompleted` | `boolean` | Finish |
| `creatorVersion` | `number` (1) | Finish |
| `creatorDraft` | `string` (JSON) | Save & continue later AND finish (kept so Edit can restore) |

### Hydration policy (`/characters/:actorId/edit`)

**Primary path** (actors with a stored `creatorDraft`): full restore — all picks, boosts, skills, languages.

**Fallback** (pre-PR actors or manually-created Foundry actors, no `creatorDraft`):

| Field | Source |
|-------|--------|
| Name / gender / age / ethnicity / nationality | `actor.system.details.*` |
| Ancestry / heritage / class / background / deity / feats | Embedded items; `flags.core.sourceId` fast path, compendium name search fallback |
| Ancestry boosts | `ancestry.system.boosts[idx].selected` |
| Background boosts | `background.system.boosts[idx].selected` |
| Class key ability | `class.system.keyAbility.selected` |
| Alternate ancestry boosts | `ancestry.system.alternateAncestryBoosts` |
| Level-1 free boosts | `actor.system.build.attributes.boosts['1']` |
| Skill picks | Class item merged `trainedSkills.value` minus original from compendium fetch |
| Language picks | `actor.system.details.languages.value` minus ancestry item's fixed languages |

Boost/skill/language picks that can't be reconstructed default to empty — user can re-pick.

### Idempotency on re-submit

Write-through is unchanged — picks are applied eagerly as the user selects them. Re-submitting an unchanged actor is a no-op at the PF2e level.

### Ability modifier display on free-boost tiles

Free boost and alternate-ancestry boost tiles now show the ability's actual current modifier (accounting for all committed boosts and flaws), so the player sees "I'm taking this from +2 to +3" rather than "+0 → +1" on every tile.

## What is NOT in scope

- Undo/history
- Conflict resolution for concurrent edits
- Level-up flow
- Cascading-edit diffing UI (Review step validation still surfaces invalid picks as before)

## Test plan

- [ ] Create a new character, fill a few steps, click "Save & continue later" → returns to list with a "Continue" button
- [ ] Click "Continue" → creator opens with all picks restored (ancestry, class, heritage, background, boosts, skills, languages)
- [ ] Finish the character → list shows "Edit" button; clicking Edit re-opens fully pre-populated
- [ ] Change ancestry in Edit → heritage / ancestry feat / ancestry boosts cleared; downstream unchanged
- [ ] Edit a character created directly in Foundry (no flags) → identity pre-filled, picks populated from embedded items
- [ ] Free-boost tiles show the ability's actual current modifier from committed boosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)