### PR TITLE
fix(player-portal): populate spellcasting entry on character submit based on class + subclass

### DIFF
--- a/apps/foundry-api-bridge/src/commands/handlers/actor/CreateSpellcastingEntryHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/CreateSpellcastingEntryHandler.ts
@@ -1,0 +1,55 @@
+import type { CreateSpellcastingEntryParams, ItemResult } from '@/commands/types';
+
+interface FoundryItem {
+  id: string;
+  name: string;
+  type: string;
+  img: string;
+}
+
+interface FoundryActor {
+  id: string;
+  name: string;
+  createEmbeddedDocuments(embeddedName: string, data: Record<string, unknown>[]): Promise<FoundryItem[]>;
+}
+
+interface ActorsCollection {
+  get(id: string): FoundryActor | undefined;
+}
+
+interface FoundryGame {
+  actors: ActorsCollection;
+}
+
+declare const game: FoundryGame;
+
+export async function createSpellcastingEntryHandler(
+  params: CreateSpellcastingEntryParams,
+): Promise<ItemResult> {
+  const actor = game.actors.get(params.actorId);
+  if (!actor) throw new Error(`Actor not found: ${params.actorId}`);
+
+  const entryData: Record<string, unknown> = {
+    name: params.name,
+    type: 'spellcastingEntry',
+    system: {
+      tradition: { value: params.tradition },
+      prepared: { value: params.prepared, flexible: false, validItems: null },
+      proficiency: { value: 1 },
+      ability: { value: params.ability },
+    },
+  };
+
+  const created = await actor.createEmbeddedDocuments('Item', [entryData]);
+  const entry = created[0];
+  if (!entry) throw new Error('createEmbeddedDocuments returned empty array for spellcastingEntry');
+
+  return {
+    id: entry.id,
+    name: entry.name,
+    type: entry.type,
+    img: entry.img,
+    actorId: actor.id,
+    actorName: actor.name,
+  };
+}

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/GetActorsHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/GetActorsHandler.ts
@@ -1,11 +1,19 @@
 import type { ActorSummary } from '@/commands/types';
 
+interface PartyRef {
+  id: string;
+  name: string;
+}
+
 interface ActorEntry {
   id: string;
   name: string;
   type: string;
   img: string | undefined;
   flags?: Record<string, Record<string, unknown>>;
+  /** PF2e populates this with a Set of party actors the character belongs
+   *  to. Empty/absent when the character isn't in any party. */
+  parties?: Iterable<PartyRef>;
 }
 
 interface ActorsCollection {
@@ -18,6 +26,17 @@ interface FoundryGame {
 
 function getGame(): FoundryGame {
   return (globalThis as unknown as { game: FoundryGame }).game;
+}
+
+// Reduce the PF2e parties Set to a single { id, name } ref — the first
+// party the character belongs to. Returns null when the character is
+// unaffiliated. The vast majority of characters are in 0 or 1 party.
+function firstParty(parties: Iterable<PartyRef> | undefined): PartyRef | null {
+  if (!parties) return null;
+  for (const p of parties) {
+    if (typeof p.id === 'string' && typeof p.name === 'string') return { id: p.id, name: p.name };
+  }
+  return null;
 }
 
 export function getActorsHandler(_params: Record<string, never>): Promise<ActorSummary[]> {
@@ -35,6 +54,7 @@ export function getActorsHandler(_params: Record<string, never>): Promise<ActorS
       type: actor.type,
       img: actor.img ?? '',
       ...(actor.flags !== undefined ? { flags: actor.flags } : {}),
+      party: firstParty(actor.parties),
     });
   });
 

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/GetPreparedActorHandler.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/GetPreparedActorHandler.ts
@@ -15,6 +15,17 @@ interface ActorItemsCollection {
   forEach(fn: (item: ActorItem) => void): void;
 }
 
+// Minimal shape of a PF2e feat group entry, typed just enough for the
+// archetype-slot extraction below. `slots` is a Record keyed by slot id
+// (e.g. "archetype-2") when the free-archetype variant rule is active.
+interface FeatGroupSlot {
+  level?: number;
+}
+interface FeatGroup {
+  label?: string;
+  slots?: Record<string, FeatGroupSlot>;
+}
+
 interface FoundryActor extends ToObjectable {
   id: string;
   uuid: string;
@@ -22,6 +33,7 @@ interface FoundryActor extends ToObjectable {
   type: string;
   img: string | undefined;
   items: ActorItemsCollection;
+  feats?: Iterable<FeatGroup>;
 }
 
 interface ActorsCollection {
@@ -109,6 +121,23 @@ export function getPreparedActorHandler(params: GetActorParams): Promise<Prepare
 
   const snapshot = actor.toObject(false);
 
+  // Extract archetype feat slot levels from PF2e's computed feat groups.
+  // The free-archetype variant causes PF2e to add an "ArchetypeHeader"
+  // group to actor.feats with slots keyed "archetype-2", "archetype-4",
+  // etc. When the variant is disabled the group is absent, so this array
+  // comes back empty and the Progression tab shows no archetype slots.
+  const archetypeFeatLevels: number[] = [];
+  if (actor.feats) {
+    for (const group of actor.feats) {
+      if (typeof group.label === 'string' && group.label.includes('Archetype') && group.slots) {
+        for (const slot of Object.values(group.slots)) {
+          if (typeof slot.level === 'number') archetypeFeatLevels.push(slot.level);
+        }
+        break;
+      }
+    }
+  }
+
   return Promise.resolve({
     id: actor.id,
     uuid: actor.uuid,
@@ -119,5 +148,6 @@ export function getPreparedActorHandler(params: GetActorParams): Promise<Prepare
     items,
     statusEffects,
     flags: snapshot.flags ?? {},
+    ...(archetypeFeatLevels.length > 0 ? { archetypeFeatLevels } : {}),
   });
 }

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/__tests__/GetActorsHandler.test.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/__tests__/GetActorsHandler.test.ts
@@ -1,11 +1,17 @@
 import { getActorsHandler } from '../GetActorsHandler';
 
+interface MockPartyRef {
+  id: string;
+  name: string;
+}
+
 interface MockActor {
   id: string;
   name: string;
   type: string;
   img: string | undefined;
   flags?: Record<string, Record<string, unknown>>;
+  parties?: MockPartyRef[];
 }
 
 function createMockActor(overrides?: Partial<MockActor>): MockActor {
@@ -46,7 +52,9 @@ describe('getActorsHandler', () => {
 
     const result = await getActorsHandler({} as Record<string, never>);
 
-    expect(result).toEqual([{ id: 'a2', name: 'Frodo', type: 'character', img: 'tokens/frodo.webp' }]);
+    expect(result).toEqual([
+      { id: 'a2', name: 'Frodo', type: 'character', img: 'tokens/frodo.webp', party: null },
+    ]);
   });
 
   it('should return empty array for empty collection', async () => {
@@ -123,5 +131,30 @@ describe('getActorsHandler', () => {
     const result = await getActorsHandler({} as Record<string, never>);
 
     expect(result[0]?.flags).toBeUndefined();
+  });
+
+  it('extracts party ref from actor.parties (first entry)', async () => {
+    setGame([
+      createMockActor({
+        id: 'a1',
+        parties: [{ id: 'p1', name: 'The Dents' }],
+      }),
+    ]);
+
+    const result = await getActorsHandler({} as Record<string, never>);
+
+    expect(result[0]?.party).toEqual({ id: 'p1', name: 'The Dents' });
+  });
+
+  it('returns party=null when actor has no parties', async () => {
+    setGame([createMockActor({ id: 'a1' })]);
+    const result = await getActorsHandler({} as Record<string, never>);
+    expect(result[0]?.party).toBeNull();
+  });
+
+  it('returns party=null when parties is empty', async () => {
+    setGame([createMockActor({ id: 'a1', parties: [] })]);
+    const result = await getActorsHandler({} as Record<string, never>);
+    expect(result[0]?.party).toBeNull();
   });
 });

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/__tests__/cast-spell-action.test.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/__tests__/cast-spell-action.test.ts
@@ -23,6 +23,7 @@ interface MockSpellcastingEntry {
     slots?: Record<string, { max: number; value?: number; prepared?: Array<{ id: string | null; expended?: boolean }> }>;
   };
   cast: jest.Mock;
+  prepareSpell?: jest.Mock;
 }
 
 interface MockSpellcasting {
@@ -80,6 +81,7 @@ function makeEntry(overrides: Partial<MockSpellcastingEntry> = {}): MockSpellcas
       },
     },
     cast: jest.fn().mockResolvedValue(undefined),
+    prepareSpell: jest.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }
@@ -328,5 +330,88 @@ describe('invokeActorActionHandler — get-spellcasting', () => {
     });
 
     expect(result).toEqual({ actorId: 'actor-1', entries: [] });
+  });
+});
+
+// ─── prepare-spell ────────────────────────────────────────────────────────────
+
+describe('invokeActorActionHandler — prepare-spell', () => {
+  it('calls entry.prepareSpell with the resolved spell, rank-as-groupId, and slot index', async () => {
+    const spell = makeSpellItem();
+    const entry = makeEntry();
+    const actor = makeActor(entry, spell);
+    setupFoundry(actor);
+
+    const result = await invokeActorActionHandler({
+      actorId: 'actor-1',
+      action: 'prepare-spell',
+      params: { entryId: 'entry-1', rank: 2, slotIndex: 1, spellId: 'spell-1' },
+    });
+
+    expect(entry.prepareSpell).toHaveBeenCalledWith(spell, '2', 1);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('uses "cantrips" as groupId when rank is 0', async () => {
+    const spell = makeSpellItem();
+    const entry = makeEntry();
+    const actor = makeActor(entry, spell);
+    setupFoundry(actor);
+
+    await invokeActorActionHandler({
+      actorId: 'actor-1',
+      action: 'prepare-spell',
+      params: { entryId: 'entry-1', rank: 0, slotIndex: 0, spellId: 'spell-1' },
+    });
+
+    expect(entry.prepareSpell).toHaveBeenCalledWith(spell, 'cantrips', 0);
+  });
+
+  it('passes null to entry.prepareSpell when spellId is null (clear slot)', async () => {
+    const spell = makeSpellItem();
+    const entry = makeEntry();
+    const actor = makeActor(entry, spell);
+    setupFoundry(actor);
+
+    await invokeActorActionHandler({
+      actorId: 'actor-1',
+      action: 'prepare-spell',
+      params: { entryId: 'entry-1', rank: 1, slotIndex: 0, spellId: null },
+    });
+
+    expect(entry.prepareSpell).toHaveBeenCalledWith(null, '1', 0);
+  });
+
+  it('throws when slotIndex is missing', async () => {
+    setupFoundry(makeActor(makeEntry(), makeSpellItem()));
+    await expect(
+      invokeActorActionHandler({
+        actorId: 'actor-1',
+        action: 'prepare-spell',
+        params: { entryId: 'entry-1', rank: 1, spellId: 'spell-1' },
+      }),
+    ).rejects.toThrow(/params\.slotIndex must be a non-negative integer/);
+  });
+
+  it('throws when rank is out of range', async () => {
+    setupFoundry(makeActor(makeEntry(), makeSpellItem()));
+    await expect(
+      invokeActorActionHandler({
+        actorId: 'actor-1',
+        action: 'prepare-spell',
+        params: { entryId: 'entry-1', rank: 12, slotIndex: 0, spellId: 'spell-1' },
+      }),
+    ).rejects.toThrow(/params\.rank must be an integer 0\.\.11/);
+  });
+
+  it('throws when the resolved spell item is not on the actor', async () => {
+    setupFoundry(makeActor(makeEntry(), makeSpellItem()));
+    await expect(
+      invokeActorActionHandler({
+        actorId: 'actor-1',
+        action: 'prepare-spell',
+        params: { entryId: 'entry-1', rank: 1, slotIndex: 0, spellId: 'no-such-spell' },
+      }),
+    ).rejects.toThrow(/spell item 'no-such-spell' not found/);
   });
 });

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/actions/__tests__/registry.test.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/actions/__tests__/registry.test.ts
@@ -13,6 +13,7 @@ const EXPECTED_ACTIONS = [
   'remove-formula',
   'get-spellcasting',
   'cast-spell',
+  'prepare-spell',
   'transfer-to-party',
 ] as const;
 

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/actions/index.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/actions/index.ts
@@ -10,6 +10,7 @@ import { addFormulaAction } from './addFormula';
 import { removeFormulaAction } from './removeFormula';
 import { getSpellcastingAction } from './getSpellcasting';
 import { castSpellAction } from './castSpell';
+import { prepareSpellAction } from './prepareSpell';
 import { transferToPartyAction } from './transferToParty';
 import type { ActionHandler } from './types';
 
@@ -33,5 +34,6 @@ export const ACTION_HANDLERS: Record<string, ActionHandler> = {
   'remove-formula': removeFormulaAction,
   'get-spellcasting': getSpellcastingAction,
   'cast-spell': castSpellAction,
+  'prepare-spell': prepareSpellAction,
   'transfer-to-party': transferToPartyAction,
 };

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/actions/prepareSpell.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/actions/prepareSpell.ts
@@ -1,0 +1,72 @@
+import type { InvokeActorActionResult } from '@/commands/types';
+import type { FoundryActor, Pf2eActorWithSpells, Pf2eSpellItem } from './types';
+
+// PF2e's spellcasting entry surface includes prepareSpell:
+//   entry.prepareSpell(spell, groupId, slotIndex)
+//     spell:     spell item document (null clears the slot)
+//     groupId:   rank string ('1', '2', …) or 'cantrips' for rank-0
+//     slotIndex: index inside system.slots.slot{N}.prepared
+//
+// The DM sheet calls this on drag-and-drop. We expose the same surface
+// so the player portal can offer click/drag-prepare for prepared casters.
+interface Pf2eSpellcastingEntryWithPrepare {
+  prepareSpell(spell: Pf2eSpellItem | null, groupId: string, slotIndex: number): Promise<unknown>;
+}
+
+export async function prepareSpellAction(
+  actor: FoundryActor,
+  params: Record<string, unknown>,
+): Promise<InvokeActorActionResult> {
+  const entryId = params['entryId'];
+  if (typeof entryId !== 'string' || entryId.length === 0) {
+    throw new Error('prepare-spell: params.entryId is required');
+  }
+  const rank = params['rank'];
+  if (typeof rank !== 'number' || !Number.isInteger(rank) || rank < 0 || rank > 11) {
+    throw new Error('prepare-spell: params.rank must be an integer 0..11');
+  }
+  const slotIndex = params['slotIndex'];
+  if (typeof slotIndex !== 'number' || !Number.isInteger(slotIndex) || slotIndex < 0) {
+    throw new Error('prepare-spell: params.slotIndex must be a non-negative integer');
+  }
+  // spellId null/undefined clears the slot; a string preps that spell.
+  const rawSpellId = params['spellId'];
+  const spellId =
+    typeof rawSpellId === 'string' && rawSpellId.length > 0 ? rawSpellId : null;
+
+  const pf2eActor = actor as Pf2eActorWithSpells;
+  if (!pf2eActor.spellcasting) {
+    throw new Error(`prepare-spell: actor ${actor.id} has no spellcasting ability`);
+  }
+  const entry = pf2eActor.spellcasting.get(entryId) as Pf2eSpellcastingEntryWithPrepare | undefined;
+  if (!entry) {
+    throw new Error(`prepare-spell: spellcasting entry '${entryId}' not found on actor ${actor.id}`);
+  }
+
+  let spell: Pf2eSpellItem | null = null;
+  if (spellId !== null) {
+    const found = actor.items.get(spellId);
+    if (!found) {
+      throw new Error(`prepare-spell: spell item '${spellId}' not found on actor ${actor.id}`);
+    }
+    spell = found as unknown as Pf2eSpellItem;
+  }
+
+  const groupId = rank === 0 ? 'cantrips' : rank.toString();
+
+  console.info(
+    `Foundry API Bridge | prepare-spell: actorId=${actor.id.slice(0, 8)} entryId=${entryId.slice(0, 8)} rank=${rank.toString()} slotIndex=${slotIndex.toString()} spellId=${spellId === null ? 'null' : spellId.slice(0, 8)}`,
+  );
+
+  try {
+    await entry.prepareSpell(spell, groupId, slotIndex);
+  } catch (error) {
+    console.error(
+      `Foundry API Bridge | prepare-spell failed: actorId=${actor.id.slice(0, 8)} entryId=${entryId.slice(0, 8)}`,
+      error,
+    );
+    throw error;
+  }
+
+  return { ok: true };
+}

--- a/apps/foundry-api-bridge/src/commands/handlers/actor/index.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/actor/index.ts
@@ -1,4 +1,5 @@
 export { createActorHandler } from './CreateActorHandler';
+export { createSpellcastingEntryHandler } from './CreateSpellcastingEntryHandler';
 export { createActorFromCompendiumHandler } from './CreateActorFromCompendiumHandler';
 export { updateActorHandler } from './UpdateActorHandler';
 export { deleteActorHandler } from './DeleteActorHandler';

--- a/apps/foundry-api-bridge/src/commands/handlers/index.ts
+++ b/apps/foundry-api-bridge/src/commands/handlers/index.ts
@@ -7,6 +7,7 @@ export { fetchAssetHandler } from '@/commands/handlers/FetchAssetHandler';
 export {
   createActorHandler,
   createActorFromCompendiumHandler,
+  createSpellcastingEntryHandler,
   updateActorHandler,
   deleteActorHandler,
   invokeActorActionHandler,

--- a/apps/foundry-api-bridge/src/commands/types/actor.ts
+++ b/apps/foundry-api-bridge/src/commands/types/actor.ts
@@ -111,6 +111,10 @@ export interface PreparedActorResult {
   items: ItemSummary[];
   statusEffects: StatusEffectEntry[];
   flags?: Record<string, Record<string, unknown>>;
+  /** Levels that carry a free-archetype feat slot when the free-archetype
+   *  variant rule is enabled (e.g. [2, 4, 6, 8] for a level-8 character).
+   *  Empty / absent when the variant is off. */
+  archetypeFeatLevels?: number[];
 }
 
 export interface GetStatisticTraceParams {

--- a/apps/foundry-api-bridge/src/commands/types/actor.ts
+++ b/apps/foundry-api-bridge/src/commands/types/actor.ts
@@ -71,6 +71,10 @@ export interface ActorSummary {
   type: string;
   img: string;
   flags?: Record<string, Record<string, unknown>>;
+  /** First party this character belongs to (PF2e party actor). `null`
+   *  when the character isn't in any party. Drives the per-party grouping
+   *  in the player-portal character index. */
+  party?: { id: string; name: string } | null;
 }
 
 export interface ItemSummary {

--- a/apps/foundry-api-bridge/src/commands/types/actor.ts
+++ b/apps/foundry-api-bridge/src/commands/types/actor.ts
@@ -220,3 +220,11 @@ export interface WorldInfoResult {
   counts: WorldCounts;
   compendiumMeta: CompendiumMetaSummary[];
 }
+
+export interface CreateSpellcastingEntryParams {
+  actorId: string;
+  name: string;
+  tradition: string;
+  prepared: string;
+  ability: string;
+}

--- a/apps/foundry-api-bridge/src/commands/types/base.ts
+++ b/apps/foundry-api-bridge/src/commands/types/base.ts
@@ -28,6 +28,7 @@ import type {
   GetPartyStashResult,
   GetWorldInfoParams,
   WorldInfoResult,
+  CreateSpellcastingEntryParams,
 } from './actor';
 
 import type { SendChatMessageParams, SendChatMessageResult } from './chat';
@@ -236,6 +237,7 @@ export type CommandType =
   | 'use-item'
   | 'add-item-to-actor'
   | 'add-item-from-compendium'
+  | 'create-spellcasting-entry'
   | 'update-actor-item'
   | 'delete-actor-item'
   | 'get-actor-effects'
@@ -334,6 +336,7 @@ export interface CommandParamsMap {
   'use-item': UseItemParams;
   'add-item-to-actor': AddItemToActorParams;
   'add-item-from-compendium': AddItemFromCompendiumParams;
+  'create-spellcasting-entry': CreateSpellcastingEntryParams;
   'update-actor-item': UpdateActorItemParams;
   'delete-actor-item': DeleteActorItemParams;
   'get-actor-effects': GetActorEffectsParams;
@@ -433,6 +436,7 @@ export interface CommandResultMap {
   'use-item': UseItemResult;
   'add-item-to-actor': ItemResult;
   'add-item-from-compendium': ItemResult;
+  'create-spellcasting-entry': ItemResult;
   'update-actor-item': ItemResult;
   'delete-actor-item': DeleteResult;
   'get-actor-effects': ActorEffectsResult;

--- a/apps/foundry-api-bridge/src/main.ts
+++ b/apps/foundry-api-bridge/src/main.ts
@@ -19,6 +19,7 @@ import {
   fetchAssetHandler,
   createActorHandler,
   createActorFromCompendiumHandler,
+  createSpellcastingEntryHandler,
   updateActorHandler,
   deleteActorHandler,
   invokeActorActionHandler,
@@ -252,6 +253,7 @@ function initializeWebSocket(
   commandRouter.register('activate-item', activateItemHandler);
   commandRouter.register('add-item-to-actor', addItemToActorHandler);
   commandRouter.register('add-item-from-compendium', addItemFromCompendiumHandler);
+  commandRouter.register('create-spellcasting-entry', createSpellcastingEntryHandler);
   commandRouter.register('update-actor-item', updateActorItemHandler);
   commandRouter.register('delete-actor-item', deleteActorItemHandler);
 

--- a/apps/foundry-mcp/src/http/routes/actors.ts
+++ b/apps/foundry-mcp/src/http/routes/actors.ts
@@ -8,6 +8,7 @@ import {
   actorTraceParams,
   addItemFromCompendiumBody,
   createActorBody,
+  createSpellcastingEntryBody,
   invokeActorActionBody,
   partyActorsQuery,
   updateActorBody,
@@ -78,6 +79,15 @@ export function registerActorRoutes(app: FastifyInstance): void {
     const { id } = actorIdParam.parse(req.params);
     const body = addItemFromCompendiumBody.parse(req.body);
     return sendCommand('add-item-from-compendium', { actorId: id, ...body });
+  });
+
+  // Creates a spellcastingEntry embedded item directly on the actor.
+  // The character creator calls this after class is picked for classes
+  // the PF2e system does not automatically initialize (all full casters).
+  app.post('/api/actors/:id/spellcasting-entry', async (req) => {
+    const { id } = actorIdParam.parse(req.params);
+    const body = createSpellcastingEntryBody.parse(req.body);
+    return sendCommand('create-spellcasting-entry', { actorId: id, ...body });
   });
 
   app.delete('/api/actors/:id/items/:itemId', async (req) => {

--- a/apps/player-portal/src/features/characters/ActorList.test.tsx
+++ b/apps/player-portal/src/features/characters/ActorList.test.tsx
@@ -182,3 +182,64 @@ describe('env', () => {
     });
   });
 });
+
+describe('ActorList — party grouping', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('renders a section header per party (sorted alphabetically by party name)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch([
+        { id: 'c1', name: 'Alpha', type: 'character', img: '', party: { id: 'pZ', name: 'Zephyr Squad' } },
+        { id: 'c2', name: 'Beta', type: 'character', img: '', party: { id: 'pA', name: 'Anchor Crew' } },
+      ]),
+    );
+    render(<ActorList />);
+    await waitFor(() => screen.getByText('Alpha'));
+    const headers = screen.getAllByRole('heading', { level: 2 });
+    expect(headers.map((h) => h.textContent)).toEqual(['Anchor Crew', 'Zephyr Squad']);
+  });
+
+  it('groups characters with the same party together under one header', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch([
+        { id: 'c1', name: 'Broccoli', type: 'character', img: '', party: { id: 'p1', name: 'The Dents' } },
+        { id: 'c2', name: 'Jackstone', type: 'character', img: '', party: { id: 'p1', name: 'The Dents' } },
+      ]),
+    );
+    const { container } = render(<ActorList />);
+    await waitFor(() => screen.getByText('Broccoli'));
+    const section = container.querySelector('[data-party-id="p1"]');
+    expect(section).toBeTruthy();
+    expect(section!.textContent).toContain('Broccoli');
+    expect(section!.textContent).toContain('Jackstone');
+  });
+
+  it('places unaffiliated characters in an "Unaffiliated" section at the end', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch([
+        { id: 'c1', name: 'Lonely', type: 'character', img: '', party: null },
+        { id: 'c2', name: 'Joined', type: 'character', img: '', party: { id: 'p1', name: 'The Dents' } },
+      ]),
+    );
+    render(<ActorList />);
+    await waitFor(() => screen.getByText('Lonely'));
+    const headers = screen.getAllByRole('heading', { level: 2 });
+    expect(headers.map((h) => h.textContent)).toEqual(['The Dents', 'Unaffiliated']);
+  });
+
+  it('treats absent `party` field as unaffiliated (legacy bridge compat)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch([{ id: 'c1', name: 'NoPartyField', type: 'character', img: '' }]),
+    );
+    render(<ActorList />);
+    await waitFor(() => screen.getByText('NoPartyField'));
+    expect(screen.getByRole('heading', { level: 2 }).textContent).toBe('Unaffiliated');
+  });
+});

