### PR TITLE
fix(deps): update sanitize-html 2.17.3→2.17.4 (GHSA-rpr9-rxv7-x643 critical XSS)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10709,6 +10709,13 @@
         "node": ">=20"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -15371,6 +15378,16 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/launder": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
+      "integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dayjs": "^1.11.7"
+      }
+    },
     "node_modules/lazy-val": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
@@ -19230,9 +19247,9 @@
       }
     },
     "node_modules/sanitize-html": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.3.tgz",
-      "integrity": "sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg==",
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.4.tgz",
+      "integrity": "sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19240,6 +19257,7 @@
         "escape-string-regexp": "^4.0.0",
         "htmlparser2": "^10.1.0",
         "is-plain-object": "^5.0.0",
+        "launder": "^1.7.1",
         "parse-srcset": "^1.0.2",
         "postcss": "^8.3.11"
       }


### PR DESCRIPTION
## Summary
- Bumps `sanitize-html` from 2.17.3 to 2.17.4 to fix GHSA-rpr9-rxv7-x643 (critical XSS via `xmp` raw-text passthrough)
- Adds two transitive deps required by 2.17.4: `dayjs` and `launder`
- Moderate issues (`showdown`, `tinymce` in `@league-of-foundry-developers/foundry-vtt-types`) left unchanged — fix requires a breaking major-version jump in foundry-vtt-types and they are below the `high` audit threshold

**Why this PR:** The new CVE advisory caused `npm audit --audit-level=high` to fail on all dependabot PR CI runs, blocking the entire dep-bump queue.

## Apps touched
None — lockfile-only change, no runtime code affected.

## Test plan
- [ ] CI passes (specifically the "Audit dependencies" step in lint-and-typecheck)
- [ ] After merge, comment `@dependabot rebase` on blocked PRs to pick up the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)