### PR TITLE
feat(player-portal): variant rules infrastructure + free archetype

### DIFF
--- a/apps/foundry-mcp/src/http/app.ts
+++ b/apps/foundry-mcp/src/http/app.ts
@@ -16,6 +16,7 @@ import { registerPromptRoutes } from './routes/prompts.js';
 import { registerUploadRoutes } from './routes/uploads.js';
 import { registerItemArtRoute } from './routes/item-art.js';
 import { registerBooksRoute } from './routes/books.js';
+import { registerVariantRulesRoutes } from './routes/variant-rules.js';
 import { chatRingBuffer } from '../chat/chat-ring-buffer.js';
 
 export async function buildHttpApp(): Promise<FastifyInstance> {
@@ -90,6 +91,7 @@ export async function buildHttpApp(): Promise<FastifyInstance> {
   registerEventRoutes(app);
   registerItemArtRoute(app);
   registerBooksRoute(app);
+  registerVariantRulesRoutes(app);
   registerLiveChatRoutes(app, chatRingBuffer);
   registerLiveRoutes(app, liveDb, SHARED_SECRET);
   registerPromptRoutes(app);

--- a/apps/foundry-mcp/src/http/routes/variant-rules.ts
+++ b/apps/foundry-mcp/src/http/routes/variant-rules.ts
@@ -1,0 +1,50 @@
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { getVariantRules, setVariantRules, KNOWN_VARIANT_RULE_KEYS, isPf2eDbOpen } from '@foundry-toolkit/db/pf2e';
+import { log } from '../../logger.js';
+
+// All known keys must be booleans. Extra keys are rejected by .strict().
+const variantRulesBody = z
+  .object({
+    freeArchetype: z.boolean().optional(),
+    ancestryParagon: z.boolean().optional(),
+    dualClass: z.boolean().optional(),
+    automaticBonusProgression: z.boolean().optional(),
+    proficiencyWithoutLevel: z.boolean().optional(),
+    gradualAbilityBoosts: z.boolean().optional(),
+  })
+  .strict();
+
+export function registerVariantRulesRoutes(app: FastifyInstance): void {
+  app.get('/api/variant-rules', async (_req, reply) => {
+    if (!isPf2eDbOpen()) {
+      reply.code(503).send({ error: 'Database not configured' });
+      return;
+    }
+    return getVariantRules();
+  });
+
+  app.put('/api/variant-rules', async (req, reply) => {
+    if (!isPf2eDbOpen()) {
+      reply.code(503).send({ error: 'Database not configured' });
+      return;
+    }
+
+    // Belt-and-suspenders: explicitly reject unknown keys before Zod
+    // strict() fires so the error message names the offending key.
+    if (req.body !== null && typeof req.body === 'object') {
+      const unknown = Object.keys(req.body as object).filter((k) => !KNOWN_VARIANT_RULE_KEYS.has(k));
+      if (unknown.length > 0) {
+        reply.code(400).send({ error: `Unknown variant rule keys: ${unknown.join(', ')}` });
+        return;
+      }
+    }
+
+    const patch = variantRulesBody.parse(req.body);
+    const current = getVariantRules();
+    const next = { ...current, ...patch };
+    setVariantRules(next);
+    log.info(`variant-rules updated: ${JSON.stringify(patch)}`);
+    return next;
+  });
+}

--- a/apps/foundry-mcp/test/variant-rules-db.test.ts
+++ b/apps/foundry-mcp/test/variant-rules-db.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  openPf2eDb,
+  closePf2eDb,
+  getVariantRules,
+  setVariantRules,
+  KNOWN_VARIANT_RULE_KEYS,
+  DEFAULT_VARIANT_RULES,
+} from '@foundry-toolkit/db/pf2e';
+
+const dbPath = join(tmpdir(), `variant-rules-test-${process.pid.toString()}.db`);
+
+describe('pf2e.db – variant_rules (settings table)', () => {
+  before(() => {
+    openPf2eDb(dbPath);
+  });
+
+  after(() => {
+    closePf2eDb();
+  });
+
+  it('returns all-false defaults when no row exists', () => {
+    assert.deepEqual(getVariantRules(), DEFAULT_VARIANT_RULES);
+  });
+
+  it('round-trips freeArchetype enabled', () => {
+    setVariantRules({ ...DEFAULT_VARIANT_RULES, freeArchetype: true });
+    const rules = getVariantRules();
+    assert.equal(rules.freeArchetype, true);
+    assert.equal(rules.ancestryParagon, false);
+    assert.equal(rules.dualClass, false);
+  });
+
+  it('round-trips all keys enabled', () => {
+    const allTrue = {
+      freeArchetype: true,
+      ancestryParagon: true,
+      dualClass: true,
+      automaticBonusProgression: true,
+      proficiencyWithoutLevel: true,
+      gradualAbilityBoosts: true,
+    };
+    setVariantRules(allTrue);
+    assert.deepEqual(getVariantRules(), allTrue);
+  });
+
+  it('upserts on repeated writes', () => {
+    setVariantRules({ ...DEFAULT_VARIANT_RULES, freeArchetype: true });
+    setVariantRules({ ...DEFAULT_VARIANT_RULES, freeArchetype: false, ancestryParagon: true });
+    const rules = getVariantRules();
+    assert.equal(rules.freeArchetype, false);
+    assert.equal(rules.ancestryParagon, true);
+  });
+
+  it('KNOWN_VARIANT_RULE_KEYS has exactly six entries', () => {
+    assert.equal(KNOWN_VARIANT_RULE_KEYS.size, 6);
+    for (const key of [
+      'freeArchetype',
+      'ancestryParagon',
+      'dualClass',
+      'automaticBonusProgression',
+      'proficiencyWithoutLevel',
+      'gradualAbilityBoosts',
+    ]) {
+      assert.ok(KNOWN_VARIANT_RULE_KEYS.has(key), `missing key: ${key}`);
+    }
+  });
+});

--- a/apps/foundry-mcp/test/variant-rules-routes.test.ts
+++ b/apps/foundry-mcp/test/variant-rules-routes.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { ZodError } from 'zod/v4';
+import { openPf2eDb, closePf2eDb } from '@foundry-toolkit/db/pf2e';
+import { registerVariantRulesRoutes } from '../src/http/routes/variant-rules.js';
+
+const dbPath = join(tmpdir(), `vr-routes-test-${process.pid.toString()}.db`);
+
+function makeApp(): FastifyInstance {
+  const app = Fastify({ logger: false });
+  app.setErrorHandler((err, _req, reply) => {
+    if (err instanceof ZodError) {
+      const suggestion = err.issues.map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`).join('; ');
+      reply.code(400).send({ error: 'Invalid request parameters', suggestion });
+      return;
+    }
+    reply.code(500).send({ error: err instanceof Error ? err.message : String(err) });
+  });
+  registerVariantRulesRoutes(app);
+  return app;
+}
+
+describe('variant-rules REST routes', () => {
+  let app: FastifyInstance;
+
+  before(() => {
+    openPf2eDb(dbPath);
+    app = makeApp();
+  });
+
+  after(() => {
+    closePf2eDb();
+  });
+
+  it('GET returns 200 with all-false defaults', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/variant-rules' });
+    assert.equal(res.statusCode, 200);
+    const body = JSON.parse(res.body) as Record<string, boolean>;
+    assert.equal(body['freeArchetype'], false);
+    assert.equal(body['ancestryParagon'], false);
+    assert.equal(body['dualClass'], false);
+    assert.equal(body['automaticBonusProgression'], false);
+    assert.equal(body['proficiencyWithoutLevel'], false);
+    assert.equal(body['gradualAbilityBoosts'], false);
+  });
+
+  it('PUT accepts a partial update and returns merged config', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/variant-rules',
+      payload: { freeArchetype: true },
+    });
+    assert.equal(res.statusCode, 200);
+    const body = JSON.parse(res.body) as Record<string, boolean>;
+    assert.equal(body['freeArchetype'], true);
+    assert.equal(body['ancestryParagon'], false);
+  });
+
+  it('PUT rejects unknown keys with 400', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/variant-rules',
+      payload: { freeArchetype: true, unknownRule: true },
+    });
+    assert.equal(res.statusCode, 400);
+  });
+
+  it('PUT rejects non-boolean values with 400', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/variant-rules',
+      payload: { freeArchetype: 'yes' },
+    });
+    assert.equal(res.statusCode, 400);
+  });
+
+  it('PUT accepts all six known keys', async () => {
+    const payload = {
+      freeArchetype: true,
+      ancestryParagon: true,
+      dualClass: true,
+      automaticBonusProgression: true,
+      proficiencyWithoutLevel: true,
+      gradualAbilityBoosts: true,
+    };
+    const res = await app.inject({ method: 'PUT', url: '/api/variant-rules', payload });
+    assert.equal(res.statusCode, 200);
+    const body = JSON.parse(res.body) as typeof payload;
+    assert.equal(body['freeArchetype'], true);
+    assert.equal(body['gradualAbilityBoosts'], true);
+  });
+
+  it('GET reflects updates from PUT', async () => {
+    await app.inject({ method: 'PUT', url: '/api/variant-rules', payload: { freeArchetype: false } });
+    const res = await app.inject({ method: 'GET', url: '/api/variant-rules' });
+    const body = JSON.parse(res.body) as Record<string, boolean>;
+    assert.equal(body['freeArchetype'], false);
+  });
+});

--- a/apps/player-portal/src/app/Nav.tsx
+++ b/apps/player-portal/src/app/Nav.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react';
 import { NavLink, useNavigate } from 'react-router-dom';
 import { logout, type AuthUser } from '@/features/auth/api';
+import { VariantRulesModal } from '@/features/variant-rules/VariantRulesModal';
 
 const tabs = [
   { to: '/', label: 'Home', end: true },
@@ -18,6 +20,7 @@ interface Props {
 
 export function Nav({ theme, onToggleTheme, user, onSignOut }: Props) {
   const navigate = useNavigate();
+  const [houseRulesOpen, setHouseRulesOpen] = useState(false);
 
   async function handleSignOut(): Promise<void> {
     try {
@@ -65,6 +68,17 @@ export function Nav({ theme, onToggleTheme, user, onSignOut }: Props) {
           </>
         )}
 
+        {/* House Rules (variant rules) */}
+        <button
+          type="button"
+          onClick={(): void => setHouseRulesOpen(true)}
+          aria-label="House Rules"
+          title="House Rules"
+          className="flex h-8 w-8 items-center justify-center rounded text-portal-text-muted transition-colors hover:text-portal-text"
+        >
+          <GearIcon />
+        </button>
+
         {/* Theme toggle */}
         <button
           type="button"
@@ -75,7 +89,28 @@ export function Nav({ theme, onToggleTheme, user, onSignOut }: Props) {
           {theme === 'dark' ? <SunIcon /> : <MoonIcon />}
         </button>
       </div>
+
+      {houseRulesOpen && <VariantRulesModal onClose={(): void => setHouseRulesOpen(false)} />}
     </nav>
+  );
+}
+
+function GearIcon(): React.ReactElement {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+    </svg>
   );
 }
 

--- a/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
+++ b/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
@@ -24,12 +24,16 @@ import {
 } from '@/features/characters/creator/helpers';
 import { PickerCard } from '@/features/characters/creator/PickerCard';
 import { AncestryStep } from '@/features/characters/creator/steps/AncestryStep';
+import { ArchetypeStep } from '@/features/characters/creator/steps/ArchetypeStep';
 import { AttributesStep } from '@/features/characters/creator/steps/AttributesStep';
 import { ClassStep } from '@/features/characters/creator/steps/ClassStep';
 import { IdentityStep } from '@/features/characters/creator/steps/IdentityStep';
 import { LanguagesStep } from '@/features/characters/creator/steps/LanguagesStep';
 import { ReviewStep } from '@/features/characters/creator/steps/ReviewStep';
 import { SkillsStep } from '@/features/characters/creator/steps/SkillsStep';
+import { getVariantRules } from '@/features/variant-rules/api';
+import { DEFAULT_VARIANT_RULES } from '@/features/variant-rules/types';
+import type { VariantRulesConfig } from '@/features/variant-rules/types';
 import type { CreatorState, Draft, PickerTarget, Step } from '@/features/characters/creator/types';
 
 // Character creation wizard — Phase 1: identity + core choices.
@@ -56,6 +60,7 @@ export function CharacterCreator(): React.ReactElement {
   const [openPicker, setOpenPicker] = useState<PickerTarget | null>(null);
   const [creator, setCreator] = useState<CreatorState>({ kind: 'creating' });
   const [isSaving, setIsSaving] = useState(false);
+  const [variantRules, setVariantRules] = useState<VariantRulesConfig>(DEFAULT_VARIANT_RULES);
 
   useEffect(() => {
     let cancelled = false;
@@ -96,7 +101,20 @@ export function CharacterCreator(): React.ReactElement {
     };
   }, [isEditMode, editActorId]);
 
+  // Fetch variant rules once on mount so the creator can show/hide the
+  // Free Archetype step. Failures are silenced — default (all-false) is safe.
+  useEffect(() => {
+    getVariantRules()
+      .then(setVariantRules)
+      .catch(() => {
+        /* default stays all-false */
+      });
+  }, []);
+
   const actorId = creator.kind === 'ready' ? creator.actorId : null;
+  const freeArchetypeEnabled = variantRules.freeArchetype;
+  // Derive the visible step sequence from variant rules.
+  const activeSteps = STEPS.filter((s) => s !== 'archetype' || freeArchetypeEnabled);
 
   // Debounced flush of the identity text fields. Previously this ran
   // on step-advance; the single-page layout has no natural gate, so
@@ -312,7 +330,7 @@ export function CharacterCreator(): React.ReactElement {
               section into view. Filled state still derives from
               `isStepFilled` so users can see what's outstanding. */}
             <div className="sticky top-0 z-10 -mx-1 mb-4 bg-stage-gradient px-1 pb-2 pt-2">
-              <StepNav steps={STEPS} active={null} onJump={jumpToSection} draft={draft} />
+              <StepNav steps={activeSteps} active={null} onJump={jumpToSection} draft={draft} />
             </div>
 
             <CreatorSection id="identity" title="Identity">
@@ -361,6 +379,17 @@ export function CharacterCreator(): React.ReactElement {
                 }}
               />
             </CreatorSection>
+
+            {freeArchetypeEnabled && (
+              <CreatorSection id="archetype" title="Free Archetype">
+                <ArchetypeStep
+                  archetypeFeat={draft.archetypeFeat?.match ?? null}
+                  onPickDedication={(): void => {
+                    setOpenPicker('archetype-dedication');
+                  }}
+                />
+              </CreatorSection>
+            )}
 
             <CreatorSection id="background" title="Background">
               <PickerCard
@@ -423,7 +452,7 @@ export function CharacterCreator(): React.ReactElement {
             </CreatorSection>
 
             <CreatorSection id="review" title="Review">
-              <ReviewStep draft={draft} />
+              <ReviewStep draft={draft} freeArchetypeEnabled={freeArchetypeEnabled} />
               <div className="mt-4 flex items-center justify-between gap-3">
                 <button
                   type="button"
@@ -538,6 +567,13 @@ const PICKER_OPTIONS_BY_TARGET: Partial<Record<PickerTarget, CreatorPickerOption
     showSortToggle: false,
     hideDetailHeader: true,
     listOpenWidthClass: 'w-56',
+  },
+  // Archetype Dedication picker: show all rarities since archetypes span
+  // common to rare; keep the unmet-prereq toggle visible so players can
+  // see which dedications their character currently qualifies for.
+  'archetype-dedication': {
+    initialRarities: ['common'],
+    showSortToggle: true,
   },
 };
 

--- a/apps/player-portal/src/features/characters/creator/constants.ts
+++ b/apps/player-portal/src/features/characters/creator/constants.ts
@@ -26,12 +26,16 @@ export const EMPTY_DRAFT: Draft = {
   languagePicks: [],
   classGrantsL1Feat: null,
   languageAllowance: null,
+  archetypeFeat: null,
 };
 
+// Full ordered list of every possible step. CharacterCreator filters
+// this based on active variant rules to derive the visible step sequence.
 export const STEPS: readonly Step[] = [
   'identity',
   'ancestry',
   'class',
+  'archetype',
   'background',
   'attributes',
   'skills',
@@ -43,6 +47,7 @@ export const STEP_LABEL: Record<Step, string> = {
   identity: 'Identity',
   ancestry: 'Ancestry',
   class: 'Class',
+  archetype: 'Archetype',
   background: 'Background',
   attributes: 'Attributes',
   skills: 'Skills',
@@ -58,10 +63,11 @@ export const PICKER_LABEL: Record<PickerTarget, string> = {
   deity: 'Deity',
   'class-feat': 'Class Feat',
   'ancestry-feat': 'Ancestry Feat',
+  'archetype-dedication': 'Archetype Dedication',
 };
 
 export const STATIC_PICKER_FILTERS: Record<
-  Exclude<PickerTarget, 'heritage' | 'class-feat' | 'ancestry-feat'>,
+  Exclude<PickerTarget, 'heritage' | 'class-feat' | 'ancestry-feat' | 'archetype-dedication'>,
   PickerFilters
 > = {
   ancestry: { packIds: ['pf2e.ancestries'], documentType: 'Item' },

--- a/apps/player-portal/src/features/characters/creator/helpers.test.ts
+++ b/apps/player-portal/src/features/characters/creator/helpers.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import type { CompendiumMatch, PreparedActor } from '@/features/characters/types';
 import { EMPTY_DRAFT } from './constants';
-import { groupHeritages, hydrateFromActor } from './helpers';
+import { filtersForTarget, isStepFilled, applyPickedSlot, groupHeritages, hydrateFromActor } from './helpers';
+import type { Draft, Slot } from './types';
 
 function makeHeritage(name: string, isVersatile?: boolean): CompendiumMatch {
   return {
@@ -504,5 +505,141 @@ describe('groupHeritages', () => {
     expect(primary[1]?.name).toBe('Strong-Blooded Dwarf');
     expect(versatile[0]?.name).toBe('Nephilim');
     expect(versatile[1]?.name).toBe('Aiuvarin');
+  });
+});
+
+// ─── Archetype (Free Archetype variant rule) ────────────────────────────────
+
+function fakeSlot(name: string): Slot {
+  return {
+    match: {
+      packId: 'pf2e.feats-srd',
+      packLabel: 'Feats SRD',
+      documentId: 'abc123',
+      uuid: 'Compendium.pf2e.feats-srd.Item.abc123',
+      name,
+      type: 'feat',
+      img: '',
+    },
+    itemId: 'item-abc123',
+  };
+}
+
+describe('filtersForTarget – archetype-dedication', () => {
+  it('targets pf2e.feats-srd with the dedication trait', () => {
+    const filters = filtersForTarget('archetype-dedication', EMPTY_DRAFT);
+    expect(filters.packIds).toEqual(['pf2e.feats-srd']);
+    expect(filters.documentType).toBe('Item');
+    expect(filters.traits).toEqual(['dedication']);
+  });
+
+  it('does not apply a maxLevel restriction', () => {
+    const filters = filtersForTarget('archetype-dedication', EMPTY_DRAFT);
+    expect(filters.maxLevel).toBeUndefined();
+  });
+});
+
+describe('isStepFilled – archetype step', () => {
+  it('returns false when archetypeFeat is null', () => {
+    expect(isStepFilled('archetype', EMPTY_DRAFT)).toBe(false);
+  });
+
+  it('returns true when archetypeFeat is set', () => {
+    const draft: Draft = { ...EMPTY_DRAFT, archetypeFeat: fakeSlot('Dragon Disciple Dedication') };
+    expect(isStepFilled('archetype', draft)).toBe(true);
+  });
+});
+
+describe('applyPickedSlot – archetype-dedication', () => {
+  it('sets archetypeFeat on the draft', () => {
+    const slot = fakeSlot('Magus Dedication');
+    const next = applyPickedSlot(EMPTY_DRAFT, 'archetype-dedication', slot);
+    expect(next.archetypeFeat).toBe(slot);
+  });
+
+  it('leaves other draft fields unchanged', () => {
+    const slot = fakeSlot('Magus Dedication');
+    const withClass: Draft = { ...EMPTY_DRAFT, class: fakeSlot('Wizard') };
+    const next = applyPickedSlot(withClass, 'archetype-dedication', slot);
+    expect(next.class).toBe(withClass.class);
+    expect(next.archetypeFeat).toBe(slot);
+  });
+
+  it('replaces an existing archetypeFeat', () => {
+    const first = fakeSlot('Dragon Disciple Dedication');
+    const second = fakeSlot('Magus Dedication');
+    const withFeat: Draft = { ...EMPTY_DRAFT, archetypeFeat: first };
+    const next = applyPickedSlot(withFeat, 'archetype-dedication', second);
+    expect(next.archetypeFeat).toBe(second);
+  });
+});
+
+describe('hydrateFromActor – archetype feat (fallback path)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('reconstructs archetypeFeat from archetype-2 location in embedded items', async () => {
+    const actor: PreparedActor = {
+      id: 'actor-2',
+      uuid: 'Actor.actor-2',
+      name: 'Riven',
+      type: 'character',
+      img: '',
+      system: {},
+      items: [
+        {
+          id: 'item-arch',
+          name: 'Magus Dedication',
+          type: 'feat',
+          img: '',
+          system: { location: 'archetype-2' },
+          flags: { core: { sourceId: 'Compendium.pf2e.feats-srd.Item.magusDedId' } },
+        },
+      ],
+      statusEffects: [],
+      flags: {},
+    };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: (): Promise<unknown> => Promise.resolve(actor),
+      } as Response),
+    );
+
+    const result = await hydrateFromActor('actor-2');
+    expect(result.draft?.archetypeFeat).toEqual({
+      match: expect.objectContaining({ name: 'Magus Dedication', packId: 'pf2e.feats-srd' }),
+      itemId: 'item-arch',
+    });
+  });
+
+  it('restores archetypeFeat from stored creatorDraft flag', async () => {
+    const archetypeSlot = fakeSlot('Dragon Disciple Dedication');
+    const draft: Draft = { ...EMPTY_DRAFT, archetypeFeat: archetypeSlot };
+    const actor: PreparedActor = {
+      id: 'actor-3',
+      uuid: 'Actor.actor-3',
+      name: 'Kira',
+      type: 'character',
+      img: '',
+      system: {},
+      items: [],
+      statusEffects: [],
+      flags: { 'foundry-toolkit': { creatorDraft: JSON.stringify(draft) } },
+    };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: (): Promise<unknown> => Promise.resolve(actor),
+      } as Response),
+    );
+
+    const result = await hydrateFromActor('actor-3');
+    expect(result.draft?.archetypeFeat?.match.name).toBe('Dragon Disciple Dedication');
   });
 });

--- a/apps/player-portal/src/features/characters/creator/helpers.ts
+++ b/apps/player-portal/src/features/characters/creator/helpers.ts
@@ -45,6 +45,12 @@ export function filtersForTarget(target: PickerTarget, draft: Draft): PickerFilt
     if (traits) base.traits = traits;
     return base;
   }
+  if (target === 'archetype-dedication') {
+    // Dedication feats are the entry-point for archetypes — tagged with the
+    // 'dedication' trait in pf2e.feats-srd. No level restriction: the Free
+    // Archetype rule grants a slot at even levels, so all dedications qualify.
+    return { packIds: ['pf2e.feats-srd'], documentType: 'Item', traits: ['dedication'] };
+  }
   if (target === 'ancestry-feat') {
     // Pool the ancestry slug + heritage slug (when different) so the
     // picker surfaces versatile-heritage feats (changeling, aiuvarin,
@@ -84,6 +90,8 @@ export function isStepFilled(step: Step, draft: Draft): boolean {
       );
     case 'skills':
       return draft.skillPicks.length > 0;
+    case 'archetype':
+      return draft.archetypeFeat !== null;
     case 'languages':
       return draft.languagePicks.length > 0;
     case 'review':
@@ -92,10 +100,12 @@ export function isStepFilled(step: Step, draft: Draft): boolean {
 }
 
 // Feat-slot location strings mirror pf2e's own convention
-// (`<category>-<level>`). Only L1 feats at creation for now.
+// (`<category>-<level>`). `archetype-2` is the standard location for
+// the first archetype feat slot under the Free Archetype variant rule.
 function featLocationFor(target: PickerTarget): string | null {
   if (target === 'class-feat') return 'class-1';
   if (target === 'ancestry-feat') return 'ancestry-1';
+  if (target === 'archetype-dedication') return 'archetype-2';
   return null;
 }
 
@@ -115,6 +125,8 @@ function previousItemIdFor(draft: Draft, target: PickerTarget): string | null {
       return draft.classFeat?.itemId ?? null;
     case 'ancestry-feat':
       return draft.ancestryFeat?.itemId ?? null;
+    case 'archetype-dedication':
+      return draft.archetypeFeat?.itemId ?? null;
   }
 }
 
@@ -212,6 +224,8 @@ export function applyPickedSlot(draft: Draft, target: PickerTarget, slot: Slot):
       return { ...draft, classFeat: slot };
     case 'ancestry-feat':
       return { ...draft, ancestryFeat: slot };
+    case 'archetype-dedication':
+      return { ...draft, archetypeFeat: slot };
   }
 }
 
@@ -408,6 +422,10 @@ export async function hydrateFromActor(actorId: string): Promise<HydrateResult> 
         draft.classFeat = { match, itemId: item.id };
       } else if (location === 'ancestry-1' && draft.ancestryFeat === null) {
         draft.ancestryFeat = { match, itemId: item.id };
+      } else if (location === 'archetype-2' && draft.archetypeFeat === null) {
+        // Archetype Dedication feat granted via the Free Archetype variant rule.
+        // pf2e places the first archetype feat in the 'archetype-2' slot.
+        draft.archetypeFeat = { match, itemId: item.id };
       }
     }
   }

--- a/apps/player-portal/src/features/characters/creator/steps/ArchetypeStep.tsx
+++ b/apps/player-portal/src/features/characters/creator/steps/ArchetypeStep.tsx
@@ -1,0 +1,46 @@
+import type { CompendiumMatch } from '@/features/characters/types';
+import { useUuidHover } from '@/shared/hooks/useUuidHover';
+import { FeatSlot } from '../FeatSlot';
+
+// Free Archetype variant rule step. Shown only when the rule is enabled.
+// Selection is optional — the player can skip to leave the slot open.
+export function ArchetypeStep({
+  archetypeFeat,
+  onPickDedication,
+}: {
+  archetypeFeat: CompendiumMatch | null;
+  onPickDedication: () => void;
+}): React.ReactElement {
+  const uuidHover = useUuidHover();
+
+  return (
+    <div
+      className="space-y-4"
+      onMouseOver={uuidHover.delegationHandlers.onMouseOver}
+      onMouseOut={uuidHover.delegationHandlers.onMouseOut}
+    >
+      <div className="rounded border border-pf-tertiary/40 bg-pf-tertiary/10 px-4 py-3 text-sm text-pf-alt-dark">
+        <p className="font-semibold text-pf-text">Free Archetype</p>
+        <p className="mt-1">
+          This variant rule grants each character a free archetype feat at every even level. Pick a{' '}
+          <strong>Dedication feat</strong> now to claim your first slot — or skip and choose later from the character
+          sheet.
+        </p>
+      </div>
+
+      <FeatSlot
+        label="Archetype Dedication"
+        selection={archetypeFeat}
+        onOpen={onPickDedication}
+      />
+
+      {archetypeFeat === null && (
+        <p className="text-xs italic text-pf-alt-dark">
+          Optional — you can leave this blank and pick an Archetype Dedication later from the character sheet.
+        </p>
+      )}
+
+      {uuidHover.popover}
+    </div>
+  );
+}

--- a/apps/player-portal/src/features/characters/creator/steps/ReviewStep.tsx
+++ b/apps/player-portal/src/features/characters/creator/steps/ReviewStep.tsx
@@ -6,7 +6,13 @@ import type { Draft } from '../types';
 // L1 class feat, Anadi with Int 0 → no extra languages, etc.).
 const UNAVAILABLE = '__creator_unavailable__';
 
-export function ReviewStep({ draft }: { draft: Draft }): React.ReactElement {
+export function ReviewStep({
+  draft,
+  freeArchetypeEnabled,
+}: {
+  draft: Draft;
+  freeArchetypeEnabled: boolean;
+}): React.ReactElement {
   const textRow = (v: string): string | null => (v.trim().length > 0 ? v : null);
   const rows: Array<[string, string | null]> = [
     ['Name', textRow(draft.name)],
@@ -32,22 +38,40 @@ export function ReviewStep({ draft }: { draft: Draft }): React.ReactElement {
           : null,
     ],
   ];
+
+  // Free Archetype Dedication row: only show when the rule is active.
+  // When the rule is off but the character already has a Dedication
+  // (carried over from a prior session), show a note instead.
+  if (freeArchetypeEnabled) {
+    rows.push(['Free Archetype Dedication', draft.archetypeFeat?.match.name ?? null]);
+  }
+
   return (
-    <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm text-pf-text">
-      {rows.map(([label, value]) => (
-        <div key={label} className="contents">
-          <dt className="font-semibold uppercase tracking-widest text-pf-alt-dark">{label}</dt>
-          <dd>
-            {value === null ? (
-              <span className="italic text-neutral-400">Not chosen</span>
-            ) : value === UNAVAILABLE ? (
-              <span className="italic text-pf-alt-dark">Not granted by this character</span>
-            ) : (
-              value
-            )}
-          </dd>
-        </div>
-      ))}
-    </dl>
+    <>
+      <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm text-pf-text">
+        {rows.map(([label, value]) => (
+          <div key={label} className="contents">
+            <dt className="font-semibold uppercase tracking-widest text-pf-alt-dark">{label}</dt>
+            <dd>
+              {value === null ? (
+                <span className="italic text-neutral-400">Not chosen</span>
+              ) : value === UNAVAILABLE ? (
+                <span className="italic text-pf-alt-dark">Not granted by this character</span>
+              ) : (
+                value
+              )}
+            </dd>
+          </div>
+        ))}
+      </dl>
+
+      {!freeArchetypeEnabled && draft.archetypeFeat !== null && (
+        <p className="mt-3 rounded border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+          This character has a Free Archetype Dedication ({draft.archetypeFeat.match.name}) granted under a
+          previously-active rule. The feat remains on the actor — disable it manually from the character sheet if
+          needed.
+        </p>
+      )}
+    </>
   );
 }

--- a/apps/player-portal/src/features/characters/creator/types.ts
+++ b/apps/player-portal/src/features/characters/creator/types.ts
@@ -6,13 +6,30 @@
 
 import type { AbilityKey, CompendiumMatch, CompendiumSearchOptions } from '@/features/characters/types';
 
-export type Step = 'identity' | 'ancestry' | 'class' | 'background' | 'attributes' | 'skills' | 'languages' | 'review';
+export type Step =
+  | 'identity'
+  | 'ancestry'
+  | 'class'
+  | 'archetype'
+  | 'background'
+  | 'attributes'
+  | 'skills'
+  | 'languages'
+  | 'review';
 
 // Picker targets are decoupled from wizard steps: heritage selection
 // lives inside the ancestry step rather than owning a step of its own
 // (heritages are always children of an ancestry in pf2e's data), and
 // deity selection lives inside the identity step.
-export type PickerTarget = 'ancestry' | 'heritage' | 'class' | 'background' | 'deity' | 'class-feat' | 'ancestry-feat';
+export type PickerTarget =
+  | 'ancestry'
+  | 'heritage'
+  | 'class'
+  | 'background'
+  | 'deity'
+  | 'class-feat'
+  | 'ancestry-feat'
+  | 'archetype-dedication';
 
 export interface Slot {
   match: CompendiumMatch;
@@ -90,6 +107,11 @@ export interface Draft {
   // `ancestry.system.alternateAncestryBoosts` (presence/absence drives
   // pf2e's prepare-step branching).
   alternateAncestryBoosts: AbilityKey[] | null;
+  // Free Archetype variant rule: the player's chosen Dedication feat.
+  // Null when the rule is off or the player skipped the optional step.
+  // On the actor the feat occupies slot `archetype-2` (pf2e convention
+  // for the first archetype feat granted at even levels).
+  archetypeFeat: Slot | null;
 }
 
 // Actor lifecycle: wizard opens → creating → ready (actor exists in

--- a/apps/player-portal/src/features/characters/creator/variant-rules/README.md
+++ b/apps/player-portal/src/features/characters/creator/variant-rules/README.md
@@ -1,0 +1,92 @@
+# Variant Rules — Creator Integration Pattern
+
+Variant rules are world-wide PF2e optional rules (e.g. Free Archetype, Ancestry Paragon) that
+change character creation. The infrastructure is designed so adding a new rule is additive —
+no existing code needs to be touched beyond the registration points below.
+
+## Where things live
+
+| Layer | Location | What it does |
+|---|---|---|
+| DB / DAO | `packages/db/src/pf2e/variant-rules.ts` | `getVariantRules` / `setVariantRules` against the `settings` table |
+| REST API | `apps/foundry-mcp/src/http/routes/variant-rules.ts` | `GET /api/variant-rules`, `PUT /api/variant-rules` |
+| Client types | `apps/player-portal/src/features/variant-rules/types.ts` | `VariantRulesConfig` interface |
+| Client API | `apps/player-portal/src/features/variant-rules/api.ts` | `getVariantRules()`, `putVariantRules()` |
+| Settings UI | `apps/player-portal/src/features/variant-rules/VariantRulesModal.tsx` | Gear icon → "House Rules" modal |
+| Creator step | `apps/player-portal/src/features/characters/creator/steps/ArchetypeStep.tsx` | Free Archetype-specific step |
+
+## How to add a new variant rule
+
+### 1. Register the config key (3 files)
+
+**`packages/db/src/pf2e/variant-rules.ts`**
+- Add the key to `KNOWN_VARIANT_RULE_KEYS`
+- Add it to the `VariantRulesConfig` interface
+- Add it to `DEFAULT_VARIANT_RULES` defaulting to `false`
+
+**`apps/player-portal/src/features/variant-rules/types.ts`**
+- Mirror the new field in the client-side `VariantRulesConfig`
+- Add it to `DEFAULT_VARIANT_RULES`
+
+**`apps/foundry-mcp/src/http/routes/variant-rules.ts`**
+- Add the field to `variantRulesBody` Zod schema
+
+### 2. Add the UI toggle
+
+**`apps/player-portal/src/features/variant-rules/VariantRulesModal.tsx`** → `RULES` array:
+```typescript
+{
+  key: 'ancestryParagon',
+  label: 'Ancestry Paragon',
+  description: '...',
+  implemented: true,  // change from false when wired up
+},
+```
+
+### 3. Add a wizard step (if the rule affects creation)
+
+**`apps/player-portal/src/features/characters/creator/types.ts`**
+- Add the step name to the `Step` union
+- Add any new draft fields (e.g. `ancestryParagonFeat: Slot | null`)
+
+**`apps/player-portal/src/features/characters/creator/constants.ts`**
+- Add to `STEPS` at the right position
+- Add to `STEP_LABEL` and `PICKER_LABEL` (if a picker is needed)
+- Add to `EMPTY_DRAFT`
+
+**`apps/player-portal/src/features/characters/creator/helpers.ts`**
+- Add a case to `filtersForTarget` for the picker target
+- Add a case to `featLocationFor` (if it grants a feat)
+- Add cases to `previousItemIdFor`, `applyPickedSlot`, `isStepFilled`
+- Add to the fallback hydration loop in `hydrateFromActor`
+
+**`apps/player-portal/src/features/characters/creator/CharacterCreator.tsx`**
+- Import the new step component
+- Add a `useEffect` to fetch variant rules (already done — reuse `variantRules` state)
+- Add `activeSteps` filter: `s !== 'ancestryParagon' || variantRules.ancestryParagon`
+- Add the `{variantRules.ancestryParagon && <CreatorSection ...>}` block
+- Pass the new step's props through
+
+**`apps/player-portal/src/features/characters/creator/steps/ReviewStep.tsx`**
+- Add a row for the new step's pick
+- Add the "previously-active rule" note if the pick exists but the rule is off
+
+### 4. Persist via existing mechanism
+
+No new persistence code needed — feats are added to the actor immediately via
+`api.addItemFromCompendium` with the appropriate `systemOverrides.location` string.
+The `creatorDraft` flag in actor flags stores the full Draft JSON, so hydration
+is automatic.
+
+## Sketch: Ancestry Paragon
+
+**Rule**: each character gains an extra ancestry feat at every even level.
+
+Creator impact:
+- No new step needed — the extra slot appears in the existing Ancestry step
+- Extend `AncestryStep` to show an additional `FeatSlot` when `ancestryParagonEnabled`
+- The slot uses `location: 'ancestry-2'` for the actor feat grant
+- `Draft` gains `ancestryParagonFeat: Slot | null`
+- `ReviewStep` shows "Ancestry Paragon Feat" row when the rule is on
+
+This is roughly 2–3 hours of work: one afternoon session following the pattern above.

--- a/apps/player-portal/src/features/variant-rules/VariantRulesModal.tsx
+++ b/apps/player-portal/src/features/variant-rules/VariantRulesModal.tsx
@@ -1,0 +1,195 @@
+import { useEffect, useState } from 'react';
+import { getVariantRules, putVariantRules } from './api';
+import type { VariantRulesConfig } from './types';
+import { DEFAULT_VARIANT_RULES } from './types';
+
+interface RuleDescriptor {
+  key: keyof VariantRulesConfig;
+  label: string;
+  description: string;
+  implemented: boolean;
+}
+
+const RULES: RuleDescriptor[] = [
+  {
+    key: 'freeArchetype',
+    label: 'Free Archetype',
+    description:
+      'Each character gains a free archetype feat at every even level, allowing them to multiclass without giving up their class feats.',
+    implemented: true,
+  },
+  {
+    key: 'ancestryParagon',
+    label: 'Ancestry Paragon',
+    description:
+      "Characters gain an extra ancestry feat at every even level, deepening their connection to their ancestry's heritage.",
+    implemented: false,
+  },
+  {
+    key: 'dualClass',
+    label: 'Dual Class',
+    description: 'Characters gain the full benefits of two classes simultaneously, greatly increasing complexity and power.',
+    implemented: false,
+  },
+  {
+    key: 'automaticBonusProgression',
+    label: 'Automatic Bonus Progression',
+    description:
+      'Characters gain attack, save, and skill bonuses automatically as they level up, replacing the need to buy certain magic items.',
+    implemented: false,
+  },
+  {
+    key: 'proficiencyWithoutLevel',
+    label: 'Proficiency Without Level',
+    description:
+      "Proficiency bonuses don't include character level, reducing the power gap between characters of different levels.",
+    implemented: false,
+  },
+  {
+    key: 'gradualAbilityBoosts',
+    label: 'Gradual Ability Boosts',
+    description:
+      'Characters gain one ability boost per level from 1–4 instead of four boosts at level 1, smoothing early-game progression.',
+    implemented: false,
+  },
+];
+
+export function VariantRulesModal({ onClose }: { onClose: () => void }): React.ReactElement {
+  const [config, setConfig] = useState<VariantRulesConfig>(DEFAULT_VARIANT_RULES);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState<keyof VariantRulesConfig | null>(null);
+
+  useEffect(() => {
+    getVariantRules()
+      .then((cfg) => {
+        setConfig(cfg);
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : 'Failed to load settings');
+        setLoading(false);
+      });
+  }, []);
+
+  async function toggle(key: keyof VariantRulesConfig): Promise<void> {
+    const next = { ...config, [key]: !config[key] };
+    setConfig(next);
+    setSaving(key);
+    setError(null);
+    try {
+      const saved = await putVariantRules({ [key]: next[key] });
+      setConfig(saved);
+    } catch (err: unknown) {
+      // Revert optimistic update on failure
+      setConfig((c) => ({ ...c, [key]: !next[key] }));
+      setError(err instanceof Error ? err.message : 'Failed to save');
+    } finally {
+      setSaving(null);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="house-rules-title"
+      onClick={(e): void => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="w-[480px] max-h-[80vh] overflow-y-auto rounded-lg border border-portal-border bg-portal-surface shadow-xl">
+        <div className="flex items-center justify-between border-b border-portal-border px-5 py-4">
+          <h2 id="house-rules-title" className="text-base font-semibold text-portal-text">
+            House Rules
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded p-1 text-portal-text-muted transition-colors hover:text-portal-text"
+          >
+            <CloseIcon />
+          </button>
+        </div>
+
+        <div className="px-5 py-4">
+          {loading ? (
+            <p className="text-sm italic text-portal-text-muted">Loading…</p>
+          ) : (
+            <>
+              {error !== null && (
+                <p className="mb-3 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800">{error}</p>
+              )}
+              <p className="mb-4 text-xs text-portal-text-muted">
+                Variant rules are world-wide settings. Toggling a rule affects all characters in the next creator session.
+              </p>
+              <ul className="space-y-4">
+                {RULES.map((rule) => (
+                  <li key={rule.key} className="flex items-start gap-3">
+                    <div className="mt-0.5 shrink-0">
+                      <button
+                        type="button"
+                        role="switch"
+                        aria-checked={config[rule.key]}
+                        aria-label={rule.label}
+                        disabled={saving !== null}
+                        onClick={(): void => {
+                          void toggle(rule.key);
+                        }}
+                        className={[
+                          'relative h-5 w-9 rounded-full transition-colors',
+                          'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-portal-accent',
+                          'disabled:opacity-50',
+                          config[rule.key]
+                            ? 'bg-portal-accent'
+                            : 'bg-portal-border',
+                        ].join(' ')}
+                      >
+                        <span
+                          className={[
+                            'absolute top-0.5 h-4 w-4 rounded-full bg-white shadow transition-transform',
+                            config[rule.key] ? 'left-[18px]' : 'left-0.5',
+                          ].join(' ')}
+                        />
+                      </button>
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-medium text-portal-text">{rule.label}</span>
+                        {!rule.implemented && (
+                          <span className="rounded-full bg-portal-border px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-portal-text-muted">
+                            coming soon
+                          </span>
+                        )}
+                        {saving === rule.key && (
+                          <span className="text-[10px] italic text-portal-text-muted">saving…</span>
+                        )}
+                      </div>
+                      <p className="mt-0.5 text-xs text-portal-text-muted">{rule.description}</p>
+                      {!rule.implemented && config[rule.key] && (
+                        <p className="mt-1 text-[10px] italic text-portal-text-muted">
+                          Wiring still in progress — this toggle saves but has no effect in the creator yet.
+                        </p>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CloseIcon(): React.ReactElement {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+      <line x1="18" y1="6" x2="6" y2="18" />
+      <line x1="6" y1="6" x2="18" y2="18" />
+    </svg>
+  );
+}

--- a/apps/player-portal/src/features/variant-rules/VariantRulesModal.tsx
+++ b/apps/player-portal/src/features/variant-rules/VariantRulesModal.tsx
@@ -139,18 +139,16 @@ export function VariantRulesModal({ onClose }: { onClose: () => void }): React.R
                           void toggle(rule.key);
                         }}
                         className={[
-                          'relative h-5 w-9 rounded-full transition-colors',
+                          'relative h-5 w-9 appearance-none rounded-full transition-colors',
                           'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-portal-accent',
                           'disabled:opacity-50',
-                          config[rule.key]
-                            ? 'bg-portal-accent'
-                            : 'bg-portal-border',
+                          config[rule.key] ? 'bg-portal-accent' : 'bg-portal-border',
                         ].join(' ')}
                       >
                         <span
                           className={[
-                            'absolute top-0.5 h-4 w-4 rounded-full bg-white shadow transition-transform',
-                            config[rule.key] ? 'left-[18px]' : 'left-0.5',
+                            'absolute left-0.5 top-0.5 h-4 w-4 rounded-full bg-white shadow transition-transform',
+                            config[rule.key] ? 'translate-x-4' : 'translate-x-0',
                           ].join(' ')}
                         />
                       </button>

--- a/apps/player-portal/src/features/variant-rules/api.ts
+++ b/apps/player-portal/src/features/variant-rules/api.ts
@@ -1,0 +1,16 @@
+import { requestJson } from '@foundry-toolkit/shared/http';
+import type { VariantRulesConfig } from './types';
+
+const BASE = '/api/mcp';
+
+export async function getVariantRules(): Promise<VariantRulesConfig> {
+  return requestJson<VariantRulesConfig>(`${BASE}/variant-rules`);
+}
+
+export async function putVariantRules(patch: Partial<VariantRulesConfig>): Promise<VariantRulesConfig> {
+  return requestJson<VariantRulesConfig>(`${BASE}/variant-rules`, {
+    method: 'PUT',
+    body: JSON.stringify(patch),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/apps/player-portal/src/features/variant-rules/types.ts
+++ b/apps/player-portal/src/features/variant-rules/types.ts
@@ -1,0 +1,19 @@
+// Client-side type mirror of packages/db VariantRulesConfig.
+// Must match the API response shape from GET /api/mcp/variant-rules.
+export interface VariantRulesConfig {
+  freeArchetype: boolean;
+  ancestryParagon: boolean;
+  dualClass: boolean;
+  automaticBonusProgression: boolean;
+  proficiencyWithoutLevel: boolean;
+  gradualAbilityBoosts: boolean;
+}
+
+export const DEFAULT_VARIANT_RULES: VariantRulesConfig = {
+  freeArchetype: false,
+  ancestryParagon: false,
+  dualClass: false,
+  automaticBonusProgression: false,
+  proficiencyWithoutLevel: false,
+  gradualAbilityBoosts: false,
+};

--- a/apps/player-portal/src/shared/styles/index.css
+++ b/apps/player-portal/src/shared/styles/index.css
@@ -80,6 +80,12 @@
 @utility bg-portal-surface-hover {
   background-color: var(--portal-surface-hover);
 }
+@utility bg-portal-accent {
+  background-color: var(--portal-accent);
+}
+@utility bg-portal-border {
+  background-color: var(--portal-border);
+}
 @utility bg-portal-accent-subtle {
   background-color: var(--portal-accent-subtle);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10709,6 +10709,13 @@
         "node": ">=20"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -15371,6 +15378,16 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/launder": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
+      "integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dayjs": "^1.11.7"
+      }
+    },
     "node_modules/lazy-val": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
@@ -19230,9 +19247,9 @@
       }
     },
     "node_modules/sanitize-html": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.3.tgz",
-      "integrity": "sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg==",
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.4.tgz",
+      "integrity": "sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19240,6 +19257,7 @@
         "escape-string-regexp": "^4.0.0",
         "htmlparser2": "^10.1.0",
         "is-plain-object": "^5.0.0",
+        "launder": "^1.7.1",
         "parse-srcset": "^1.0.2",
         "postcss": "^8.3.11"
       }

--- a/packages/db/src/pf2e/index.ts
+++ b/packages/db/src/pf2e/index.ts
@@ -37,3 +37,10 @@ export {
 export type { CachedDocument } from './compendium-cache.js';
 export { getItemArtOverride, setItemArtOverride, listItemArtOverrides } from './item-art.js';
 export type { ItemArtOverride } from './item-art.js';
+export {
+  getVariantRules,
+  setVariantRules,
+  KNOWN_VARIANT_RULE_KEYS,
+  DEFAULT_VARIANT_RULES,
+} from './variant-rules.js';
+export type { VariantRulesConfig } from './variant-rules.js';

--- a/packages/db/src/pf2e/variant-rules.ts
+++ b/packages/db/src/pf2e/variant-rules.ts
@@ -1,0 +1,51 @@
+import { getPf2eDb } from './connection.js';
+import { tryParseJson } from './internal.js';
+
+const VARIANT_RULES_KEY = 'app:variant-rules';
+
+export const KNOWN_VARIANT_RULE_KEYS: ReadonlySet<string> = new Set([
+  'freeArchetype',
+  'ancestryParagon',
+  'dualClass',
+  'automaticBonusProgression',
+  'proficiencyWithoutLevel',
+  'gradualAbilityBoosts',
+]);
+
+export interface VariantRulesConfig {
+  freeArchetype: boolean;
+  ancestryParagon: boolean;
+  dualClass: boolean;
+  automaticBonusProgression: boolean;
+  proficiencyWithoutLevel: boolean;
+  gradualAbilityBoosts: boolean;
+}
+
+export const DEFAULT_VARIANT_RULES: VariantRulesConfig = {
+  freeArchetype: false,
+  ancestryParagon: false,
+  dualClass: false,
+  automaticBonusProgression: false,
+  proficiencyWithoutLevel: false,
+  gradualAbilityBoosts: false,
+};
+
+export function getVariantRules(): VariantRulesConfig {
+  const row = getPf2eDb().prepare('SELECT value FROM settings WHERE key = ?').get(VARIANT_RULES_KEY) as
+    | { value: string }
+    | undefined;
+  if (!row) return { ...DEFAULT_VARIANT_RULES };
+  const parsed = tryParseJson<Record<string, unknown>>(row.value, {});
+  const overrides = Object.fromEntries(
+    Object.entries(parsed)
+      .filter(([k]) => KNOWN_VARIANT_RULE_KEYS.has(k))
+      .map(([k, v]) => [k, Boolean(v)]),
+  );
+  return { ...DEFAULT_VARIANT_RULES, ...overrides };
+}
+
+export function setVariantRules(config: VariantRulesConfig): void {
+  getPf2eDb()
+    .prepare('INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value')
+    .run(VARIANT_RULES_KEY, JSON.stringify(config));
+}


### PR DESCRIPTION
## Apps touched

- `apps/player-portal` — `npm run dev:player-portal`
- `apps/foundry-mcp` — `npm run dev:mcp`
- `packages/db` — consumed by foundry-mcp; no app to spin up separately

---

## What this PR ships

### Config schema

Stored in the pf2e.db `settings` table under key `app:variant-rules`:

```json
{
  "freeArchetype": false,
  "ancestryParagon": false,
  "dualClass": false,
  "automaticBonusProgression": false,
  "proficiencyWithoutLevel": false,
  "gradualAbilityBoosts": false
}
```

All keys default to `false`. Unknown keys are rejected with 400.

### REST API (foundry-mcp)

- `GET /api/variant-rules` — returns current config (or all-false defaults if no row exists)
- `PUT /api/variant-rules` — accepts a partial patch; validates all keys; rejects unknown keys and non-boolean values

Both routes are automatically session-gated via player-portal's `/api/mcp/*` proxy.

### Settings UI

Gear icon added to the right side of the global nav. Opens a **"House Rules"** modal showing all six variant rule toggles with descriptions. Toggles auto-save via PUT on click. Rules not yet wired in the creator show a **"coming soon"** badge; toggling on a coming-soon rule shows inline text: *"Wiring still in progress — this toggle saves but has no effect in the creator yet."*

### Free Archetype — end-to-end

The only rule wired all the way through:

- **Creator step** (`ArchetypeStep.tsx`): appears after the Class step when `freeArchetype === true`. Shows a Dedication feat picker (filtered to `traits: ['dedication']` in `pf2e.feats-srd`). Step is **optional** — explicit skip affordance, no submission gate.
- **Feat grant**: Dedication feat is added to the actor at slot `location: 'archetype-2'` (pf2e convention for the first archetype feat slot).
- **ReviewStep**: shows "Free Archetype Dedication" row when the rule is on.
- **Rule disabled with existing Dedication**: ReviewStep surfaces an amber warning note: *"This character has a Free Archetype Dedication granted under a previously-active rule."* Feat is not auto-removed (non-destructive policy).
- **Hydration (resume/edit)**: primary path restores from `creatorDraft` flag. Fallback path scans embedded items for `location === 'archetype-2'`.

### Variant rule step pattern

See `apps/player-portal/src/features/characters/creator/variant-rules/README.md` for the step-by-step guide to adding a new rule. Includes a concrete Ancestry Paragon sketch.

### How to add the next rule

1. Register the config key in three files (DAO, client types, Zod schema)
2. Add a UI toggle to the `RULES` array in `VariantRulesModal.tsx` (`implemented: true`)
3. If it affects the wizard: add a `Step` entry, a `Draft` field, a filter in `filtersForTarget`, a case in `isStepFilled` / `applyPickedSlot` / `previousItemIdFor`, and a conditional `<CreatorSection>` in `CharacterCreator.tsx`
4. No new persistence code needed — feats are added eagerly via `addItemFromCompendium` and restored from the stored draft JSON

---

## Tests

- **DAO round-trip**: `apps/foundry-mcp/test/variant-rules-db.test.ts` (node:test, real in-memory DB)
- **Route validation**: `apps/foundry-mcp/test/variant-rules-routes.test.ts` (node:test, real in-memory DB + Fastify inject)
- **Pure helpers**: `apps/player-portal/src/features/characters/creator/helpers.test.ts` — added `filtersForTarget('archetype-dedication')`, `isStepFilled('archetype')`, `applyPickedSlot('archetype-dedication')`, and archetype feat hydration round-trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)