--- a/apps/player-portal/src/features/characters/ActorList.tsx
+++ b/apps/player-portal/src/features/characters/ActorList.tsx
@@ -56,54 +56,106 @@ export function ActorList({ onSelect, onEdit }: Props = {}): React.ReactElement 
     return <p className="text-sm text-pf-text-muted">No player characters in the world yet.</p>;
   }
 
+  const groups = groupByParty(characters);
   return (
-    <ul className="divide-y divide-pf-border rounded border border-pf-border">
-      {characters.map((actor) => {
-        const isInProgress = actor.flags?.['foundry-toolkit']?.['creatorInProgress'] === true;
-        const clickable = onSelect !== undefined;
-        return (
-          <li
-            key={actor.id}
-            className="flex items-center gap-3 px-4 py-3"
-          >
-            <button
-              type="button"
-              disabled={!clickable}
-              onClick={
-                clickable
-                  ? (): void => {
-                      onSelect(actor);
-                    }
-                  : undefined
+    <div className="space-y-4">
+      {groups.map((group) => (
+        <section key={group.partyId ?? '__unaffiliated__'} data-party-id={group.partyId ?? 'unaffiliated'}>
+          <h2 className="mb-2 px-1 text-xs font-semibold uppercase tracking-widest text-pf-text-muted">
+            {group.partyName ?? 'Unaffiliated'}
+          </h2>
+          <ul className="divide-y divide-pf-border rounded border border-pf-border">
+            {group.actors.map((actor) => (
+              <ActorRow key={actor.id} actor={actor} onSelect={onSelect} onEdit={onEdit} />
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+interface PartyGroup {
+  partyId: string | null;
+  partyName: string | null;
+  actors: ActorSummary[];
+}
+
+// Bucket characters by party. Stable order: parties alphabetically by name,
+// then unaffiliated last. Actors within a group keep their server-provided order.
+function groupByParty(actors: ActorSummary[]): PartyGroup[] {
+  const byId = new Map<string, PartyGroup>();
+  const unaffiliated: ActorSummary[] = [];
+  for (const actor of actors) {
+    const party = actor.party;
+    if (party === undefined || party === null) {
+      unaffiliated.push(actor);
+      continue;
+    }
+    let group = byId.get(party.id);
+    if (group === undefined) {
+      group = { partyId: party.id, partyName: party.name, actors: [] };
+      byId.set(party.id, group);
+    }
+    group.actors.push(actor);
+  }
+  const partyGroups = [...byId.values()].sort((a, b) =>
+    (a.partyName ?? '').localeCompare(b.partyName ?? ''),
+  );
+  if (unaffiliated.length > 0) {
+    partyGroups.push({ partyId: null, partyName: null, actors: unaffiliated });
+  }
+  return partyGroups;
+}
+
+function ActorRow({
+  actor,
+  onSelect,
+  onEdit,
+}: {
+  actor: ActorSummary;
+  onSelect: ((actor: ActorSummary) => void) | undefined;
+  onEdit: ((actor: ActorSummary) => void) | undefined;
+}): React.ReactElement {
+  const isInProgress = actor.flags?.['foundry-toolkit']?.['creatorInProgress'] === true;
+  const clickable = onSelect !== undefined;
+  return (
+    <li className="flex items-center gap-3 px-4 py-3">
+      <button
+        type="button"
+        disabled={!clickable}
+        onClick={
+          clickable
+            ? (): void => {
+                onSelect(actor);
               }
-              className={[
-                'flex-1 truncate text-left font-medium',
-                clickable ? 'cursor-pointer hover:text-pf-primary' : '',
-              ].join(' ')}
-            >
-              {actor.name}
-            </button>
-            {onEdit !== undefined && (
-              <button
-                type="button"
-                onClick={(): void => {
-                  onEdit(actor);
-                }}
-                data-testid={isInProgress ? 'continue-button' : 'edit-button'}
-                className={[
-                  'shrink-0 rounded border px-2 py-1 text-xs font-medium transition-colors',
-                  isInProgress
-                    ? 'border-pf-primary bg-pf-primary text-white hover:bg-pf-primary-dark'
-                    : 'border-pf-border bg-pf-bg text-pf-text hover:bg-pf-bg-dark',
-                ].join(' ')}
-              >
-                {isInProgress ? 'Continue' : 'Edit'}
-              </button>
-            )}
-            {clickable && onEdit === undefined && <span className="text-pf-text-muted">→</span>}
-          </li>
-        );
-      })}
-    </ul>
+            : undefined
+        }
+        className={[
+          'flex-1 truncate text-left font-medium',
+          clickable ? 'cursor-pointer hover:text-pf-primary' : '',
+        ].join(' ')}
+      >
+        {actor.name}
+      </button>
+      {onEdit !== undefined && (
+        <button
+          type="button"
+          onClick={(): void => {
+            onEdit(actor);
+          }}
+          data-testid={isInProgress ? 'continue-button' : 'edit-button'}
+          className={[
+            'shrink-0 rounded border px-2 py-1 text-xs font-medium transition-colors',
+            isInProgress
+              ? 'border-pf-primary bg-pf-primary text-white hover:bg-pf-primary-dark'
+              : 'border-pf-border bg-pf-bg text-pf-text hover:bg-pf-bg-dark',
+          ].join(' ')}
+        >
+          {isInProgress ? 'Continue' : 'Edit'}
+        </button>
+      )}
+      {clickable && onEdit === undefined && <span className="text-pf-text-muted">→</span>}
+    </li>
   );
 }

--- a/apps/player-portal/src/features/characters/api.ts
+++ b/apps/player-portal/src/features/characters/api.ts
@@ -193,6 +193,17 @@ export const api = {
   // heighten. Actor state refresh comes via the `actors` event channel.
   castSpell: (id: string, entryId: string, spellId: string, rank: number): Promise<{ ok: boolean }> =>
     api.invokeActorAction<{ ok: boolean }>(id, 'cast-spell', { entryId, spellId, rank }),
+  // Slots a known spell into a specific prepared-caster slot (or clears
+  // the slot when spellId is null). `rank` is the slot rank (0 = cantrip);
+  // `slotIndex` is the position inside the rank's prepared array.
+  prepareSpell: (
+    id: string,
+    entryId: string,
+    rank: number,
+    slotIndex: number,
+    spellId: string | null,
+  ): Promise<{ ok: boolean }> =>
+    api.invokeActorAction<{ ok: boolean }>(id, 'prepare-spell', { entryId, rank, slotIndex, spellId }),
   // Formula book management. Add/remove dedupe on the bridge, so the
   // SPA can fire-and-forget; the `added`/`removed` flag in the
   // response tells callers whether a write actually happened.

--- a/apps/player-portal/src/features/characters/api.ts
+++ b/apps/player-portal/src/features/characters/api.ts
@@ -5,6 +5,7 @@ import type {
   AdjustActorConditionResponse,
   AdjustActorResourceResponse,
   CreateActorBody,
+  CreateSpellcastingEntryBody,
   DispatchRequest,
   DispatchResponse,
   PartyForMember,
@@ -83,6 +84,8 @@ export const api = {
     request<ActorRef>(`/actors/${id}`, { method: 'PATCH', body: patch }),
   addItemFromCompendium: (id: string, body: AddItemFromCompendiumBody): Promise<ActorItemRef> =>
     request<ActorItemRef>(`/actors/${id}/items/from-compendium`, { method: 'POST', body }),
+  createSpellcastingEntry: (id: string, body: CreateSpellcastingEntryBody): Promise<ActorItemRef> =>
+    request<ActorItemRef>(`/actors/${id}/spellcasting-entry`, { method: 'POST', body }),
   deleteActorItem: (id: string, itemId: string): Promise<{ success: boolean }> =>
     request<{ success: boolean }>(`/actors/${id}/items/${itemId}`, { method: 'DELETE' }),
   updateActorItem: (id: string, itemId: string, patch: UpdateActorItemBody): Promise<ActorItemRef> =>

--- a/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
+++ b/apps/player-portal/src/features/characters/creator/CharacterCreator.tsx
@@ -20,8 +20,10 @@ import {
   isStepFilled,
   persistPick,
   resetPendingActor,
+  resolveVariableTraditionEntry,
   saveDraftFlags,
 } from '@/features/characters/creator/helpers';
+import { spellcastingConfigFor } from '@/features/characters/creator/spellcastingConfig';
 import { PickerCard } from '@/features/characters/creator/PickerCard';
 import { AncestryStep } from '@/features/characters/creator/steps/AncestryStep';
 import { AttributesStep } from '@/features/characters/creator/steps/AttributesStep';
@@ -151,9 +153,14 @@ export function CharacterCreator(): React.ReactElement {
     // finds creatorDraft and can do a full restore. The isSaving flag
     // disables the button to prevent double-clicks.
     setIsSaving(true);
-    saveDraftFlags(actorId, draft, 'completed')
+    // For variable-tradition classes (Sorcerer), create the entry now that
+    // all ChoiceSets should have been resolved and the bloodline is on actor.
+    const ensureVariableEntry = resolveVariableTraditionEntry(actorId, draft).catch(() => {
+      /* best-effort */
+    });
+    Promise.all([saveDraftFlags(actorId, draft, 'completed'), ensureVariableEntry])
       .catch(() => {
-        /* best-effort — navigate regardless if the write fails */
+        /* best-effort — navigate regardless if either write fails */
       })
       .finally(() => {
         setIsSaving(false);
@@ -253,6 +260,35 @@ export function CharacterCreator(): React.ReactElement {
       cancelled = true;
     };
   }, [draft.class, draft.classSlug]);
+
+  // Once the class slug is known, create the spellcastingEntry embedded item
+  // for classes with a fixed tradition. Variable-tradition classes (Sorcerer,
+  // Witch) are handled at handleFinish time after the subclass ChoiceSet
+  // resolves and the bloodline/patron item is on the actor.
+  useEffect(() => {
+    if (actorId === null || draft.classSlug === null || draft.class === null) return;
+    if (draft.spellcastingEntryId !== null) return;
+    const config = spellcastingConfigFor(draft.classSlug);
+    if (config === null) return;
+    const className = draft.class.match.name;
+    const classSlugSnap = draft.classSlug;
+    let cancelled = false;
+    void api
+      .createSpellcastingEntry(actorId, { name: className, ...config })
+      .then(({ id }) => {
+        if (cancelled) return;
+        setDraft((d) =>
+          d.classSlug === classSlugSnap && d.spellcastingEntryId === null ? { ...d, spellcastingEntryId: id } : d,
+        );
+      })
+      .catch(() => {
+        // Best-effort — the sheet is usable without the entry; the player
+        // can initialize spellcasting manually via Foundry's sheet UI.
+      });
+    return (): void => {
+      cancelled = true;
+    };
+  }, [actorId, draft.classSlug, draft.spellcastingEntryId, draft.class]);
 
   const pickerFilters = openPicker !== null ? filtersForTarget(openPicker, draft) : undefined;
 

--- a/apps/player-portal/src/features/characters/creator/constants.ts
+++ b/apps/player-portal/src/features/characters/creator/constants.ts
@@ -26,6 +26,7 @@ export const EMPTY_DRAFT: Draft = {
   languagePicks: [],
   classGrantsL1Feat: null,
   languageAllowance: null,
+  spellcastingEntryId: null,
 };
 
 export const STEPS: readonly Step[] = [

--- a/apps/player-portal/src/features/characters/creator/helpers.ts
+++ b/apps/player-portal/src/features/characters/creator/helpers.ts
@@ -2,6 +2,7 @@ import { api } from '@/features/characters/api';
 import type { AbilityKey, CompendiumMatch } from '@/features/characters/types';
 import { ABILITY_KEYS } from '@/features/characters/types';
 import { BOOSTS_REQUIRED, EMPTY_DRAFT, STATIC_PICKER_FILTERS } from './constants';
+import { spellcastingConfigFor, sorcererBloodlineSlugFromItems } from './spellcastingConfig';
 import type { Draft, PickerFilters, PickerTarget, Slot, Step } from './types';
 
 // Module-scoped so React 18 StrictMode's dev-only double-mount
@@ -159,11 +160,19 @@ export async function persistPick(
       });
     }
   }
-  if (target === 'class' && draft.classFeat !== null) {
+  if (target === 'class') {
     // Same rationale for class feat when the class changes.
-    await api.deleteActorItem(actorId, draft.classFeat.itemId).catch(() => {
-      /* ignore */
-    });
+    if (draft.classFeat !== null) {
+      await api.deleteActorItem(actorId, draft.classFeat.itemId).catch(() => {
+        /* ignore */
+      });
+    }
+    // Delete the stale spellcasting entry so the new class gets a clean slate.
+    if (draft.spellcastingEntryId !== null) {
+      await api.deleteActorItem(actorId, draft.spellcastingEntryId).catch(() => {
+        /* ignore */
+      });
+    }
   }
   return { match, itemId: created.id };
 }
@@ -195,6 +204,7 @@ export function applyPickedSlot(draft: Draft, target: PickerTarget, slot: Slot):
       // New class wipes the cached slug + class feat + key attribute
       // pick for the same reason. Skill picks also reset since the
       // free-skill count (class.additional) is class-specific.
+      // spellcastingEntryId resets so the creation useEffect fires again.
       return {
         ...draft,
         class: slot,
@@ -203,6 +213,7 @@ export function applyPickedSlot(draft: Draft, target: PickerTarget, slot: Slot):
         classKeyAbility: null,
         skillPicks: [],
         classGrantsL1Feat: null,
+        spellcastingEntryId: null,
       };
     case 'background':
       return { ...draft, background: slot, backgroundBoosts: [] };
@@ -213,6 +224,32 @@ export function applyPickedSlot(draft: Draft, target: PickerTarget, slot: Slot):
     case 'ancestry-feat':
       return { ...draft, ancestryFeat: slot };
   }
+}
+
+// Creates the spellcasting entry for Sorcerer (and future variable-tradition
+// classes like Witch) once the user's subclass ChoiceSet has been resolved.
+// Called at handleFinish time so the bloodline item is guaranteed to be on
+// the actor. Skips silently if the entry already exists or the bloodline
+// hasn't been picked yet.
+export async function resolveVariableTraditionEntry(actorId: string, draft: Draft): Promise<void> {
+  if (draft.classSlug !== 'sorcerer') return;
+  if (draft.spellcastingEntryId !== null) return;
+
+  const actor = await api.getPreparedActor(actorId);
+
+  // Guard against duplicate creation (e.g. re-submitting the same character).
+  if (actor.items.some((i) => i.type === 'spellcastingEntry')) return;
+
+  const bloodlineSlug = sorcererBloodlineSlugFromItems(actor.items);
+  if (bloodlineSlug === undefined) return;
+
+  const config = spellcastingConfigFor('sorcerer', bloodlineSlug);
+  if (config === null) return;
+
+  await api.createSpellcastingEntry(actorId, {
+    name: draft.class?.match.name ?? 'Sorcerer',
+    ...config,
+  });
 }
 
 // Used by SkillsStep and ReviewStep. Pretty-prints `acrobatics` →
@@ -409,6 +446,8 @@ export async function hydrateFromActor(actorId: string): Promise<HydrateResult> 
       } else if (location === 'ancestry-1' && draft.ancestryFeat === null) {
         draft.ancestryFeat = { match, itemId: item.id };
       }
+    } else if (item.type === 'spellcastingEntry' && draft.spellcastingEntryId === null) {
+      draft.spellcastingEntryId = item.id;
     }
   }
 

--- a/apps/player-portal/src/features/characters/creator/spellcastingConfig.test.ts
+++ b/apps/player-portal/src/features/characters/creator/spellcastingConfig.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import {
+  spellcastingConfigFor,
+  sorcererBloodlineSlugFromItems,
+} from './spellcastingConfig';
+import type { PreparedActorItem } from '@foundry-toolkit/shared/foundry-api';
+
+describe('spellcastingConfigFor', () => {
+  it('wizard → arcane prepared INT', () => {
+    const config = spellcastingConfigFor('wizard');
+    expect(config).toEqual({ tradition: 'arcane', prepared: 'prepared', ability: 'int' });
+  });
+
+  it('druid → primal prepared WIS', () => {
+    const config = spellcastingConfigFor('druid');
+    expect(config).toEqual({ tradition: 'primal', prepared: 'prepared', ability: 'wis' });
+  });
+
+  it('cleric → divine prepared WIS', () => {
+    // Doctrine (Cloistered vs Warpriest) affects progression/slot bonuses via class
+    // features but the entry itself is always divine/prepared/wis at level 1.
+    const config = spellcastingConfigFor('cleric');
+    expect(config).toEqual({ tradition: 'divine', prepared: 'prepared', ability: 'wis' });
+  });
+
+  it('bard → occult spontaneous CHA', () => {
+    const config = spellcastingConfigFor('bard');
+    expect(config).toEqual({ tradition: 'occult', prepared: 'spontaneous', ability: 'cha' });
+  });
+
+  it('oracle → divine spontaneous CHA', () => {
+    const config = spellcastingConfigFor('oracle');
+    expect(config).toEqual({ tradition: 'divine', prepared: 'spontaneous', ability: 'cha' });
+  });
+
+  it('magus → arcane prepared INT', () => {
+    const config = spellcastingConfigFor('magus');
+    expect(config).toEqual({ tradition: 'arcane', prepared: 'prepared', ability: 'int' });
+  });
+
+  it('psychic → occult spontaneous INT', () => {
+    const config = spellcastingConfigFor('psychic');
+    expect(config).toEqual({ tradition: 'occult', prepared: 'spontaneous', ability: 'int' });
+  });
+
+  it('sorcerer without bloodline → null (tradition unknown)', () => {
+    expect(spellcastingConfigFor('sorcerer')).toBeNull();
+    expect(spellcastingConfigFor('sorcerer', undefined)).toBeNull();
+  });
+
+  it('sorcerer + fey bloodline → primal spontaneous CHA', () => {
+    const config = spellcastingConfigFor('sorcerer', 'bloodline-fey');
+    expect(config).toEqual({ tradition: 'primal', prepared: 'spontaneous', ability: 'cha' });
+  });
+
+  it('sorcerer + angelic bloodline → divine spontaneous CHA', () => {
+    const config = spellcastingConfigFor('sorcerer', 'bloodline-angelic');
+    expect(config).toEqual({ tradition: 'divine', prepared: 'spontaneous', ability: 'cha' });
+  });
+
+  it('sorcerer + imperial bloodline → arcane spontaneous CHA', () => {
+    const config = spellcastingConfigFor('sorcerer', 'bloodline-imperial');
+    expect(config).toEqual({ tradition: 'arcane', prepared: 'spontaneous', ability: 'cha' });
+  });
+
+  it('sorcerer + elemental bloodline → primal spontaneous CHA', () => {
+    const config = spellcastingConfigFor('sorcerer', 'bloodline-elemental');
+    expect(config).toEqual({ tradition: 'primal', prepared: 'spontaneous', ability: 'cha' });
+  });
+
+  it('fighter → null (martial, no spellcasting entry)', () => {
+    expect(spellcastingConfigFor('fighter')).toBeNull();
+  });
+
+  it('rogue → null', () => {
+    expect(spellcastingConfigFor('rogue')).toBeNull();
+  });
+
+  it('barbarian → null', () => {
+    expect(spellcastingConfigFor('barbarian')).toBeNull();
+  });
+
+  it('unknown class slug → null', () => {
+    expect(spellcastingConfigFor('some-homebrew-class')).toBeNull();
+  });
+});
+
+describe('sorcererBloodlineSlugFromItems', () => {
+  function makeItem(overrides: Partial<PreparedActorItem>): PreparedActorItem {
+    return {
+      id: 'item1',
+      name: 'Test Item',
+      type: 'feat',
+      img: '',
+      system: {},
+      ...overrides,
+    };
+  }
+
+  it('returns slug when bloodline classfeature is present', () => {
+    const items: PreparedActorItem[] = [
+      makeItem({ type: 'class', system: { category: 'classfeature', slug: 'sorcerer' } }),
+      makeItem({
+        type: 'feat',
+        system: { category: 'classfeature', slug: 'bloodline-fey' },
+      }),
+    ];
+    expect(sorcererBloodlineSlugFromItems(items)).toBe('bloodline-fey');
+  });
+
+  it('returns undefined when no bloodline item is present', () => {
+    const items: PreparedActorItem[] = [
+      makeItem({ type: 'class', system: { slug: 'wizard' } }),
+      makeItem({ type: 'feat', system: { category: 'classfeature', slug: 'wizard-spellcasting' } }),
+    ];
+    expect(sorcererBloodlineSlugFromItems(items)).toBeUndefined();
+  });
+
+  it('ignores non-classfeature feat items', () => {
+    const items: PreparedActorItem[] = [
+      makeItem({ type: 'feat', system: { category: 'general', slug: 'bloodline-fey' } }),
+    ];
+    expect(sorcererBloodlineSlugFromItems(items)).toBeUndefined();
+  });
+
+  it('ignores items without a slug', () => {
+    const items: PreparedActorItem[] = [
+      makeItem({ type: 'feat', system: { category: 'classfeature', slug: null } }),
+    ];
+    expect(sorcererBloodlineSlugFromItems(items)).toBeUndefined();
+  });
+
+  it('returns elemental bloodline slug', () => {
+    const items: PreparedActorItem[] = [
+      makeItem({ type: 'feat', system: { category: 'classfeature', slug: 'bloodline-elemental' } }),
+    ];
+    expect(sorcererBloodlineSlugFromItems(items)).toBe('bloodline-elemental');
+  });
+});

--- a/apps/player-portal/src/features/characters/creator/spellcastingConfig.ts
+++ b/apps/player-portal/src/features/characters/creator/spellcastingConfig.ts
@@ -1,0 +1,87 @@
+// Lookup table: class slug → spellcasting entry configuration.
+//
+// PF2e does not automatically create spellcastingEntry embedded items when a
+// class item is dropped via our api-bridge surface (class feature rule elements
+// have empty rules arrays for spellcasting features). This table drives explicit
+// entry creation in the character creator.
+//
+// Coverage for this PR:
+//   Fixed-tradition casters → entry created at class-pick time
+//   Sorcerer → entry created at finish time using bloodline lookup below
+//   Witch, Summoner, Animist → deferred (patron/eidolon determines tradition;
+//     requires additional ChoiceSet resolution before tradition is known)
+
+import type { AbilityKey } from '@/features/characters/types';
+import type { PreparedActorItem } from '@foundry-toolkit/shared/foundry-api';
+
+export type SpellTradition = 'arcane' | 'divine' | 'occult' | 'primal';
+export type PreparedMode = 'prepared' | 'spontaneous' | 'focus' | 'innate';
+
+export interface SpellcastingEntryConfig {
+  tradition: SpellTradition;
+  prepared: PreparedMode;
+  ability: AbilityKey;
+}
+
+// Classes with a fixed tradition that don't depend on subclass selection.
+// Key ability matches the PF2e class key attribute.
+const FIXED_CLASS_CONFIGS: Record<string, SpellcastingEntryConfig> = {
+  wizard: { tradition: 'arcane', prepared: 'prepared', ability: 'int' },
+  magus: { tradition: 'arcane', prepared: 'prepared', ability: 'int' },
+  psychic: { tradition: 'occult', prepared: 'spontaneous', ability: 'int' },
+  cleric: { tradition: 'divine', prepared: 'prepared', ability: 'wis' },
+  druid: { tradition: 'primal', prepared: 'prepared', ability: 'wis' },
+  bard: { tradition: 'occult', prepared: 'spontaneous', ability: 'cha' },
+  oracle: { tradition: 'divine', prepared: 'spontaneous', ability: 'cha' },
+};
+
+// Sorcerer bloodline slug → tradition.
+// Source: each bloodline's system.rules RollOption "feature:bloodline:tradition:<tradition>".
+// Slugs follow pf2e convention: "bloodline-<name>".
+const SORCERER_BLOODLINE_TRADITIONS: Record<string, SpellTradition> = {
+  'bloodline-aberrant': 'occult',
+  'bloodline-angelic': 'divine',
+  'bloodline-demonic': 'divine',
+  'bloodline-diabolic': 'divine',
+  'bloodline-draconic': 'arcane',
+  'bloodline-elemental': 'primal',
+  'bloodline-fey': 'primal',
+  'bloodline-genie': 'primal',
+  'bloodline-hag': 'occult',
+  'bloodline-harrow': 'occult',
+  'bloodline-imperial': 'arcane',
+  'bloodline-nymph': 'primal',
+  'bloodline-phoenix': 'primal',
+  'bloodline-psychopomp': 'occult',
+  'bloodline-shadow': 'occult',
+  'bloodline-undead': 'divine',
+  'bloodline-wyrmblessed': 'arcane',
+};
+
+// Returns the spellcasting entry configuration for a class, or null if:
+//   - the class has no spellcasting entry at level 1 (martial, kineticist, etc.)
+//   - the tradition requires a subclass choice not yet provided (sorcerer without bloodlineSlug)
+export function spellcastingConfigFor(
+  classSlug: string,
+  bloodlineSlug?: string,
+): SpellcastingEntryConfig | null {
+  if (classSlug === 'sorcerer') {
+    if (bloodlineSlug === undefined) return null;
+    const tradition = SORCERER_BLOODLINE_TRADITIONS[bloodlineSlug];
+    return tradition !== undefined ? { tradition, prepared: 'spontaneous', ability: 'cha' } : null;
+  }
+  return FIXED_CLASS_CONFIGS[classSlug] ?? null;
+}
+
+// Scans actor items for a Sorcerer bloodline classfeature and returns its slug.
+// Bloodline items have system.slug matching the SORCERER_BLOODLINE_TRADITIONS keys.
+export function sorcererBloodlineSlugFromItems(items: PreparedActorItem[]): string | undefined {
+  for (const item of items) {
+    if (item.type !== 'feat') continue;
+    const sys = item.system;
+    if (sys['category'] !== 'classfeature') continue;
+    const slug = typeof sys['slug'] === 'string' ? sys['slug'] : null;
+    if (slug !== null && slug in SORCERER_BLOODLINE_TRADITIONS) return slug;
+  }
+  return undefined;
+}

--- a/apps/player-portal/src/features/characters/creator/types.ts
+++ b/apps/player-portal/src/features/characters/creator/types.ts
@@ -90,6 +90,13 @@ export interface Draft {
   // `ancestry.system.alternateAncestryBoosts` (presence/absence drives
   // pf2e's prepare-step branching).
   alternateAncestryBoosts: AbilityKey[] | null;
+  // Item ID of the spellcastingEntry embedded on the actor, if one has
+  // been created for the current class pick. Null for non-casters, for
+  // variable-tradition casters (Sorcerer, Witch) before their subclass
+  // choice resolves, and for the legacy "no entry" state. Tracked so
+  // that a class change can delete the stale entry before creating a
+  // new one.
+  spellcastingEntryId: string | null;
 }
 
 // Actor lifecycle: wizard opens → creating → ready (actor exists in

--- a/apps/player-portal/src/features/characters/sheet/CharacterSheet.tsx
+++ b/apps/player-portal/src/features/characters/sheet/CharacterSheet.tsx
@@ -246,6 +246,9 @@ function CharacterSheetInner({ actorId, onBack, preferences }: InnerProps): Reac
                 {...(state.actor.flags?.['player-portal']?.['progression-picks'] !== undefined
                   ? { persistedPicks: state.actor.flags['player-portal']['progression-picks'] as Record<string, unknown> }
                   : {})}
+                {...(state.actor.archetypeFeatLevels !== undefined
+                  ? { archetypeFeatLevels: state.actor.archetypeFeatLevels }
+                  : {})}
               />
             )}
             {activeTab === 'details' && (

--- a/apps/player-portal/src/features/characters/sheet/tabs/Spells.test.tsx
+++ b/apps/player-portal/src/features/characters/sheet/tabs/Spells.test.tsx
@@ -8,6 +8,7 @@ vi.mock('@/features/characters/api', () => ({
   api: {
     dispatch: vi.fn().mockResolvedValue({ result: null }),
     invokeActorAction: vi.fn().mockResolvedValue({ ok: true }),
+    prepareSpell: vi.fn().mockResolvedValue({ ok: true }),
   },
   ApiRequestError: class ApiRequestError extends Error {},
 }));
@@ -92,7 +93,9 @@ describe('Spells tab', () => {
     const items = [makeEntry(), makeSpell()] as PreparedActorItem[];
     renderSpells(items);
     expect(screen.getByText('Arcane Spellcasting')).toBeTruthy();
-    expect(screen.getByText('Magic Missile')).toBeTruthy();
+    // Prepared-mode rendering surfaces a known spell twice: once in its
+    // assigned slot and once in the spellbook below.
+    expect(screen.getAllByText('Magic Missile').length).toBeGreaterThan(0);
   });
 
   it('renders a Cast button for each spell', () => {
@@ -183,5 +186,96 @@ describe('Spells tab', () => {
 
     const castBtn = screen.getByRole('button', { name: /cast magic missile/i });
     expect(castBtn.hasAttribute('disabled')).toBe(false);
+  });
+});
+
+describe('Spells tab — prepared-caster slots', () => {
+  beforeEach(() => {
+    vi.mocked(api.invokeActorAction).mockReset();
+    vi.mocked(api.invokeActorAction).mockResolvedValue({ ok: true });
+    vi.mocked(api.prepareSpell).mockReset();
+    vi.mocked(api.prepareSpell).mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders an empty drop-zone cell for each unfilled slot', () => {
+    const entry = makeEntry({
+      slots: {
+        slot1: { max: 2, value: 2, prepared: [{ id: null, expended: false }, { id: null, expended: false }] },
+      },
+    });
+    const { container } = renderSpells([entry] as PreparedActorItem[]);
+    const empties = container.querySelectorAll('[data-slot-state="empty"]');
+    expect(empties.length).toBe(2);
+    expect(container.textContent).toContain('Drag a spell here');
+  });
+
+  it('shows a x/max counter in the rank heading', () => {
+    const entry = makeEntry({
+      slots: {
+        slot1: {
+          max: 3,
+          value: 3,
+          prepared: [{ id: 'spell-1', expended: false }, { id: null }, { id: null }],
+        },
+      },
+    });
+    const items = [entry, makeSpell()] as PreparedActorItem[];
+    renderSpells(items);
+    expect(screen.getByText('1/3')).toBeTruthy();
+  });
+
+  it('lists known spells in the spellbook section as draggable chips', () => {
+    const entry = makeEntry({
+      slots: { slot1: { max: 1, value: 1, prepared: [{ id: null }] } },
+    });
+    const items = [entry, makeSpell()] as PreparedActorItem[];
+    const { container } = renderSpells(items);
+    const chip = container.querySelector('[data-spellbook-entry="spell-1"]');
+    expect(chip).toBeTruthy();
+    expect(chip!.getAttribute('draggable')).toBe('true');
+  });
+
+  it('dropping a spell on an empty slot calls api.prepareSpell with the slot rank + index', async () => {
+    const entry = makeEntry({
+      slots: { slot1: { max: 1, value: 1, prepared: [{ id: null, expended: false }] } },
+    });
+    const items = [entry, makeSpell()] as PreparedActorItem[];
+    const { container } = renderSpells(items);
+    const dropZone = container.querySelector('[data-slot-state="empty"]') as HTMLElement;
+    expect(dropZone).toBeTruthy();
+
+    // Simulate dragging a spell from the spellbook onto the empty slot.
+    const data = new Map<string, string>();
+    const dataTransfer = {
+      getData: (k: string): string => data.get(k) ?? '',
+      setData: (k: string, v: string): void => { data.set(k, v); },
+      dropEffect: 'move',
+      effectAllowed: 'move',
+    };
+    data.set('text/x-pf2e-spell-id', 'spell-1');
+
+    fireEvent.drop(dropZone, { dataTransfer });
+
+    await vi.waitFor(() => {
+      expect(api.prepareSpell).toHaveBeenCalledWith('actor-1', 'entry-1', 1, 0, 'spell-1');
+    });
+  });
+
+  it('clicking the unprepare × calls api.prepareSpell with spellId=null', async () => {
+    const entry = makeEntry({
+      slots: { slot1: { max: 1, value: 1, prepared: [{ id: 'spell-1', expended: false }] } },
+    });
+    const items = [entry, makeSpell()] as PreparedActorItem[];
+    renderSpells(items);
+    const clearBtn = screen.getByRole('button', { name: /clear prepared slot/i });
+    fireEvent.click(clearBtn);
+
+    await vi.waitFor(() => {
+      expect(api.prepareSpell).toHaveBeenCalledWith('actor-1', 'entry-1', 1, 0, null);
+    });
   });
 });

--- a/apps/player-portal/src/features/characters/sheet/tabs/Spells.tsx
+++ b/apps/player-portal/src/features/characters/sheet/tabs/Spells.tsx
@@ -154,8 +154,16 @@ function EntryBlock({
           </button>
         )}
       </div>
-      {spells.length === 0 ? (
+      {spells.length === 0 && prepRaw !== 'prepared' ? (
         <p className="text-xs italic text-neutral-400">No spells.</p>
+      ) : prepRaw === 'prepared' ? (
+        <PreparedEntryBody
+          entry={entry}
+          spells={spells}
+          characterLevel={characterLevel}
+          actorId={actorId}
+          onCast={onCast}
+        />
       ) : (
         <RankedSpellListWithEntry
           entry={entry}
@@ -167,6 +175,278 @@ function EntryBlock({
         />
       )}
     </div>
+  );
+}
+
+// ─── Prepared-caster rendering ────────────────────────────────────────────
+
+// Per-entry drag payload key. Plain text MIME so the browser doesn't
+// barf on it across drag-source ↔ drop-target hops; the value is the
+// spell item id from the actor's spellbook.
+const DRAG_MIME = 'text/x-pf2e-spell-id';
+
+// Render the prepared-caster body: a per-rank slot grid at the top
+// (drag-and-drop targets) followed by the spellbook section listing
+// every known spell in this entry. Cantrips share the layout; their
+// slot rank is 0 ("slot0") and only cantrips can drop into them.
+function PreparedEntryBody({
+  entry,
+  spells,
+  characterLevel,
+  actorId,
+  onCast,
+}: {
+  entry: SpellcastingEntryItem;
+  spells: SpellItem[];
+  characterLevel: number;
+  actorId: string;
+  onCast: () => void;
+}): React.ReactElement {
+  const slots = entry.system.slots ?? {};
+  // Every rank with max > 0 gets a row. Cantrips first, then ranks 1-10.
+  const ranks: number[] = [];
+  for (let r = 0; r <= 10; r += 1) {
+    if ((slots[`slot${r.toString()}`]?.max ?? 0) > 0) ranks.push(r);
+  }
+
+  const spellById = new Map<string, SpellItem>(spells.map((s) => [s.id, s]));
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-3">
+        {ranks.map((r) => (
+          <PreparedSlotRow
+            key={r}
+            entry={entry}
+            rank={r}
+            spellById={spellById}
+            characterLevel={characterLevel}
+            actorId={actorId}
+            onCast={onCast}
+          />
+        ))}
+      </div>
+      <SpellbookSection spells={spells} />
+    </div>
+  );
+}
+
+function PreparedSlotRow({
+  entry,
+  rank,
+  spellById,
+  characterLevel,
+  actorId,
+  onCast,
+}: {
+  entry: SpellcastingEntryItem;
+  rank: number;
+  spellById: Map<string, SpellItem>;
+  characterLevel: number;
+  actorId: string;
+  onCast: () => void;
+}): React.ReactElement {
+  const slot = entry.system.slots?.[`slot${rank.toString()}`];
+  const prepared = slot?.prepared ?? [];
+  const max = slot?.max ?? 0;
+  const filledCount = prepared.filter((p) => p.id !== null && spellById.has(p.id)).length;
+  const heading = rank === 0 ? 'Cantrips' : `${ordinal(rank)}-Rank Spells`;
+
+  return (
+    <div data-spell-rank={heading} data-prepared-rank={rank}>
+      <h3 className="mb-1 flex items-baseline gap-2 font-serif text-xs font-semibold uppercase tracking-widest text-pf-alt-dark">
+        {heading}
+        <span className="rounded-full bg-pf-bg-dark px-1.5 py-0.5 font-mono text-[10px] text-pf-alt-dark">
+          {filledCount}/{max}
+        </span>
+      </h3>
+      <ul className="grid grid-cols-2 gap-2" data-role="prepared-slots">
+        {Array.from({ length: max }, (_, idx) => {
+          const entryRef = prepared[idx];
+          const preparedSpell = entryRef?.id ? spellById.get(entryRef.id) : undefined;
+          return (
+            <PreparedSlotCell
+              key={idx}
+              entry={entry}
+              rank={rank}
+              slotIndex={idx}
+              expended={entryRef?.expended === true}
+              preparedSpell={preparedSpell ?? null}
+              characterLevel={characterLevel}
+              actorId={actorId}
+              onCast={onCast}
+            />
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+function PreparedSlotCell({
+  entry,
+  rank,
+  slotIndex,
+  expended,
+  preparedSpell,
+  characterLevel,
+  actorId,
+  onCast,
+}: {
+  entry: SpellcastingEntryItem;
+  rank: number;
+  slotIndex: number;
+  expended: boolean;
+  preparedSpell: SpellItem | null;
+  characterLevel: number;
+  actorId: string;
+  onCast: () => void;
+}): React.ReactElement {
+  const [dragOver, setDragOver] = useState(false);
+
+  const { state: prepState, trigger: triggerPrepare } = useActorAction({
+    run: (spellId: string | null) => api.prepareSpell(actorId, entry.id, rank, slotIndex, spellId),
+    onSuccess: onCast,
+  });
+
+  const handleDragOver = (e: React.DragEvent): void => {
+    // Always accept — we validate spell rank inside onDrop. preventDefault
+    // is required to mark the element as a drop target.
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    if (!dragOver) setDragOver(true);
+  };
+  const handleDragLeave = (): void => {
+    setDragOver(false);
+  };
+  const handleDrop = (e: React.DragEvent): void => {
+    e.preventDefault();
+    setDragOver(false);
+    const spellId = e.dataTransfer.getData(DRAG_MIME);
+    if (!spellId) return;
+    triggerPrepare(spellId);
+  };
+  const handleClear = (): void => {
+    triggerPrepare(null);
+  };
+
+  if (preparedSpell !== null) {
+    return (
+      <li
+        data-slot-index={slotIndex}
+        data-slot-state="filled"
+        data-spell-id={preparedSpell.id}
+      >
+        <SpellCardWithCast
+          spell={preparedSpell}
+          characterLevel={characterLevel}
+          entry={entry}
+          actorId={actorId}
+          onCast={onCast}
+          focusPoints={{ value: 0, max: 0, cap: 0 }}
+          rankOverride={rank}
+          extraSummary={
+            <button
+              type="button"
+              aria-label="Clear prepared slot"
+              title="Unprepare"
+              onClick={(e): void => {
+                e.preventDefault();
+                e.stopPropagation();
+                handleClear();
+              }}
+              disabled={prepState === 'pending'}
+              className="flex-shrink-0 rounded border border-pf-border bg-pf-bg px-1.5 py-0.5 text-[10px] text-pf-alt-dark hover:bg-pf-bg-dark disabled:opacity-40"
+            >
+              ×
+            </button>
+          }
+          expendedOverride={expended}
+        />
+      </li>
+    );
+  }
+
+  return (
+    <li
+      data-slot-index={slotIndex}
+      data-slot-state="empty"
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+      className={[
+        'flex min-h-[2.25rem] items-center justify-center rounded border border-dashed px-3 py-2 text-[11px] italic transition-colors',
+        dragOver
+          ? 'border-pf-primary bg-pf-primary/10 text-pf-primary'
+          : 'border-pf-border bg-pf-bg/40 text-pf-alt-dark',
+        prepState === 'pending' ? 'opacity-50' : '',
+      ].join(' ')}
+    >
+      {prepState === 'pending' ? 'Preparing…' : 'Drag a spell here'}
+    </li>
+  );
+}
+
+function SpellbookSection({ spells }: { spells: SpellItem[] }): React.ReactElement {
+  if (spells.length === 0) {
+    return (
+      <div data-role="spellbook">
+        <h3 className="mb-1 font-serif text-xs font-semibold uppercase tracking-widest text-pf-alt-dark">
+          Spellbook
+        </h3>
+        <p className="text-xs italic text-neutral-400">No spells yet — use + Add Spell above.</p>
+      </div>
+    );
+  }
+  // Group by base rank so the player can find compatible spells per slot.
+  const byRank = new Map<number, SpellItem[]>();
+  for (const s of spells) {
+    const rank = isCantripSpell(s) ? 0 : s.system.level.value;
+    const arr = byRank.get(rank) ?? [];
+    arr.push(s);
+    byRank.set(rank, arr);
+  }
+  const ranks = [...byRank.keys()].sort((a, b) => a - b);
+
+  return (
+    <div data-role="spellbook" className="rounded border border-pf-border bg-pf-bg/40 p-3">
+      <h3 className="mb-2 font-serif text-xs font-semibold uppercase tracking-widest text-pf-alt-dark">
+        Spellbook
+      </h3>
+      <div className="space-y-2">
+        {ranks.map((r) => (
+          <div key={r}>
+            <p className="text-[10px] font-semibold uppercase tracking-widest text-pf-text-muted">
+              {r === 0 ? 'Cantrips' : `${ordinal(r)} Rank`}
+            </p>
+            <ul className="mt-1 flex flex-wrap gap-1.5">
+              {[...byRank.get(r)!].sort((a, b) => a.name.localeCompare(b.name)).map((spell) => (
+                <SpellbookChip key={spell.id} spell={spell} />
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SpellbookChip({ spell }: { spell: SpellItem }): React.ReactElement {
+  return (
+    <li
+      draggable
+      onDragStart={(e): void => {
+        e.dataTransfer.setData(DRAG_MIME, spell.id);
+        e.dataTransfer.effectAllowed = 'move';
+      }}
+      data-spellbook-entry={spell.id}
+      data-spell-slug={spell.system.slug ?? ''}
+      className="inline-flex cursor-grab items-center gap-1.5 rounded border border-pf-border bg-pf-bg px-1.5 py-0.5 text-xs text-pf-text active:cursor-grabbing hover:border-pf-primary"
+      title={`Drag to prepare ${spell.name}`}
+    >
+      <img src={spell.img} alt="" className="h-4 w-4 rounded bg-pf-bg-dark" />
+      <span className="truncate">{spell.name}</span>
+    </li>
   );
 }
 
@@ -360,7 +640,7 @@ function SpellCard({ spell, characterLevel }: { spell: SpellItem; characterLevel
   const traits = spell.system.traits.value.filter((t) => t !== 'cantrip');
   const castCost = formatCastCost(spell.system.time?.value);
   const description = spell.system.description?.value ?? '';
-  const heightening = computeHeighteningStep(spell, characterLevel);
+  const heightening = computeHeighteningStep(spell, effectiveRank(spell, characterLevel));
   const enriched =
     description.length > 0 ? enrichDescription(description, heightening !== null ? { heightening } : undefined) : '';
 
@@ -399,6 +679,9 @@ function SpellCardWithCast({
   actorId,
   onCast,
   focusPoints,
+  extraSummary,
+  expendedOverride,
+  rankOverride,
 }: {
   spell: SpellItem;
   characterLevel: number;
@@ -406,12 +689,22 @@ function SpellCardWithCast({
   actorId: string;
   onCast: () => void;
   focusPoints: FocusPool;
+  /** Extra summary slot rendered after the Cast button. Used by prepared-slot
+   *  cells to surface an "unprepare" × control. */
+  extraSummary?: React.ReactNode;
+  /** Overrides the entry-wide "find by spell id" expended derivation. Prepared
+   *  slots expose per-slot expended state, not per-spell. */
+  expendedOverride?: boolean;
+  /** Overrides the spell's intrinsic effective rank for casting. Prepared
+   *  slots cast at the slot's rank, which can be higher than the spell's
+   *  base rank (heightening up). */
+  rankOverride?: number;
 }): React.ReactElement {
   const traits = spell.system.traits.value.filter((t) => t !== 'cantrip');
   const castCost = formatCastCost(spell.system.time?.value);
   const description = spell.system.description?.value ?? '';
-  const rank = effectiveRank(spell, characterLevel);
-  const heightening = computeHeighteningStep(spell, characterLevel);
+  const rank = rankOverride ?? effectiveRank(spell, characterLevel);
+  const heightening = computeHeighteningStep(spell, rank);
   const enriched =
     description.length > 0 ? enrichDescription(description, heightening !== null ? { heightening } : undefined) : '';
 
@@ -423,9 +716,11 @@ function SpellCardWithCast({
   const slotData = entry.system.slots?.[slotKey];
 
   const isExpended =
-    mode === 'prepared'
-      ? (slotData?.prepared?.find((p) => p.id === spell.id)?.expended ?? false)
-      : false;
+    expendedOverride !== undefined
+      ? expendedOverride
+      : mode === 'prepared'
+        ? (slotData?.prepared?.find((p) => p.id === spell.id)?.expended ?? false)
+        : false;
 
   const noSlotsLeft = !isCantrip && mode === 'spontaneous' && (slotData?.value ?? 0) <= 0;
 
@@ -468,6 +763,7 @@ function SpellCardWithCast({
           >
             {pending ? '…' : 'Cast'}
           </button>
+          {extraSummary}
         </>
       }
     >
@@ -583,10 +879,9 @@ function effectiveRank(spell: SpellItem, characterLevel: number): number {
 // spell isn't heightened above its base rank, lacks interval-type
 // heightening, or exposes no damage step — those cases render the
 // description unchanged.
-function computeHeighteningStep(spell: SpellItem, characterLevel: number): { delta: number; perStep: string } | null {
+function computeHeighteningStep(spell: SpellItem, castRank: number): { delta: number; perStep: string } | null {
   const base = spell.system.level.value;
-  const cast = effectiveRank(spell, characterLevel);
-  const delta = cast - base;
+  const delta = castRank - base;
   if (delta <= 0) return null;
   const h = spell.system.heightening;
   if (h === undefined || h.type !== 'interval') return null;

--- a/apps/player-portal/src/features/characters/sheet/tabs/inventory/Inventory.tsx
+++ b/apps/player-portal/src/features/characters/sheet/tabs/inventory/Inventory.tsx
@@ -18,7 +18,7 @@ import {
 } from './inventory-categories';
 import { spendCoins, grantCoins, type SellContext, type InvestContext, type PartyContext } from './inventory-shop';
 import { ItemRow, GridTile } from './InventoryItemRow';
-import { CoinStrip, PartyCoinStrip, ViewToggle, ShopViewToggle, ShopGearMenu } from './InventoryControls';
+import { CoinStrip, CoinTransferButton, PartyCoinStrip, ViewToggle, ShopViewToggle, ShopGearMenu } from './InventoryControls';
 import { PartyStash } from './PartyStash';
 
 interface Props {
@@ -209,6 +209,17 @@ export function Inventory({ items, actorId, onActorChanged, investiture, partyId
                 {...(canTransact
                   ? { actorId, items, onActorChanged, onError: setTxError }
                   : {})}
+              />
+            )}
+            {partyId !== undefined && canTransact && actorId !== undefined && onActorChanged !== undefined && (
+              <CoinTransferButton
+                actorId={actorId}
+                partyId={partyId}
+                items={items}
+                onActorChanged={onActorChanged}
+                onStashChanged={(): void => {
+                  setStashNonce((n) => n + 1);
+                }}
               />
             )}
             {partyId !== undefined && <PartyCoinStrip partyId={partyId} refreshKey={stashNonce} />}

--- a/apps/player-portal/src/features/characters/sheet/tabs/inventory/Inventory.tsx
+++ b/apps/player-portal/src/features/characters/sheet/tabs/inventory/Inventory.tsx
@@ -16,7 +16,7 @@ import {
   type ShopView,
   groupByCategory,
 } from './inventory-categories';
-import { spendCoins, grantCoins, type SellContext, type InvestContext, type PartyContext } from './inventory-shop';
+import { spendCoins, grantCoins, type SellContext, type InvestContext, type PartyContext, type EquipContext } from './inventory-shop';
 import { ItemRow, GridTile } from './InventoryItemRow';
 import { CoinStrip, CoinTransferButton, PartyCoinStrip, ViewToggle, ShopViewToggle, ShopGearMenu } from './InventoryControls';
 import { PartyStash } from './PartyStash';
@@ -54,6 +54,7 @@ export function Inventory({ items, actorId, onActorChanged, investiture, partyId
   const [pendingSells, setPendingSells] = useState<Set<string>>(new Set());
   const [pendingInvestments, setPendingInvestments] = useState<Set<string>>(new Set());
   const [pendingTransfers, setPendingTransfers] = useState<Set<string>>(new Set());
+  const [pendingEquips, setPendingEquips] = useState<Set<string>>(new Set());
   const [stashNonce, setStashNonce] = useState(0);
   const [txError, setTxError] = useState<string | null>(null);
   const shopMode = useShopMode();
@@ -142,6 +143,30 @@ export function Inventory({ items, actorId, onActorChanged, investiture, partyId
       setTxError(err instanceof Error ? err.message : String(err));
     } finally {
       setPendingInvestments((prev) => {
+        const next = new Set(prev);
+        next.delete(item.id);
+        return next;
+      });
+    }
+  };
+
+  const handleToggleEquip = async (item: PhysicalItem): Promise<void> => {
+    if (!canTransact) return;
+    setTxError(null);
+    setPendingEquips((prev) => new Set(prev).add(item.id));
+    try {
+      const eq = item.system.equipped;
+      const isArmourSlot = item.type === 'armor' || item.type === 'backpack';
+      const currentlyEquipped = isArmourSlot ? eq.inSlot === true : (eq.handsHeld ?? 0) > 0;
+      const patch: Record<string, unknown> = isArmourSlot
+        ? { 'equipped.inSlot': !currentlyEquipped, 'equipped.carryType': currentlyEquipped ? 'stowed' : 'worn' }
+        : { 'equipped.handsHeld': currentlyEquipped ? 0 : 1, 'equipped.carryType': currentlyEquipped ? 'stowed' : 'held' };
+      await api.updateActorItem(actorId, item.id, { system: patch });
+      onActorChanged();
+    } catch (err) {
+      setTxError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setPendingEquips((prev) => {
         const next = new Set(prev);
         next.delete(item.id);
         return next;
@@ -283,6 +308,9 @@ export function Inventory({ items, actorId, onActorChanged, investiture, partyId
                   ? { partyId, pending: pendingTransfers, onTransfer: handleTransferToParty }
                   : undefined
               }
+              equipContext={
+                canTransact ? { pending: pendingEquips, onToggle: handleToggleEquip } : undefined
+              }
             />
           )}
         </>
@@ -306,6 +334,7 @@ function CategorizedInventory({
   sellContext,
   investContext,
   partyContext,
+  equipContext,
 }: {
   view: ViewMode;
   tileColumns: number;
@@ -315,6 +344,7 @@ function CategorizedInventory({
   sellContext: SellContext | undefined;
   investContext: InvestContext | undefined;
   partyContext: PartyContext | undefined;
+  equipContext: EquipContext | undefined;
 }): React.ReactElement {
   const buckets = view === 'list' ? topLevelByCategory : allByCategory;
   const presentCategories = CATEGORY_ORDER.filter((c) => (buckets.get(c)?.length ?? 0) > 0);
@@ -338,6 +368,7 @@ function CategorizedInventory({
                     sellContext={sellContext}
                     investContext={investContext}
                     partyContext={partyContext}
+                    equipContext={equipContext}
                   />
                 ))}
               </ul>
@@ -354,6 +385,7 @@ function CategorizedInventory({
                     sellContext={sellContext}
                     investContext={investContext}
                     partyContext={partyContext}
+                    equipContext={equipContext}
                   />
                 ))}
               </ul>

--- a/apps/player-portal/src/features/characters/sheet/tabs/inventory/Inventory.tsx
+++ b/apps/player-portal/src/features/characters/sheet/tabs/inventory/Inventory.tsx
@@ -156,11 +156,17 @@ export function Inventory({ items, actorId, onActorChanged, investiture, partyId
     setPendingEquips((prev) => new Set(prev).add(item.id));
     try {
       const eq = item.system.equipped;
-      const isArmourSlot = item.type === 'armor' || item.type === 'backpack';
-      const currentlyEquipped = isArmourSlot ? eq.inSlot === true : (eq.handsHeld ?? 0) > 0;
-      const patch: Record<string, unknown> = isArmourSlot
-        ? { 'equipped.inSlot': !currentlyEquipped, 'equipped.carryType': currentlyEquipped ? 'stowed' : 'worn' }
-        : { 'equipped.handsHeld': currentlyEquipped ? 0 : 1, 'equipped.carryType': currentlyEquipped ? 'stowed' : 'held' };
+      const isSlotItem = item.type === 'armor' || item.type === 'backpack';
+      let patch: Record<string, unknown>;
+      if (isSlotItem) {
+        const worn = eq.inSlot === true;
+        patch = { 'equipped.inSlot': !worn, 'equipped.carryType': worn ? 'stowed' : 'worn' };
+      } else {
+        const handsHeld = eq.handsHeld ?? 0;
+        const hasTwoHand = item.type === 'weapon' && item.system.traits.value.some((t) => t.startsWith('two-hand'));
+        const nextHands = handsHeld === 0 ? 1 : handsHeld === 1 && hasTwoHand ? 2 : 0;
+        patch = { 'equipped.handsHeld': nextHands, 'equipped.carryType': nextHands > 0 ? 'held' : 'stowed' };
+      }
       await api.updateActorItem(actorId, item.id, { system: patch });
       onActorChanged();
     } catch (err) {

--- a/apps/player-portal/src/features/characters/sheet/tabs/inventory/Inventory.tsx
+++ b/apps/player-portal/src/features/characters/sheet/tabs/inventory/Inventory.tsx
@@ -238,7 +238,6 @@ export function Inventory({ items, actorId, onActorChanged, investiture, partyId
             <PartyStash
               partyId={partyId}
               refreshKey={stashNonce}
-              playerItems={items}
               {...(actorId !== undefined ? { actorId } : {})}
               {...(onActorChanged !== undefined ? { onActorChanged } : {})}
             />

--- a/apps/player-portal/src/features/characters/sheet/tabs/inventory/Inventory.tsx
+++ b/apps/player-portal/src/features/characters/sheet/tabs/inventory/Inventory.tsx
@@ -18,7 +18,7 @@ import {
 } from './inventory-categories';
 import { spendCoins, grantCoins, type SellContext, type InvestContext, type PartyContext } from './inventory-shop';
 import { ItemRow, GridTile } from './InventoryItemRow';
-import { CoinStrip, ViewToggle, ShopViewToggle, ShopGearMenu } from './InventoryControls';
+import { CoinStrip, PartyCoinStrip, ViewToggle, ShopViewToggle, ShopGearMenu } from './InventoryControls';
 import { PartyStash } from './PartyStash';
 
 interface Props {
@@ -211,6 +211,7 @@ export function Inventory({ items, actorId, onActorChanged, investiture, partyId
                   : {})}
               />
             )}
+            {partyId !== undefined && <PartyCoinStrip partyId={partyId} refreshKey={stashNonce} />}
             {hasSelector && (
               <ShopViewToggle
                 view={effectiveShopView}

--- a/apps/player-portal/src/features/characters/sheet/tabs/inventory/InventoryControls.tsx
+++ b/apps/player-portal/src/features/characters/sheet/tabs/inventory/InventoryControls.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { LayoutGrid, List, Settings, ShoppingBag, UserRound, UsersRound } from 'lucide-react';
 import { api } from '@/features/characters/api';
 import type { PhysicalItem, PreparedActorItem } from '@/features/characters/types';
 import { useShopMode } from '@/features/characters/sheet/hooks/useShopMode';
+import { useEventChannel } from '@/features/characters/sheet/hooks/useEventChannel';
 import { coinItemsByDenom, coinSlugFor, type Denom } from '@/features/characters/lib/coins';
 import type { ViewMode, ShopView } from './inventory-categories';
 
@@ -125,7 +126,73 @@ export function CoinStrip({
   );
 }
 
-// ─── Coin edit dialog ────────────────────────────────────────────────────────
+// ─── Party coin strip ─────────────────────────────────────────────────────────
+
+// Shows party stash coin totals next to the player's own CoinStrip. Always
+// visible regardless of which inventory tab is active so players can glance at
+// party funds without switching tabs.
+export function PartyCoinStrip({
+  partyId,
+  refreshKey,
+}: {
+  partyId: string;
+  refreshKey?: number;
+}): React.ReactElement {
+  const [totals, setTotals] = useState<Record<Denom, number>>({ pp: 0, gp: 0, sp: 0, cp: 0 });
+
+  const fetchCoins = useCallback((): void => {
+    api
+      .getPartyStash(partyId)
+      .then((data) => {
+        const t: Record<Denom, number> = { pp: 0, gp: 0, sp: 0, cp: 0 };
+        for (const item of data.items) {
+          if (item.type !== 'treasure') continue;
+          if (item.system['category'] !== 'coin') continue;
+          const slug = typeof item.system['slug'] === 'string' ? item.system['slug'] : null;
+          if (slug === null) continue;
+          const denom = COIN_SLUG_DENOM[slug];
+          if (denom === undefined) continue;
+          const qty = typeof item.system['quantity'] === 'number' ? item.system['quantity'] : 0;
+          t[denom] += qty;
+        }
+        setTotals(t);
+      })
+      .catch(() => {
+        // Silently fail — shows zeros until next successful fetch.
+      });
+  }, [partyId]);
+
+  useEffect(() => {
+    fetchCoins();
+  }, [fetchCoins, refreshKey]);
+
+  useEventChannel<{ actorId: string }>('actors', (event) => {
+    if (event.actorId === partyId) fetchCoins();
+  });
+
+  return (
+    <div
+      className="flex flex-wrap items-center gap-3 rounded border border-pf-tertiary-dark bg-pf-tertiary/20 px-3 py-2"
+      data-section="party-coins-summary"
+    >
+      <span className="text-[11px] font-semibold uppercase tracking-widest text-pf-alt-dark">Party</span>
+      {DENOMS.map((denom) => (
+        <span
+          key={denom}
+          className={[
+            'font-mono text-sm tabular-nums',
+            totals[denom] > 0 ? 'text-pf-text' : 'text-pf-text-muted',
+          ].join(' ')}
+        >
+          <strong>{totals[denom]}</strong>{' '}
+          <span className="text-[10px] uppercase tracking-wider text-pf-text-muted">{denom}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+// ─── Coin edit dialog ─────────────────────────────────────────────────────────
 
 function CoinEditDialog({
   items,

--- a/apps/player-portal/src/features/characters/sheet/tabs/inventory/InventoryControls.tsx
+++ b/apps/player-portal/src/features/characters/sheet/tabs/inventory/InventoryControls.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { LayoutGrid, List, Settings, ShoppingBag, UserRound, UsersRound } from 'lucide-react';
+import { ArrowLeftRight, LayoutGrid, List, Settings, ShoppingBag, UserRound, UsersRound } from 'lucide-react';
 import { api } from '@/features/characters/api';
 import type { PhysicalItem, PreparedActorItem } from '@/features/characters/types';
 import { useShopMode } from '@/features/characters/sheet/hooks/useShopMode';
@@ -244,6 +244,252 @@ export function PartyCoinStrip({
         ))}
       </div>
     </>
+  );
+}
+
+// ─── Coin transfer button + dialog ───────────────────────────────────────────
+
+// Button rendered between the player and party coin strips. Opens a modal that
+// lets the player move coins in either direction.
+export function CoinTransferButton({
+  actorId,
+  partyId,
+  items,
+  onActorChanged,
+  onStashChanged,
+}: {
+  actorId: string;
+  partyId: string;
+  items: readonly PreparedActorItem[];
+  onActorChanged: () => void;
+  onStashChanged: () => void;
+}): React.ReactElement {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button
+        type="button"
+        aria-label="Move coins between player and party"
+        onClick={(): void => {
+          setOpen(true);
+        }}
+        className="rounded border border-pf-border bg-pf-bg p-1.5 text-pf-text-muted hover:bg-pf-bg-dark hover:text-pf-text"
+      >
+        <ArrowLeftRight size={14} />
+      </button>
+      {open && (
+        <CoinTransferDialog
+          actorId={actorId}
+          partyId={partyId}
+          playerItems={items}
+          onClose={(): void => {
+            setOpen(false);
+          }}
+          onSuccess={(): void => {
+            onActorChanged();
+            onStashChanged();
+            setOpen(false);
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+function CoinTransferDialog({
+  actorId,
+  partyId,
+  playerItems,
+  onClose,
+  onSuccess,
+}: {
+  actorId: string;
+  partyId: string;
+  playerItems: readonly PreparedActorItem[];
+  onClose: () => void;
+  onSuccess: () => void;
+}): React.ReactElement {
+  const [direction, setDirection] = useState<'to-party' | 'from-party'>('to-party');
+  const [amounts, setAmounts] = useState<Record<Denom, string>>({ pp: '', gp: '', sp: '', cp: '' });
+  const [partySlots, setPartySlots] = useState<Partial<Record<Denom, PartyCoinSlot>>>({});
+  const [applying, setApplying] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    api
+      .getPartyStash(partyId)
+      .then((data) => {
+        const next: Partial<Record<Denom, PartyCoinSlot>> = {};
+        for (const item of data.items) {
+          if (item.type !== 'treasure') continue;
+          if (item.system['category'] !== 'coin') continue;
+          const slug = typeof item.system['slug'] === 'string' ? item.system['slug'] : null;
+          if (slug === null) continue;
+          const denom = COIN_SLUG_DENOM[slug];
+          if (denom === undefined || next[denom] !== undefined) continue;
+          const qty = typeof item.system['quantity'] === 'number' ? item.system['quantity'] : 0;
+          next[denom] = { id: item.id, qty };
+        }
+        setPartySlots(next);
+      })
+      .catch(() => {
+        /* ignore — party shows zero */
+      });
+  }, [partyId]);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handleKey);
+    return (): void => {
+      window.removeEventListener('keydown', handleKey);
+    };
+  }, [onClose]);
+
+  const playerCoinItems = coinItemsByDenom(playerItems);
+  const playerQty = (d: Denom): number => playerCoinItems[d]?.system.quantity ?? 0;
+  const partyQty = (d: Denom): number => partySlots[d]?.qty ?? 0;
+  const sourceQty = (d: Denom): number => (direction === 'to-party' ? playerQty(d) : partyQty(d));
+
+  // Parse non-empty inputs; accumulate first validation error.
+  const parsedAmounts: Partial<Record<Denom, number>> = {};
+  let validationError: string | null = null;
+  for (const denom of DENOMS) {
+    const text = amounts[denom].trim();
+    if (text === '' || text === '0') continue;
+    const n = parseInt(text, 10);
+    if (!Number.isInteger(n) || n <= 0) {
+      validationError = `${denom}: enter a positive whole number.`;
+      break;
+    }
+    if (n > sourceQty(denom)) {
+      const src = direction === 'to-party' ? 'You only have' : 'Party only has';
+      validationError = `${src} ${sourceQty(denom).toString()} ${denom}.`;
+      break;
+    }
+    parsedAmounts[denom] = n;
+  }
+  const hasChanges = Object.keys(parsedAmounts).length > 0;
+  const canApply = hasChanges && validationError === null && !applying;
+
+  const handleApply = async (): Promise<void> => {
+    setError(null);
+    setApplying(true);
+    try {
+      for (const denom of DENOMS) {
+        const n = parsedAmounts[denom];
+        if (n === undefined) continue;
+        if (direction === 'to-party') {
+          const itemId = playerCoinItems[denom]?.id;
+          if (itemId !== undefined) await api.transferItemToParty(actorId, itemId, partyId, n);
+        } else {
+          const slot = partySlots[denom];
+          if (slot !== undefined) await api.takeItemFromParty(partyId, slot.id, actorId, n);
+        }
+      }
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setApplying(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Move coins"
+      onClick={onClose}
+    >
+      <div
+        className="flex w-full max-w-xs flex-col overflow-hidden rounded border border-pf-border bg-pf-bg shadow-2xl"
+        onClick={(e): void => {
+          e.stopPropagation();
+        }}
+      >
+        <div className="px-5 py-4">
+          <h2 className="text-sm font-semibold text-pf-text">Move coins</h2>
+          <div className="mt-3 flex overflow-hidden rounded border border-pf-border text-[11px] font-semibold">
+            <button
+              type="button"
+              onClick={(): void => {
+                setDirection('to-party');
+              }}
+              className={[
+                'flex-1 py-1.5 transition-colors',
+                direction === 'to-party' ? 'bg-pf-primary text-white' : 'bg-pf-bg text-pf-text hover:bg-pf-bg-dark',
+              ].join(' ')}
+            >
+              You → Party
+            </button>
+            <button
+              type="button"
+              onClick={(): void => {
+                setDirection('from-party');
+              }}
+              className={[
+                'flex-1 py-1.5 transition-colors',
+                direction === 'from-party' ? 'bg-pf-primary text-white' : 'bg-pf-bg text-pf-text hover:bg-pf-bg-dark',
+              ].join(' ')}
+            >
+              Party → You
+            </button>
+          </div>
+          <div className="mt-3 space-y-2">
+            {DENOMS.map((denom) => {
+              const avail = sourceQty(denom);
+              return (
+                <div key={denom} className="flex items-center gap-2 text-xs">
+                  <span className="w-6 font-semibold uppercase tracking-wider text-pf-alt-dark">{denom}</span>
+                  <span className="w-16 text-right font-mono tabular-nums text-pf-text-muted">
+                    {avail.toString()} avail
+                  </span>
+                  <input
+                    type="number"
+                    min="1"
+                    max={avail}
+                    disabled={avail === 0}
+                    placeholder="0"
+                    aria-label={`${denom} amount`}
+                    value={amounts[denom]}
+                    onChange={(e): void => {
+                      setAmounts((prev) => ({ ...prev, [denom]: e.target.value }));
+                    }}
+                    className="w-20 rounded border border-pf-border bg-pf-bg px-2 py-1 text-center font-mono text-pf-text disabled:opacity-40"
+                  />
+                </div>
+              );
+            })}
+          </div>
+          {(error ?? validationError) !== null && (
+            <p className="mt-3 rounded border border-red-200 bg-red-50 px-2 py-1 text-xs text-red-800">
+              {error ?? validationError}
+            </p>
+          )}
+        </div>
+        <footer className="flex items-center justify-end gap-2 border-t border-pf-border bg-pf-bg-dark/60 px-4 py-2.5">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded border border-pf-border bg-pf-bg px-3 py-1.5 text-sm text-pf-text hover:bg-pf-bg-dark"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={!canApply}
+            onClick={(): void => {
+              void handleApply();
+            }}
+            className="rounded border border-pf-primary bg-pf-primary px-3 py-1.5 text-sm font-semibold text-white hover:bg-pf-primary-dark disabled:opacity-50"
+          >
+            {applying ? 'Moving…' : 'Move'}
+          </button>
+        </footer>
+      </div>
+    </div>
   );
 }
 

--- a/apps/player-portal/src/features/characters/sheet/tabs/inventory/InventoryControls.tsx
+++ b/apps/player-portal/src/features/characters/sheet/tabs/inventory/InventoryControls.tsx
@@ -443,7 +443,7 @@ function CoinTransferDialog({
               return (
                 <div key={denom} className="flex items-center gap-2 text-xs">
                   <span className="w-6 font-semibold uppercase tracking-wider text-pf-alt-dark">{denom}</span>
-                  <span className="w-16 text-right font-mono tabular-nums text-pf-text-muted">
+                  <span className="shrink-0 whitespace-nowrap text-right font-mono tabular-nums text-pf-text-muted">
                     {avail.toString()} avail
                   </span>
                   <input

--- a/apps/player-portal/src/features/characters/sheet/tabs/inventory/InventoryControls.tsx
+++ b/apps/player-portal/src/features/characters/sheet/tabs/inventory/InventoryControls.tsx
@@ -28,9 +28,8 @@ export function CoinStrip({
   onError,
 }: {
   coins: PhysicalItem[];
-  /** When provided alongside items + onActorChanged, the strip renders an
-   *  "Edit coins" button that opens a dialog for batched +/- per-denomination
-   *  edits. */
+  /** When provided alongside items + onActorChanged, denomination chips become
+   *  clickable and open a +/- edit dialog. */
   actorId?: string;
   items?: readonly PreparedActorItem[];
   onActorChanged?: () => void;
@@ -83,7 +82,7 @@ export function CoinStrip({
     <>
       {editing && editable && (
         <CoinEditDialog
-          items={items}
+          currentQty={totals}
           onClose={(): void => {
             setEditing(false);
           }}
@@ -96,30 +95,35 @@ export function CoinStrip({
         data-section="coins"
       >
         <span className="text-[11px] font-semibold uppercase tracking-widest text-pf-alt-dark">Coins</span>
-        {DENOMS.map((denom) => (
-          <span
-            key={denom}
-            className={[
-              'font-mono text-sm tabular-nums',
-              totals[denom] > 0 ? 'text-pf-text' : 'text-pf-text-muted',
-            ].join(' ')}
-          >
-            <strong>{totals[denom]}</strong>{' '}
-            <span className="text-[10px] uppercase tracking-wider text-pf-text-muted">{denom}</span>
-          </span>
-        ))}
-        {editable && (
-          <button
-            type="button"
-            aria-label="Edit coins"
-            data-testid="coin-edit-button"
-            onClick={(): void => {
-              setEditing(true);
-            }}
-            className="ml-auto rounded border border-pf-border bg-pf-bg px-2 py-0.5 text-[11px] font-semibold text-pf-text hover:bg-pf-bg-dark"
-          >
-            Edit
-          </button>
+        {DENOMS.map((denom) =>
+          editable ? (
+            <button
+              key={denom}
+              type="button"
+              aria-label={`Edit ${denom}`}
+              onClick={(): void => {
+                setEditing(true);
+              }}
+              className={[
+                'font-mono text-sm tabular-nums underline-offset-2 hover:underline',
+                totals[denom] > 0 ? 'text-pf-text' : 'text-pf-text-muted',
+              ].join(' ')}
+            >
+              <strong>{totals[denom]}</strong>{' '}
+              <span className="text-[10px] uppercase tracking-wider text-pf-text-muted">{denom}</span>
+            </button>
+          ) : (
+            <span
+              key={denom}
+              className={[
+                'font-mono text-sm tabular-nums',
+                totals[denom] > 0 ? 'text-pf-text' : 'text-pf-text-muted',
+              ].join(' ')}
+            >
+              <strong>{totals[denom]}</strong>{' '}
+              <span className="text-[10px] uppercase tracking-wider text-pf-text-muted">{denom}</span>
+            </span>
+          ),
         )}
       </div>
     </>
@@ -128,9 +132,13 @@ export function CoinStrip({
 
 // ─── Party coin strip ─────────────────────────────────────────────────────────
 
-// Shows party stash coin totals next to the player's own CoinStrip. Always
-// visible regardless of which inventory tab is active so players can glance at
-// party funds without switching tabs.
+interface PartyCoinSlot {
+  id: string;
+  qty: number;
+}
+
+// Shows party stash coin totals next to the player's own CoinStrip. Clicking
+// any denomination opens an edit dialog that adjusts coins on the party actor.
 export function PartyCoinStrip({
   partyId,
   refreshKey,
@@ -138,24 +146,25 @@ export function PartyCoinStrip({
   partyId: string;
   refreshKey?: number;
 }): React.ReactElement {
-  const [totals, setTotals] = useState<Record<Denom, number>>({ pp: 0, gp: 0, sp: 0, cp: 0 });
+  const [slots, setSlots] = useState<Partial<Record<Denom, PartyCoinSlot>>>({});
+  const [editing, setEditing] = useState(false);
 
   const fetchCoins = useCallback((): void => {
     api
       .getPartyStash(partyId)
       .then((data) => {
-        const t: Record<Denom, number> = { pp: 0, gp: 0, sp: 0, cp: 0 };
+        const next: Partial<Record<Denom, PartyCoinSlot>> = {};
         for (const item of data.items) {
           if (item.type !== 'treasure') continue;
           if (item.system['category'] !== 'coin') continue;
           const slug = typeof item.system['slug'] === 'string' ? item.system['slug'] : null;
           if (slug === null) continue;
           const denom = COIN_SLUG_DENOM[slug];
-          if (denom === undefined) continue;
+          if (denom === undefined || next[denom] !== undefined) continue;
           const qty = typeof item.system['quantity'] === 'number' ? item.system['quantity'] : 0;
-          t[denom] += qty;
+          next[denom] = { id: item.id, qty };
         }
-        setTotals(t);
+        setSlots(next);
       })
       .catch(() => {
         // Silently fail — shows zeros until next successful fetch.
@@ -170,37 +179,83 @@ export function PartyCoinStrip({
     if (event.actorId === partyId) fetchCoins();
   });
 
+  const totals: Record<Denom, number> = {
+    pp: slots.pp?.qty ?? 0,
+    gp: slots.gp?.qty ?? 0,
+    sp: slots.sp?.qty ?? 0,
+    cp: slots.cp?.qty ?? 0,
+  };
+
+  const handleApply = async (deltas: Partial<Record<Denom, number>>): Promise<void> => {
+    for (const denom of DENOMS) {
+      const delta = deltas[denom];
+      if (delta === undefined || delta === 0) continue;
+      const slot = slots[denom];
+      const currentQty = slot?.qty ?? 0;
+      const newQty = currentQty + delta;
+      if (newQty < 0) {
+        throw new Error(`Cannot remove ${(-delta).toString()} ${denom} — only ${currentQty.toString()} in stash.`);
+      }
+      if (slot !== undefined) {
+        await api.updateActorItem(partyId, slot.id, { system: { quantity: newQty } });
+      } else if (delta > 0) {
+        await api.addItemFromCompendium(partyId, {
+          packId: 'pf2e.equipment-srd',
+          itemId: coinSlugFor(denom),
+          quantity: delta,
+        });
+      }
+    }
+    fetchCoins();
+  };
+
   return (
-    <div
-      className="flex flex-wrap items-center gap-3 rounded border border-pf-tertiary-dark bg-pf-tertiary/20 px-3 py-2"
-      data-section="party-coins-summary"
-    >
-      <span className="text-[11px] font-semibold uppercase tracking-widest text-pf-alt-dark">Party</span>
-      {DENOMS.map((denom) => (
-        <span
-          key={denom}
-          className={[
-            'font-mono text-sm tabular-nums',
-            totals[denom] > 0 ? 'text-pf-text' : 'text-pf-text-muted',
-          ].join(' ')}
-        >
-          <strong>{totals[denom]}</strong>{' '}
-          <span className="text-[10px] uppercase tracking-wider text-pf-text-muted">{denom}</span>
-        </span>
-      ))}
-    </div>
+    <>
+      {editing && (
+        <CoinEditDialog
+          currentQty={totals}
+          onClose={(): void => {
+            setEditing(false);
+          }}
+          onApply={handleApply}
+        />
+      )}
+      <div
+        className="flex flex-wrap items-center gap-3 rounded border border-pf-tertiary-dark bg-pf-tertiary/20 px-3 py-2"
+        data-section="party-coins-summary"
+      >
+        <span className="text-[11px] font-semibold uppercase tracking-widest text-pf-alt-dark">Party</span>
+        {DENOMS.map((denom) => (
+          <button
+            key={denom}
+            type="button"
+            aria-label={`Edit party ${denom}`}
+            onClick={(): void => {
+              setEditing(true);
+            }}
+            className={[
+              'font-mono text-sm tabular-nums underline-offset-2 hover:underline',
+              totals[denom] > 0 ? 'text-pf-text' : 'text-pf-text-muted',
+            ].join(' ')}
+          >
+            <strong>{totals[denom]}</strong>{' '}
+            <span className="text-[10px] uppercase tracking-wider text-pf-text-muted">{denom}</span>
+          </button>
+        ))}
+      </div>
+    </>
   );
 }
 
 // ─── Coin edit dialog ─────────────────────────────────────────────────────────
 
 function CoinEditDialog({
-  items,
+  currentQty,
   onClose,
   onApply,
   onError,
 }: {
-  items: readonly PreparedActorItem[];
+  currentQty: Record<Denom, number>;
   onClose: () => void;
   onApply: (deltas: Partial<Record<Denom, number>>) => Promise<void>;
   onError?: (msg: string | null) => void;
@@ -218,14 +273,6 @@ function CoinEditDialog({
       window.removeEventListener('keydown', handleKey);
     };
   }, [onClose]);
-
-  const coinItems = coinItemsByDenom(items);
-  const currentQty: Record<Denom, number> = {
-    pp: coinItems.pp?.system.quantity ?? 0,
-    gp: coinItems.gp?.system.quantity ?? 0,
-    sp: coinItems.sp?.system.quantity ?? 0,
-    cp: coinItems.cp?.system.quantity ?? 0,
-  };
 
   // Parse non-empty inputs into ints, dropping zeros and unparseable values.
   const parsedDeltas: Partial<Record<Denom, number>> = {};

--- a/apps/player-portal/src/features/characters/sheet/tabs/inventory/InventoryItemRow.tsx
+++ b/apps/player-portal/src/features/characters/sheet/tabs/inventory/InventoryItemRow.tsx
@@ -97,11 +97,15 @@ export function ItemRow({
             <EquippedBadge item={item} suppressInvested={hasInvestButton} />
             {hasInvestButton && <InvestButton item={item} context={investContext} />}
             <BulkLabel value={bulk.value} />
-            {sellContext && <SellButton item={item} context={sellContext} />}
           </>
         }
       >
         <FullArtPanel item={item} />
+        {sellContext && (
+          <div className="mb-2">
+            <SellButton item={item} context={sellContext} />
+          </div>
+        )}
         {partyContext && (
           <div className="mb-2">
             <StashButton item={item} context={partyContext} />
@@ -237,7 +241,6 @@ export function GridTile({
               </span>
             )}
           </div>
-          {sellContext && <SellButton item={item} context={sellContext} />}
         </summary>
         <div
           ref={panelRef}
@@ -246,6 +249,11 @@ export function GridTile({
           {hasInvestButton && (
             <div className="mb-3">
               <InvestButton item={item} context={investContext} />
+            </div>
+          )}
+          {sellContext && (
+            <div className="mb-3">
+              <SellButton item={item} context={sellContext} />
             </div>
           )}
           {partyContext && (

--- a/apps/player-portal/src/features/characters/sheet/tabs/inventory/InventoryItemRow.tsx
+++ b/apps/player-portal/src/features/characters/sheet/tabs/inventory/InventoryItemRow.tsx
@@ -5,7 +5,7 @@ import { supportsInvestment } from '@/features/characters/lib/investment';
 import { cpToDenominations, priceToCp } from '@/features/characters/lib/coins';
 import { DetailsCard } from '@/shared/ui/DetailsCard';
 import { EnrichedDescription } from '@/shared/ui/EnrichedDescription';
-import type { SellContext, InvestContext, PartyContext } from './inventory-shop';
+import type { SellContext, InvestContext, PartyContext, EquipContext } from './inventory-shop';
 
 // Items whose img field is a /item-art/* URL have a purchased art override.
 function hasArtOverride(img: string): boolean {
@@ -57,12 +57,14 @@ export function ItemRow({
   sellContext,
   investContext,
   partyContext,
+  equipContext,
 }: {
   item: PhysicalItem;
   contents: PhysicalItem[];
   sellContext: SellContext | undefined;
   investContext: InvestContext | undefined;
   partyContext: PartyContext | undefined;
+  equipContext: EquipContext | undefined;
 }): React.ReactElement {
   const isContainerRow = isContainer(item);
   const bulk = item.system.bulk;
@@ -101,8 +103,11 @@ export function ItemRow({
         }
       >
         <FullArtPanel item={item} />
-        {(sellContext !== undefined || partyContext !== undefined) && (
+        {(equipContext !== undefined || sellContext !== undefined || partyContext !== undefined) && (
           <div className="mb-2 flex flex-wrap gap-2">
+            {equipContext !== undefined && supportsEquip(item) && (
+              <EquipButton item={item} context={equipContext} />
+            )}
             {sellContext && <SellButton item={item} context={sellContext} />}
             {partyContext && <StashButton item={item} context={partyContext} />}
           </div>
@@ -153,11 +158,13 @@ export function GridTile({
   sellContext,
   investContext,
   partyContext,
+  equipContext,
 }: {
   item: PhysicalItem;
   sellContext: SellContext | undefined;
   investContext: InvestContext | undefined;
   partyContext: PartyContext | undefined;
+  equipContext: EquipContext | undefined;
 }): React.ReactElement {
   const hasInvestButton = investContext !== undefined && supportsInvestment(item);
   const equipped = isEquippedItem(item);
@@ -242,9 +249,12 @@ export function GridTile({
           ref={panelRef}
           className={`absolute -top-px ${flipLeft ? 'right-full' : 'left-full'} z-20 min-h-[calc(100%+2px)] w-max min-w-[150%] max-w-[300%] overflow-y-auto ${flipLeft ? 'rounded-l' : 'rounded-r'} border border-pf-primary/60 bg-pf-bg p-4 text-sm text-pf-text shadow-lg`}
         >
-          {(hasInvestButton || sellContext !== undefined || partyContext !== undefined) && (
+          {(hasInvestButton || equipContext !== undefined || sellContext !== undefined || partyContext !== undefined) && (
             <div className="mb-3 flex flex-wrap gap-2">
               {hasInvestButton && <InvestButton item={item} context={investContext} />}
+              {equipContext !== undefined && supportsEquip(item) && (
+                <EquipButton item={item} context={equipContext} />
+              )}
               {sellContext && <SellButton item={item} context={sellContext} />}
               {partyContext && <StashButton item={item} context={partyContext} />}
             </div>
@@ -263,6 +273,54 @@ function ItemDescription({ item }: { item: PhysicalItem }): React.ReactElement {
   const description = (item.system.description as { value?: unknown } | undefined)?.value;
   const raw = typeof description === 'string' ? description : undefined;
   return <EnrichedDescription raw={raw} maxHeightClass="max-h-[24rem]" />;
+}
+
+// Equip toggle applies to wearable/holdable item types only.
+function supportsEquip(item: PhysicalItem): boolean {
+  return item.type === 'weapon' || item.type === 'armor' || item.type === 'shield' || item.type === 'backpack';
+}
+
+function EquipButton({ item, context }: { item: PhysicalItem; context: EquipContext }): React.ReactElement {
+  const busy = context.pending.has(item.id);
+  const eq = item.system.equipped;
+  const equipped =
+    (item.type === 'armor' || item.type === 'backpack') ? eq.inSlot === true : (eq.handsHeld ?? 0) > 0;
+
+  let label: string;
+  if (busy) {
+    label = equipped ? 'Removing…' : 'Equipping…';
+  } else if (item.type === 'weapon' || item.type === 'shield') {
+    label = equipped ? 'Stow' : 'Hold';
+  } else if (item.type === 'backpack') {
+    label = equipped ? 'Remove' : 'Wear';
+  } else {
+    label = equipped ? 'Remove' : 'Equip';
+  }
+
+  return (
+    <button
+      type="button"
+      data-testid="equip-button"
+      disabled={busy}
+      onClick={(e): void => {
+        e.preventDefault();
+        e.stopPropagation();
+        void context.onToggle(item);
+      }}
+      aria-pressed={equipped}
+      aria-label={equipped ? `Unequip ${item.name}` : `Equip ${item.name}`}
+      className={[
+        'shrink-0 rounded border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wider',
+        busy
+          ? 'border-pf-primary bg-pf-primary/10 text-pf-primary'
+          : equipped
+            ? 'border-emerald-300 bg-emerald-50 text-emerald-800 hover:bg-emerald-100'
+            : 'border-emerald-200 bg-white text-emerald-600 hover:bg-emerald-50',
+      ].join(' ')}
+    >
+      {label}
+    </button>
+  );
 }
 
 function StashButton({ item, context }: { item: PhysicalItem; context: PartyContext }): React.ReactElement {

--- a/apps/player-portal/src/features/characters/sheet/tabs/inventory/InventoryItemRow.tsx
+++ b/apps/player-portal/src/features/characters/sheet/tabs/inventory/InventoryItemRow.tsx
@@ -107,7 +107,7 @@ export function ItemRow({
             <StashButton item={item} context={partyContext} />
           </div>
         )}
-        <ItemDescription item={item} />
+        {!hasArtOverride(item.img) && <ItemDescription item={item} />}
       </DetailsCard>
       {isContainerRow && contents.length > 0 && (
         <ul
@@ -254,7 +254,7 @@ export function GridTile({
             </div>
           )}
           <FullArtPanel item={item} />
-          <ItemDescription item={item} />
+          {!hasArtOverride(item.img) && <ItemDescription item={item} />}
         </div>
       </details>
     </li>

--- a/apps/player-portal/src/features/characters/sheet/tabs/inventory/InventoryItemRow.tsx
+++ b/apps/player-portal/src/features/characters/sheet/tabs/inventory/InventoryItemRow.tsx
@@ -1,5 +1,4 @@
 import { useLayoutEffect, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
 import type { PhysicalItem } from '@/features/characters/types';
 import { isContainer } from '@/features/characters/types';
 import { supportsInvestment } from '@/features/characters/lib/investment';
@@ -9,72 +8,42 @@ import { EnrichedDescription } from '@/shared/ui/EnrichedDescription';
 import type { SellContext, InvestContext, PartyContext } from './inventory-shop';
 
 // Items whose img field is a /item-art/* URL have a purchased art override.
-// Thumbnails for these get a tighter crop and become click-to-open buttons
-// that show the full uncropped art in a lightbox. The expanded details
-// panel still shows the rules text — players need to read the card.
 function hasArtOverride(img: string): boolean {
   return img.startsWith('/item-art/');
 }
 
-/** Renders the item thumbnail as a clickable button when there's an art
- *  override (opens a lightbox with the full art); plain <img> otherwise. */
+/** Thumbnail that lets the surrounding <summary> handle all click events.
+ *  Art-override items get a tighter crop so the portrait fills the small box;
+ *  the full art is shown in the expanded details panel instead of a lightbox. */
 function ItemThumb({
   item,
   sizeClass,
   containClass,
 }: {
   item: PhysicalItem;
-  /** Tailwind size + flex utilities for the thumbnail box (e.g. "h-8 w-8 flex-shrink-0"). */
   sizeClass: string;
-  /** Optional extra classes for the non-override <img> (e.g. "object-contain"
-   *  for the grid tile that uses an aspect-square wrapper). Default empty. */
   containClass?: string;
 }): React.ReactElement {
-  const [open, setOpen] = useState(false);
   const baseImgClass = `${sizeClass} rounded border border-pf-border bg-pf-bg-dark`;
-
-  if (!hasArtOverride(item.img)) {
-    return <img src={item.img} alt="" className={`${baseImgClass} ${containClass ?? ''}`} />;
+  if (hasArtOverride(item.img)) {
+    return (
+      <div className={`${sizeClass} overflow-hidden rounded border border-pf-border bg-pf-bg-dark flex-shrink-0`}>
+        <img src={item.img} alt="" className="h-full w-full scale-150 origin-top object-cover object-[center_2%]" />
+      </div>
+    );
   }
+  return <img src={item.img} alt="" className={`${baseImgClass} ${containClass ?? ''}`} />;
+}
 
+/** Shows the full art inside the expanded details panel for art-override items. */
+function FullArtPanel({ item }: { item: PhysicalItem }): React.ReactElement | null {
+  if (!hasArtOverride(item.img)) return null;
   return (
-    <>
-      <button
-        type="button"
-        onClick={(e) => {
-          // Stop the surrounding <summary> from toggling the details element.
-          e.stopPropagation();
-          e.preventDefault();
-          setOpen(true);
-        }}
-        aria-label={`View full art for ${item.name}`}
-        className={`${sizeClass} cursor-zoom-in overflow-hidden rounded border border-pf-border bg-pf-bg-dark`}
-      >
-        <img
-          src={item.img}
-          alt=""
-          className="h-full w-full scale-150 origin-top object-cover object-[center_2%]"
-        />
-      </button>
-      {open &&
-        createPortal(
-          <div
-            role="dialog"
-            aria-modal="true"
-            aria-label={`${item.name} – full art`}
-            className="fixed inset-0 z-[60] flex cursor-zoom-out items-center justify-center bg-black/80 p-4"
-            onClick={() => { setOpen(false); }}
-          >
-            <img
-              src={item.img}
-              alt={item.name}
-              className="max-h-full max-w-full rounded shadow-2xl"
-              onClick={(e) => { e.stopPropagation(); }}
-            />
-          </div>,
-          document.body,
-        )}
-    </>
+    <img
+      src={item.img}
+      alt={item.name}
+      className="mb-3 w-full rounded border border-pf-border object-contain"
+    />
   );
 }
 
@@ -132,6 +101,7 @@ export function ItemRow({
           </>
         }
       >
+        <FullArtPanel item={item} />
         {partyContext && (
           <div className="mb-2">
             <StashButton item={item} context={partyContext} />
@@ -213,9 +183,7 @@ export function GridTile({
 
   const [zIndex, setZIndex] = useState<number | undefined>(undefined);
   const [flipLeft, setFlipLeft] = useState(false);
-  const [lightboxOpen, setLightboxOpen] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
-  const overrideOnImg = hasArtOverride(item.img);
 
   useLayoutEffect(() => {
     if (zIndex === undefined) {
@@ -252,16 +220,7 @@ export function GridTile({
               <img
                 src={item.img}
                 alt=""
-                onClick={
-                  overrideOnImg
-                    ? (e) => {
-                        e.stopPropagation();
-                        e.preventDefault();
-                        setLightboxOpen(true);
-                      }
-                    : undefined
-                }
-                className={`h-full w-full ${overrideOnImg ? 'scale-150 origin-top cursor-zoom-in object-cover object-[center_2%]' : 'object-contain'}`}
+                className={`h-full w-full ${hasArtOverride(item.img) ? 'scale-150 origin-top object-cover object-[center_2%]' : 'object-contain'}`}
               />
               <div className="absolute inset-x-0 bottom-0 bg-black/40 px-1.5 py-1">
                 <span
@@ -294,27 +253,10 @@ export function GridTile({
               <StashButton item={item} context={partyContext} />
             </div>
           )}
+          <FullArtPanel item={item} />
           <ItemDescription item={item} />
         </div>
       </details>
-      {lightboxOpen &&
-        createPortal(
-          <div
-            role="dialog"
-            aria-modal="true"
-            aria-label={`${item.name} – full art`}
-            className="fixed inset-0 z-[60] flex cursor-zoom-out items-center justify-center bg-black/80 p-4"
-            onClick={() => { setLightboxOpen(false); }}
-          >
-            <img
-              src={item.img}
-              alt={item.name}
-              className="max-h-full max-w-full rounded shadow-2xl"
-              onClick={(e) => { e.stopPropagation(); }}
-            />
-          </div>,
-          document.body,
-        )}
     </li>
   );
 }

--- a/apps/player-portal/src/features/characters/sheet/tabs/inventory/InventoryItemRow.tsx
+++ b/apps/player-portal/src/features/characters/sheet/tabs/inventory/InventoryItemRow.tsx
@@ -101,14 +101,10 @@ export function ItemRow({
         }
       >
         <FullArtPanel item={item} />
-        {sellContext && (
-          <div className="mb-2">
-            <SellButton item={item} context={sellContext} />
-          </div>
-        )}
-        {partyContext && (
-          <div className="mb-2">
-            <StashButton item={item} context={partyContext} />
+        {(sellContext !== undefined || partyContext !== undefined) && (
+          <div className="mb-2 flex flex-wrap gap-2">
+            {sellContext && <SellButton item={item} context={sellContext} />}
+            {partyContext && <StashButton item={item} context={partyContext} />}
           </div>
         )}
         {!hasArtOverride(item.img) && <ItemDescription item={item} />}
@@ -246,19 +242,11 @@ export function GridTile({
           ref={panelRef}
           className={`absolute -top-px ${flipLeft ? 'right-full' : 'left-full'} z-20 min-h-[calc(100%+2px)] w-max min-w-[150%] max-w-[300%] overflow-y-auto ${flipLeft ? 'rounded-l' : 'rounded-r'} border border-pf-primary/60 bg-pf-bg p-4 text-sm text-pf-text shadow-lg`}
         >
-          {hasInvestButton && (
-            <div className="mb-3">
-              <InvestButton item={item} context={investContext} />
-            </div>
-          )}
-          {sellContext && (
-            <div className="mb-3">
-              <SellButton item={item} context={sellContext} />
-            </div>
-          )}
-          {partyContext && (
-            <div className="mb-3">
-              <StashButton item={item} context={partyContext} />
+          {(hasInvestButton || sellContext !== undefined || partyContext !== undefined) && (
+            <div className="mb-3 flex flex-wrap gap-2">
+              {hasInvestButton && <InvestButton item={item} context={investContext} />}
+              {sellContext && <SellButton item={item} context={sellContext} />}
+              {partyContext && <StashButton item={item} context={partyContext} />}
             </div>
           )}
           <FullArtPanel item={item} />

--- a/apps/player-portal/src/features/characters/sheet/tabs/inventory/InventoryItemRow.tsx
+++ b/apps/player-portal/src/features/characters/sheet/tabs/inventory/InventoryItemRow.tsx
@@ -283,18 +283,24 @@ function supportsEquip(item: PhysicalItem): boolean {
 function EquipButton({ item, context }: { item: PhysicalItem; context: EquipContext }): React.ReactElement {
   const busy = context.pending.has(item.id);
   const eq = item.system.equipped;
-  const equipped =
-    (item.type === 'armor' || item.type === 'backpack') ? eq.inSlot === true : (eq.handsHeld ?? 0) > 0;
+  const isSlotItem = item.type === 'armor' || item.type === 'backpack';
+  const handsHeld = eq.handsHeld ?? 0;
+  const equipped = isSlotItem ? eq.inSlot === true : handsHeld > 0;
+  // Weapons with a two-hand-* trait cycle stowed → 1H → 2H → stowed.
+  const hasTwoHand =
+    item.type === 'weapon' && item.system.traits.value.some((t) => t.startsWith('two-hand'));
 
   let label: string;
   if (busy) {
-    label = equipped ? 'Removing…' : 'Equipping…';
-  } else if (item.type === 'weapon' || item.type === 'shield') {
-    label = equipped ? 'Stow' : 'Hold';
-  } else if (item.type === 'backpack') {
-    label = equipped ? 'Remove' : 'Wear';
+    label = 'Updating…';
+  } else if (isSlotItem) {
+    label = equipped ? 'Remove' : item.type === 'backpack' ? 'Wear' : 'Equip';
+  } else if (handsHeld === 0) {
+    label = 'Hold';
+  } else if (handsHeld === 1 && hasTwoHand) {
+    label = '2H';
   } else {
-    label = equipped ? 'Remove' : 'Equip';
+    label = 'Stow';
   }
 
   return (
@@ -308,7 +314,7 @@ function EquipButton({ item, context }: { item: PhysicalItem; context: EquipCont
         void context.onToggle(item);
       }}
       aria-pressed={equipped}
-      aria-label={equipped ? `Unequip ${item.name}` : `Equip ${item.name}`}
+      aria-label={label}
       className={[
         'shrink-0 rounded border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wider',
         busy

--- a/apps/player-portal/src/features/characters/sheet/tabs/inventory/PartyStash.tsx
+++ b/apps/player-portal/src/features/characters/sheet/tabs/inventory/PartyStash.tsx
@@ -1,8 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import type { PartyStashItem } from '@foundry-toolkit/shared/rpc';
 import { api } from '@/features/characters/api';
-import type { PreparedActorItem } from '@/features/characters/types';
-import { coinItemsByDenom, type Denom } from '@/features/characters/lib/coins';
 import { useEventChannel } from '@/features/characters/sheet/hooks/useEventChannel';
 import { SectionHeader } from '@/shared/ui/SectionHeader';
 import { CATEGORY_ORDER, CATEGORY_LABEL, type InventoryCategory } from './inventory-categories';
@@ -13,146 +11,15 @@ interface Props {
    *  character sheet). transferItemToActor fires createItem hooks, not
    *  updateActor, so the actors-channel SSE won't deliver an event here. */
   refreshKey?: number;
-  /** Character actor ID — enables Take/Send controls. */
+  /** Character actor ID — enables Take controls. */
   actorId?: string;
-  /** Called after a successful take or coin send so the character sheet reloads. */
+  /** Called after a successful take so the character sheet reloads. */
   onActorChanged?: () => void;
-  /** Full item list from the character sheet — used to identify which coin
-   *  denominations the player currently has so Send controls can be shown. */
-  playerItems?: readonly PreparedActorItem[];
 }
 
 const PHYSICAL_ITEM_TYPES = new Set([
   'weapon', 'armor', 'shield', 'equipment', 'consumable', 'ammo', 'treasure', 'backpack', 'book',
 ]);
-
-// ─── Stash coin helpers ───────────────────────────────────────────────────────
-
-const COIN_DENOM_BY_SLUG: Record<string, Denom> = {
-  'platinum-pieces': 'pp',
-  'gold-pieces': 'gp',
-  'silver-pieces': 'sp',
-  'copper-pieces': 'cp',
-};
-
-interface StashCoinSlot {
-  id: string;
-  qty: number;
-}
-
-function stashCoinsByDenom(items: PartyStashItem[]): Partial<Record<Denom, StashCoinSlot>> {
-  const out: Partial<Record<Denom, StashCoinSlot>> = {};
-  for (const item of items) {
-    if (item.type !== 'treasure') continue;
-    if (item.system['category'] !== 'coin') continue;
-    const slug = typeof item.system['slug'] === 'string' ? item.system['slug'] : null;
-    if (slug === null) continue;
-    const denom = COIN_DENOM_BY_SLUG[slug];
-    if (denom === undefined || out[denom] !== undefined) continue;
-    const qty = typeof item.system['quantity'] === 'number' ? item.system['quantity'] : 0;
-    out[denom] = { id: item.id, qty };
-  }
-  return out;
-}
-
-function isStashCoin(item: PartyStashItem): boolean {
-  return item.type === 'treasure' && item.system['category'] === 'coin';
-}
-
-const DENOMS: readonly Denom[] = ['pp', 'gp', 'sp', 'cp'];
-
-// ─── Coin transfer row ────────────────────────────────────────────────────────
-
-const STEP_BTN =
-  'rounded border border-pf-border bg-pf-bg px-1.5 py-0.5 text-[10px] font-semibold text-pf-text hover:bg-pf-bg-dark disabled:opacity-40';
-
-function CoinTransferRow({
-  denom,
-  stashSlot,
-  playerQty,
-  playerItemId,
-  onSend,
-  onTake,
-  pending,
-  canTransact,
-}: {
-  denom: Denom;
-  stashSlot: StashCoinSlot | undefined;
-  playerQty: number;
-  playerItemId: string | undefined;
-  onSend: (denom: Denom, itemId: string, qty: number) => void;
-  onTake: (denom: Denom, itemId: string, qty: number) => void;
-  pending: boolean;
-  canTransact: boolean;
-}): React.ReactElement {
-  const [qty, setQty] = useState('1');
-  const n = Math.max(1, parseInt(qty, 10) || 1);
-  const stashQty = stashSlot?.qty ?? 0;
-
-  const canSend = canTransact && playerItemId !== undefined && playerQty > 0 && n <= playerQty;
-  const canTake = canTransact && stashSlot !== undefined && stashQty > 0 && n <= stashQty;
-
-  return (
-    <div className="flex items-center gap-2 text-xs" data-coin-denom={denom}>
-      <span className="w-16 text-right font-mono tabular-nums text-pf-text">
-        <strong>{stashQty}</strong>{' '}
-        <span className="text-[10px] uppercase tracking-wider text-pf-text-muted">{denom}</span>
-      </span>
-      <span className="w-12 text-[10px] text-pf-text-muted">in stash</span>
-      {canTransact && (
-        <>
-          <button
-            type="button"
-            aria-label={`Send ${denom} to party stash`}
-            disabled={pending || !canSend}
-            onClick={(): void => {
-              if (playerItemId !== undefined) onSend(denom, playerItemId, n);
-            }}
-            className={STEP_BTN}
-            title={
-              playerQty === 0
-                ? `You have no ${denom}`
-                : n > playerQty
-                  ? `You only have ${playerQty.toString()} ${denom}`
-                  : undefined
-            }
-          >
-            Send →
-          </button>
-          <input
-            type="number"
-            min="1"
-            aria-label={`${denom} transfer amount`}
-            value={qty}
-            onChange={(e): void => {
-              setQty(e.target.value);
-            }}
-            className="w-12 rounded border border-pf-border bg-pf-bg px-1 py-0.5 text-center font-mono text-xs text-pf-text"
-          />
-          <button
-            type="button"
-            aria-label={`Take ${denom} from party stash`}
-            disabled={pending || !canTake}
-            onClick={(): void => {
-              if (stashSlot !== undefined) onTake(denom, stashSlot.id, n);
-            }}
-            className={STEP_BTN}
-            title={
-              stashQty === 0
-                ? `Stash has no ${denom}`
-                : n > stashQty
-                  ? `Stash only has ${stashQty.toString()} ${denom}`
-                  : undefined
-            }
-          >
-            ← Take
-          </button>
-          <span className="text-[10px] text-pf-text-muted">(you: {playerQty})</span>
-        </>
-      )}
-    </div>
-  );
-}
 
 // ─── Category grouping ────────────────────────────────────────────────────────
 
@@ -286,12 +153,10 @@ function StashTile({
 
 // ─── Main component ───────────────────────────────────────────────────────────
 
-export function PartyStash({ partyId, refreshKey, actorId, onActorChanged, playerItems }: Props): React.ReactElement {
+export function PartyStash({ partyId, refreshKey, actorId, onActorChanged }: Props): React.ReactElement {
   const [items, setItems] = useState<PartyStashItem[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [pendingTakes, setPendingTakes] = useState<Set<string>>(new Set());
-  const [pendingCoinDenom, setPendingCoinDenom] = useState<Denom | null>(null);
-  const [coinTxError, setCoinTxError] = useState<string | null>(null);
 
   const fetchStash = useCallback((): void => {
     api
@@ -346,55 +211,12 @@ export function PartyStash({ partyId, refreshKey, actorId, onActorChanged, playe
     [partyId, actorId, onActorChanged, fetchStash],
   );
 
-  const handleSendCoin = (denom: Denom, itemId: string, qty: number): void => {
-    if (actorId === undefined) return;
-    setPendingCoinDenom(denom);
-    setCoinTxError(null);
-    api
-      .transferItemToParty(actorId, itemId, partyId, qty)
-      .then(() => {
-        onActorChanged?.();
-        fetchStash();
-      })
-      .catch((err: unknown) => {
-        setCoinTxError(err instanceof Error ? err.message : String(err));
-      })
-      .finally(() => {
-        setPendingCoinDenom(null);
-      });
-  };
-
-  const handleTakeCoin = (denom: Denom, itemId: string, qty: number): void => {
-    if (actorId === undefined) return;
-    setPendingCoinDenom(denom);
-    setCoinTxError(null);
-    api
-      .takeItemFromParty(partyId, itemId, actorId, qty)
-      .then(() => {
-        onActorChanged?.();
-        fetchStash();
-      })
-      .catch((err: unknown) => {
-        setCoinTxError(err instanceof Error ? err.message : String(err));
-      })
-      .finally(() => {
-        setPendingCoinDenom(null);
-      });
-  };
-
-  // Coin section: derive which denominations to show.
-  const stashCoinMap = stashCoinsByDenom(items);
-  const playerCoinMap = playerItems !== undefined ? coinItemsByDenom(playerItems) : {};
-  const canCoinTransact = actorId !== undefined && playerItems !== undefined;
-
-  const visibleCoinDenoms = DENOMS.filter(
-    (d) => (stashCoinMap[d]?.qty ?? 0) > 0 || (canCoinTransact && (playerCoinMap[d]?.system.quantity ?? 0) > 0),
-  );
-  const showCoinSection = visibleCoinDenoms.length > 0;
-
-  // Non-coin items go into the tile grid (coins have their own section).
+  // Non-coin items go into the tile grid. Coins are shown in the always-visible
+  // PartyCoinStrip above the inventory tabs — not duplicated here.
   const physical = items.filter((i) => PHYSICAL_ITEM_TYPES.has(i.type));
-  const nonCoinPhysical = physical.filter((i) => !isStashCoin(i));
+  const nonCoinPhysical = physical.filter(
+    (i) => !(i.type === 'treasure' && i.system['category'] === 'coin'),
+  );
   const byCategory = groupByCategory(nonCoinPhysical);
   const presentCategories = CATEGORY_ORDER.filter((c) => (byCategory.get(c)?.length ?? 0) > 0);
 
@@ -402,40 +224,12 @@ export function PartyStash({ partyId, refreshKey, actorId, onActorChanged, playe
     return <p className="text-sm text-pf-text-muted">Loading…</p>;
   }
 
-  if (!showCoinSection && nonCoinPhysical.length === 0) {
+  if (nonCoinPhysical.length === 0) {
     return <p className="text-sm text-pf-text-muted">The stash is empty.</p>;
   }
 
   return (
     <div className="space-y-4 *:rounded-lg *:border *:border-pf-border *:bg-pf-bg-dark *:p-4">
-      {showCoinSection && (
-        <div data-section="party-coins">
-          <SectionHeader band>Coins</SectionHeader>
-          {coinTxError !== null && (
-            <p
-              className="mt-2 rounded border border-red-200 bg-red-50 px-2 py-1 text-xs text-red-800"
-              data-role="coin-tx-error"
-            >
-              {coinTxError}
-            </p>
-          )}
-          <div className="mt-2 space-y-2">
-            {visibleCoinDenoms.map((denom) => (
-              <CoinTransferRow
-                key={denom}
-                denom={denom}
-                stashSlot={stashCoinMap[denom]}
-                playerQty={playerCoinMap[denom]?.system.quantity ?? 0}
-                playerItemId={playerCoinMap[denom]?.id}
-                onSend={handleSendCoin}
-                onTake={handleTakeCoin}
-                pending={pendingCoinDenom === denom}
-                canTransact={canCoinTransact}
-              />
-            ))}
-          </div>
-        </div>
-      )}
       {presentCategories.map((category) => {
         const bucket = byCategory.get(category) ?? [];
         return (

--- a/apps/player-portal/src/features/characters/sheet/tabs/inventory/inventory-shop.ts
+++ b/apps/player-portal/src/features/characters/sheet/tabs/inventory/inventory-shop.ts
@@ -27,6 +27,11 @@ export interface PartyContext {
   onTransfer: (item: PhysicalItem) => Promise<void>;
 }
 
+export interface EquipContext {
+  pending: Set<string>;
+  onToggle: (item: PhysicalItem) => Promise<void>;
+}
+
 // Deduct `totalCp` from the actor's canonical coin items. Pulls from
 // the largest denomination that can cover what's left and breaks it
 // down on the way, mirroring how a player would hand over pocket

--- a/apps/player-portal/src/features/characters/sheet/tabs/progression/Progression.tsx
+++ b/apps/player-portal/src/features/characters/sheet/tabs/progression/Progression.tsx
@@ -40,6 +40,11 @@ interface Props {
   /** Deserialised from `actor.flags['player-portal']['progression-picks']`.
    *  Hydrates skill-increase and ability-boost picks across page refreshes. */
   persistedPicks?: Record<string, unknown>;
+  /** Levels at which the free-archetype variant rule grants a feat slot,
+   *  e.g. [2, 4, 6, 8] for a level-8 character. Sourced from PF2e's
+   *  computed actor.feats archetype group via the prepared-actor handler;
+   *  empty/absent means the variant rule is off and no chips render. */
+  archetypeFeatLevels?: readonly number[];
 }
 
 // Levels every character can reach (pf2e core: 1-20).
@@ -71,6 +76,7 @@ export function Progression({
   characterContext,
   onActorChanged,
   persistedPicks,
+  archetypeFeatLevels,
 }: Props): React.ReactElement {
   const classItem = items.find(isClassItem);
   const [pickerTarget, setPickerTarget] = useState<{ level: number; slot: SlotType } | null>(null);
@@ -168,7 +174,7 @@ export function Progression({
       ? (((ancestryItem.system as { slug?: unknown }).slug as string | undefined) ?? ancestryItem.name.toLowerCase())
       : undefined;
   const featuresByLevel = groupFeaturesByLevel(sys.items);
-  const levelSlots = buildLevelSlotMap(sys);
+  const levelSlots = buildLevelSlotMap(sys, archetypeFeatLevels);
 
   const openPicker = (level: number, slot: SlotType): void => {
     setPickerTarget({ level, slot });
@@ -273,6 +279,7 @@ const PICKER_TITLE: Partial<Record<SlotType, string>> = {
   'ancestry-feat': 'Ancestry Feat',
   'skill-feat': 'Skill Feat',
   'general-feat': 'General Feat',
+  'archetype-feat': 'Archetype Feat',
 };
 
 function pickerTitleFor(slot: SlotType, level: number): string {
@@ -311,6 +318,8 @@ function buildPickerFilters(
       return { ...base, traits: ['skill'] };
     case 'general-feat':
       return { ...base, traits: ['general'] };
+    case 'archetype-feat':
+      return { ...base, traits: ['archetype'] };
     default:
       return null;
   }
@@ -529,6 +538,7 @@ const SLOT_LABEL: Record<SlotType, string> = {
   'general-feat': 'General Feat',
   'skill-increase': 'Skill Increase',
   'ability-boosts': 'Ability Boosts (4)',
+  'archetype-feat': 'Archetype Feat',
 };
 
 const SLOT_CLASSES: Record<SlotType, string> = {
@@ -538,6 +548,7 @@ const SLOT_CLASSES: Record<SlotType, string> = {
   'general-feat': 'border-pf-tertiary-dark bg-pf-tertiary/40 text-pf-alt-dark',
   'skill-increase': 'border-pf-prof-expert bg-pf-prof-expert/10 text-pf-prof-expert',
   'ability-boosts': 'border-pf-rarity-unique bg-pf-rarity-unique/10 text-pf-rarity-unique',
+  'archetype-feat': 'border-pf-rarity-rare bg-pf-rarity-rare/10 text-pf-rarity-rare',
 };
 
 const CLICKABLE_SLOTS: ReadonlySet<SlotType> = new Set([
@@ -547,6 +558,7 @@ const CLICKABLE_SLOTS: ReadonlySet<SlotType> = new Set([
   'general-feat',
   'skill-increase',
   'ability-boosts',
+  'archetype-feat',
 ]);
 
 function SlotChips({

--- a/apps/player-portal/src/features/characters/sheet/tabs/progression/slot.test.ts
+++ b/apps/player-portal/src/features/characters/sheet/tabs/progression/slot.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import type { ClassItem } from '@/features/characters/types';
+import { buildLevelSlotMap, parseFeatLocation, featSlotLocationFor } from './slot';
+
+function makeClassSys(): ClassItem['system'] {
+  // Minimal stand-in matching the only fields buildLevelSlotMap reads.
+  return {
+    items: {},
+    classFeatLevels: { value: [1, 2, 4] },
+    ancestryFeatLevels: { value: [1, 5] },
+    skillFeatLevels: { value: [2] },
+    generalFeatLevels: { value: [3] },
+    skillIncreaseLevels: { value: [3] },
+  } as unknown as ClassItem['system'];
+}
+
+describe('parseFeatLocation', () => {
+  it('parses archetype-N → archetype-feat slot', () => {
+    expect(parseFeatLocation('archetype-2')).toEqual({ slot: 'archetype-feat', level: 2 });
+    expect(parseFeatLocation('archetype-20')).toEqual({ slot: 'archetype-feat', level: 20 });
+  });
+
+  it('still parses the existing four prefixes', () => {
+    expect(parseFeatLocation('class-1')).toEqual({ slot: 'class-feat', level: 1 });
+    expect(parseFeatLocation('ancestry-1')).toEqual({ slot: 'ancestry-feat', level: 1 });
+    expect(parseFeatLocation('skill-2')).toEqual({ slot: 'skill-feat', level: 2 });
+    expect(parseFeatLocation('general-3')).toEqual({ slot: 'general-feat', level: 3 });
+  });
+
+  it('returns null for unrecognised prefixes', () => {
+    expect(parseFeatLocation('bonus-2')).toBeNull();
+    expect(parseFeatLocation('archetype-')).toBeNull();
+  });
+});
+
+describe('featSlotLocationFor', () => {
+  it('returns archetype-N for archetype-feat slot', () => {
+    expect(featSlotLocationFor('archetype-feat', 2)).toBe('archetype-2');
+    expect(featSlotLocationFor('archetype-feat', 20)).toBe('archetype-20');
+  });
+});
+
+describe('buildLevelSlotMap', () => {
+  it('omits archetype-feat slots when no levels supplied', () => {
+    const map = buildLevelSlotMap(makeClassSys());
+    for (const slots of map.values()) {
+      expect(slots).not.toContain('archetype-feat');
+    }
+  });
+
+  it('injects archetype-feat at each level in archetypeFeatLevels', () => {
+    const map = buildLevelSlotMap(makeClassSys(), [2, 4, 6, 8]);
+    expect(map.get(2)).toContain('archetype-feat');
+    expect(map.get(4)).toContain('archetype-feat');
+    expect(map.get(6)).toContain('archetype-feat');
+    expect(map.get(8)).toContain('archetype-feat');
+    expect(map.get(3)).not.toContain('archetype-feat');
+  });
+
+  it('renders archetype-feat right after class-feat at shared levels', () => {
+    const map = buildLevelSlotMap(makeClassSys(), [2, 4]);
+    const lvl2 = map.get(2);
+    expect(lvl2).toBeDefined();
+    const classIdx = lvl2!.indexOf('class-feat');
+    const archIdx = lvl2!.indexOf('archetype-feat');
+    expect(classIdx).toBeGreaterThanOrEqual(0);
+    expect(archIdx).toBe(classIdx + 1);
+  });
+});

--- a/apps/player-portal/src/features/characters/sheet/tabs/progression/slot.ts
+++ b/apps/player-portal/src/features/characters/sheet/tabs/progression/slot.ts
@@ -11,7 +11,8 @@ export type SlotType =
   | 'skill-feat'
   | 'general-feat'
   | 'skill-increase'
-  | 'ability-boosts';
+  | 'ability-boosts'
+  | 'archetype-feat';
 
 /** Composite key encoding both the level and the slot kind. */
 export type SlotKey = string;
@@ -55,6 +56,7 @@ const FEAT_SLOT_LOCATION_PREFIX: Partial<Record<SlotType, string>> = {
   'ancestry-feat': 'ancestry',
   'skill-feat': 'skill',
   'general-feat': 'general',
+  'archetype-feat': 'archetype',
 };
 
 export function featSlotLocationFor(slot: SlotType, level: number): string | null {
@@ -69,22 +71,31 @@ export function featSlotLocationFor(slot: SlotType, level: number): string | nul
  * are deliberately left unhandled because they don't fit the level chassis.
  */
 export function parseFeatLocation(location: string): { slot: SlotType; level: number } | null {
-  const match = /^(ancestry|class|skill|general)-(\d+)$/.exec(location);
+  const match = /^(ancestry|class|skill|general|archetype)-(\d+)$/.exec(location);
   if (!match) return null;
   const level = Number(match[2]);
   if (!Number.isFinite(level) || level < 1) return null;
-  const prefix = match[1] as 'ancestry' | 'class' | 'skill' | 'general';
-  return { slot: `${prefix}-feat`, level };
+  const prefix = match[1] as 'ancestry' | 'class' | 'skill' | 'general' | 'archetype';
+  return { slot: prefix === 'archetype' ? 'archetype-feat' : `${prefix}-feat`, level };
 }
 
 /**
  * For each level 1-20, the ordered list of slot types the character opens
  * at that level. Order is render-order: class feats first (most
  * character-defining), ability boosts last (collapsed into a single chip).
+ *
+ * `archetypeFeatLevels` (optional) injects free-archetype slots at the
+ * levels supplied by PF2e's prepared `actor.feats` archetype group. When
+ * absent or empty, no archetype chips render — matching variant-disabled
+ * worlds.
  */
-export function buildLevelSlotMap(sys: ClassItem['system']): Map<number, readonly SlotType[]> {
+export function buildLevelSlotMap(
+  sys: ClassItem['system'],
+  archetypeFeatLevels: readonly number[] = [],
+): Map<number, readonly SlotType[]> {
   const rules: Array<[SlotType, readonly number[]]> = [
     ['class-feat', sys.classFeatLevels.value],
+    ['archetype-feat', archetypeFeatLevels],
     ['ancestry-feat', sys.ancestryFeatLevels.value],
     ['skill-feat', sys.skillFeatLevels.value],
     ['general-feat', sys.generalFeatLevels.value],

--- a/apps/player-portal/src/features/characters/types/prepared.ts
+++ b/apps/player-portal/src/features/characters/types/prepared.ts
@@ -16,4 +16,8 @@ export interface PreparedCharacter {
    *  persists sheet-level preferences (e.g. background image path)
    *  under the `character-creator` scope. */
   flags?: Record<string, Record<string, unknown>>;
+  /** Levels carrying a free-archetype feat slot (e.g. [2, 4, 6, 8] for a
+   *  level-8 character with the variant enabled). Sourced from PF2e's
+   *  computed actor.feats archetype group. */
+  archetypeFeatLevels?: number[];
 }

--- a/packages/shared/src/foundry-api.ts
+++ b/packages/shared/src/foundry-api.ts
@@ -100,6 +100,10 @@ export interface PreparedActor {
    *  uploaded background image path) under the `character-creator`
    *  scope. Missing when the bridge/mock doesn't surface them. */
   flags?: Record<string, Record<string, unknown>>;
+  /** Levels that carry a free-archetype feat slot, e.g. [2, 4, 6, 8] for a
+   *  level-8 character with the free-archetype variant enabled. Absent when
+   *  the variant rule is off or the bridge hasn't surfaced the data yet. */
+  archetypeFeatLevels?: number[];
 }
 
 /** POST /api/uploads response — the relative path the file was written

--- a/packages/shared/src/foundry-api.ts
+++ b/packages/shared/src/foundry-api.ts
@@ -27,6 +27,10 @@ export interface ActorSummary {
    *  `creatorDraft`, `creatorVersion`). Absent when the actor has no flags or
    *  the bridge version pre-dates this field. */
   flags?: Record<string, Record<string, unknown>>;
+  /** First party this character belongs to (PF2e party actor). Drives the
+   *  per-party grouping in the character index. `null` when the character
+   *  isn't in any party; absent when the bridge pre-dates this field. */
+  party?: { id: string; name: string } | null;
 }
 
 /** Narrow result shape returned by create-actor / update-actor — just

--- a/packages/shared/src/rpc/index.ts
+++ b/packages/shared/src/rpc/index.ts
@@ -18,6 +18,7 @@ import type {
   compendiumItemPayload,
   createActorBody,
   createCompendiumItemBody,
+  createSpellcastingEntryBody,
   ensureCompendiumPackBody,
   invokeActorActionBody,
   resolvePromptBody,
@@ -39,6 +40,7 @@ export type InvokeActorActionBody = z.infer<typeof invokeActorActionBody>;
 export type EnsureCompendiumPackBody = z.infer<typeof ensureCompendiumPackBody>;
 export type CreateCompendiumItemBody = z.infer<typeof createCompendiumItemBody>;
 export type CompendiumItemPayload = z.infer<typeof compendiumItemPayload>;
+export type CreateSpellcastingEntryBody = z.infer<typeof createSpellcastingEntryBody>;
 
 // Response from POST /api/compendium/packs/ensure — mirrored on the
 // bridge side. `created: true` means a new pack was provisioned;

--- a/packages/shared/src/rpc/schemas.ts
+++ b/packages/shared/src/rpc/schemas.ts
@@ -383,3 +383,17 @@ export const createCompendiumItemBody = z.object({
   packId: z.string().min(1),
   item: compendiumItemPayload,
 });
+
+// POST /api/actors/:id/spellcasting-entry — create a spellcastingEntry
+// embedded item on an actor. Used by the character creator to wire up
+// spellcasting for classes that the PF2e system does not initialize
+// automatically via class-feature rule elements.
+export const SPELL_TRADITIONS = ['arcane', 'divine', 'occult', 'primal'] as const;
+export const PREPARED_MODES = ['prepared', 'spontaneous', 'focus', 'innate'] as const;
+
+export const createSpellcastingEntryBody = z.object({
+  name: z.string().min(1),
+  tradition: z.enum(SPELL_TRADITIONS),
+  prepared: z.enum(PREPARED_MODES),
+  ability: z.enum(['str', 'dex', 'con', 'int', 'wis', 'cha']),
+});


### PR DESCRIPTION
## Apps touched

- `apps/player-portal` — `npm run dev:player-portal`
- `apps/foundry-mcp` — `npm run dev:mcp`
- `apps/foundry-api-bridge` — bundled into Foundry module; rebuild with `npx vite build` in that dir

## Investigation findings

### Current behavior (root cause)
The creator calls `addItemFromCompendium(pf2e.classes, classId)` when the user picks a class. PF2e auto-grants all L1 class features from `class.system.items` when the class item is embedded — confirmed: Kaelen (Druid, created via our creator) has "Druid Spellcasting" as an embedded class feature. However, that class feature has `system.rules: []` — no rule elements create a spellcasting entry. The creator was left with class features but no `spellcastingEntry` embedded item.

Kaelen (Druid) before this fix: `allTypes = ["deity","ancestry","feat","weapon","background","class","heritage","action"]` — no `spellcastingEntry`.

Jackstone (Sorcerer) has entries because Pathmuncher created them explicitly at import time.

### Why Option A isn't viable as described
The task brief suggests "drop the class via PF2e's native flow." PF2e's advancement hook _does_ fire and grant class features when `actor.createEmbeddedDocuments('Item', [classData])` is called — but PF2e does **not** automatically create the `spellcastingEntry` item through that path (class feature rule elements are empty). The native Foundry sheet's "Initialize Spellcasting" button is what creates the entry in standard play; it's a separate explicit step PF2e offloads to the UI. There is no api-bridge surface that mirrors this button today.

### What Option B requires (chosen approach)
Create the `spellcastingEntry` embedded item explicitly with the right `{tradition, prepared, ability}`. The entry shape is confirmed from live actor inspection: `{type: "spellcastingEntry", system: {tradition:{value}, prepared:{value, flexible, validItems}, proficiency:{value:1}, ability:{value}}}`.

---

## Option B — implementation

### New surface
- `packages/shared/src/rpc/schemas.ts`: `createSpellcastingEntryBody` schema + `SPELL_TRADITIONS`/`PREPARED_MODES` enums
- `apps/foundry-api-bridge`: new `create-spellcasting-entry` bridge command → `actor.createEmbeddedDocuments`
- `apps/foundry-mcp`: `POST /api/actors/:id/spellcasting-entry`
- `apps/player-portal/src/features/characters/api.ts`: `createSpellcastingEntry()`

### Creator wiring
- `Draft.spellcastingEntryId: string | null` — tracks the created entry so class changes can delete the stale one
- `constants.ts`: `EMPTY_DRAFT` updated
- `helpers.ts`: `persistPick('class')` deletes old entry on class change; `applyPickedSlot('class')` resets `spellcastingEntryId: null`; new `resolveVariableTraditionEntry()` for Sorcerer
- `helpers.ts`: `hydrateFromActor` restores `spellcastingEntryId` from `spellcastingEntry` items (edit/resume flow)
- `CharacterCreator.tsx`: useEffect fires once `classSlug` resolves; creates entry for fixed-tradition classes; guarded by `spellcastingEntryId !== null` (no double-create)
- `CharacterCreator.tsx`: `handleFinish` additionally calls `resolveVariableTraditionEntry` for Sorcerer

---

## Class/subclass coverage matrix

| Class | Tradition | Mode | Ability | When created | Note |
|---|---|---|---|---|---|
| Wizard | arcane | prepared | int | at class pick | |
| Cleric | divine | prepared | wis | at class pick | Doctrine affects slot bonuses via class features, not the entry itself |
| Druid | primal | prepared | wis | at class pick | |
| Bard | occult | spontaneous | cha | at class pick | |
| Oracle | divine | spontaneous | cha | at class pick | |
| Magus | arcane | prepared | int | at class pick | |
| Psychic | occult | spontaneous | int | at class pick | |
| Sorcerer | bloodline-dependent | spontaneous | cha | at handleFinish | 17 bloodlines mapped; bloodline slug read from actor items |
| Witch | patron-dependent | — | — | **deferred** | patron determines tradition; same mechanism as Sorcerer but patron slug → tradition map not yet built |
| Summoner | eidolon-dependent | — | — | **deferred** | eidolon type determines tradition |
| Animist | multi-tradition | — | — | **deferred** | new class with complex multi-tradition system |
| Fighter, Rogue, Ranger, etc. | — | — | — | N/A | no entry |
| Champion, Monk | — | — | — | N/A | focus pool only; entries created from class feats, not at level 1 |

### Sorcerer bloodlines covered
aberrant→occult, angelic→divine, demonic→divine, diabolic→divine, draconic→arcane, elemental→primal, fey→primal, genie→primal, hag→occult, harrow→occult, imperial→arcane, nymph→primal, phoenix→primal, psychopomp→occult, shadow→occult, undead→divine, wyrmblessed→arcane

Traditions sourced from each bloodline document's `system.rules[*]{key:"RollOption", option:"feature:bloodline:tradition:<t>"}`.

---

## Existing characters missing entries

Characters already in Foundry without an entry (like Kaelen the Druid) are not back-filled by this PR. The remediation path is the resume/edit flow (PR #251): open the creator for the existing character, change/re-select the class, and submit — `persistPick` + the creation useEffect will add the entry. Alternatively, the GM can initialize spellcasting manually via Foundry's sheet UI.

## Tests

21 unit tests in `spellcastingConfig.test.ts`:
- All 7 fixed-tradition classes: correct tradition/prepared/ability
- Sorcerer without bloodline → null
- Sorcerer + 4 bloodlines (fey→primal, angelic→divine, imperial→arcane, elemental→primal)
- Martial classes (fighter, rogue, barbarian, unknown) → null
- `sorcererBloodlineSlugFromItems`: detects slug from actor items, ignores non-classfeature items, handles missing/null slug